### PR TITLE
feat: registry query projection flags (spec 010)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "da0403c020db615d731a9f7f378ca0742254d1182f52f81746dce7be3bad0050",
+    "contentHash": "d1820b6e7f3721316247a2180f79c212e7e59668ffc2a11c30f5ee6398dd9f72",
     "indexerId": "spec-spine",
     "indexerVersion": "0.1.0",
     "repoRoot": "."
@@ -817,6 +817,85 @@
         ],
         "specId": "008-python-distribution",
         "specStatus": "approved"
+      },
+      {
+        "dependsOn": [
+          "002-registry-query"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-cli/src/cmd_registry.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/tests/cli.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/query.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/cmd_registry.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/tests/cli.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/tests/cli.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/lib.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/query.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/query.rs"
+            }
+          }
+        ],
+        "specId": "010-registry-query-projection-flags",
+        "specStatus": "draft"
       }
     ],
     "orphanedSpecs": [],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.1.0",
-    "contentHash": "29982d00f935c4806110e08e17c75608d6c204419d18b95c8833a338a168dc51",
+    "contentHash": "cd439077bb504f01ba9e3f5172e319195b4e844957bdb8ae0cefe70a6ac8797a",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -452,6 +452,65 @@
       "status": "approved",
       "summary": "The Python parallel of 007's npm shim: a uvx/PyPI channel so a Python or polyglot team can `uvx spec-spine ...` (or `uv tool install spec-spine`) and get the CLI with no Rust toolchain. Where npm uses a main launcher package + five os/cpu-gated platform packages, Python collapses the same idea into one PyPI project + five per-platform wheels (+ one sdist): the wheel platform tag IS the selector, and the prebuilt binary ships in the wheel's data/scripts dir so pip/uv place it directly on PATH. There is no Python in the run path, no postinstall, no network at install, and no archive extraction at install: it works offline and under --no-build-isolation. Unsupported hosts (musl/Alpine, win-arm64, 32-bit) match no wheel and fall to the sdist, whose only artifact is a `spec-spine` console entry point that names the host and points at `cargo install spec-spine-cli` -- exact parity with 007 §3.4. Wheels are assembled from the same release archives the build job already produces (no second Rust build), are byte-reproducible, and are version-locked to the tag.\n",
       "title": "Distribution: uvx/PyPI wheel shim"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "002-registry-query"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "002-registry-query",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/query.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "002-registry-query",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        }
+      ],
+      "id": "010-registry-query-projection-flags",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "010: Query projection flags",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 `registry list --ids-only`",
+        "3.2 `registry status-report --nonzero-only`",
+        "3.3 Contract",
+        "3.4 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/010-registry-query-projection-flags/spec.md",
+      "status": "draft",
+      "summary": "Two additive projection flags on the spec 002 query verbs: `registry list --ids-only` (newline-delimited spec ids; a JSON string array under --json) and `registry status-report --nonzero-only` (omit zero-count statuses). Both are load-bearing in adopter session-init protocols (OAP's /init and /setup read exactly these projections); neither changes any existing output shape when absent.\n",
+      "title": "Registry query: --ids-only and --nonzero-only projection flags"
     }
   ],
   "validation": {

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -6,7 +6,9 @@ use std::fs;
 use std::path::Path;
 
 use clap::Subcommand;
-use spec_spine_core::{ListFilter, list, load_registry, relationships, show, status_report};
+use spec_spine_core::{
+    ListFilter, list, list_ids, load_registry, relationships, show, status_report,
+};
 use spec_spine_types::{Error, Status};
 
 use crate::load_repo_config;
@@ -19,6 +21,9 @@ pub enum RegistryQuery {
         status: Option<String>,
         #[arg(long)]
         json: bool,
+        /// Print bare spec ids, one per line (a JSON string array with --json).
+        #[arg(long)]
+        ids_only: bool,
     },
     /// Show one spec by id.
     Show {
@@ -30,6 +35,9 @@ pub enum RegistryQuery {
     StatusReport {
         #[arg(long)]
         json: bool,
+        /// Omit statuses whose count is zero (the total still covers the corpus).
+        #[arg(long)]
+        nonzero_only: bool,
     },
     /// Show a spec's relationship neighborhood.
     Relationships {
@@ -56,18 +64,35 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
     let registry = load_registry(&bytes)?;
 
     match query {
-        RegistryQuery::List { status, json } => {
+        RegistryQuery::List {
+            status,
+            json,
+            ids_only,
+        } => {
             let filter = ListFilter {
                 status: status.as_deref().map(parse_status).transpose()?,
             };
-            let specs = list(&registry, &filter);
-            if *json {
-                print_json(&specs)?;
-            } else if specs.is_empty() {
-                println!("(no specs)");
+            if *ids_only {
+                // Spec 010 §3.1: ids and nothing else — an empty corpus prints
+                // nothing (no "(no specs)" placeholder) and still exits 0.
+                let ids = list_ids(&registry, &filter);
+                if *json {
+                    print_json(&ids)?;
+                } else {
+                    for id in ids {
+                        println!("{id}");
+                    }
+                }
             } else {
-                for s in specs {
-                    println!("{}  {:<11}  {}", s.id, status_label(s.status), s.title);
+                let specs = list(&registry, &filter);
+                if *json {
+                    print_json(&specs)?;
+                } else if specs.is_empty() {
+                    println!("(no specs)");
+                } else {
+                    for s in specs {
+                        println!("{}  {:<11}  {}", s.id, status_label(s.status), s.title);
+                    }
                 }
             }
         }
@@ -84,9 +109,20 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 println!("summary: {}", spec.summary.trim());
             }
         }
-        RegistryQuery::StatusReport { json } => {
+        RegistryQuery::StatusReport { json, nonzero_only } => {
             let report = status_report(&registry);
-            if *json {
+            if *nonzero_only {
+                let projected = report.nonzero_only();
+                if *json {
+                    print_json(&projected)?;
+                } else {
+                    println!("total:      {}", projected.total);
+                    print_count("draft:     ", projected.draft);
+                    print_count("approved:  ", projected.approved);
+                    print_count("superseded:", projected.superseded);
+                    print_count("retired:   ", projected.retired);
+                }
+            } else if *json {
                 print_json(&report)?;
             } else {
                 println!("total:      {}", report.total);
@@ -132,6 +168,12 @@ fn status_label(s: Status) -> &'static str {
         Status::Approved => "approved",
         Status::Superseded => "superseded",
         Status::Retired => "retired",
+    }
+}
+
+fn print_count(label: &str, count: Option<usize>) {
+    if let Some(n) = count {
+        println!("{label} {n}");
     }
 }
 

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -61,6 +61,139 @@ fn compile_ok_then_queries() {
 }
 
 #[test]
+fn registry_list_ids_only_projection() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "approved");
+    write_spec(tmp.path(), "002-b", "002-b", "approved");
+    write_spec(tmp.path(), "003-c", "003-c", "draft");
+    let compiled = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .arg("compile")
+        .output()
+        .unwrap();
+    assert_eq!(code(&compiled), 0);
+
+    // Text form: newline-delimited ids in id order, nothing else.
+    let text = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "list", "--ids-only"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&text), 0);
+    assert_eq!(
+        String::from_utf8_lossy(&text.stdout),
+        "001-a\n002-b\n003-c\n"
+    );
+
+    // JSON form: an array of id strings, same order.
+    let json = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "list", "--ids-only", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&json), 0);
+    let ids: Vec<String> = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(ids, ["001-a", "002-b", "003-c"]);
+
+    // --status filters first, then the projection applies.
+    let filtered = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "list", "--ids-only", "--status", "approved"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&filtered), 0);
+    assert_eq!(String::from_utf8_lossy(&filtered.stdout), "001-a\n002-b\n");
+
+    let filtered_json = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args([
+            "registry",
+            "list",
+            "--ids-only",
+            "--status",
+            "retired",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(code(&filtered_json), 0);
+    let none: Vec<String> = serde_json::from_slice(&filtered_json.stdout).unwrap();
+    assert!(none.is_empty());
+
+    // Empty projection in text mode: empty output (no "(no specs)"), exit 0.
+    let empty = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "list", "--ids-only", "--status", "retired"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&empty), 0);
+    assert!(empty.stdout.is_empty());
+}
+
+#[test]
+fn registry_status_report_nonzero_only_projection() {
+    let tmp = tempfile::tempdir().unwrap();
+    // approved + draft present; superseded + retired are the zero-count rows.
+    write_spec(tmp.path(), "001-a", "001-a", "approved");
+    write_spec(tmp.path(), "002-b", "002-b", "approved");
+    write_spec(tmp.path(), "003-c", "003-c", "draft");
+    let compiled = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .arg("compile")
+        .output()
+        .unwrap();
+    assert_eq!(code(&compiled), 0);
+
+    // Without the flag, output is byte-identical to pre-010 behavior.
+    let plain = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "status-report"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&plain), 0);
+    assert_eq!(
+        String::from_utf8_lossy(&plain.stdout),
+        "total:      3\ndraft:      1\napproved:   2\nsuperseded: 0\nretired:    0\n"
+    );
+
+    // Human form: zero-count rows omitted, total unaffected.
+    let human = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "status-report", "--nonzero-only"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&human), 0);
+    assert_eq!(
+        String::from_utf8_lossy(&human.stdout),
+        "total:      3\ndraft:      1\napproved:   2\n"
+    );
+
+    // JSON form: zero-count keys absent, total present.
+    let json = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "status-report", "--nonzero-only", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&json), 0);
+    let report: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(report["total"], 3);
+    assert_eq!(report["draft"], 1);
+    assert_eq!(report["approved"], 2);
+    assert!(report.get("superseded").is_none());
+    assert!(report.get("retired").is_none());
+}
+
+#[test]
 fn compile_validation_failure_exits_1() {
     let tmp = tempfile::tempdir().unwrap();
     // Directory name != id -> V-001 (error tier).

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -43,8 +43,8 @@ pub use couple::{
 pub use index::{Freshness, IndexOutcome, authorities, check_index_freshness, index};
 pub use lint::{LintReport, lint};
 pub use query::{
-    ListFilter, RelationshipView, StatusReport, list, load_index, load_registry, relationships,
-    show, status_report,
+    ListFilter, RelationshipView, StatusReport, StatusReportNonzero, list, list_ids, load_index,
+    load_registry, relationships, show, status_report,
 };
 pub use scaffold::{Scaffold, ScaffoldFile, scaffold_init};
 
@@ -64,7 +64,9 @@ pub fn compile_json(config_json: &str, repo_root: &str) -> Result<String, Error>
 /// Run a read-only query described by `request_json`.
 ///
 /// Request shape: `{ "registry": "<registry.json text>", "op": "list" |
-/// "show" | "status-report" | "relationships", "id"?: string, "status"?: string }`.
+/// "show" | "status-report" | "relationships", "id"?: string, "status"?: string,
+/// "idsOnly"?: bool, "nonzeroOnly"?: bool }`. The projection fields (spec 010)
+/// default to `false`, so pre-010 requests behave identically.
 pub fn query_json(request_json: &str) -> Result<String, Error> {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -75,6 +77,10 @@ pub fn query_json(request_json: &str) -> Result<String, Error> {
         id: Option<String>,
         #[serde(default)]
         status: Option<Status>,
+        #[serde(default)]
+        ids_only: bool,
+        #[serde(default)]
+        nonzero_only: bool,
     }
     #[derive(Deserialize)]
     #[serde(rename_all = "kebab-case")]
@@ -94,7 +100,11 @@ pub fn query_json(request_json: &str) -> Result<String, Error> {
             let filter = ListFilter {
                 status: request.status,
             };
-            to_json(&list(&registry, &filter))?
+            if request.ids_only {
+                to_json(&query::list_ids(&registry, &filter))?
+            } else {
+                to_json(&list(&registry, &filter))?
+            }
         }
         Op::Show => {
             let id = request
@@ -102,7 +112,14 @@ pub fn query_json(request_json: &str) -> Result<String, Error> {
                 .ok_or_else(|| Error::NotFound("missing 'id' for show".into()))?;
             to_json(show(&registry, &id)?)?
         }
-        Op::StatusReport => to_json(&status_report(&registry))?,
+        Op::StatusReport => {
+            let report = status_report(&registry);
+            if request.nonzero_only {
+                to_json(&report.nonzero_only())?
+            } else {
+                to_json(&report)?
+            }
+        }
         Op::Relationships => {
             let id = request
                 .id

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -55,6 +55,15 @@ pub fn list<'a>(registry: &'a Registry, filter: &ListFilter) -> Vec<&'a SpecReco
         .collect()
 }
 
+/// The `--ids-only` projection of [`list`] (spec 010 §3.1): the same filter and
+/// order, reduced to bare spec ids.
+pub fn list_ids<'a>(registry: &'a Registry, filter: &ListFilter) -> Vec<&'a str> {
+    list(registry, filter)
+        .iter()
+        .map(|s| s.id.as_str())
+        .collect()
+}
+
 /// One spec by id, or [`Error::NotFound`].
 pub fn show<'a>(registry: &'a Registry, id: &str) -> Result<&'a SpecRecord, Error> {
     registry
@@ -73,6 +82,37 @@ pub struct StatusReport {
     pub approved: usize,
     pub superseded: usize,
     pub retired: usize,
+}
+
+/// The `--nonzero-only` projection of a [`StatusReport`] (spec 010 §3.2):
+/// zero-count statuses are omitted from serialization; `total` always
+/// serializes and still reflects the whole corpus.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusReportNonzero {
+    pub total: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approved: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retired: Option<usize>,
+}
+
+impl StatusReport {
+    /// Project to the `--nonzero-only` form.
+    pub fn nonzero_only(&self) -> StatusReportNonzero {
+        let keep = |n: usize| (n > 0).then_some(n);
+        StatusReportNonzero {
+            total: self.total,
+            draft: keep(self.draft),
+            approved: keep(self.approved),
+            superseded: keep(self.superseded),
+            retired: keep(self.retired),
+        }
+    }
 }
 
 /// Tally specs by status.

--- a/docs/api.md
+++ b/docs/api.md
@@ -209,7 +209,8 @@ pub fn scaffold_init_json  (config_json: &str)                  -> Result<String
 - `config_json` is a JSON object matching `Config`; `"{}"` ⇒ `Config::default()`.
 - `query_json` request: `{ "registry": "<registry.json text>", "op":
   "list" | "show" | "status-report" | "relationships", "id"?: string,
-  "status"?: string }`.
+  "status"?: string, "idsOnly"?: bool, "nonzeroOnly"?: bool }` (the projection
+  fields, spec 010, default to `false`).
 - `couple_json` request: `{ "config"?: Config, "repoRoot": string, "diff":
   DiffInput, "waiver"?: { "reason": string } }`.
 - `check_freshness_json` returns `{ "fresh": bool, "expected"?, "actual"? }`.

--- a/specs/010-registry-query-projection-flags/spec.md
+++ b/specs/010-registry-query-projection-flags/spec.md
@@ -1,0 +1,83 @@
+---
+id: "010-registry-query-projection-flags"
+title: "Registry query: --ids-only and --nonzero-only projection flags"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "002-registry-query"
+extends:
+  - { spec: "002-registry-query", unit: "crates/spec-spine-core/src/query.rs", nature: additive }
+  - { spec: "002-registry-query", unit: "crates/spec-spine-cli/src/cmd_registry.rs", nature: additive }
+  # §3.3 widens the query_json facade (and the re-export list) in 001's lib.rs;
+  # §3.4's e2e tests live in 001's cli.rs. Both additive, same shape as 002/005.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+summary: >
+  Two additive projection flags on the spec 002 query verbs: `registry list
+  --ids-only` (newline-delimited spec ids; a JSON string array under --json)
+  and `registry status-report --nonzero-only` (omit zero-count statuses).
+  Both are load-bearing in adopter session-init protocols (OAP's /init and
+  /setup read exactly these projections); neither changes any existing output
+  shape when absent.
+---
+
+# 010: Query projection flags
+
+## 1. Purpose
+
+Adopter automation consumes two narrow projections of the registry that spec
+002's verbs almost -- but not quite -- provide. OAP's cross-agent init protocol
+(AGENTS.md) runs `list --ids-only` for latest-spec detection and
+`status-report --json --nonzero-only` for lifecycle counts on every session
+start. Without these flags the consumer either post-processes JSON in shell
+(exactly the ad-hoc parsing spec 000's read discipline forbids) or carries a
+fork. Both flags are pure projections: no new data, no new queries.
+
+## 2. Territory
+
+`query.rs` (projection options on `list` / `status_report`) and
+`cmd_registry.rs` (flag parsing + rendering), plus additive touches to 001's
+`lib.rs` (the `query_json` option fields of §3.3 and the re-export list) and
+its e2e test file `cli.rs` (§3.4). Spec 002 remains the owner of the verbs
+themselves.
+
+## 3. Behavior
+
+### 3.1 `registry list --ids-only`
+
+- Text mode: newline-delimited spec ids, in `id` order, nothing else. Empty
+  corpus ⇒ empty output, exit 0.
+- With `--json`: a JSON array of id strings (not record objects), same order.
+- Composes with `--status`: the filter applies first, then the projection.
+
+### 3.2 `registry status-report --nonzero-only`
+
+- Statuses whose count is zero are omitted from both human and `--json`
+  output. The total line (human) / total field (JSON), if present, is
+  unaffected -- it reflects the whole corpus.
+- Without the flag, output is byte-identical to pre-010 behavior.
+
+### 3.3 Contract
+
+- Exit codes unchanged (`0` ok, `1` not found, `3` I/O / parse / schema).
+- The JSON facade (`query_json`) accepts the corresponding option fields;
+  absent fields default to current behavior, so existing callers are
+  untouched (schema-versioning: additive, no bump needed -- the registry
+  artifact itself is unchanged; only CLI/API output projections are added).
+- Both flags are deterministic projections of `registry.json`; same input,
+  byte-identical output.
+
+### 3.4 Tests (minimum)
+
+- `--ids-only` text and JSON forms; with and without `--status`.
+- `--nonzero-only` against a corpus with at least one zero-count status; and
+  the no-flag byte-identity check against the pre-010 fixture.
+
+## 4. Out of scope
+
+New query verbs (graph traversal, by-authority -- consciously deferred; see the
+amendments README). Filtering extensions beyond composing with the existing
+`--status`. Changes to `registry.json` itself.


### PR DESCRIPTION
Lands `specs/010-registry-query-projection-flags` (PR 1 of 6 in the staged amendment series; strictly serial). Two additive projections on the spec 002 query verbs, both load-bearing in adopter session-init protocols:

- `registry list --ids-only`: newline-delimited spec ids; a JSON string array under `--json`; composes with `--status` (filter first, then projection); an empty projection prints nothing and exits 0.
- `registry status-report --nonzero-only`: omits zero-count statuses from human and JSON output; the total line/field still covers the whole corpus.

Implementation notes:
- Core: `list_ids()` and `StatusReport::nonzero_only()` (serialized as `StatusReportNonzero` with zero-count keys omitted). The `query_json` facade accepts `idsOnly`/`nonzeroOnly`, defaulting to `false`; pre-010 requests and no-flag CLI output are byte-identical (covered by an exact-bytes test). Exit codes and `registry.json` unchanged.
- The staged spec frontmatter under-declared its territory: its own §3.3 (facade fields) and §3.4 (e2e tests) require touching 001's `lib.rs` and `cli.rs`, and the coupling gate rightly flagged the gap. Added the two additive `extends` edges (same shape as specs 002/005) and aligned the Territory prose. Also normalized em dashes in the spec body to the repo's `--` style.
- `docs/api.md`: `query_json` request shape updated.

Gates: `compile` (0 warnings), `index` (0 errors), `lint` (0/0/0), `couple --base origin/main --head HEAD` (5 paths, no drift). Full workspace test suite passes.

**Review call for the maintainer:** spec lands with `implementation: complete`, `status: draft`. The draft -> approved flip is yours; happy to do the flip + regen as a follow-up micro-PR or fold it here on request.

Merge ordering: rewrites the committed `.derived` artifacts; conflicts with any other open branch that does the same (e.g. #5). Next staged spec (011) moves in only after this merges.