### PR TITLE
chore(specs): approve 008-python-distribution post-release

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "8e7e041d9cbfd8ba31d523c4f36fe3f89b8737fa9f279de39180acddea7355d7",
+    "contentHash": "da0403c020db615d731a9f7f378ca0742254d1182f52f81746dce7be3bad0050",
     "indexerId": "spec-spine",
     "indexerVersion": "0.1.0",
     "repoRoot": "."
@@ -816,7 +816,7 @@
           }
         ],
         "specId": "008-python-distribution",
-        "specStatus": "draft"
+        "specStatus": "approved"
       }
     ],
     "orphanedSpecs": [],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.1.0",
-    "contentHash": "32c9164a496e850edb60309e43f8a0b8a7a1ea7f7acb2f9d6bfd32e7fef0c3ae",
+    "contentHash": "29982d00f935c4806110e08e17c75608d6c204419d18b95c8833a338a168dc51",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -449,7 +449,7 @@
         "4. Out of scope"
       ],
       "specPath": "specs/008-python-distribution/spec.md",
-      "status": "draft",
+      "status": "approved",
       "summary": "The Python parallel of 007's npm shim: a uvx/PyPI channel so a Python or polyglot team can `uvx spec-spine ...` (or `uv tool install spec-spine`) and get the CLI with no Rust toolchain. Where npm uses a main launcher package + five os/cpu-gated platform packages, Python collapses the same idea into one PyPI project + five per-platform wheels (+ one sdist): the wheel platform tag IS the selector, and the prebuilt binary ships in the wheel's data/scripts dir so pip/uv place it directly on PATH. There is no Python in the run path, no postinstall, no network at install, and no archive extraction at install: it works offline and under --no-build-isolation. Unsupported hosts (musl/Alpine, win-arm64, 32-bit) match no wheel and fall to the sdist, whose only artifact is a `spec-spine` console entry point that names the host and points at `cargo install spec-spine-cli` -- exact parity with 007 §3.4. Wheels are assembled from the same release archives the build job already produces (no second Rust build), are byte-reproducible, and are version-locked to the tag.\n",
       "title": "Distribution: uvx/PyPI wheel shim"
     }

--- a/specs/008-python-distribution/spec.md
+++ b/specs/008-python-distribution/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "008-python-distribution"
 title: "Distribution: uvx/PyPI wheel shim"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-06-11"
 implementation: complete


### PR DESCRIPTION
Standalone micro-PR: flips `specs/008-python-distribution/spec.md` from `status: draft` to `status: approved` (maintainer-authorized 2026-06-11, post-release; the 0.1.0 PyPI channel is live).

Contents, nothing else:
- the one-line status flip in the spec frontmatter
- regenerated `.derived/spec-registry/registry.json` and `.derived/codebase-index/index.json` (the index records `specStatus` per mapping, so both artifacts change; the only semantic delta is 008's status plus the derived content hashes)

`lint` and `couple --base origin/main --head HEAD` are green.

Note for merge ordering: this branch was cut from `origin/main` (3c01bef). Any other open branch that regenerates the `.derived` artifacts will conflict with this one on those files; merge serially and regenerate on the follow-up branch.