### PR TITLE
feat: PyPI/uvx binary-distribution shim (spec 008)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "d7fe4a2b6db49db4ef3eb66a109fe44c49aa756d0fb6219bcd2f53bcbce4dcb5",
+    "contentHash": "8e7e041d9cbfd8ba31d523c4f36fe3f89b8737fa9f279de39180acddea7355d7",
     "indexerId": "spec-spine",
     "indexerVersion": "0.1.0",
     "repoRoot": "."
@@ -755,6 +755,68 @@
         ],
         "specId": "007-distribution",
         "specStatus": "approved"
+      },
+      {
+        "dependsOn": [
+          "007-distribution"
+        ],
+        "implementingPaths": [
+          {
+            "path": ".github/workflows/release.yml",
+            "source": "spec-edge"
+          },
+          {
+            "path": "py/",
+            "source": "spec-edge"
+          },
+          {
+            "path": "py/scripts/generate_wheels.py",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "py/"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "py/"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "py/scripts/generate_wheels.py"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "py/scripts/generate_wheels.py"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": ".github/workflows/release.yml"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": ".github/workflows/release.yml"
+            }
+          }
+        ],
+        "specId": "008-python-distribution",
+        "specStatus": "draft"
       }
     ],
     "orphanedSpecs": [],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.1.0",
-    "contentHash": "1c7d248cdbfabb6c4e99700737763834fb5d3c09e1965a9c81ab5b505dd62e02",
+    "contentHash": "32c9164a496e850edb60309e43f8a0b8a7a1ea7f7acb2f9d6bfd32e7fef0c3ae",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -405,6 +405,53 @@
       "status": "approved",
       "summary": "How the spec-spine CLI reaches users who do not have a Rust toolchain. Two channels already existed but were unspecced: the tag-gated GitHub release pipeline (release.yml) that builds the five per-triple archives, and install.sh (curl | sh) that consumes them. This spec adopts both as governed territory and adds a third channel: an npm binary-distribution shim under npm/ so a TS/JS repo can `npm i -D spec-spine` and get the CLI with no Rust. The shim is a launcher, not a native addon: the main package's bin resolves a per-triple platform package (optionalDependencies, os/cpu-gated) and exec's the prebuilt binary, forwarding argv and exit code. No postinstall, no network at install, no archive extraction; it works under `npm ci --ignore-scripts` and offline. Version-locked to the binary release tag (npm 0.1.0 ships the v0.1.0 assets).\n",
       "title": "Distribution: npm binary shim + the release pipeline"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "007-distribution"
+      ],
+      "establishes": [
+        {
+          "kind": "file",
+          "path": "py/"
+        },
+        {
+          "kind": "file",
+          "path": "py/scripts/generate_wheels.py"
+        }
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "007-distribution",
+          "unit": {
+            "kind": "file",
+            "path": ".github/workflows/release.yml"
+          }
+        }
+      ],
+      "id": "008-python-distribution",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "008: Distribution — uvx/PyPI wheel shim",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 The pattern: per-platform wheels, not download-on-first-use",
+        "3.2 Platform map (the same five triples)",
+        "3.3 The launcher (there isn't one)",
+        "3.4 Unsupported hosts fail clearly",
+        "3.5 Version lock",
+        "3.6 Release integration",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/008-python-distribution/spec.md",
+      "status": "draft",
+      "summary": "The Python parallel of 007's npm shim: a uvx/PyPI channel so a Python or polyglot team can `uvx spec-spine ...` (or `uv tool install spec-spine`) and get the CLI with no Rust toolchain. Where npm uses a main launcher package + five os/cpu-gated platform packages, Python collapses the same idea into one PyPI project + five per-platform wheels (+ one sdist): the wheel platform tag IS the selector, and the prebuilt binary ships in the wheel's data/scripts dir so pip/uv place it directly on PATH. There is no Python in the run path, no postinstall, no network at install, and no archive extraction at install: it works offline and under --no-build-isolation. Unsupported hosts (musl/Alpine, win-arm64, 32-bit) match no wheel and fall to the sdist, whose only artifact is a `spec-spine` console entry point that names the host and points at `cargo install spec-spine-cli` -- exact parity with 007 §3.4. Wheels are assembled from the same release archives the build job already produces (no second Rust build), are byte-reproducible, and are version-locked to the tag.\n",
+      "title": "Distribution: uvx/PyPI wheel shim"
     }
   ],
   "validation": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,12 @@ name: release
 # deprecated and queues badly. The crate source is identical, so the binary matches
 # what the determinism workflow proves byte-identical.
 #
-# publish-crates and publish-npm are idempotent: each skips any version already
-# live (crates.io / npm), so re-running a tag is safe. publish-npm assembles the
-# per-triple npm platform packages from the SAME build archives (no second Rust
-# build) and is gated on NPM_TOKEN: absent the secret it is a clean no-op.
-# CycloneDX SBOM is deferred (Q7): low v1 value.
+# publish-crates, publish-npm, and publish-pypi are idempotent: each skips any
+# version already live (crates.io / npm / PyPI), so re-running a tag is safe.
+# publish-npm and publish-pypi assemble their packages/wheels from the SAME build
+# archives (no second Rust build); publish-npm is gated on NPM_TOKEN and
+# publish-pypi on vars.PYPI_TRUSTED_PUBLISHING: absent the one-time setup each
+# is a clean no-op. CycloneDX SBOM is deferred (Q7): low v1 value.
 
 on:
   push:
@@ -225,3 +226,117 @@ jobs:
             publish_if_absent "$d"
           done
           publish_if_absent "."
+
+  publish-pypi:
+    name: publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # OIDC Trusted Publishing needs an id-token; nothing here writes repo contents.
+    permissions:
+      id-token: write
+    # A dedicated environment is the recommended scope for the Trusted Publisher
+    # (configure the same name on PyPI). Harmless if the environment is absent.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/spec-spine
+    steps:
+      - uses: actions/checkout@v4
+
+      # Gate on a repository variable, not a secret: Trusted Publishing has no
+      # token to detect. Absent/false => clean skip (a notice, never a red X),
+      # the same posture as publish-npm's NPM_TOKEN gate. A human flips this on
+      # after the one-time PyPI project + Trusted Publisher setup (docs/releasing.md).
+      - name: Check Trusted Publishing is enabled
+        id: gate
+        env:
+          ENABLED: ${{ vars.PYPI_TRUSTED_PUBLISHING }}
+        run: |
+          if [ "${ENABLED:-false}" = "true" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=PyPI publish skipped::vars.PYPI_TRUSTED_PUBLISHING is not 'true'; skipping PyPI publish"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.gate.outputs.present == 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Install the build frontend
+        if: steps.gate.outputs.present == 'true'
+        run: python -m pip install --upgrade build
+
+      # The wheels bundle the prebuilt binaries directly, so they are assembled
+      # from the build job's archives (no second Rust build) -- exactly the
+      # publish-npm pattern.
+      - uses: actions/download-artifact@v4
+        if: steps.gate.outputs.present == 'true'
+        with:
+          path: dist/archives
+          pattern: archive-*
+          merge-multiple: true
+
+      - name: Assemble wheels + sdist from the release archives
+        if: steps.gate.outputs.present == 'true'
+        working-directory: py
+        run: |
+          set -euo pipefail
+          cp ../LICENSE LICENSE                         # ship the license in the sdist + wheels
+          VERSION="${GITHUB_REF_NAME#v}"                # tag v0.1.0 -> 0.1.0
+          # generate_wheels.py verifies the tag matches the committed project
+          # version and fails loudly on a mismatch, so the lock cannot drift
+          # silently (parity with the npm generator's --write-main check).
+          python scripts/generate_wheels.py \
+            --version "$VERSION" --archives ../dist/archives --out dist/pypi --build-sdist
+          ls -la dist/pypi
+
+      # Trusted Publishing + PEP 740 attestations. `skip-existing: true` makes a
+      # re-run of the same tag idempotent (already-uploaded artifacts are a skip,
+      # not a failure) -- the property publish-npm gets from its `npm view`
+      # precheck. The action mints the OIDC token and signs each artifact; no
+      # token is stored in the repo.
+      - name: Publish to PyPI (idempotent; signed)
+        if: steps.gate.outputs.present == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: py/dist/pypi
+          skip-existing: true
+          attestations: true
+
+# -----------------------------------------------------------------------------
+# publish-pypi token fallback (only if OIDC Trusted Publishing is not available)
+#
+# Replace the job's `permissions`/`environment` blocks and the gate + publish
+# steps with a PYPI_API_TOKEN secret gate that mirrors publish-npm's NPM_TOKEN
+# gate one-for-one (absent secret => clean no-op), and publish with twine:
+#
+#   permissions:
+#     contents: read
+#   ...
+#   - name: Check for PYPI_API_TOKEN
+#     id: gate
+#     env:
+#       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+#     run: |
+#       if [ -n "${PYPI_API_TOKEN:-}" ]; then
+#         echo "present=true" >> "$GITHUB_OUTPUT"
+#       else
+#         echo "present=false" >> "$GITHUB_OUTPUT"
+#         echo "::notice title=PyPI publish skipped::PYPI_API_TOKEN secret not set; skipping PyPI publish"
+#       fi
+#   ...
+#   - name: Publish (idempotent)
+#     if: steps.gate.outputs.present == 'true'
+#     working-directory: py
+#     env:
+#       TWINE_USERNAME: __token__
+#       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+#     run: |
+#       python -m pip install --upgrade twine
+#       # --skip-existing: re-running a tag is idempotent.
+#       twine upload --skip-existing dist/pypi/*
+#
+# The OIDC path is preferred: no long-lived token in the repo and PEP 740
+# attestations come for free.
+# -----------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@
 /npm/LICENSE
 node_modules/
 
+# Python binary-distribution shim (spec 008): wheels/sdist are assembled from
+# release artifacts at publish time, never committed; ditto the publish-time
+# LICENSE copy and local build/test residue.
+/py/dist/
+/py/LICENSE
+/py/src/spec_spine.egg-info/
+__pycache__/
+
 # NOTE: .derived/ (compiler/indexer output) is intentionally NOT ignored — it is
 # committed so the coupling gate and content-hash staleness check can compare the
 # committed registry/index against current inputs. Determinism makes this sane.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ cargo install spec-spine-cli                                           # from cr
 curl -fsSL https://raw.githubusercontent.com/bartekus/spec-spine/main/install.sh | sh
 # or, in a TS/JS repo (prebuilt binary, no Rust toolchain):
 npm i -D spec-spine
+# or, in a Python repo (prebuilt wheel, no Rust toolchain):
+uvx spec-spine                 # or: pip install spec-spine
 # or, from this checkout:
 cargo install --path crates/spec-spine-cli
 ```
 
 Each yields a `spec-spine` binary (on your `PATH`, or via `npx spec-spine` for the
-npm install). The npm package ships the prebuilt binary per platform; its Linux
-binaries are glibc (Alpine/musl use `cargo install`). See [npm/](npm/).
+npm install). The npm and PyPI packages ship the prebuilt binary per platform;
+their Linux binaries are glibc (Alpine/musl use `cargo install`). See
+[npm/](npm/) and [py/](py/).
 
 ## Quickstart
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,10 +1,12 @@
 # Releasing spec-spine (maintainers)
 
-> Three distribution paths ship together: **crates.io** (the library + CLI, and
+> Four distribution paths ship together: **crates.io** (the library + CLI, and
 > the path that unblocks bindings), **prebuilt binaries** (the `curl | sh` install
-> path), and **npm** (the same prebuilt binaries, repackaged so a TS/JS repo can
-> `npm i -D spec-spine`; spec 007). This is the maintainer runbook. Adopters do
-> not read this; they read [adoption-guide.md](adoption-guide.md).
+> path), **npm** (the same prebuilt binaries, repackaged so a TS/JS repo can
+> `npm i -D spec-spine`; spec 007), and **PyPI** (the same binaries again, as
+> platform wheels so a Python team can `uvx spec-spine`; spec 008). This is the
+> maintainer runbook. Adopters do not read this; they read
+> [adoption-guide.md](adoption-guide.md).
 
 ## Pre-flight
 
@@ -14,6 +16,8 @@
 - [ ] Versions bumped consistently (workspace `version` in the root `Cargo.toml`;
       `version` in `npm/package.json` and its `optionalDependencies` pins, which
       the release workflow re-locks to the tag but should match in source;
+      `version` in `py/pyproject.toml`, which the release workflow verifies
+      against the tag and fails loudly on a mismatch;
       schema-version constants in `spec-spine-types` per
       [schema-versioning.md](schema-versioning.md) if the schema changed).
 - [ ] `cargo package --workspace --locked` succeeds (it cross-verifies every
@@ -107,7 +111,60 @@ Local dry-run before tagging (no publish, no network): from `npm/`, run
 binary, packs + installs both packages into a throwaway project, and runs
 `spec-spine --version` through the launcher).
 
-## 4. Determinism gate
+## 4. PyPI: the wheel shim (spec 008)
+
+The same `v*` tag drives the `publish-pypi` job. Like npm, it does **not**
+rebuild Rust: it downloads the build matrix's archives and repackages them, here
+as **five platform wheels + one sdist** under a single `spec-spine` PyPI
+project. The wheel platform tag is the selector (the Python analogue of npm's
+`os`/`cpu` fields): pip/uv install only the wheel matching the host, and each
+wheel carries its prebuilt binary in the `*.data/scripts/` directory so the
+binary lands directly on `PATH` as the `spec-spine` command. There is no Python
+in the run path, no postinstall, and no network at install. Unsupported hosts
+(musl/Alpine, win-arm64, 32-bit) match no wheel and fall to the sdist, whose
+`spec-spine` entry point refuses clearly and points at
+`cargo install spec-spine-cli`.
+
+The `py/scripts/generate_wheels.py` generator assembles the wheels from the
+archives at publish time; binaries, wheels, and the sdist are never committed.
+
+The job is **idempotent** (`skip-existing: true` makes re-running a tag skip
+artifacts already on PyPI) and **gated on the repository variable
+`PYPI_TRUSTED_PUBLISHING`** (a variable, not a secret: Trusted Publishing has no
+token to detect). Absent or not `'true'`, the job is a clean no-op, the same
+posture as `NPM_TOKEN`. **First-time human setup (once):**
+
+```sh
+# 1. On PyPI, register this repo as a Trusted Publisher for the `spec-spine`
+#    project (for the not-yet-existing project: Account → Publishing → "Add a
+#    new pending publisher"): owner bartekus, repo spec-spine, workflow
+#    release.yml, environment pypi. The first publish then creates the project.
+# 2. Create the matching `pypi` environment in this repo
+#    (Settings → Environments → New environment).
+# 3. Set the repository variable PYPI_TRUSTED_PUBLISHING=true
+#    (Settings → Secrets and variables → Actions → Variables).
+```
+
+Publishing uses OIDC Trusted Publishing with PEP 740 attestations, so no
+long-lived token lives in the repo. If OIDC is ever unavailable, the documented
+fallback is a `PYPI_API_TOKEN` secret + `twine upload --skip-existing`; see the
+comment block at the bottom of `release.yml`.
+
+Once the variable is set, every `v*` tag publishes PyPI alongside npm, crates.io,
+and the GitHub Release. Verify a release with:
+
+```sh
+pip index versions spec-spine            # versions live on PyPI
+uvx spec-spine@<version> --version       # end-to-end smoke through a wheel
+```
+
+Local dry-run before tagging (no publish): from `py/`, run
+`PYTHONPATH=src python3 -m unittest discover -s test` (the platform-mapping unit
+test) and `./scripts/smoke_test.sh` (builds the host binary, generates the host
+platform wheel, installs it into a throwaway env with uv or pip, and runs
+`spec-spine --version` through the installed binary).
+
+## 5. Determinism gate
 
 `.github/workflows/determinism.yml` proves the emitted `registry.json` and
 `index.json` (including tree-sitter symbol line-spans) are **byte-identical

--- a/py/README.md
+++ b/py/README.md
@@ -1,0 +1,47 @@
+# spec-spine (Python / uvx)
+
+The `spec-spine` CLI for Python users: compile a markdown spec corpus into a
+deterministic authority ledger and refuse code that drifts from its owning spec.
+Ships the prebuilt binary; **no Rust toolchain required**.
+
+```sh
+uvx spec-spine check          # run the CLI with no install
+uv tool install spec-spine    # or install it as a persistent tool
+pip install spec-spine        # or into a project/venv
+```
+
+## How it works
+
+This is a **binary distribution**, not a Python binding. There is no native
+extension and the engine is never called from Python. The project publishes:
+
+- **five platform wheels** — one per supported target, each carrying the prebuilt
+  `spec-spine` binary in the wheel's scripts directory. pip/uv select the one
+  matching your host by its platform tag and install the binary onto `PATH`. On a
+  supported host there is **no Python in the run path and no network at install**
+  beyond fetching the wheel itself; it works offline from a warm cache or a
+  private mirror, and under `--no-binary`-free resolution.
+- **one sdist** — the unsupported-host fallback. It builds only when no wheel
+  matches (musl/Alpine, win-arm64, 32-bit), and its `spec-spine` command prints a
+  clear message pointing at `cargo install spec-spine-cli`.
+
+This mirrors the npm shim (spec 007): npm uses `os`/`cpu`-gated
+`optionalDependencies`; Python uses wheel platform tags. One project, many
+wheels.
+
+## Supported targets
+
+| host | wheel platform tag | release triple |
+|---|---|---|
+| macOS arm64 | `macosx_11_0_arm64` | `aarch64-apple-darwin` |
+| macOS x86_64 | `macosx_10_12_x86_64` | `x86_64-apple-darwin` |
+| Linux x86_64 (glibc) | `manylinux_2_17_x86_64` | `x86_64-unknown-linux-gnu` |
+| Linux arm64 (glibc) | `manylinux_2_17_aarch64` | `aarch64-unknown-linux-gnu` |
+| Windows x86_64 | `win_amd64` | `x86_64-pc-windows-msvc` |
+
+Linux binaries are **glibc**. Alpine/musl hosts have no wheel and must use
+`cargo install spec-spine-cli` or a glibc-based image.
+
+## License
+
+Apache-2.0. See [LICENSE](./LICENSE).

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,0 +1,56 @@
+# Spec: specs/008-python-distribution/spec.md
+#
+# This pyproject builds ONLY the source distribution (sdist). The five platform
+# wheels are assembled by scripts/generate_wheels.py from the release archives
+# (no build backend, no second Rust build) -- the exact parallel of npm's
+# generate-platform-packages.js. We publish: 5 platform wheels + this sdist.
+# We never publish the pure `py3-none-any` wheel this backend would build; that
+# wheel is built locally, only on a host where no platform wheel matched, where
+# its `spec-spine` entry point is the clear refusal (_refuse.py).
+# setuptools>=77 gives us the standard SPDX `license`/`license-files` fields
+# (PEP 639); with it, a license *classifier* is rejected as redundant.
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spec-spine"
+# Single source of truth at publish time is the git tag; generate_wheels.py and
+# the sdist build are both invoked with --version / SETUPTOOLS_SCM-free explicit
+# version by release.yml, and the lock check fails on a tag/version mismatch
+# (§3.5 parity). 0.1.0 here tracks the workspace version.
+version = "0.1.0"
+description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [{ name = "The spec-spine Authors" }]
+keywords = ["spec", "specification", "authority", "governance", "coupling", "cli", "rust", "deterministic"]
+# Honest floor for the tiny Python that the sdist actually runs. The platform
+# wheels declare a more permissive floor (set in generate_wheels.py) so a Python
+# version mismatch never pushes a supported host onto this sdist.
+requires-python = ">=3.9"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Programming Language :: Rust",
+  "Topic :: Software Development :: Quality Assurance",
+]
+
+[project.urls]
+Homepage = "https://github.com/bartekus/spec-spine"
+Repository = "https://github.com/bartekus/spec-spine"
+Issues = "https://github.com/bartekus/spec-spine/issues"
+
+# Same command name on every host. On a supported host the platform wheel's
+# bundled binary provides `spec-spine`; on an unsupported host this sdist
+# provides `spec-spine` -> the refusal. Only one is ever installed per host, so
+# the names never collide.
+[project.scripts]
+spec-spine = "spec_spine._refuse:main"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/py/scripts/generate_wheels.py
+++ b/py/scripts/generate_wheels.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Spec: specs/008-python-distribution/spec.md (extends 007-distribution).
+
+Assemble the five per-triple platform wheels for the Python/uvx channel from the
+release archives, at publish time -- the Python parallel of npm's
+generate-platform-packages.js. Each wheel carries exactly one prebuilt binary in
+its `*.data/scripts/` directory and a platform tag, so pip/uv install only the
+matching one and the binary lands on PATH (executable) with no Python launcher.
+Binaries and wheels are never committed; this script rebuilds them on demand from
+the same archives release.yml already produced (no second Rust build).
+
+Two input modes (mirroring the npm generator):
+  --archives <dir>   extract binaries from spec-spine-<tag>-<triple>.{tar.gz,zip}
+  --binary <path>    use one already-built binary (requires a single --target)
+
+Options:
+  --version <v>      release version (e.g. 0.1.0 or v0.1.0); default: pyproject
+  --out <dir>        output root; default: <py>/dist/wheels
+  --target <key>     build only this platform key (repeatable); default: all five
+  --requires-python  Requires-Python stamped on the wheels (default: >=3.8;
+                     deliberately permissive so a Python version mismatch never
+                     pushes a supported host onto the sdist)
+  --write-main       rewrite pyproject version to lock to --version
+  --lock-only        do not build wheels; only verify/lock the version (implies
+                     --write-main)
+  --build-sdist      also build the source distribution (the unsupported-host
+                     refusal) via `python -m build --sdist`
+
+Usage:
+  python scripts/generate_wheels.py --archives ./dist/archives
+  python scripts/generate_wheels.py --target linux-x64 \
+      --binary ../target/release/spec-spine
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+PY_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PY_DIR / "src"))
+from spec_spine import platform_map as pm  # noqa: E402  (after sys.path setup)
+
+REPO_ROOT = PY_DIR.parent
+GENERATOR = "spec-spine-generate-wheels 1.0"
+
+
+def die(msg: str) -> None:
+    sys.stderr.write(f"generate-wheels: {msg}\n")
+    raise SystemExit(1)
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+
+
+def normalize_version(v: str) -> str:
+    return v[1:] if v.startswith("v") else v
+
+
+def read_pyproject_version() -> str:
+    import tomllib
+
+    with open(PY_DIR / "pyproject.toml", "rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
+# --- binary acquisition ------------------------------------------------------
+
+def _extract_from_archive(target: str, archives_dir: Path, tag: str, bin_file: str) -> Path:
+    """Extract the binary for `target` from its release archive into a temp dir.
+
+    Extracts the WHOLE archive and then reads the binary by its known name rather
+    than selecting a member: the release tar is built with `tar -C staging .`, so
+    members are stored "./"-prefixed (./spec-spine). A strict tar (GNU tar) will
+    not match a bare `spec-spine`; extracting everything lands the binary at
+    <tmp>/<bin_file> on every tar/zip flavor. (The npm generator learned this the
+    hard way; see spec 007 §3.6.)
+    """
+    rec = pm.TARGETS[target]
+    is_win = rec["windows"]
+    ext = "zip" if is_win else "tar.gz"
+    archive = archives_dir / f"spec-spine-{tag}-{rec['triple']}.{ext}"
+    if not archive.exists():
+        die(f"archive not found for {target}: {archive}")
+    tmp = Path(tempfile.mkdtemp(prefix="spec-spine-extract-"))
+    if is_win:
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(tmp)
+    else:
+        with tarfile.open(archive, "r:gz") as tf:
+            try:
+                tf.extractall(tmp, filter="data")  # py3.12+: path-traversal safe
+            except TypeError:  # pragma: no cover - older Python on the runner
+                tf.extractall(tmp)
+    # Find by basename anywhere in the tree (handles ./ prefix and flat layouts).
+    matches = [p for p in tmp.rglob(bin_file) if p.is_file()]
+    if not matches:
+        die(f"archive {archive} did not contain {bin_file}")
+    return matches[0]
+
+
+def _resolve_binary(target: str, opts: argparse.Namespace, tag: str, bin_file: str) -> Path:
+    if opts.binary:
+        src = Path(opts.binary).resolve()
+        if not src.exists():
+            die(f"--binary not found: {src}")
+        return src
+    return _extract_from_archive(target, Path(opts.archives).resolve(), tag, bin_file)
+
+
+# --- wheel assembly ----------------------------------------------------------
+
+def _record_hash(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _metadata(version: str, requires_python: str) -> bytes:
+    body = (
+        "Metadata-Version: 2.4\n"
+        f"Name: {pm.DIST_NAME}\n"
+        f"Version: {version}\n"
+        "Summary: The spec-spine CLI: compile a markdown spec corpus into a "
+        "deterministic authority ledger and refuse code that drifts from its "
+        "owning spec. Ships the prebuilt binary; no Rust toolchain required.\n"
+        "License-Expression: Apache-2.0\n"
+        "License-File: LICENSE\n"
+        "Project-URL: Homepage, https://github.com/bartekus/spec-spine\n"
+        "Project-URL: Repository, https://github.com/bartekus/spec-spine\n"
+        "Project-URL: Issues, https://github.com/bartekus/spec-spine/issues\n"
+        "Keywords: spec,specification,authority,governance,coupling,cli,rust,deterministic\n"
+        "Classifier: Development Status :: 4 - Beta\n"
+        "Classifier: Environment :: Console\n"
+        "Classifier: Programming Language :: Rust\n"
+        "Classifier: Topic :: Software Development :: Quality Assurance\n"
+        f"Requires-Python: {requires_python}\n"
+        "Description-Content-Type: text/markdown\n"
+        "\n"
+        "Prebuilt `spec-spine` binary wheel. The binary is installed to your "
+        "environment's scripts directory; `spec-spine`/`uvx spec-spine` runs it "
+        "directly. See https://github.com/bartekus/spec-spine#readme.\n"
+    )
+    return body.encode("utf-8")
+
+
+def _wheel_meta(tag: str) -> bytes:
+    return (
+        "Wheel-Version: 1.0\n"
+        f"Generator: {GENERATOR}\n"
+        "Root-Is-Purelib: false\n"
+        f"Tag: {tag}\n"
+    ).encode("utf-8")
+
+
+def _zipinfo(name: str, mode: int) -> zipfile.ZipInfo:
+    zi = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))  # fixed -> reproducible
+    zi.compress_type = zipfile.ZIP_DEFLATED
+    zi.create_system = 3  # Unix, so the mode bits are honored
+    zi.external_attr = (0o100000 | (mode & 0o7777)) << 16  # S_IFREG | mode
+    return zi
+
+
+def _build_wheel(target: str, version: str, requires_python: str,
+                 binary_path: Path, out_root: Path) -> Path:
+    rec = pm.TARGETS[target]
+    bin_file = pm.binary_name(rec["windows"])
+    tag = f"py3-none-{rec['wheel_platform']}"
+    distinfo = f"{pm.DIST_STEM}-{version}.dist-info"
+    datadir = f"{pm.DIST_STEM}-{version}.data/scripts"
+
+    # METADATA unconditionally declares `License-File: LICENSE`, so the file MUST
+    # be present in the wheel or the artifact is internally inconsistent (and
+    # twine check will not catch it). Resolve it deterministically: prefer the
+    # in-channel copy (what `cp ../LICENSE LICENSE` produces and what the sdist
+    # ships via pyproject license-files), fall back to the repo root for an
+    # in-tree build. Fail loudly if neither exists -- never emit a wheel whose
+    # METADATA claims a license file it does not carry.
+    license_path = next(
+        (p for p in (PY_DIR / "LICENSE", REPO_ROOT / "LICENSE") if p.exists()),
+        None,
+    )
+    if license_path is None:
+        raise SystemExit(
+            "generate_wheels: LICENSE not found at "
+            f"{PY_DIR / 'LICENSE'} or {REPO_ROOT / 'LICENSE'}; "
+            "METADATA declares 'License-File: LICENSE' so the file is required. "
+            "Run `cp ../LICENSE LICENSE` in the channel dir first (see the "
+            "publish-pypi job)."
+        )
+    license_data = license_path.read_bytes()
+
+    # (arcname, bytes, mode). RECORD is appended last and lists every entry.
+    entries: list[tuple[str, bytes, int]] = [
+        (f"{datadir}/{bin_file}", binary_path.read_bytes(), 0o755),
+        (f"{distinfo}/METADATA", _metadata(version, requires_python), 0o644),
+        (f"{distinfo}/WHEEL", _wheel_meta(tag), 0o644),
+    ]
+    entries.append((f"{distinfo}/licenses/LICENSE", license_data, 0o644))
+
+    record_lines = [f"{name},{_record_hash(data)},{len(data)}" for name, data, _ in entries]
+    record_name = f"{distinfo}/RECORD"
+    record_lines.append(f"{record_name},,")  # RECORD lists itself with no hash/size
+    record_data = ("\n".join(record_lines) + "\n").encode("utf-8")
+    entries.append((record_name, record_data, 0o644))
+
+    out_root.mkdir(parents=True, exist_ok=True)
+    wheel_path = out_root / f"{pm.DIST_STEM}-{version}-{tag}.whl"
+    if wheel_path.exists():
+        wheel_path.unlink()
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data, mode in entries:
+            zf.writestr(_zipinfo(name, mode), data)
+    log(f"  generated {wheel_path.name}  ({len(binary_path.read_bytes())} byte binary)")
+    return wheel_path
+
+
+# --- sdist normalization ------------------------------------------------------
+
+def _normalize_sdist(sdist: Path) -> None:
+    """Rewrite the sdist into a canonical form: members sorted by name, owner
+    cleared, mtimes clamped to SOURCE_DATE_EPOCH (default 1980-01-01, the same
+    fixed date the wheels' zip entries use), gzip header timestamp zeroed.
+    setuptools stamps wall-clock mtimes on the files it regenerates at build
+    time (PKG-INFO, egg-info, setup.cfg), so the raw sdist differs byte-wise
+    run to run; after this rewrite it is a pure function of file contents --
+    the same reproducibility property the wheels get from _zipinfo. Member
+    contents are untouched."""
+    epoch = int(os.environ.get("SOURCE_DATE_EPOCH", "315532800"))  # 1980-01-01
+    with tarfile.open(sdist, "r:gz") as tf:
+        members = [
+            (m, tf.extractfile(m).read() if m.isfile() else None)
+            for m in tf.getmembers()
+        ]
+    members.sort(key=lambda pair: pair[0].name)  # dirs prefix-sort before contents
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w", format=tarfile.PAX_FORMAT) as out:
+        for m, data in members:
+            m.mtime = epoch
+            m.uid = m.gid = 0
+            m.uname = m.gname = ""
+            # Read-back members carry the original float mtime in their PAX
+            # extended headers, which would override the clamp at write time.
+            m.pax_headers = {}
+            out.addfile(m, io.BytesIO(data) if data is not None else None)
+    with open(sdist, "wb") as fh:
+        with gzip.GzipFile(fileobj=fh, mode="wb", mtime=0) as gz:
+            gz.write(raw.getvalue())
+
+
+# --- version lock (Python-side §3.5) -----------------------------------------
+
+def _pyproject_path() -> Path:
+    return PY_DIR / "pyproject.toml"
+
+
+def lock_version(version: str) -> None:
+    """Rewrite the single `version = "..."` line in [project]. Python has one
+    project + N wheels, so there are no per-dependency pins to lock (unlike npm's
+    optionalDependencies) -- the wheels are stamped with --version at build."""
+    path = _pyproject_path()
+    text = path.read_text(encoding="utf-8")
+    import re
+
+    new, n = re.subn(
+        r'(?m)^(version\s*=\s*)"[^"]*"', rf'\g<1>"{version}"', text, count=1
+    )
+    if n != 1:
+        die("could not find a single version line to lock in pyproject.toml")
+    path.write_text(new, encoding="utf-8")
+    log(f"  locked pyproject version to {version}")
+
+
+def verify_version_lock(version: str) -> None:
+    current = read_pyproject_version()
+    if current != version:
+        die(
+            "version lock mismatch (spec 008 §3.5):\n"
+            f"  - pyproject version is {current}, expected {version}\n"
+            "Re-run with --write-main to update, or fix pyproject.toml."
+        )
+
+
+# --- cli ---------------------------------------------------------------------
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="generate-wheels", add_help=True)
+    p.add_argument("--version")
+    p.add_argument("--archives")
+    p.add_argument("--binary")
+    p.add_argument("--out")
+    p.add_argument("--target", action="append", default=[], dest="targets")
+    p.add_argument("--requires-python", default=">=3.8")
+    p.add_argument("--write-main", action="store_true")
+    p.add_argument("--lock-only", action="store_true")
+    p.add_argument("--build-sdist", action="store_true")
+    opts = p.parse_args(argv)
+    if opts.lock_only:
+        opts.write_main = True
+    return opts
+
+
+def main(argv: list[str]) -> int:
+    opts = parse_args(argv)
+    version = normalize_version(opts.version or read_pyproject_version())
+    tag = f"v{version}"
+
+    if opts.binary and len(opts.targets) != 1:
+        die("--binary requires exactly one --target")
+
+    if opts.write_main:
+        lock_version(version)
+    else:
+        verify_version_lock(version)
+
+    if opts.lock_only:
+        log(f"version lock verified/applied: {version}")
+        return 0
+
+    out_root = Path(opts.out).resolve() if opts.out else (PY_DIR / "dist" / "wheels")
+    targets = opts.targets or list(pm.TARGETS.keys())
+    for t in targets:
+        if t not in pm.TARGETS:
+            die(f"unknown target: {t}")
+
+    log(f"generating platform wheels for {version} ({tag}):")
+    for t in targets:
+        rec = pm.TARGETS[t]
+        bin_file = pm.binary_name(rec["windows"])
+        binary = _resolve_binary(t, opts, tag, bin_file)
+        _build_wheel(t, version, opts.requires_python, binary, out_root)
+
+    if opts.build_sdist:
+        log("building sdist (the unsupported-host refusal)…")
+        subprocess.run(
+            [sys.executable, "-m", "build", "--sdist", "--outdir", str(out_root), str(PY_DIR)],
+            check=True,
+        )
+        sdist = out_root / f"{pm.DIST_STEM}-{version}.tar.gz"
+        if not sdist.exists():
+            die(f"sdist build did not produce {sdist}")
+        _normalize_sdist(sdist)
+        log(f"  normalized {sdist.name} (deterministic member order/mtimes)")
+
+    log(f"done -> {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/py/scripts/smoke_test.sh
+++ b/py/scripts/smoke_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Spec: specs/008-python-distribution/spec.md
+#
+# Local build + install smoke test: prove `spec-spine --version` resolves through
+# a generated platform wheel to a real prebuilt binary, end to end, no network.
+#
+#   1. cargo build the host binary
+#   2. generate the host platform wheel from that binary
+#   3. install the wheel into a throwaway env (uv tool install, or pip into a venv)
+#   4. run the installed `spec-spine --version` and assert it works + round-trips
+#
+# macOS / Linux only (bash). Windows uses `cargo install` or the .zip directly.
+
+set -euo pipefail
+
+PY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$PY_DIR/.." && pwd)"
+
+say() { printf 'smoke: %s\n' "$1" >&2; }
+die() { printf 'smoke: error: %s\n' "$1" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+have cargo || die "cargo not found (needed to build the host binary)"
+PYBIN="$(command -v python3 || command -v python)" || die "python not found"
+
+VERSION="$("$PYBIN" - <<'PY'
+import tomllib, pathlib, os
+p = pathlib.Path(os.environ["PY_DIR"]) / "pyproject.toml"
+print(tomllib.load(open(p, "rb"))["project"]["version"])
+PY
+)"
+export PY_DIR
+TARGET="$("$PYBIN" - <<'PY'
+import sys, platform
+osname = {"darwin": "darwin", "linux": "linux", "win32": "win32"}.get(sys.platform, sys.platform)
+m = platform.machine().lower()
+cpu = "arm64" if m in ("arm64", "aarch64") else "x64" if m in ("x86_64", "amd64") else m
+print(f"{osname}-{cpu}")
+PY
+)"
+say "host target: ${TARGET}, version: ${VERSION}"
+case "$TARGET" in
+  darwin-arm64|darwin-x64|linux-x64|linux-arm64) : ;;
+  *) die "unsupported host target ${TARGET}; the shim has no wheel for it" ;;
+esac
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/spec-spine-py-smoke.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+say "building host binary (cargo build --release --bin spec-spine)…"
+cargo build --release --bin spec-spine --manifest-path "${REPO_ROOT}/Cargo.toml" >/dev/null
+HOST_BIN="${REPO_ROOT}/target/release/spec-spine"
+[ -x "$HOST_BIN" ] || die "built binary not found at ${HOST_BIN}"
+
+say "generating the ${TARGET} platform wheel…"
+WHEEL_OUT="${WORK}/wheels"
+"$PYBIN" "${PY_DIR}/scripts/generate_wheels.py" \
+  --version "$VERSION" --target "$TARGET" --binary "$HOST_BIN" --out "$WHEEL_OUT"
+WHEEL="$(ls "${WHEEL_OUT}"/spec_spine-*.whl)"
+[ -f "$WHEEL" ] || die "generator did not produce a wheel"
+say "  wheel: $(basename "$WHEEL")"
+
+if have uv; then
+  say "installing with uv tool install and running…"
+  export UV_TOOL_DIR="${WORK}/uv-tools" UV_TOOL_BIN_DIR="${WORK}/uv-bin"
+  mkdir -p "$UV_TOOL_BIN_DIR"
+  uv tool install --reinstall "$WHEEL" >/dev/null
+  RUN="${UV_TOOL_BIN_DIR}/spec-spine"
+else
+  say "uv not found; installing into a venv with pip…"
+  "$PYBIN" -m venv "${WORK}/venv"
+  "${WORK}/venv/bin/pip" install --quiet "$WHEEL"
+  RUN="${WORK}/venv/bin/spec-spine"
+fi
+[ -x "$RUN" ] || die "installed launcher not found/executable at ${RUN}"
+
+say "running: spec-spine --version"
+OUT="$("$RUN" --version)"
+say "  -> ${OUT}"
+echo "$OUT" | grep -q "$VERSION" || die "version output '${OUT}' did not contain ${VERSION}"
+"$RUN" --help >/dev/null || die "spec-spine --help failed through the installed binary"
+
+say "OK: wheel installs and the bundled binary runs as the spec-spine command"

--- a/py/src/spec_spine/__init__.py
+++ b/py/src/spec_spine/__init__.py
@@ -1,0 +1,19 @@
+"""spec-spine — Python/uvx distribution.
+
+On a supported host you never import this package: pip/uv select a platform
+wheel whose only payload is the prebuilt `spec-spine` binary in the wheel's
+scripts directory, so `spec-spine`/`uvx spec-spine` runs the native binary with
+no Python in the path. This importable package ships only in the sdist, which is
+built solely on hosts with no matching wheel (musl, win-arm64, 32-bit), where its
+`spec-spine` entry point prints a clear refusal (see _refuse.py). Spec:
+specs/008-python-distribution/spec.md.
+"""
+
+from __future__ import annotations
+
+try:  # populated from installed dist metadata; no hardcoded second source of truth
+    from importlib.metadata import version as _version
+
+    __version__ = _version("spec-spine")
+except Exception:  # pragma: no cover - not installed as a dist
+    __version__ = "0+unknown"

--- a/py/src/spec_spine/_refuse.py
+++ b/py/src/spec_spine/_refuse.py
@@ -1,0 +1,28 @@
+"""Spec: specs/008-python-distribution/spec.md §3.4 (unsupported hosts fail clearly).
+
+The `spec-spine` console entry point shipped by the sdist. It is reached only on
+a host with no prebuilt wheel (musl/Alpine, win-arm64, 32-bit, ...), because on a
+supported host the platform wheel's bundled binary IS the `spec-spine` command
+and this module is never installed. Its whole job is to name the host, explain
+why there is no binary, and point at the source-build escape hatch -- the exact
+posture of npm/lib/platform.js's unsupported-host message. It never tries to run
+anything; it exits non-zero.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from . import platform_map
+
+
+def main() -> int:
+    host = platform_map.detect_host()
+    sys.stderr.write(
+        platform_map.unsupported_message(host["os"], host["cpu"], host["reason"]) + "\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":  # `python -m spec_spine._refuse`
+    raise SystemExit(main())

--- a/py/src/spec_spine/platform_map.py
+++ b/py/src/spec_spine/platform_map.py
@@ -1,0 +1,148 @@
+"""Spec: specs/008-python-distribution/spec.md (extends 007-distribution).
+
+The single (os, cpu) -> target table for the Python/uvx channel, plus host
+detection and the unsupported-host message. This is the Python-side mirror of
+npm/lib/platform.js's SUPPORTED map and the §3.2 table in spec 007: the five
+triples, the in-archive binary name, and the per-target wheel platform tag are
+ONE FACT, and this module is its home on the Python side. A drift between this
+table, release.yml's matrix, install.sh's detection, and npm/lib/platform.js is
+a governed change (spec 007 §2, now four places).
+
+Pure data + pure functions: no filesystem or network on the mapping path, so the
+table is unit-tested directly (test/test_platform_map.py). Used by three
+consumers: scripts/generate_wheels.py (publish time), _refuse.py (runtime, on the
+unsupported path), and the tests.
+"""
+
+from __future__ import annotations
+
+import platform as _platform
+import sys
+import sysconfig
+
+# platform key -> release triple, npm-style (os, cpu), wheel platform tag, and
+# whether the in-archive binary is `.exe`. The wheel platform tag is what makes
+# pip/uv install only the matching wheel on a host -- the Python analogue of
+# npm's os/cpu fields. glibc is encoded by the `manylinux_*` tags: a musl host
+# matches none of these and falls through to the sdist refusal (§3.4 parity).
+TARGETS: dict[str, dict] = {
+    "darwin-arm64": {
+        "triple": "aarch64-apple-darwin",
+        "os": "darwin",
+        "cpu": "arm64",
+        "wheel_platform": "macosx_11_0_arm64",
+        "windows": False,
+    },
+    "darwin-x64": {
+        "triple": "x86_64-apple-darwin",
+        "os": "darwin",
+        "cpu": "x64",
+        "wheel_platform": "macosx_10_12_x86_64",
+        "windows": False,
+    },
+    "linux-x64": {
+        "triple": "x86_64-unknown-linux-gnu",
+        "os": "linux",
+        "cpu": "x64",
+        "wheel_platform": "manylinux_2_17_x86_64",
+        "windows": False,
+    },
+    "linux-arm64": {
+        "triple": "aarch64-unknown-linux-gnu",
+        "os": "linux",
+        "cpu": "arm64",
+        "wheel_platform": "manylinux_2_17_aarch64",
+        "windows": False,
+    },
+    "win32-x64": {
+        "triple": "x86_64-pc-windows-msvc",
+        "os": "win32",
+        "cpu": "x64",
+        "wheel_platform": "win_amd64",
+        "windows": True,
+    },
+}
+
+# The Python distribution name and the importable package / data-dir stem. PyPI
+# normalizes "spec-spine" <-> "spec_spine"; the .data/scripts and .dist-info
+# directories inside a wheel use the underscore form.
+DIST_NAME = "spec-spine"
+DIST_STEM = "spec_spine"
+
+
+class UnsupportedHostError(RuntimeError):
+    """Raised when the running host has no prebuilt binary."""
+
+
+def binary_name(windows: bool) -> str:
+    """In-archive / in-wheel binary name: `.exe` on Windows, bare elsewhere."""
+    return "spec-spine.exe" if windows else "spec-spine"
+
+
+def target_for(os_name: str, cpu: str) -> dict:
+    """(os, cpu) -> target record. Raises UnsupportedHostError for any host with
+    no prebuilt binary. `os`/`cpu` are the npm-style names ('darwin'/'linux'/
+    'win32', 'x64'/'arm64'), not Python's ('linux2', 'x86_64')."""
+    key = f"{os_name}-{cpu}"
+    rec = TARGETS.get(key)
+    if rec is None:
+        raise UnsupportedHostError(unsupported_message(os_name, cpu))
+    return {"key": key, **rec, "binary_name": binary_name(rec["windows"])}
+
+
+# --- runtime host detection (the unsupported / sdist path) -------------------
+
+def _normalize_machine(machine: str) -> str | None:
+    m = machine.lower()
+    if m in ("arm64", "aarch64"):
+        return "arm64"
+    if m in ("x86_64", "amd64", "x64"):
+        return "x64"
+    return None  # i686/ppc64/etc. -> unsupported, surfaced clearly
+
+
+def is_musl_linux() -> bool:
+    """True on a musl (non-glibc) Linux. Permissive: if we cannot tell, assume
+    glibc and let resolution fail loudly later (mirrors npm's isMuslLinux)."""
+    if sys.platform != "linux":
+        return False
+    try:
+        if "musl" in (sysconfig.get_platform() or ""):
+            return True
+        libc, _ver = _platform.libc_ver()
+        return libc != "" and "glibc" not in libc.lower()
+    except Exception:
+        return False
+
+
+def detect_host() -> dict:
+    """Best-effort host classification for messaging. Returns a dict with `key`
+    (platform key or None), `os`, `cpu`, and `reason` ('musl' | 'arch' | None)."""
+    os_map = {"darwin": "darwin", "linux": "linux", "win32": "win32"}
+    os_name = os_map.get(sys.platform, sys.platform)
+    cpu = _normalize_machine(_platform.machine())
+    if os_name == "linux" and is_musl_linux():
+        return {"key": None, "os": os_name, "cpu": cpu or "?", "reason": "musl"}
+    if cpu is None or f"{os_name}-{cpu}" not in TARGETS:
+        return {"key": None, "os": os_name, "cpu": cpu or _platform.machine().lower(),
+                "reason": "arch"}
+    return {"key": f"{os_name}-{cpu}", "os": os_name, "cpu": cpu, "reason": None}
+
+
+def unsupported_message(os_name: str, cpu: str, reason: str | None = None) -> str:
+    host = f"{os_name}-{cpu}" + (" (musl libc)" if reason == "musl" else "")
+    lines = [
+        f"spec-spine: no prebuilt binary for {host}.",
+        "Prebuilt wheels cover darwin-arm64, darwin-x64, linux-x64 (glibc),",
+        "linux-arm64 (glibc), and win32-x64. Install from source instead:",
+        "    cargo install spec-spine-cli",
+    ]
+    if reason == "musl":
+        lines.append(
+            "(Alpine/musl: use a glibc-based image, or cargo install spec-spine-cli.)"
+        )
+    lines.append(
+        "(If you are on a supported host and reached this message, you likely "
+        "installed with --no-binary; reinstall allowing wheels.)"
+    )
+    return "\n".join(lines)

--- a/py/test/test_platform_map.py
+++ b/py/test/test_platform_map.py
@@ -1,0 +1,70 @@
+"""Spec: specs/008-python-distribution/spec.md.
+
+Network- and disk-free unit test of the (os, cpu) -> target mapping, the wheel
+platform tags, and the unsupported-host refusal -- the Python parallel of
+npm/test/platform.test.js. Stdlib unittest so it runs with no third-party deps:
+`python -m unittest discover -s test`.
+"""
+
+import unittest
+
+from spec_spine import platform_map as pm
+
+
+class PlatformMapTest(unittest.TestCase):
+    def test_maps_every_supported_target(self):
+        cases = [
+            ("darwin", "arm64", "aarch64-apple-darwin", "macosx_11_0_arm64", "spec-spine"),
+            ("darwin", "x64", "x86_64-apple-darwin", "macosx_10_12_x86_64", "spec-spine"),
+            ("linux", "x64", "x86_64-unknown-linux-gnu", "manylinux_2_17_x86_64", "spec-spine"),
+            ("linux", "arm64", "aarch64-unknown-linux-gnu", "manylinux_2_17_aarch64", "spec-spine"),
+            ("win32", "x64", "x86_64-pc-windows-msvc", "win_amd64", "spec-spine.exe"),
+        ]
+        for os_name, cpu, triple, wheel_plat, binname in cases:
+            t = pm.target_for(os_name, cpu)
+            self.assertEqual(t["triple"], triple, f"{os_name}-{cpu} triple")
+            self.assertEqual(t["wheel_platform"], wheel_plat, f"{os_name}-{cpu} wheel tag")
+            self.assertEqual(t["binary_name"], binname, f"{os_name}-{cpu} binary")
+            self.assertEqual(t["key"], f"{os_name}-{cpu}")
+
+    def test_table_is_exactly_the_five_release_triples(self):
+        self.assertEqual(
+            sorted(pm.TARGETS),
+            ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-x64"],
+        )
+
+    def test_triples_match_release_yml_matrix(self):
+        # These five strings must equal release.yml's build matrix exactly.
+        self.assertEqual(
+            sorted(rec["triple"] for rec in pm.TARGETS.values()),
+            [
+                "aarch64-apple-darwin",
+                "aarch64-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "x86_64-pc-windows-msvc",
+                "x86_64-unknown-linux-gnu",
+            ],
+        )
+
+    def test_refuses_unsupported_targets_with_source_hint(self):
+        for os_name, cpu in [("win32", "arm64"), ("linux", "ia32"),
+                             ("freebsd", "x64"), ("darwin", "ppc64")]:
+            with self.assertRaises(pm.UnsupportedHostError) as ctx:
+                pm.target_for(os_name, cpu)
+            msg = str(ctx.exception)
+            self.assertIn(f"{os_name}-{cpu}", msg)
+            self.assertIn("cargo install spec-spine-cli", msg)
+
+    def test_musl_message_mentions_glibc_image(self):
+        msg = pm.unsupported_message("linux", "x64", reason="musl")
+        self.assertIn("musl", msg)
+        self.assertIn("glibc-based image", msg)
+        self.assertIn("cargo install spec-spine-cli", msg)
+
+    def test_binary_name(self):
+        self.assertEqual(pm.binary_name(False), "spec-spine")
+        self.assertEqual(pm.binary_name(True), "spec-spine.exe")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/008-python-distribution/spec.md
+++ b/specs/008-python-distribution/spec.md
@@ -1,0 +1,182 @@
+---
+id: "008-python-distribution"
+title: "Distribution: uvx/PyPI wheel shim"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "007-distribution"
+establishes:
+  - "py/"
+  - "py/scripts/generate_wheels.py"
+extends:
+  # 007 establishes release.yml; 008 adds a `publish-pypi` job to it. This is the
+  # same additive file-level relationship 002 has to 001's lib.rs: 007 remains the
+  # owner, 008 is an additive extender. Authority is scoped to the publish-pypi
+  # job -- 008 does not touch publish/publish-crates/publish-npm.
+  - spec: "007-distribution"
+    unit: { kind: file, path: ".github/workflows/release.yml" }
+    nature: additive
+summary: >
+  The Python parallel of 007's npm shim: a uvx/PyPI channel so a Python or
+  polyglot team can `uvx spec-spine ...` (or `uv tool install spec-spine`) and
+  get the CLI with no Rust toolchain. Where npm uses a main launcher package +
+  five os/cpu-gated platform packages, Python collapses the same idea into one
+  PyPI project + five per-platform wheels (+ one sdist): the wheel platform tag
+  IS the selector, and the prebuilt binary ships in the wheel's data/scripts dir
+  so pip/uv place it directly on PATH. There is no Python in the run path, no
+  postinstall, no network at install, and no archive extraction at install: it
+  works offline and under --no-build-isolation. Unsupported hosts (musl/Alpine,
+  win-arm64, 32-bit) match no wheel and fall to the sdist, whose only artifact is
+  a `spec-spine` console entry point that names the host and points at
+  `cargo install spec-spine-cli` -- exact parity with 007 §3.4. Wheels are
+  assembled from the same release archives the build job already produces (no
+  second Rust build), are byte-reproducible, and are version-locked to the tag.
+---
+
+# 008: Distribution — uvx/PyPI wheel shim
+
+## 1. Purpose
+
+007 gave the `npm i -D spec-spine` audience a first-class, Rust-free path. The
+Python and polyglot audience has the same reflex spelled `uvx` / `pipx` /
+`uv tool install`, and the same refusal to install a Rust toolchain to lint a
+spec corpus. This spec gives that audience the same first-class path, reusing
+007's machinery rather than duplicating it: the release archives, the platform
+map, the version-lock discipline, and the "absent setup = clean no-op" publish
+posture all carry over. It adds one channel (`py/` + a `publish-pypi` job); it
+does not change how the binary is built or how 007's channels behave.
+
+## 2. Territory
+
+This spec establishes `py/` (the Python distribution channel) and extends
+007 §3.6 additively with a `publish-pypi` job in `release.yml`. The `py/`
+subtree deliberately mirrors `npm/`:
+
+    py/
+      pyproject.toml              # the sdist project (the refusal fallback)
+      src/spec_spine/
+        __init__.py               # version via importlib.metadata
+        platform_map.py           # the five triples <-> wheel tags (mirrors npm/lib/platform.js)
+        _refuse.py                # sdist console entry point (mirrors the npm unsupported-host message)
+      scripts/
+        generate_wheels.py        # wheel assembler (mirrors scripts/generate-platform-packages.js)
+        smoke_test.sh             # install-and-run check (mirrors npm/smoke-test.sh)
+      test/test_platform_map.py   # asserts the triples equal release.yml's matrix
+      README.md
+      LICENSE                     # copied from repo root at build time
+
+## 3. Behavior
+
+### 3.1 The pattern: per-platform wheels, not download-on-first-use
+
+npm selects the right binary with `optionalDependencies` plus `os`/`cpu` fields.
+Python's equivalent selector is the **wheel platform tag**: pip/uv resolve the
+one wheel whose tag matches the host and ignore the rest. So the npm "main
+package + five platform packages" shape collapses into **one PyPI project + five
+wheels (+ one sdist)**. Each wheel is `py3-none-<platform>`, `Root-Is-Purelib:
+false`, and carries exactly one prebuilt binary in its
+`spec_spine-<v>.data/scripts/` directory; on install pip/uv drop that file into
+the environment's scripts dir as the `spec-spine` executable. `uvx spec-spine`
+then runs the native binary directly.
+
+This is a faithful translation of 007 §3.1's non-goals, not the download-shim
+pattern: **no network at install, no archive extraction at install, no
+postinstall, no Python interpreter on the run path**. It works offline, under
+`uv tool install --offline`, and the run path is the binary itself (faster and
+more robust than a Python launcher that fetches from GitHub on first use, which
+would reintroduce every failure mode 007 §3.1 exists to avoid).
+
+### 3.2 Platform map (the same five triples)
+
+The wheel selector is the same five triples 007 §3.2 governs, each paired with
+its wheel platform tag:
+
+| target        | rust triple                    | wheel platform tag        |
+| ------------- | ------------------------------ | ------------------------- |
+| darwin-arm64  | aarch64-apple-darwin           | macosx_11_0_arm64         |
+| darwin-x64    | x86_64-apple-darwin            | macosx_10_12_x86_64       |
+| linux-x64     | x86_64-unknown-linux-gnu       | manylinux_2_17_x86_64     |
+| linux-arm64   | aarch64-unknown-linux-gnu      | manylinux_2_17_aarch64    |
+| win32-x64     | x86_64-pc-windows-msvc         | win_amd64                 |
+
+This is now **the one fact in four places**: npm/lib/platform.js, install.sh,
+release.yml's build matrix, and py/src/spec_spine/platform_map.py. The fourth
+copy is kept honest by `py/test/test_platform_map.py`, which asserts the table
+equals release.yml's matrix; a triple added to the release without updating the
+Python map fails that test. Linux wheels target **glibc** (manylinux_2_17 ==
+glibc 2.17); musl is out of scope by the same decision as 007 (see §3.4).
+
+### 3.3 The launcher (there isn't one)
+
+npm needs a launcher because npm cannot itself put a native binary on PATH; the
+JS `bin` resolves the platform package and exec's the binary. A Python wheel can
+put a binary on PATH directly (the `*.data/scripts/` convention), so the launcher
+disappears: the binary IS the installed `spec-spine` command. The launcher
+contract from 007 §3.3 (forward argv, forward exit code, surface signals, nothing
+on the success path) is satisfied trivially because nothing intermediates — the
+process the user invokes is the binary.
+
+### 3.4 Unsupported hosts fail clearly
+
+A host with no matching wheel (musl/Alpine, win-arm64, 32-bit, anything off the
+five) gets no platform wheel, so pip/uv fall back to the **sdist**. The sdist
+carries no binary and builds no Rust; its only artifact is a `spec-spine` console
+entry point (`spec_spine._refuse:main`) that names the host, explains there is no
+prebuilt binary for it, and points at the source build:
+
+    cargo install spec-spine-cli
+
+This is the exact posture of 007 §3.4 / npm's unsupported-host message. The
+sdist is reached two ways — no matching wheel, or an explicit `--no-binary` — and
+the message covers both (musl gets an extra Alpine hint; an explicit `--no-binary`
+on a supported host gets a "reinstall allowing wheels" hint). It exits non-zero.
+
+### 3.5 Version lock
+
+The wheels and sdist are version-locked to the binary release tag: the v0.1.0
+tag ships 0.1.0 artifacts. `generate_wheels.py` takes `--version` from the tag
+(`v0.1.0` -> `0.1.0`) and, in CI, runs against the committed `py/` so a tag that
+disagrees with the project's declared version is caught rather than published.
+There is no second source of truth for the version: `__init__.py` reads it from
+installed metadata, and the sdist's pyproject is the only declared copy.
+
+### 3.6 Release integration
+
+`release.yml` gains a `publish-pypi` job parallel to `publish-npm` (007 §3.6):
+
+- It **reuses the build job's archives** (`download-artifact` of `archive-*`),
+  exactly like publish-npm — there is no second Rust build for Python.
+- It runs `generate_wheels.py --archives <dist> --build-sdist` to assemble the
+  five wheels and the sdist, then uploads them.
+- It is **idempotent**: re-running a tag skips artifacts already on PyPI
+  (`--skip-existing`), the same property publish-npm gets from its `npm view`
+  precheck.
+- It is a **clean no-op until a human does the one-time setup**, the same posture
+  as publish-npm's NPM_TOKEN gate. The recommended gate is a repository variable
+  (`vars.PYPI_TRUSTED_PUBLISHING == 'true'`) flipped on once the PyPI project and
+  its Trusted Publisher are created; absent that, the job is a skip, never a red
+  X. The first publish, the project creation, and the Trusted Publisher config
+  are a human's job (docs/releasing.md), mirroring the npm org-creation note.
+- Publishing uses **PyPI Trusted Publishing (OIDC)** with **PEP 740
+  attestations**, so no long-lived token lives in the repo and each artifact is
+  signed by the workflow that built it. A `PYPI_API_TOKEN`-gated `twine upload
+  --skip-existing` is the documented fallback for environments without OIDC.
+
+## 4. Out of scope
+
+- **musl / Alpine wheels.** glibc-only, same decision as 007; musl hosts get the
+  sdist refusal with an Alpine hint. (If musl is ever added, it is one new triple
+  in all four map copies + one release-matrix entry, and this spec amends.)
+- **win-arm64, 32-bit.** Off the five triples; sdist refusal.
+- **A pure-Python reimplementation or a download-on-first-use shim.** Explicitly
+  rejected: it reintroduces the install/run-time network dependency and the loss
+  of offline + `--ignore-scripts`-equivalent behavior that 007 §3.1 forbids.
+- **maturin-built wheels.** A valid alternative (maturin can emit `bin` wheels),
+  but it adds a second cargo build per target and diverges from the repo's
+  build -> archives -> packagers shape; the archive-reuse generator is preferred
+  for that reason. Recorded here so the choice is not relitigated silently.
+- **An enterprise/private index.** The channel targets public PyPI; a private
+  index is a deployment concern, not a property of this shim.


### PR DESCRIPTION
## Summary

Spec **008-python-distribution**: the Python parallel of 007's npm shim. One PyPI project (`spec-spine`), **five platform wheels + one sdist**:

- The **wheel platform tag is the selector** (the Python analogue of npm's `os`/`cpu` fields): pip/uv install only the wheel matching the host. Each wheel carries the prebuilt binary in its `*.data/scripts/` dir, so the binary lands directly on `PATH` as the `spec-spine` command. `uvx spec-spine` / `uv tool install spec-spine` / `pip install spec-spine` all work with **no Rust toolchain, no Python in the run path, no network at install, no postinstall**.
- Unsupported hosts (musl/Alpine, win-arm64, 32-bit) match no wheel and fall to the **sdist**, whose only artifact is a `spec-spine` entry point that names the host, refuses clearly, and points at `cargo install spec-spine-cli` (exact 007 §3.4 parity; musl gets an Alpine hint).
- The `publish-pypi` job assembles wheels **from the same release archives the build job already produces** (no second Rust build), publishes via **PyPI Trusted Publishing (OIDC) + PEP 740 attestations**, is **idempotent** (`skip-existing: true`), and is a **clean no-op** until `vars.PYPI_TRUSTED_PUBLISHING` is set (same posture as publish-npm's `NPM_TOKEN` gate). One-time PyPI setup is documented in `docs/releasing.md`; the token fallback stays as a comment in `release.yml`.
- The platform table is now the one fact in four places (npm/lib/platform.js, install.sh, release.yml matrix, py platform_map.py); `py/test/test_platform_map.py` pins the Python copy to the release matrix.
- Spine self-governance: regenerated `registry.json` + `index.json` are in this PR; spec 008 `establishes: py/` and extends 007's `release.yml` additively (publish-pypi job only).

One functional addition over the proven add-on implementation: the sdist is **canonicalized after build** (sorted members, owner cleared, mtimes clamped to 1980-01-01, gzip timestamp zeroed) in `generate_wheels.py`. setuptools stamps wall-clock mtimes on regenerated files (PKG-INFO, egg-info), which made the raw sdist non-reproducible; after normalization all **six** artifacts are byte-identical run to run, matching the wheels' fixed zip dates and the repo's determinism doctrine.

## For the maintainer

`specs/008-python-distribution/spec.md` ships `status: draft` + `implementation: complete` as authored. Repo convention (001–007) is `approved` + `complete`. **The draft→approved flip is left for you to decide**; flip it (plus `spec-spine compile`/`index` to regenerate the artifacts) either on this branch or in a follow-up.

## Verification evidence

1. **Unit tests** (`PYTHONPATH=src python3 -m unittest discover -s test -v`): 6/6 OK.
2. **Wheel assembly without a real release**: fabricated all five archives with the real layout (`tar -C stage -czf … .` → `./`-prefixed members; Windows `.zip` with `spec-spine.exe`) around a stub binary; `generate_wheels.py --version 0.1.0 --archives … --build-sdist` produced exactly **5 wheels + 1 sdist**.
3. **`twine check`**: all six artifacts **PASSED**.
4. **Determinism**: generator run twice into separate dirs; `cmp` on every artifact pair → **all six byte-identical** (the sdist required the normalization described above; before it, regenerated-file mtimes and the gzip header timestamp differed).
5. **Refusal path**: `pip install <sdist>` into a scratch venv; running `spec-spine` printed the unsupported-host message on stderr (incl. `cargo install spec-spine-cli` and the `--no-binary` hint) and **exited 1**.
6. **Install path**: `uv tool install` of the host wheel (`macosx_11_0_arm64`); installed command printed the stub's version banner, passed argv through intact (`argv: alpha beta gamma delta`), and **forwarded exit code 7**.
7. **Tag↔version lock**: `--version 0.2.0` against the committed `pyproject.toml` (0.1.0) failed loudly with the §3.5 mismatch message, exit 1.
8. **Spine**: `compile` (9 specs, 0 warnings), `index` (4 packages, 9 mappings, 0 errors), `lint` (0/0/0), `couple --base origin/main --head HEAD` → **OK, 8 paths checked, no drift**.

All scratch venvs/archives were created under gitignored paths and removed; none are in the commit.

## Out of scope (by design)

PyPI project creation, Trusted Publisher registration, setting `PYPI_TRUSTED_PUBLISHING`, tagging, publishing; musl/win-arm64/32-bit wheels (sdist refusal covers them); maturin or download-on-first-use alternatives (rejected in spec §4).