### PR TITLE
fix(npm): publish scoped platform packages with public access

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "97753013a6ca8e44cf7cf8644f70adf1b97668f51e15cacb8290a1d9048ebe3f",
+    "contentHash": "d7fe4a2b6db49db4ef3eb66a109fe44c49aa756d0fb6219bcd2f53bcbce4dcb5",
     "indexerId": "spec-spine",
     "indexerVersion": "0.1.0",
     "repoRoot": "."

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.1.0",
-    "contentHash": "a2e203d87090b4c3037a72af84fcc8c20b09ffa3dcf8a9a94ca0e9f9c98af31e",
+    "contentHash": "1c7d248cdbfabb6c4e99700737763834fb5d3c09e1965a9c81ab5b505dd62e02",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",

--- a/npm/scripts/generate-platform-packages.js
+++ b/npm/scripts/generate-platform-packages.js
@@ -149,6 +149,10 @@ function platformPackageJson(target, version) {
     os: [t.os],
     cpu: [t.cpu],
     files: ['bin/'],
+    // Scoped packages default to restricted on npm; publishConfig.access is the
+    // reliable way to publish them publicly (the `npm publish --access public`
+    // flag alone proved insufficient). See specs/007-distribution/spec.md sec 3.6.
+    publishConfig: { access: 'public' },
   };
 }
 

--- a/specs/007-distribution/spec.md
+++ b/specs/007-distribution/spec.md
@@ -156,7 +156,11 @@ stamps every platform package with the release version and fails on a mismatch.
 - it is **idempotent** (a version already live on npm is skipped, matching the
   crates.io job), so re-running a tag is safe;
 - it is **gated on an `NPM_TOKEN` secret**: absent the token the job is a no-op,
-  never a failure;
+  never a failure. The token must be an npm **automation** token (it bypasses the
+  2FA one-time-password that CI cannot supply);
+- scoped packages default to **restricted** on npm, so each platform package
+  carries `publishConfig.access: public` (and the job also passes
+  `--access public`) to publish publicly;
 - the platform packages are generated from the same per-triple archives the build
   matrix already produced (no second Rust build), then published, then the main
   package. The generator extracts each binary tolerant of archive member layout:


### PR DESCRIPTION
## Problem

The first successful release (`v0.1.0`) published all six packages, but the five
scoped `@spec-spine/cli-*` packages landed as **restricted (private)**:

| read path | `spec-spine` (main) | `@spec-spine/cli-darwin-arm64` |
|---|---|---|
| registry.npmjs.org | **200** | **404** (anonymous reads of private pkgs 404) |
| npmjs.com web page | 200 | **403** (exists, but forbidden = private) |

So `npm i -D spec-spine` currently fails: the launcher correctly reports the
matching platform package as not installed. `npm publish --access public` (the
CLI flag) did **not** make the scoped packages public.

## Durable fix (this PR)

Add `"publishConfig": { "access": "public" }` to each generated platform
`package.json` — the reliable mechanism for publishing scoped packages publicly.
The workflow still passes `--access public` as well. Spec 007 §3.6 now records
both this and the automation-token requirement (learned from the earlier `EOTP`
failure). Self-governance stays green (compile / index check / lint / couple);
`.derived/` regenerated; generated output verified to carry `publishConfig`.

This corrects **future** releases (0.1.1+).

## Immediate fix (out of band, no re-release)

The already-published `0.1.0` platform packages cannot be republished at the same
version, so flip their visibility directly. Either the npm web UI (each package →
Settings → Public), or:

```sh
for t in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
  npm access set status=public "@spec-spine/cli-$t"
done
```

After that, `npm i -D spec-spine@0.1.0` resolves end to end.