### PR TITLE
feat: npm binary-distribution shim (spec 007)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "2da261da7d9b3ef363443c1a7e65d6db24fb7c15dfba71c5c1dc561b685a78e2",
+    "contentHash": "1f33dbadec0ecd5447a46775c4d88af333a25f1efe5140692ced0e976e8a442e",
     "indexerId": "spec-spine",
     "indexerVersion": "0.1.0",
     "repoRoot": "."
@@ -27,6 +27,13 @@
       "name": "spec-spine-types",
       "path": "crates/spec-spine-types",
       "specRef": "000-spec-spine-bootstrap"
+    },
+    {
+      "kind": "npm-package",
+      "name": "spec-spine",
+      "path": "npm",
+      "specRef": "007-distribution",
+      "version": "0.1.0"
     }
   ],
   "schemaVersion": "0.1.0",
@@ -644,6 +651,109 @@
           }
         ],
         "specId": "006-init-scaffold",
+        "specStatus": "approved"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry"
+        ],
+        "implementingPaths": [
+          {
+            "path": ".github/workflows/release.yml",
+            "source": "spec-edge"
+          },
+          {
+            "path": "docs/releasing.md",
+            "source": "spec-edge"
+          },
+          {
+            "path": "install.sh",
+            "source": "spec-edge"
+          },
+          {
+            "path": "npm",
+            "source": "manifest-metadata"
+          },
+          {
+            "path": "npm/",
+            "source": "spec-edge"
+          },
+          {
+            "path": "npm/bin/spec-spine.js",
+            "source": "comment-header"
+          },
+          {
+            "path": "npm/lib/platform.js",
+            "source": "comment-header"
+          },
+          {
+            "path": "npm/scripts/generate-platform-packages.js",
+            "source": "comment-header"
+          },
+          {
+            "path": "npm/scripts/smoke-test.sh",
+            "source": "comment-header"
+          },
+          {
+            "path": "npm/test/platform.test.js",
+            "source": "comment-header"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": ".github/workflows/release.yml"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": ".github/workflows/release.yml"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "docs/releasing.md"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "docs/releasing.md"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "install.sh"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "install.sh"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "npm/"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "npm/"
+            }
+          }
+        ],
+        "specId": "007-distribution",
         "specStatus": "approved"
       }
     ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.1.0",
-    "contentHash": "52da5535542313d57a63275d7e796a8a633bae55d19f83f69390abb3581f7fe1",
+    "contentHash": "8f8a08a37d3e4e9f7d6f1d62dc3900774cd0ff21c4f17d8727622193a8e8a356",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -360,6 +360,51 @@
       "status": "approved",
       "summary": "The adoption UX: `spec-spine init` scaffolds a fresh repo so it can be governed with zero source edits to the library: a starter spec-spine.toml, a standards/spec/ constitution + contract + templates, a bootstrap specs/000-* spec.md, and the .claude/rules/ agent rule files. Core stays IO-light: scaffold_init returns the files as data (rel_path, contents, overwrite); the CLI writes them, with --force to overwrite existing files. Establishes the scaffold generator and the `spec-spine init` CLI subcommand.\n",
       "title": "init: scaffold a new adopter"
+    },
+    {
+      "created": "2026-06-09",
+      "dependsOn": [
+        "001-compile-registry"
+      ],
+      "establishes": [
+        {
+          "kind": "file",
+          "path": "npm/"
+        },
+        {
+          "kind": "file",
+          "path": "install.sh"
+        },
+        {
+          "kind": "file",
+          "path": ".github/workflows/release.yml"
+        },
+        {
+          "kind": "file",
+          "path": "docs/releasing.md"
+        }
+      ],
+      "id": "007-distribution",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "007: Distribution",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 The pattern: optional-dependencies platform packages",
+        "3.2 Platform map (the five triples)",
+        "3.3 The launcher",
+        "3.4 Unsupported hosts fail clearly",
+        "3.5 Version lock",
+        "3.6 Release integration",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/007-distribution/spec.md",
+      "status": "approved",
+      "summary": "How the spec-spine CLI reaches users who do not have a Rust toolchain. Two channels already existed but were unspecced: the tag-gated GitHub release pipeline (release.yml) that builds the five per-triple archives, and install.sh (curl | sh) that consumes them. This spec adopts both as governed territory and adds a third channel: an npm binary-distribution shim under npm/ so a TS/JS repo can `npm i -D spec-spine` and get the CLI with no Rust. The shim is a launcher, not a native addon: the main package's bin resolves a per-triple platform package (optionalDependencies, os/cpu-gated) and exec's the prebuilt binary, forwarding argv and exit code. No postinstall, no network at install, no archive extraction; it works under `npm ci --ignore-scripts` and offline. Version-locked to the binary release tag (npm 0.1.0 ships the v0.1.0 assets).\n",
+      "title": "Distribution: npm binary shim + the release pipeline"
     }
   ],
   "validation": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,11 @@ name: release
 # deprecated and queues badly. The crate source is identical, so the binary matches
 # what the determinism workflow proves byte-identical.
 #
-# publish-crates is idempotent: it skips any crate version already on crates.io, so
-# re-running a tag is safe. CycloneDX SBOM is deferred (Q7): low v1 value.
+# publish-crates and publish-npm are idempotent: each skips any version already
+# live (crates.io / npm), so re-running a tag is safe. publish-npm assembles the
+# per-triple npm platform packages from the SAME build archives (no second Rust
+# build) and is gated on NPM_TOKEN: absent the secret it is a clean no-op.
+# CycloneDX SBOM is deferred (Q7): low v1 value.
 
 on:
   push:
@@ -139,3 +142,86 @@ jobs:
             fi
             echo "::endgroup::"
           done
+
+  publish-npm:
+    name: publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Gate on NPM_TOKEN: absent the secret, the whole job is a clean no-op (a
+      # skip, never a red X), the same posture as the crates.io token. The first
+      # publish, the NPM_TOKEN, and the one-time `@spec-spine` org creation are a
+      # human's job (see docs/releasing.md).
+      - name: Check for NPM_TOKEN
+        id: gate
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=npm publish skipped::NPM_TOKEN secret not set; skipping npm publish"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.present == 'true'
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      # The npm platform packages bundle the prebuilt binaries directly, so they
+      # are assembled from the build job's archives (no second Rust build).
+      - uses: actions/download-artifact@v4
+        if: steps.gate.outputs.present == 'true'
+        with:
+          path: dist/archives
+          pattern: archive-*
+          merge-multiple: true
+
+      - name: Assemble platform packages from the release archives
+        if: steps.gate.outputs.present == 'true'
+        working-directory: npm
+        run: |
+          set -euo pipefail
+          cp ../LICENSE LICENSE                         # ship the license in the main tarball
+          VERSION="${GITHUB_REF_NAME#v}"                # tag v0.1.0 -> 0.1.0
+          # --write-main locks the main package version + optionalDependencies to
+          # the tag; the generator fails loudly if the tag and committed version
+          # disagree on a non-write run, so the lock can never drift silently.
+          node scripts/generate-platform-packages.js \
+            --version "$VERSION" --archives ../dist/archives --out dist/packages --write-main
+          ls -la dist/packages/@spec-spine
+
+      - name: Publish (idempotent; skip versions already on npm)
+        if: steps.gate.outputs.present == 'true'
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # No -e: we inspect each publish so an already-published version is a
+          # skip, not a failure (re-running a tag is then idempotent). `npm view`
+          # is the precheck: it 404s (non-zero) for an unpublished version.
+          set -uo pipefail
+          publish_if_absent() {
+            local dir="$1" name version
+            name="$(node -p "require('./${dir}/package.json').name")"
+            version="$(node -p "require('./${dir}/package.json').version")"
+            echo "::group::publish ${name}@${version}"
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo ">> ${name}@${version} already on npm, skipping"
+            else
+              # --access public: scoped packages default to restricted.
+              npm publish "${dir}" --access public
+              echo ">> published ${name}@${version}"
+            fi
+            echo "::endgroup::"
+          }
+          # Platform packages first, then the main package, so there is never a
+          # window where `spec-spine` is live without its binaries.
+          for d in dist/packages/@spec-spine/*; do
+            publish_if_absent "$d"
+          done
+          publish_if_absent "."

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,15 @@
 /target
 **/*.rs.bk
 
+# npm binary-distribution shim (spec 007): generated platform packages (and the
+# prebuilt binaries they carry) are assembled from release artifacts at publish
+# time, never committed; ditto local install artifacts and the publish-time
+# LICENSE copy.
+/npm/dist/
+/npm/package-lock.json
+/npm/LICENSE
+node_modules/
+
 # NOTE: .derived/ (compiler/indexer output) is intentionally NOT ignored — it is
 # committed so the coupling gate and content-hash staleness check can compare the
 # committed registry/index against current inputs. Determinism makes this sane.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ contents)`**: same inputs, byte-identical output, on every platform.
 cargo install spec-spine-cli                                           # from crates.io
 # or, no Rust toolchain:
 curl -fsSL https://raw.githubusercontent.com/bartekus/spec-spine/main/install.sh | sh
+# or, in a TS/JS repo (prebuilt binary, no Rust toolchain):
+npm i -D spec-spine
 # or, from this checkout:
 cargo install --path crates/spec-spine-cli
 ```
 
-All three yield a `spec-spine` binary on your `PATH`.
+Each yields a `spec-spine` binary (on your `PATH`, or via `npx spec-spine` for the
+npm install). The npm package ships the prebuilt binary per platform; its Linux
+binaries are glibc (Alpine/musl use `cargo install`). See [npm/](npm/).
 
 ## Quickstart
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,10 @@
 # Releasing spec-spine (maintainers)
 
-> Two distribution paths ship together: **crates.io** (the library + CLI, and the
-> path that unblocks bindings) and **prebuilt binaries** (the `curl | sh` install
-> path). This is the maintainer runbook. Adopters do not read this; they read
-> [adoption-guide.md](adoption-guide.md).
+> Three distribution paths ship together: **crates.io** (the library + CLI, and
+> the path that unblocks bindings), **prebuilt binaries** (the `curl | sh` install
+> path), and **npm** (the same prebuilt binaries, repackaged so a TS/JS repo can
+> `npm i -D spec-spine`; spec 007). This is the maintainer runbook. Adopters do
+> not read this; they read [adoption-guide.md](adoption-guide.md).
 
 ## Pre-flight
 
@@ -11,6 +12,8 @@
 - [ ] Self-governance green: `spec-spine compile && spec-spine index check &&
       spec-spine lint --fail-on-warn && spec-spine couple --base origin/main --head HEAD`.
 - [ ] Versions bumped consistently (workspace `version` in the root `Cargo.toml`;
+      `version` in `npm/package.json` and its `optionalDependencies` pins, which
+      the release workflow re-locks to the tag but should match in source;
       schema-version constants in `spec-spine-types` per
       [schema-versioning.md](schema-versioning.md) if the schema changed).
 - [ ] `cargo package --workspace --locked` succeeds (it cross-verifies every
@@ -57,7 +60,54 @@ GitHub-hosted runner, and attaches them to the GitHub Release.
 Per-archive CycloneDX SBOM is deferred for v1 (low value/time ratio); add to the
 release workflow on request.
 
-## 3. Determinism gate
+## 3. npm: the binary-distribution shim (spec 007)
+
+The same `v*` tag drives the `publish-npm` job. It does **not** rebuild Rust: it
+downloads the build matrix's archives and repackages them as npm packages, then
+publishes them. It is a binary shim (a launcher that exec's the prebuilt binary),
+**not** a native addon.
+
+The shape (esbuild / biome / turbo model):
+
+- a main package **`spec-spine`** whose `bin` is a tiny launcher
+  (`npm/bin/spec-spine.js`);
+- five **platform packages** `@spec-spine/cli-<os>-<cpu>`, each carrying one
+  prebuilt binary, `os`/`cpu`-gated and listed as `optionalDependencies` of the
+  main package, **version-locked** to the tag (npm `0.1.0` ⇔ `v0.1.0` assets).
+
+There is **no `postinstall`**, so it installs under `npm ci --ignore-scripts` and
+offline. The `npm/scripts/generate-platform-packages.js` generator assembles the
+platform packages from the archives at publish time; binaries and generated
+packages are never committed.
+
+The job is **idempotent** (`npm view` precheck skips versions already live) and
+**gated on the `NPM_TOKEN` secret** (absent the token it is a clean no-op, the
+same posture as the crates.io token). **First-time human setup (once):**
+
+```sh
+# 1. Create the @spec-spine org on npm (Settings → Add Organization), so the
+#    scoped platform packages @spec-spine/cli-* can be published.
+# 2. Create an automation access token (npmjs.com → Access Tokens → Granular/
+#    Automation; bypasses 2FA for CI) with publish rights to `spec-spine` and the
+#    @spec-spine scope.
+# 3. Add it as the repo secret NPM_TOKEN (Settings → Secrets → Actions).
+```
+
+Once `NPM_TOKEN` is set, every `v*` tag publishes npm alongside crates.io and the
+GitHub Release. Verify a release with:
+
+```sh
+npm view spec-spine@<version> version          # main package live
+npm view @spec-spine/cli-darwin-arm64@<version> version
+npx spec-spine@<version> --version             # end-to-end smoke
+```
+
+Local dry-run before tagging (no publish, no network): from `npm/`, run
+`npm test` (the platform-mapping unit test) and `npm run smoke` (builds the host
+binary, packs + installs both packages into a throwaway project, and runs
+`spec-spine --version` through the launcher).
+
+## 4. Determinism gate
 
 `.github/workflows/determinism.yml` proves the emitted `registry.json` and
 `index.json` (including tree-sitter symbol line-spans) are **byte-identical

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,75 @@
+# spec-spine (npm)
+
+**The [`spec-spine`](https://github.com/bartekus/spec-spine) CLI, distributed as a
+prebuilt binary through npm. No Rust toolchain required.**
+
+spec-spine turns a markdown spec corpus into a deterministic, hash-verifiable
+authority ledger and refuses code that drifts from its owning spec at PR time.
+This package lets a TypeScript/JS repo install and run the CLI like any other dev
+tool.
+
+```sh
+npm i -D spec-spine
+npx spec-spine --version
+```
+
+```sh
+npx spec-spine init                                  # scaffold a spec corpus
+npx spec-spine compile                               # specs/*/spec.md -> registry.json
+npx spec-spine index                                 # codebase index
+npx spec-spine lint --fail-on-warn                   # corpus conformance
+npx spec-spine couple --base origin/main --head HEAD # the PR-time drift gate
+```
+
+Add it to your CI / package scripts like any other binary CLI:
+
+```json
+{
+  "scripts": {
+    "spec:check": "spec-spine compile && spec-spine index check && spec-spine lint --fail-on-warn"
+  }
+}
+```
+
+## How it works
+
+This is a **binary-distribution shim, not a native (napi) addon**. The package's
+`bin` is a tiny Node launcher that resolves the one prebuilt binary matching your
+platform and runs it as a child process, forwarding arguments and the exit code.
+
+The binaries ship as **optional dependencies** (`@spec-spine/cli-<os>-<cpu>`),
+each gated by npm's `os`/`cpu` fields so only the one for your machine is
+installed. There is **no `postinstall` script, no network access at install time,
+and no archive extraction**, so it works under `npm ci --ignore-scripts` and
+fully offline (from a warm cache or a private mirror).
+
+## Supported platforms
+
+| OS | Arch | Notes |
+|---|---|---|
+| macOS | arm64, x64 | |
+| Linux | x64, arm64 | **glibc only** (see below) |
+| Windows | x64 | |
+
+**Linux binaries are glibc, not musl.** On **Alpine** or any musl host the
+launcher refuses with a clear message: use a glibc-based image, or install from
+source with `cargo install spec-spine-cli`. The same applies to any platform
+without a prebuilt binary (Windows on ARM, 32-bit, …).
+
+## Versioning
+
+The npm version equals the binary release tag it ships: `spec-spine@0.1.0` runs
+the binary built from `v0.1.0`. There is no floating range, so a pinned npm
+version always runs a known binary.
+
+## Alternatives (no npm)
+
+```sh
+cargo install spec-spine-cli                                          # from crates.io
+curl -fsSL https://raw.githubusercontent.com/bartekus/spec-spine/main/install.sh | sh
+```
+
+## License
+
+Apache-2.0. See the [repository](https://github.com/bartekus/spec-spine) for full
+documentation, the Rust library API, and the design docs.

--- a/npm/bin/spec-spine.js
+++ b/npm/bin/spec-spine.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict';
+
+// Spec: specs/007-distribution/spec.md
+//
+// The launcher. Resolves the prebuilt binary for this host (see lib/platform.js)
+// and exec's it, forwarding argv and the child's exit code. It is a pure
+// translation layer: no flags added, no arguments rewritten, nothing printed on
+// the success path. `spec-spine <args>` through npm is identical to the native
+// binary. NOT a native addon; the Rust engine runs as a child process.
+
+const { execFileSync } = require('node:child_process');
+const { resolveBinaryPath } = require('../lib/platform.js');
+
+let binPath;
+try {
+  binPath = resolveBinaryPath();
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(1);
+}
+
+try {
+  execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+} catch (err) {
+  if (typeof err.status === 'number') {
+    process.exit(err.status); // forward the binary's own exit code
+  }
+  if (err.signal) {
+    process.stderr.write(`spec-spine: binary terminated by signal ${err.signal}\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`spec-spine: failed to run binary: ${err.message}\n`);
+  process.exit(1);
+}

--- a/npm/lib/platform.js
+++ b/npm/lib/platform.js
@@ -1,0 +1,122 @@
+'use strict';
+
+// Spec: specs/007-distribution/spec.md
+//
+// The pure (process.platform, process.arch) -> platform-package mapping behind
+// the launcher (bin/spec-spine.js). No I/O on the mapping path, so it is
+// unit-tested directly (test/platform.test.js). Resolution of the installed
+// binary is the one filesystem touch, and it takes injectable seams so the
+// tests stay network- and disk-free.
+
+const path = require('node:path');
+
+// The five supported (platform-arch) targets. This table is one fact shared
+// with release.yml's build matrix and install.sh's detection; keep all three in
+// lockstep (specs/007-distribution/spec.md sec 3.2).
+const SUPPORTED = {
+  'darwin-arm64': '@spec-spine/cli-darwin-arm64',
+  'darwin-x64': '@spec-spine/cli-darwin-x64',
+  'linux-x64': '@spec-spine/cli-linux-x64',
+  'linux-arm64': '@spec-spine/cli-linux-arm64',
+  'win32-x64': '@spec-spine/cli-win32-x64',
+};
+
+class UnsupportedPlatformError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UnsupportedPlatformError';
+  }
+}
+
+// The in-archive binary name: `.exe` on Windows, bare elsewhere (matches the
+// names release.yml stages into each archive).
+function binaryName(platform) {
+  return platform === 'win32' ? 'spec-spine.exe' : 'spec-spine';
+}
+
+// Pure resolution: (platform, arch, { muslLinux }) -> { key, packageName, binaryName }.
+// Throws UnsupportedPlatformError on any host without a prebuilt binary.
+function targetFor(platform, arch, opts = {}) {
+  if (platform === 'linux' && opts.muslLinux === true) {
+    throw new UnsupportedPlatformError(unsupportedMessage(platform, arch, 'musl'));
+  }
+  const key = `${platform}-${arch}`;
+  const packageName = SUPPORTED[key];
+  if (!packageName) {
+    throw new UnsupportedPlatformError(unsupportedMessage(platform, arch));
+  }
+  return { key, packageName, binaryName: binaryName(platform) };
+}
+
+function unsupportedMessage(platform, arch, reason) {
+  const host = reason === 'musl' ? `${platform}-${arch} (musl libc)` : `${platform}-${arch}`;
+  const lines = [
+    `spec-spine: no prebuilt binary for ${host}.`,
+    'Prebuilt binaries cover darwin-arm64, darwin-x64, linux-x64 (glibc),',
+    'linux-arm64 (glibc), and win32-x64. Install from source instead:',
+    '    cargo install spec-spine-cli',
+  ];
+  if (reason === 'musl') {
+    lines.push('(Alpine/musl: use a glibc-based image, or cargo install spec-spine-cli.)');
+  }
+  return lines.join('\n');
+}
+
+function missingPackageMessage(packageName) {
+  return [
+    `spec-spine: the prebuilt binary package '${packageName}' is not installed.`,
+    'It is an optional dependency, so this happens with `npm install --no-optional`,',
+    'on an unsupported platform, or when its download failed.',
+    'Reinstall without --no-optional, or install from source:',
+    '    cargo install spec-spine-cli',
+  ].join('\n');
+}
+
+// Detect a musl (non-glibc) Linux. Returns false off Linux. Uses process.report's
+// glibcVersionRuntime, which is present on glibc and absent on musl. Permissive
+// on error: if we cannot tell, assume glibc and let resolution fail loudly later.
+function isMuslLinux(proc = process) {
+  if (proc.platform !== 'linux') {
+    return false;
+  }
+  try {
+    if (!proc.report || typeof proc.report.getReport !== 'function') {
+      return false; // cannot tell; assume glibc and let resolution fail loudly if wrong
+    }
+    const report = proc.report.getReport();
+    const glibc = report && report.header ? report.header.glibcVersionRuntime : undefined;
+    return !glibc; // report present but no glibc runtime => musl
+  } catch {
+    return false;
+  }
+}
+
+// Resolve the absolute path to the platform binary on this host. `process` and
+// `resolve` are injectable for tests; `resolve` defaults to this module's
+// require.resolve so optional platform packages are found from the main package.
+// Throws UnsupportedPlatformError when the matching optional package is absent.
+function resolveBinaryPath(opts = {}) {
+  const proc = opts.process || process;
+  const resolve = opts.resolve || ((request) => require.resolve(request));
+  const { packageName, binaryName: bin } = targetFor(proc.platform, proc.arch, {
+    muslLinux: isMuslLinux(proc),
+  });
+  let manifest;
+  try {
+    manifest = resolve(`${packageName}/package.json`);
+  } catch {
+    throw new UnsupportedPlatformError(missingPackageMessage(packageName));
+  }
+  return path.join(path.dirname(manifest), 'bin', bin);
+}
+
+module.exports = {
+  SUPPORTED,
+  UnsupportedPlatformError,
+  binaryName,
+  targetFor,
+  unsupportedMessage,
+  missingPackageMessage,
+  isMuslLinux,
+  resolveBinaryPath,
+};

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "spec-spine",
+  "version": "0.1.0",
+  "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
+  "keywords": [
+    "spec",
+    "specification",
+    "authority",
+    "governance",
+    "coupling",
+    "cli",
+    "rust",
+    "deterministic"
+  ],
+  "homepage": "https://github.com/bartekus/spec-spine#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bartekus/spec-spine.git",
+    "directory": "npm"
+  },
+  "bugs": {
+    "url": "https://github.com/bartekus/spec-spine/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "The spec-spine Authors",
+  "type": "commonjs",
+  "bin": {
+    "spec-spine": "bin/spec-spine.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "LICENSE",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js",
+    "generate": "node scripts/generate-platform-packages.js",
+    "smoke": "scripts/smoke-test.sh"
+  },
+  "optionalDependencies": {
+    "@spec-spine/cli-darwin-arm64": "0.1.0",
+    "@spec-spine/cli-darwin-x64": "0.1.0",
+    "@spec-spine/cli-linux-x64": "0.1.0",
+    "@spec-spine/cli-linux-arm64": "0.1.0",
+    "@spec-spine/cli-win32-x64": "0.1.0"
+  },
+  "spec-spine": {
+    "spec": "007-distribution"
+  }
+}

--- a/npm/scripts/generate-platform-packages.js
+++ b/npm/scripts/generate-platform-packages.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+'use strict';
+
+// Spec: specs/007-distribution/spec.md
+//
+// Assemble the per-triple platform packages (@spec-spine/cli-<os>-<cpu>) from
+// the release archives, at publish time. Each package carries exactly one
+// prebuilt binary plus os/cpu fields so npm installs only the matching one.
+// Binaries and generated packages are never committed; this script rebuilds
+// them from artifacts on demand.
+//
+// Two input modes:
+//   --archives <dir>   extract binaries from spec-spine-<tag>-<triple>.{tar.gz,zip}
+//   --binary <path>    use one already-built binary (requires a single --target)
+//
+// Usage:
+//   node scripts/generate-platform-packages.js --archives ./dist/archives
+//   node scripts/generate-platform-packages.js --target darwin-arm64 --binary ../target/release/spec-spine
+//
+// Options:
+//   --version <v>   release version (e.g. 0.1.0 or v0.1.0); default: main package.json version
+//   --out <dir>     output root; default: <npm>/dist/packages
+//   --target <key>  build only this platform key (repeatable); default: all five
+//   --write-main    rewrite the main package.json version + optionalDependencies to lock to --version
+//   --lock-only     do not generate packages; only verify/lock the main package (implies --write-main)
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const NPM_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(NPM_DIR, '..');
+
+// platform key -> { release triple, node os, node cpu }. Mirrors release.yml and
+// lib/platform.js's SUPPORTED map (specs/007-distribution/spec.md sec 3.2).
+const TARGETS = {
+  'darwin-arm64': { triple: 'aarch64-apple-darwin', os: 'darwin', cpu: 'arm64' },
+  'darwin-x64': { triple: 'x86_64-apple-darwin', os: 'darwin', cpu: 'x64' },
+  'linux-x64': { triple: 'x86_64-unknown-linux-gnu', os: 'linux', cpu: 'x64' },
+  'linux-arm64': { triple: 'aarch64-unknown-linux-gnu', os: 'linux', cpu: 'arm64' },
+  'win32-x64': { triple: 'x86_64-pc-windows-msvc', os: 'win32', cpu: 'x64' },
+};
+
+function die(msg) {
+  process.stderr.write(`generate-platform-packages: ${msg}\n`);
+  process.exit(1);
+}
+
+function log(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+function parseArgs(argv) {
+  const opts = { targets: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) die(`missing value for ${a}`);
+      return argv[i];
+    };
+    switch (a) {
+      case '--version':
+        opts.version = next();
+        break;
+      case '--archives':
+        opts.archives = next();
+        break;
+      case '--binary':
+        opts.binary = next();
+        break;
+      case '--out':
+        opts.out = next();
+        break;
+      case '--target':
+        opts.targets.push(next());
+        break;
+      case '--write-main':
+        opts.writeMain = true;
+        break;
+      case '--lock-only':
+        opts.lockOnly = true;
+        opts.writeMain = true;
+        break;
+      default:
+        die(`unknown argument: ${a}`);
+    }
+  }
+  return opts;
+}
+
+// Strip a leading "v": "v0.1.0" -> "0.1.0".
+function normalizeVersion(v) {
+  return v.replace(/^v/, '');
+}
+
+function mainPackageJsonPath() {
+  return path.join(NPM_DIR, 'package.json');
+}
+
+function readMainPackage() {
+  return JSON.parse(fs.readFileSync(mainPackageJsonPath(), 'utf8'));
+}
+
+// Extract the binary for one target from an archive directory into a temp file;
+// returns its path. Tarballs via `tar`, zips via `unzip` (both present on the
+// publish runner).
+function extractBinary(target, archivesDir, tag, binFile) {
+  const t = TARGETS[target];
+  const isWin = t.os === 'win32';
+  const archive = path.join(
+    archivesDir,
+    `spec-spine-${tag}-${t.triple}.${isWin ? 'zip' : 'tar.gz'}`,
+  );
+  if (!fs.existsSync(archive)) {
+    die(`archive not found for ${target}: ${archive}`);
+  }
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'spec-spine-extract-'));
+  if (isWin) {
+    execFileSync('unzip', ['-o', '-q', archive, binFile, '-d', tmp], { stdio: 'inherit' });
+  } else {
+    execFileSync('tar', ['-C', tmp, '-xzf', archive, binFile], { stdio: 'inherit' });
+  }
+  const extracted = path.join(tmp, binFile);
+  if (!fs.existsSync(extracted)) {
+    die(`archive ${archive} did not contain ${binFile}`);
+  }
+  return extracted;
+}
+
+function platformPackageJson(target, version) {
+  const t = TARGETS[target];
+  return {
+    name: `@spec-spine/cli-${target}`,
+    version,
+    description: `Prebuilt spec-spine CLI binary for ${target}. Installed automatically by the \`spec-spine\` package; do not depend on it directly.`,
+    license: 'Apache-2.0',
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/bartekus/spec-spine.git',
+    },
+    os: [t.os],
+    cpu: [t.cpu],
+    files: ['bin/'],
+  };
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function generateOne(target, version, tag, outRoot, opts) {
+  const t = TARGETS[target];
+  const binFile = t.os === 'win32' ? 'spec-spine.exe' : 'spec-spine';
+
+  let source;
+  if (opts.binary) {
+    source = path.resolve(opts.binary);
+    if (!fs.existsSync(source)) die(`--binary not found: ${source}`);
+  } else {
+    source = extractBinary(target, path.resolve(opts.archives), tag, binFile);
+  }
+
+  const pkgDir = path.join(outRoot, '@spec-spine', `cli-${target}`);
+  const binDir = path.join(pkgDir, 'bin');
+  fs.rmSync(pkgDir, { recursive: true, force: true });
+  fs.mkdirSync(binDir, { recursive: true });
+
+  fs.copyFileSync(source, path.join(binDir, binFile));
+  fs.chmodSync(path.join(binDir, binFile), 0o755);
+
+  writeJson(path.join(pkgDir, 'package.json'), platformPackageJson(target, version));
+
+  const license = path.join(REPO_ROOT, 'LICENSE');
+  if (fs.existsSync(license)) {
+    fs.copyFileSync(license, path.join(pkgDir, 'LICENSE'));
+  }
+  fs.writeFileSync(
+    path.join(pkgDir, 'README.md'),
+    `# @spec-spine/cli-${target}\n\n` +
+      `Prebuilt \`spec-spine\` binary for \`${target}\` (${t.triple}).\n\n` +
+      'This package is installed automatically as an optional dependency of the\n' +
+      '[`spec-spine`](https://www.npmjs.com/package/spec-spine) package. Do not\n' +
+      'depend on it directly; its name and contents are an implementation detail.\n',
+  );
+
+  log(`  generated ${pkgDir}`);
+  return pkgDir;
+}
+
+// Lock the main package.json version + optionalDependencies to `version`.
+function lockMainPackage(version) {
+  const file = mainPackageJsonPath();
+  const pkg = readMainPackage();
+  pkg.version = version;
+  pkg.optionalDependencies = pkg.optionalDependencies || {};
+  for (const target of Object.keys(TARGETS)) {
+    pkg.optionalDependencies[`@spec-spine/cli-${target}`] = version;
+  }
+  writeJson(file, pkg);
+  log(`  locked main package.json to ${version}`);
+}
+
+// Verify the committed main package already locks every target to `version`.
+function verifyMainLock(version) {
+  const pkg = readMainPackage();
+  const problems = [];
+  if (pkg.version !== version) {
+    problems.push(`main version is ${pkg.version}, expected ${version}`);
+  }
+  const deps = pkg.optionalDependencies || {};
+  for (const target of Object.keys(TARGETS)) {
+    const name = `@spec-spine/cli-${target}`;
+    if (deps[name] !== version) {
+      problems.push(`${name} is pinned to ${deps[name]}, expected ${version}`);
+    }
+  }
+  if (problems.length > 0) {
+    die(
+      `version lock mismatch (specs/007-distribution/spec.md sec 3.5):\n  - ${problems.join('\n  - ')}\n` +
+        'Re-run with --write-main to update, or fix package.json.',
+    );
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const version = normalizeVersion(opts.version || readMainPackage().version);
+  const tag = `v${version}`;
+
+  if (opts.binary && opts.targets.length !== 1) {
+    die('--binary requires exactly one --target');
+  }
+
+  if (opts.writeMain) {
+    lockMainPackage(version);
+  } else {
+    verifyMainLock(version);
+  }
+
+  if (opts.lockOnly) {
+    log(`version lock verified/applied: ${version}`);
+    return;
+  }
+
+  const outRoot = path.resolve(opts.out || path.join(NPM_DIR, 'dist', 'packages'));
+  const targets = opts.targets.length > 0 ? opts.targets : Object.keys(TARGETS);
+  for (const target of targets) {
+    if (!TARGETS[target]) die(`unknown target: ${target}`);
+  }
+
+  log(`generating platform packages for ${version} (${tag}):`);
+  for (const target of targets) {
+    generateOne(target, version, tag, outRoot, opts);
+  }
+  log(`done -> ${outRoot}`);
+}
+
+main();

--- a/npm/scripts/smoke-test.sh
+++ b/npm/scripts/smoke-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Spec: specs/007-distribution/spec.md
+#
+# Local pack + install smoke test: prove `spec-spine --version` resolves through
+# the npm launcher to a real prebuilt binary, end to end, with no network.
+#
+#   1. cargo build the host binary
+#   2. generate the host platform package from that binary
+#   3. npm pack the main package and the platform package
+#   4. install both tarballs into a throwaway project
+#   5. run the installed `spec-spine --version` and assert it works
+#
+# macOS / Linux only (bash). Windows uses `cargo install` or the .zip directly.
+
+set -euo pipefail
+
+NPM_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$NPM_DIR/.." && pwd)"
+
+say() { printf 'smoke: %s\n' "$1" >&2; }
+die() { printf 'smoke: error: %s\n' "$1" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || die "node not found"
+command -v npm  >/dev/null 2>&1 || die "npm not found"
+command -v cargo >/dev/null 2>&1 || die "cargo not found (needed to build the host binary)"
+
+VERSION="$(node -p "require('${NPM_DIR}/package.json').version")"
+TARGET="$(node -p "process.platform + '-' + process.arch")"
+say "host target: ${TARGET}, version: ${VERSION}"
+
+case "$TARGET" in
+  darwin-arm64|darwin-x64|linux-x64|linux-arm64) BIN="spec-spine" ;;
+  win32-x64) die "use the Windows smoke path (.zip); this script is bash-only" ;;
+  *) die "unsupported host target ${TARGET}; the shim has no binary for it" ;;
+esac
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/spec-spine-smoke.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+say "building host binary (cargo build --release --bin spec-spine)…"
+cargo build --release --bin spec-spine --manifest-path "${REPO_ROOT}/Cargo.toml" >/dev/null
+HOST_BIN="${REPO_ROOT}/target/release/${BIN}"
+[ -x "$HOST_BIN" ] || die "built binary not found at ${HOST_BIN}"
+
+say "generating the ${TARGET} platform package…"
+PKG_OUT="${WORK}/packages"
+node "${NPM_DIR}/scripts/generate-platform-packages.js" \
+  --version "$VERSION" --target "$TARGET" --binary "$HOST_BIN" --out "$PKG_OUT"
+PLATFORM_PKG_DIR="${PKG_OUT}/@spec-spine/cli-${TARGET}"
+[ -d "$PLATFORM_PKG_DIR" ] || die "generator did not produce ${PLATFORM_PKG_DIR}"
+
+say "packing tarballs…"
+PACK_DIR="${WORK}/tarballs"
+mkdir -p "$PACK_DIR"
+# `npm pack` honors the package `files` field; LICENSE is copied in by the
+# release workflow at publish time and is optional here.
+MAIN_TGZ="$(cd "$PACK_DIR" && npm pack "$NPM_DIR" --silent)"
+PLATFORM_TGZ="$(cd "$PACK_DIR" && npm pack "$PLATFORM_PKG_DIR" --silent)"
+say "  main:     ${MAIN_TGZ}"
+say "  platform: ${PLATFORM_TGZ}"
+
+say "installing into a throwaway project…"
+PROJ="${WORK}/proj"
+mkdir -p "$PROJ"
+( cd "$PROJ" && npm init -y >/dev/null 2>&1 )
+( cd "$PROJ" && npm install --no-audit --no-fund --silent \
+    "${PACK_DIR}/${MAIN_TGZ}" "${PACK_DIR}/${PLATFORM_TGZ}" )
+
+BIN_LINK="${PROJ}/node_modules/.bin/spec-spine"
+[ -e "$BIN_LINK" ] || die "launcher not linked at ${BIN_LINK}"
+
+say "running the installed launcher: spec-spine --version"
+OUT="$("$BIN_LINK" --version)"
+say "  -> ${OUT}"
+echo "$OUT" | grep -q "$VERSION" || die "version output '${OUT}' did not contain ${VERSION}"
+
+# A real subcommand round-trips through the launcher (exit code forwarding).
+"$BIN_LINK" --help >/dev/null || die "spec-spine --help failed through the launcher"
+
+say "OK: launcher resolves the platform package and exec's the binary"

--- a/npm/test/platform.test.js
+++ b/npm/test/platform.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+// Spec: specs/007-distribution/spec.md
+//
+// Network- and disk-free unit test of the (platform, arch) -> platform-package
+// mapping and the unsupported-host error (spec 007 sec 3.2 / 3.4). Runs under
+// the built-in node:test runner: `node --test test/`.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const platform = require('../lib/platform.js');
+const { targetFor, resolveBinaryPath, isMuslLinux, UnsupportedPlatformError } = platform;
+
+test('maps every supported triple to its scoped package and binary name', () => {
+  const cases = [
+    ['darwin', 'arm64', '@spec-spine/cli-darwin-arm64', 'spec-spine'],
+    ['darwin', 'x64', '@spec-spine/cli-darwin-x64', 'spec-spine'],
+    ['linux', 'x64', '@spec-spine/cli-linux-x64', 'spec-spine'],
+    ['linux', 'arm64', '@spec-spine/cli-linux-arm64', 'spec-spine'],
+    ['win32', 'x64', '@spec-spine/cli-win32-x64', 'spec-spine.exe'],
+  ];
+  for (const [os, arch, pkg, bin] of cases) {
+    const t = targetFor(os, arch);
+    assert.equal(t.packageName, pkg, `${os}-${arch} package`);
+    assert.equal(t.binaryName, bin, `${os}-${arch} binary`);
+    assert.equal(t.key, `${os}-${arch}`);
+  }
+});
+
+test('the SUPPORTED table is exactly the five release triples', () => {
+  assert.deepEqual(
+    Object.keys(platform.SUPPORTED).sort(),
+    ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64'],
+  );
+});
+
+test('refuses unsupported triples with a source-build hint', () => {
+  for (const [os, arch] of [
+    ['win32', 'arm64'],
+    ['linux', 'ia32'],
+    ['freebsd', 'x64'],
+    ['darwin', 'ppc64'],
+  ]) {
+    assert.throws(
+      () => targetFor(os, arch),
+      (err) => {
+        assert.ok(err instanceof UnsupportedPlatformError);
+        assert.match(err.message, new RegExp(`${os}-${arch}`));
+        assert.match(err.message, /cargo install spec-spine-cli/);
+        return true;
+      },
+      `${os}-${arch} should be unsupported`,
+    );
+  }
+});
+
+test('refuses musl Linux even on an otherwise-supported arch', () => {
+  assert.throws(
+    () => targetFor('linux', 'x64', { muslLinux: true }),
+    (err) => {
+      assert.ok(err instanceof UnsupportedPlatformError);
+      assert.match(err.message, /musl/);
+      assert.match(err.message, /glibc-based image/);
+      assert.match(err.message, /cargo install spec-spine-cli/);
+      return true;
+    },
+  );
+  // glibc Linux on the same arch still resolves.
+  assert.equal(targetFor('linux', 'x64', { muslLinux: false }).packageName, '@spec-spine/cli-linux-x64');
+});
+
+test('isMuslLinux: false off Linux; tracks glibcVersionRuntime on Linux', () => {
+  assert.equal(isMuslLinux({ platform: 'darwin' }), false);
+  assert.equal(isMuslLinux({ platform: 'win32' }), false);
+
+  const glibcProc = {
+    platform: 'linux',
+    report: { getReport: () => ({ header: { glibcVersionRuntime: '2.39' } }) },
+  };
+  assert.equal(isMuslLinux(glibcProc), false);
+
+  const muslProc = {
+    platform: 'linux',
+    report: { getReport: () => ({ header: {} }) },
+  };
+  assert.equal(isMuslLinux(muslProc), true);
+
+  // No report available: permissive (assume glibc, fail later at resolution).
+  assert.equal(isMuslLinux({ platform: 'linux' }), false);
+});
+
+test('resolveBinaryPath joins the resolved package dir with bin/<name>', () => {
+  const fakeProcess = { platform: 'darwin', arch: 'arm64' };
+  const resolve = (request) => {
+    assert.equal(request, '@spec-spine/cli-darwin-arm64/package.json');
+    return path.join('/fake/node_modules/@spec-spine/cli-darwin-arm64', 'package.json');
+  };
+  const got = resolveBinaryPath({ process: fakeProcess, resolve });
+  assert.equal(got, path.join('/fake/node_modules/@spec-spine/cli-darwin-arm64', 'bin', 'spec-spine'));
+});
+
+test('resolveBinaryPath reports a missing optional package clearly', () => {
+  const fakeProcess = { platform: 'darwin', arch: 'x64' };
+  const resolve = () => {
+    throw new Error('Cannot find module');
+  };
+  assert.throws(
+    () => resolveBinaryPath({ process: fakeProcess, resolve }),
+    (err) => {
+      assert.ok(err instanceof UnsupportedPlatformError);
+      assert.match(err.message, /@spec-spine\/cli-darwin-x64/);
+      assert.match(err.message, /--no-optional/);
+      assert.match(err.message, /cargo install spec-spine-cli/);
+      return true;
+    },
+  );
+});

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -24,7 +24,9 @@ cargo_workspace = "Cargo.toml"
 # No npm in this repo; the default still probes these at the root and finds none.
 npm_workspaces = ["package.json", "pnpm-workspace.yaml"]
 standalone_rust_workspaces = []
-standalone_npm_packages    = []
+# The npm binary-distribution shim (spec 007) is a tracked npm package outside any
+# npm workspace (this repo has none), so it is declared as a standalone package.
+standalone_npm_packages    = ["npm"]
 
 [index]
 extra_hashed_inputs = ["standards/**", ".github/workflows/**"]

--- a/specs/007-distribution/spec.md
+++ b/specs/007-distribution/spec.md
@@ -1,0 +1,178 @@
+---
+id: "007-distribution"
+title: "Distribution: npm binary shim + the release pipeline"
+status: approved
+kind: "tooling"
+created: "2026-06-09"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+establishes:
+  - "npm/"
+  - "install.sh"
+  - ".github/workflows/release.yml"
+  - "docs/releasing.md"
+summary: >
+  How the spec-spine CLI reaches users who do not have a Rust toolchain. Two
+  channels already existed but were unspecced: the tag-gated GitHub release
+  pipeline (release.yml) that builds the five per-triple archives, and install.sh
+  (curl | sh) that consumes them. This spec adopts both as governed territory and
+  adds a third channel: an npm binary-distribution shim under npm/ so a TS/JS repo
+  can `npm i -D spec-spine` and get the CLI with no Rust. The shim is a launcher,
+  not a native addon: the main package's bin resolves a per-triple platform
+  package (optionalDependencies, os/cpu-gated) and exec's the prebuilt binary,
+  forwarding argv and exit code. No postinstall, no network at install, no archive
+  extraction; it works under `npm ci --ignore-scripts` and offline. Version-locked
+  to the binary release tag (npm 0.1.0 ships the v0.1.0 assets).
+---
+
+# 007: Distribution
+
+## 1. Purpose
+
+`cargo install spec-spine-cli` and `curl | sh` (install.sh) already put the
+`spec-spine` binary on a machine, but a TypeScript/JS team's reflex is
+`npm i -D <tool>`, and they will not install a Rust toolchain to lint a spec
+corpus. This spec gives that audience a first-class path and, while doing so,
+brings the previously-unspecced release machinery (release.yml, install.sh, the
+release runbook) under the same authority ledger that governs the rest of the
+library.
+
+The framing is deliberate and load-bearing: this is a **binary-distribution
+shim, not a napi / N-API binding.** No Rust is compiled into a Node addon, and
+the engine is never called from JS. The shim ships the existing prebuilt
+`spec-spine` CLI through npm and exec's it as a child process. The stable surface
+that bindings wrap remains the Rust library API (spec 000, docs/bindings-plan.md),
+untouched by this work.
+
+## 2. Territory
+
+- **`npm/`** (directory subtree): the entire npm shim. The main package
+  (`package.json`, the `bin/` launcher, the `lib/` resolution logic), the
+  publish-time platform-package generator (`scripts/`), and the tests. Generated
+  platform packages and the prebuilt binaries they carry are **not** committed
+  (they are assembled at publish time from release artifacts), so they are not
+  part of this territory.
+- **`install.sh`**: the `curl | sh` installer that detects platform/arch,
+  downloads the matching release archive and its `.sha256` sidecar, verifies the
+  checksum, and drops the binary on `PATH`.
+- **`.github/workflows/release.yml`**: the tag-gated pipeline that builds the
+  five per-triple archives, publishes the GitHub Release and the crates, and (new
+  in this spec) publishes the npm packages.
+- **`docs/releasing.md`**: the maintainer release runbook.
+
+The platform map (`npm/`), the install.sh detection table, and the release.yml
+build matrix are **one fact in three places**; this spec makes that shared fact
+its responsibility so a drift in any one of them is a governed change.
+
+## 3. Behavior
+
+### 3.1 The pattern: optional-dependencies platform packages
+
+The shim follows the esbuild / `@biomejs/biome` / turbo model:
+
+- A single main package, **`spec-spine`**, whose
+  `bin: { "spec-spine": "bin/spec-spine.js" }` is a tiny Node launcher.
+- One **platform package per supported triple**
+  (`@spec-spine/cli-<os>-<cpu>`), each carrying exactly one prebuilt binary and
+  declaring `os` / `cpu` so npm installs only the matching one and skips the rest.
+- The platform packages are listed as **`optionalDependencies`** of the main
+  package, version-locked (§3.5).
+
+There is **no `postinstall` script**, no network access at install time, and no
+archive extraction. Installation is npm placing the one matching platform package
+into `node_modules`; the binary is already a plain file inside it. This is what
+lets the shim work under `npm ci --ignore-scripts` and fully offline (from a
+warm cache or a private mirror), the failure modes that sink download-on-install
+shims.
+
+### 3.2 Platform map (the five triples)
+
+The map is derived from `release.yml`'s build matrix and **must match it
+exactly**, including the in-archive binary name:
+
+| `process.platform` | `process.arch` | platform package | release triple | in-archive binary |
+|---|---|---|---|---|
+| `darwin` | `arm64` | `@spec-spine/cli-darwin-arm64` | `aarch64-apple-darwin` | `spec-spine` |
+| `darwin` | `x64` | `@spec-spine/cli-darwin-x64` | `x86_64-apple-darwin` | `spec-spine` |
+| `linux` | `x64` | `@spec-spine/cli-linux-x64` | `x86_64-unknown-linux-gnu` | `spec-spine` |
+| `linux` | `arm64` | `@spec-spine/cli-linux-arm64` | `aarch64-unknown-linux-gnu` | `spec-spine` |
+| `win32` | `x64` | `@spec-spine/cli-win32-x64` | `x86_64-pc-windows-msvc` | `spec-spine.exe` |
+
+The Linux binaries are **glibc** (the `-gnu` triples), not musl. Alpine / musl
+hosts are unsupported by the shim and must use `cargo install spec-spine-cli` or
+a glibc-based image (§3.4).
+
+### 3.3 The launcher
+
+`bin/spec-spine.js` is a pure translation layer with no logic of its own beyond
+resolution and process forwarding:
+
+1. Map `(process.platform, process.arch)` to a platform-package name and binary
+   name via the table in §3.2 (the mapping lives in `lib/`, is a pure function of
+   its inputs, and is unit-tested with no I/O).
+2. Resolve the installed platform package's binary with `require.resolve`.
+3. `execFileSync` the binary with `process.argv.slice(2)` and `stdio: "inherit"`,
+   then exit with the child's exit code (and surface a terminating signal as a
+   non-zero exit).
+
+The launcher adds no flags, rewrites no arguments, and prints nothing on the
+success path: `spec-spine <args>` through npm is behaviorally identical to the
+native binary.
+
+### 3.4 Unsupported hosts fail clearly
+
+On any host without a matching prebuilt binary, the launcher exits non-zero with
+a message that names the host and points at the source-build escape hatch. This
+covers, at minimum:
+
+- triples with no archive (`win32-arm64`, `linux` 32-bit, …): the mapping
+  function itself refuses them;
+- **musl / Alpine** Linux: detected (the glibc runtime is absent) and refused
+  even though `linux-<arch>` is otherwise supported, because the glibc binary
+  would not run;
+- a supported triple whose optional platform package is **missing** (installed
+  with `--no-optional`, or its install failed): `require.resolve` fails and the
+  launcher reports how to recover.
+
+Every such message recommends `cargo install spec-spine-cli` (and, for
+Alpine/musl, a glibc-based image). The README states the glibc constraint up
+front so Alpine CI reaches for `cargo install` or a `-gnu` image from the start.
+
+### 3.5 Version lock
+
+The npm package version **equals** the binary release tag it ships: npm `0.1.0`
+carries the `v0.1.0` archives, and the main package pins each
+`optionalDependencies` entry to that exact version. There is no floating range,
+so a given `spec-spine` npm version always exec's the binary built from the
+matching tag. The lock is enforced at publish time by the generator, which
+stamps every platform package with the release version and fails on a mismatch.
+
+### 3.6 Release integration
+
+`release.yml`, on a `v*` tag, additionally publishes the npm packages:
+
+- it is **idempotent** (a version already live on npm is skipped, matching the
+  crates.io job), so re-running a tag is safe;
+- it is **gated on an `NPM_TOKEN` secret**: absent the token the job is a no-op,
+  never a failure;
+- the platform packages are generated from the same per-triple archives the build
+  matrix already produced (no second Rust build), then published, then the main
+  package.
+
+The first npm publish and the `NPM_TOKEN` (and the one-time creation of the
+`@spec-spine` org) are left to a human, the same posture as the crates.io token.
+The runbook step lives in `docs/releasing.md`.
+
+## 4. Out of scope
+
+- **No napi / native binding.** No Node addon, no `napi-rs` / `neon`, no calling
+  the engine in-process from JS. That path is design-only in
+  `docs/bindings-plan.md` and wraps the Rust library API, not this CLI shim.
+- **No actual `npm publish` from the build session.** The pipeline is made
+  publish-ready; the human performs the first publish.
+- **Migrating any existing repo** (e.g. template-encore) onto the shim.
+- **Windows-on-ARM, musl, and 32-bit** prebuilt binaries: out of the v1 triple
+  set; those hosts use `cargo install` (§3.4). Adding a triple is an additive
+  change to the §3.2 map and the release matrix together.


### PR DESCRIPTION
## What

Ship the `spec-spine` CLI through **npm** so a TypeScript/JS repo can
`npm i -D spec-spine` and get the CLI with **no Rust toolchain**. This is a
**binary-distribution shim, not a napi/N-API binding**: a tiny launcher resolves
the per-triple platform package and `execFileSync`'s the existing prebuilt
binary, forwarding argv and the exit code.

## Approach (esbuild / biome / turbo model)

- Main package **`spec-spine`** whose `bin` is `bin/spec-spine.js` (a launcher).
- Five **platform packages** `@spec-spine/cli-<os>-<cpu>`, each carrying one
  prebuilt binary, `os`/`cpu`-gated, listed as `optionalDependencies` and
  **version-locked** to the release tag (npm `0.1.0` ⇔ `v0.1.0` assets).
- **No `postinstall`, no network at install, no archive extraction** — works
  under `npm ci --ignore-scripts` and offline.
- Unsupported hosts (win32-arm64, **musl/Alpine**, 32-bit, missing optional
  package) fail with a clear message pointing at `cargo install spec-spine-cli`.

## Spec-first + dogfood

- **Spec 007** (`specs/007-distribution/spec.md`) establishes the `npm/` surface
  and adopts `install.sh`, `release.yml`, and `docs/releasing.md` as governed
  territory, closing the previously-unspecced-distribution gap.
- `spec-spine.toml` gains `standalone_npm_packages = ["npm"]`; `npm/package.json`
  carries the `"spec-spine": { "spec": "007-distribution" }` link; `.derived/`
  regenerated.

## Release integration

`release.yml` gains a `publish-npm` job: **idempotent** (`npm view` precheck),
**`NPM_TOKEN`-gated** (clean no-op without the secret), assembling the packages
from the existing build archives (no second Rust build). Documented in
`docs/releasing.md`.

## Validation (all green)

| Check | Result |
|---|---|
| `compile` / `index check` / `lint --fail-on-warn` / `couple` | 8 specs · fresh · 0/0/0 · no drift |
| `cargo test --workspace --locked` | pass |
| `npm test` (network-free mapping + unsupported error) | 7/7 |
| `npm run smoke` (pack → install → `spec-spine --version`) | resolves through launcher ✓ |
| Generator on **real** v0.1.0 assets | Mach-O arm64 (tar.gz) + PE32+ (zip) ✓ |
| version-lock guard / determinism re-run | refuses mismatch / byte-identical ✓ |

## Left to a human (by design, same posture as the crates.io token)

Create the `@spec-spine` npm org, set the `NPM_TOKEN` secret, and run the first
publish. The `publish-npm` job is a no-op until `NPM_TOKEN` exists. **This PR
does not publish anything.**

## Note

The "403 curl" fix the brief mentioned is **moot** — `publish-crates` already
greps `cargo publish` output with no curl precheck (landed in `1036a23`).