### PR TITLE
fix(npm): extract release binary tolerant of tar member layout

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "1f33dbadec0ecd5447a46775c4d88af333a25f1efe5140692ced0e976e8a442e",
+    "contentHash": "97753013a6ca8e44cf7cf8644f70adf1b97668f51e15cacb8290a1d9048ebe3f",
     "indexerId": "spec-spine",
     "indexerVersion": "0.1.0",
     "repoRoot": "."

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.1.0",
-    "contentHash": "8f8a08a37d3e4e9f7d6f1d62dc3900774cd0ff21c4f17d8727622193a8e8a356",
+    "contentHash": "a2e203d87090b4c3037a72af84fcc8c20b09ffa3dcf8a9a94ca0e9f9c98af31e",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",

--- a/npm/scripts/generate-platform-packages.js
+++ b/npm/scripts/generate-platform-packages.js
@@ -117,10 +117,16 @@ function extractBinary(target, archivesDir, tag, binFile) {
     die(`archive not found for ${target}: ${archive}`);
   }
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'spec-spine-extract-'));
+  // Extract the whole archive rather than selecting one member: the release tar
+  // is built with `tar -C staging .`, so members are stored "./"-prefixed
+  // (./spec-spine). GNU tar (the Linux runner) will not match a bare
+  // `spec-spine` against `./spec-spine` and errors "Not found in archive";
+  // macOS bsdtar matches leniently, which masked this locally. Extracting all
+  // members lands the binary at <tmp>/<binFile> on every tar/unzip flavor.
   if (isWin) {
-    execFileSync('unzip', ['-o', '-q', archive, binFile, '-d', tmp], { stdio: 'inherit' });
+    execFileSync('unzip', ['-o', '-q', archive, '-d', tmp], { stdio: 'inherit' });
   } else {
-    execFileSync('tar', ['-C', tmp, '-xzf', archive, binFile], { stdio: 'inherit' });
+    execFileSync('tar', ['-C', tmp, '-xzf', archive], { stdio: 'inherit' });
   }
   const extracted = path.join(tmp, binFile);
   if (!fs.existsSync(extracted)) {

--- a/specs/007-distribution/spec.md
+++ b/specs/007-distribution/spec.md
@@ -159,7 +159,10 @@ stamps every platform package with the release version and fails on a mismatch.
   never a failure;
 - the platform packages are generated from the same per-triple archives the build
   matrix already produced (no second Rust build), then published, then the main
-  package.
+  package. The generator extracts each binary tolerant of archive member layout:
+  the release tarballs store members `./`-prefixed, which a strict `tar` (GNU tar
+  on the Linux runner) will not match by bare name, so it extracts the whole
+  archive and reads the binary by its known path rather than selecting a member.
 
 The first npm publish and the `NPM_TOKEN` (and the one-time creation of the
 `@spec-spine` org) are left to a human, the same posture as the crates.io token.


### PR DESCRIPTION
## Problem

The `publish-npm` job (first run, on the re-pushed `v0.1.0` tag) failed at the
generate step:

```
tar: spec-spine: Not found in archive
Error: Command failed: tar -C /tmp/... -xzf .../spec-spine-v0.1.0-aarch64-apple-darwin.tar.gz spec-spine
```

The release tarballs are built with `tar -C staging .`, so members are stored
`./`-prefixed (`./spec-spine`). **GNU tar** (the Linux runner) will not match a
bare `spec-spine` against `./spec-spine`; **macOS bsdtar matches leniently**,
which is exactly why the local archive-extraction test gave a false pass.

## Fix

Extract the whole archive (no member selection) and read the binary by its known
path. The release archives are flat, so the binary lands at `<tmp>/<binName>` on
every `tar`/`unzip` flavor. The `unzip` path is changed symmetrically.

## Validation

Re-ran the generator inside a Linux container (**GNU tar 1.34**, the failing
environment) against the real v0.1.0 archives, all five targets:

| target | extracted |
|---|---|
| darwin-arm64 | Mach-O arm64 |
| darwin-x64 | Mach-O x86_64 |
| linux-x64 | ELF x86-64 |
| linux-arm64 | ELF aarch64 |
| win32-x64 | PE32+ (unzip path) |

Self-governance stays green: compile / index check / lint / couple, npm unit
tests 7/7.

## Spec-first

The bug was an under-specified requirement (cross-`tar`-flavor extraction), so
spec 007 §3.6 now states the generator must extract tolerant of archive member
layout. `.derived/` regenerated.

## Re-trigger note

This must land in the commit the `v0.1.0` tag points to. After merge, the tag
needs to be force-moved onto the new `main` HEAD again (a release-history rewrite
the harness reserves for you), or switch to cutting `v0.1.1`.