### PR TITLE
feat: index render and orphans projections (spec 011)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "d501504087fb0aefee71e3cb5bead96b038e8fd8f85c65779d9d2d9cc0143563",
+    "contentHash": "b46eef307d927c10909686cf437219833b5c1d20ae32cf9405edb3f3e173857a",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -912,6 +912,102 @@
           }
         ],
         "specId": "010-registry-query-projection-flags",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "004-codebase-index"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-cli/src/cmd_index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/tests/cli.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/render.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/render.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/render.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/render.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/render.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/render.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/cmd_index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/cmd_index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/tests/cli.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/tests/cli.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/lib.rs"
+            }
+          }
+        ],
+        "specId": "011-index-render-orphans",
         "specStatus": "draft"
       }
     ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "94be63edc2cdd5380a98427fc863eb21bca987437b8b4be1bc04e2cac48d6534",
+    "contentHash": "12206dab05175cc88634065ded1f8d3dabab78939bb461c6abd8158f975fa921",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -517,6 +517,67 @@
       "status": "draft",
       "summary": "Two additive projection flags on the spec 002 query verbs: `registry list --ids-only` (newline-delimited spec ids; a JSON string array under --json) and `registry status-report --nonzero-only` (omit zero-count statuses). Both are load-bearing in adopter session-init protocols (OAP's /init and /setup read exactly these projections); neither changes any existing output shape when absent.\n",
       "title": "Registry query: --ids-only and --nonzero-only projection flags"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "004-codebase-index"
+      ],
+      "establishes": [
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/render.rs"
+        },
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/render.rs"
+        }
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        }
+      ],
+      "id": "011-index-render-orphans",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "011: `index render` and `index orphans`",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Common contract",
+        "3.2 `index render` -- the markdown projection",
+        "3.3 `index orphans`",
+        "3.4 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/011-index-render-orphans/spec.md",
+      "status": "draft",
+      "summary": "Implements the two subcommands spec 004's CLI reserved but stubbed: `spec-spine index render` (a deterministic human-shaped markdown projection of the committed index.json -- package inventory, traceability, diagnostics) and `spec-spine index orphans` (the orphanedSpecs list, newline ids or a --json array). Both are pure read-side projections of the committed artifact; neither recomputes the index. Establishes the render module; extends the index CLI dispatch.\n",
+      "title": "Index: implement the reserved render and orphans subcommands"
     }
   ],
   "validation": {

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -1,11 +1,15 @@
-//! `spec-spine index` — write `index.json`; `spec-spine index check` — staleness.
+//! `spec-spine index` — write `index.json`; `spec-spine index check` — staleness;
+//! `spec-spine index render` / `index orphans` — read-side projections of the
+//! committed artifact (spec 011; never recompute, never check freshness).
 
 use std::fs;
 use std::path::Path;
 
 use clap::Subcommand;
-use spec_spine_core::{Freshness, check_index_freshness, index};
-use spec_spine_types::Error;
+use spec_spine_core::{
+    Freshness, check_index_freshness, index, load_index, orphans, render_markdown,
+};
+use spec_spine_types::{CodebaseIndex, Config, Error};
 
 use crate::load_repo_config;
 
@@ -13,6 +17,29 @@ use crate::load_repo_config;
 pub enum IndexAction {
     /// Check the committed index against current inputs (the staleness gate).
     Check,
+    /// Render the committed index as markdown (a projection; never recomputes).
+    Render,
+    /// List orphaned specs from the committed index.
+    Orphans {
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Read and parse the committed `index.json` (spec 011 §3.1: the projections
+/// read the artifact, never the working tree).
+fn load_committed_index(repo: &Path, cfg: &Config) -> Result<CodebaseIndex, Error> {
+    let path = repo
+        .join(&cfg.layout.derived_dir)
+        .join("codebase-index")
+        .join("index.json");
+    let bytes = fs::read(&path).map_err(|e| {
+        Error::Io(format!(
+            "read {} (run `spec-spine index` first?): {e}",
+            path.display()
+        ))
+    })?;
+    load_index(&bytes)
 }
 
 /// `index` (no action) writes the index; `index check` verifies freshness.
@@ -20,6 +47,25 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
     let cfg = load_repo_config(repo)?;
 
     match action {
+        Some(IndexAction::Render) => {
+            let idx = load_committed_index(repo, &cfg)?;
+            print!("{}", render_markdown(&cfg, &idx));
+            Ok(0)
+        }
+        Some(IndexAction::Orphans { json }) => {
+            let idx = load_committed_index(repo, &cfg)?;
+            let ids = orphans(&idx);
+            if *json {
+                let s =
+                    serde_json::to_string_pretty(&ids).map_err(|e| Error::Schema(e.to_string()))?;
+                println!("{s}");
+            } else {
+                for id in ids {
+                    println!("{id}");
+                }
+            }
+            Ok(0)
+        }
         Some(IndexAction::Check) => match check_index_freshness(&cfg, repo)? {
             Freshness::Fresh => {
                 println!("index is fresh");

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -272,6 +272,113 @@ fn index_then_check_fresh_then_stale() {
 }
 
 #[test]
+fn index_render_and_orphans_projections() {
+    let tmp = tempfile::tempdir().unwrap();
+    let write_claiming_spec = |id: &str, target: &str| {
+        let dir = tmp.path().join("specs").join(id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("spec.md"),
+            format!(
+                "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-08\"\nsummary: \"s\"\nestablishes:\n  - \"{target}\"\n---\n# {id}\n"
+            ),
+        )
+        .unwrap();
+    };
+    // 001-a claims a path that resolves -> mapped; 002-b claims a path that
+    // resolves nowhere -> orphaned.
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+    fs::write(tmp.path().join("src/lib.rs"), "// Spec: 001-a\n").unwrap();
+    write_claiming_spec("001-a", "src/lib.rs");
+    write_claiming_spec("002-b", "src/missing.rs");
+
+    // Projections before `index` has run: exit 3 (missing artifact).
+    let early_render = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["index", "render"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&early_render), 3, "render without index -> 3");
+    let early_orphans = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["index", "orphans"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&early_orphans), 3, "orphans without index -> 3");
+
+    let built = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .arg("index")
+        .output()
+        .unwrap();
+    assert_eq!(code(&built), 0);
+
+    // Orphans, text and JSON forms.
+    let orphans_text = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["index", "orphans"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&orphans_text), 0, "orphans is a query, not a gate");
+    assert_eq!(String::from_utf8_lossy(&orphans_text.stdout), "002-b\n");
+
+    let orphans_json = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["index", "orphans", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&orphans_json), 0);
+    let ids: Vec<String> = serde_json::from_slice(&orphans_json.stdout).unwrap();
+    assert_eq!(ids, ["002-b"]);
+
+    // Render: exit 0 even with diagnostics in the artifact; contractual
+    // sections present in order.
+    let render = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["index", "render"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&render), 0, "diagnostics do not fail a render");
+    let md = String::from_utf8_lossy(&render.stdout);
+    let positions: Vec<usize> = [
+        "# spec-spine codebase index",
+        "## Packages",
+        "## Traceability",
+    ]
+    .iter()
+    .map(|s| md.find(s).unwrap_or_else(|| panic!("missing section {s}")))
+    .collect();
+    assert!(positions.windows(2).all(|w| w[0] < w[1]), "section order");
+    assert!(md.contains("### Orphaned specs"));
+    assert!(md.contains("- 002-b"));
+    assert!(md.ends_with('\n'));
+
+    // Empty orphans list -> empty output, still exit 0.
+    fs::remove_dir_all(tmp.path().join("specs/002-b")).unwrap();
+    let rebuilt = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .arg("index")
+        .output()
+        .unwrap();
+    assert_eq!(code(&rebuilt), 0);
+    let none = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["index", "orphans"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&none), 0);
+    assert!(none.stdout.is_empty());
+}
+
+#[test]
 fn lint_fail_on_warn_gating() {
     let tmp = tempfile::tempdir().unwrap();
     // An ordinary spec with no ownership edge -> L-001 (warning).

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod manifest;
 mod markdown;
 pub mod pathutil;
 pub mod query;
+pub mod render;
 pub mod scaffold;
 pub mod sections;
 pub mod symbols;
@@ -51,6 +52,7 @@ pub use query::{
     ListFilter, RelationshipView, StatusReport, StatusReportNonzero, list, list_ids, load_index,
     load_registry, relationships, show, status_report,
 };
+pub use render::{orphans, render_markdown};
 pub use scaffold::{Scaffold, ScaffoldFile, scaffold_init};
 
 // ===== JSON-in / JSON-out facade (the FFI seam) =====
@@ -158,6 +160,22 @@ pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String
         }
     };
     Ok(value.to_string())
+}
+
+/// Render the committed index as markdown (spec 011). `index_json` is the
+/// `index.json` text; the returned string is the markdown projection,
+/// JSON-encoded (a JSON string literal).
+pub fn render_json(config_json: &str, index_json: &str) -> Result<String, Error> {
+    let config = config_from_json(config_json)?;
+    let index = load_index(index_json.as_bytes())?;
+    to_json(&render::render_markdown(&config, &index))
+}
+
+/// List the committed index's orphaned specs as a JSON array of id strings
+/// (spec 011). `index_json` is the `index.json` text.
+pub fn orphans_json(index_json: &str) -> Result<String, Error> {
+    let index = load_index(index_json.as_bytes())?;
+    to_json(&render::orphans(&index))
 }
 
 /// Parse a `spec-spine.toml` and return the normalized [`Config`] as JSON.

--- a/crates/spec-spine-core/src/render.rs
+++ b/crates/spec-spine-core/src/render.rs
@@ -1,0 +1,129 @@
+//! The render capability (spec 011): deterministic, human-shaped projections
+//! of the **committed** `index.json`. Pure read-side — never recomputes the
+//! index, never consults the working tree, never signals staleness
+//! (recomputation is `index`, freshness is `index check`; three verbs, three
+//! jobs). Output is a pure function of `(config, index)`: byte-identical
+//! across platforms, LF line endings, trailing newline.
+
+use std::fmt::Write as _;
+
+use spec_spine_types::{CodebaseIndex, Config, Diagnostic, PackageKind};
+
+/// The id-sorted `traceability.orphanedSpecs` list (spec 011 §3.3).
+pub fn orphans(index: &CodebaseIndex) -> Vec<&str> {
+    let mut ids: Vec<&str> = index
+        .traceability
+        .orphaned_specs
+        .iter()
+        .map(String::as_str)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// The markdown projection of the committed index (spec 011 §3.2).
+///
+/// Section inventory and order are the v1 contract: header, package
+/// inventory, traceability (orphans / untraced flat lists omitted when
+/// empty), diagnostics (omitted when empty). The prose between sections is
+/// not contractual.
+pub fn render_markdown(config: &Config, index: &CodebaseIndex) -> String {
+    let mut out = String::new();
+
+    // 1. Header — traceable to the exact artifact that produced it.
+    let _ = writeln!(out, "# {} codebase index", config.branding.indexer_id);
+    out.push('\n');
+    let _ = writeln!(out, "- schemaVersion: {}", index.schema_version);
+    let _ = writeln!(out, "- contentHash: {}", index.build.content_hash);
+
+    // 2. Package inventory, sorted by name, ties by path.
+    out.push_str("\n## Packages\n\n");
+    let mut packages: Vec<_> = index.packages.iter().collect();
+    packages.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.path.cmp(&b.path)));
+    out.push_str("| name | path | kind | version | spec |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for p in packages {
+        let _ = writeln!(
+            out,
+            "| {} | {} | {} | {} | {} |",
+            p.name,
+            p.path,
+            kind_label(p.kind),
+            p.version.as_deref().unwrap_or("-"),
+            p.spec_ref.as_deref().unwrap_or("-"),
+        );
+    }
+
+    // 3. Traceability: per-spec summary, then the flat lists (omitted when
+    //    empty).
+    out.push_str("\n## Traceability\n\n");
+    let mut mappings: Vec<_> = index.traceability.mappings.iter().collect();
+    mappings.sort_by(|a, b| a.spec_id.cmp(&b.spec_id));
+    out.push_str("| spec | status | paths | units |\n");
+    out.push_str("|---|---|---|---|\n");
+    for m in mappings {
+        let _ = writeln!(
+            out,
+            "| {} | {} | {} | {} |",
+            m.spec_id,
+            m.spec_status.as_deref().unwrap_or("-"),
+            m.implementing_paths.len(),
+            m.resolved_units.len(),
+        );
+    }
+    if !index.traceability.orphaned_specs.is_empty() {
+        out.push_str("\n### Orphaned specs\n\n");
+        for id in orphans(index) {
+            let _ = writeln!(out, "- {id}");
+        }
+    }
+    if !index.traceability.untraced_code.is_empty() {
+        out.push_str("\n### Untraced code\n\n");
+        let mut paths: Vec<&str> = index
+            .traceability
+            .untraced_code
+            .iter()
+            .map(String::as_str)
+            .collect();
+        paths.sort_unstable();
+        for path in paths {
+            let _ = writeln!(out, "- {path}");
+        }
+    }
+
+    // 4. Diagnostics, sorted by (code, file); omitted when empty.
+    let mut diagnostics: Vec<(&Diagnostic, &str)> = index
+        .diagnostics
+        .errors
+        .iter()
+        .map(|d| (d, "error"))
+        .chain(index.diagnostics.warnings.iter().map(|d| (d, "warning")))
+        .collect();
+    if !diagnostics.is_empty() {
+        diagnostics.sort_by_key(|(d, _)| (d.code.as_str(), d.path.as_deref().unwrap_or("")));
+        out.push_str("\n## Diagnostics\n\n");
+        for (d, severity) in diagnostics {
+            match &d.path {
+                Some(path) => {
+                    let _ = writeln!(out, "- {} [{severity}] {} ({path})", d.code, d.message);
+                }
+                None => {
+                    let _ = writeln!(out, "- {} [{severity}] {}", d.code, d.message);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// The kebab-case kind label, matching the serde wire form in `index.json`.
+fn kind_label(kind: PackageKind) -> &'static str {
+    match kind {
+        PackageKind::RustLib => "rust-lib",
+        PackageKind::RustBin => "rust-bin",
+        PackageKind::RustLibBin => "rust-lib-bin",
+        PackageKind::NpmPackage => "npm-package",
+        PackageKind::NpmWorkspace => "npm-workspace",
+    }
+}

--- a/crates/spec-spine-core/tests/render.rs
+++ b/crates/spec-spine-core/tests/render.rs
@@ -1,0 +1,153 @@
+//! Golden tests for the spec 011 projections: the rendered markdown is a pure
+//! function of `(config, index.json bytes)` — byte-exact, LF endings, trailing
+//! newline. Fixtures go through `load_index` so the wire shapes are exercised
+//! end to end.
+
+use spec_spine_core::{load_index, orphans, render_markdown};
+use spec_spine_types::Config;
+
+/// Packages, mappings, orphans and diagnostics deliberately unsorted in the
+/// fixture: the render order below is the projection's doing.
+const FULL_FIXTURE: &str = r#"{
+  "schemaVersion": "0.1.0",
+  "build": {
+    "indexerId": "spec-spine",
+    "indexerVersion": "0.2.0",
+    "repoRoot": ".",
+    "contentHash": "cafe1234"
+  },
+  "packages": [
+    {
+      "name": "zeta",
+      "path": "crates/zeta",
+      "kind": "rust-lib",
+      "version": "0.1.0",
+      "specRef": "002-zeta"
+    },
+    { "name": "alpha", "path": "npm/alpha", "kind": "npm-package" }
+  ],
+  "traceability": {
+    "mappings": [
+      {
+        "specId": "002-zeta",
+        "specStatus": "approved",
+        "implementingPaths": [{ "path": "crates/zeta", "source": "spec-edge" }]
+      },
+      { "specId": "001-alpha", "implementingPaths": [] }
+    ],
+    "orphanedSpecs": ["009-zzz", "003-orphan"],
+    "untracedCode": ["npm/alpha"]
+  },
+  "diagnostics": {
+    "warnings": [
+      { "code": "I-002", "message": "untraced package", "path": "npm/alpha" }
+    ],
+    "errors": [
+      {
+        "code": "I-003",
+        "message": "unit resolved nowhere",
+        "path": "crates/zeta/src/gone.rs"
+      }
+    ]
+  }
+}"#;
+
+const FULL_EXPECTED: &str = "# spec-spine codebase index\n\
+\n\
+- schemaVersion: 0.1.0\n\
+- contentHash: cafe1234\n\
+\n\
+## Packages\n\
+\n\
+| name | path | kind | version | spec |\n\
+|---|---|---|---|---|\n\
+| alpha | npm/alpha | npm-package | - | - |\n\
+| zeta | crates/zeta | rust-lib | 0.1.0 | 002-zeta |\n\
+\n\
+## Traceability\n\
+\n\
+| spec | status | paths | units |\n\
+|---|---|---|---|\n\
+| 001-alpha | - | 0 | 0 |\n\
+| 002-zeta | approved | 1 | 0 |\n\
+\n\
+### Orphaned specs\n\
+\n\
+- 003-orphan\n\
+- 009-zzz\n\
+\n\
+### Untraced code\n\
+\n\
+- npm/alpha\n\
+\n\
+## Diagnostics\n\
+\n\
+- I-002 [warning] untraced package (npm/alpha)\n\
+- I-003 [error] unit resolved nowhere (crates/zeta/src/gone.rs)\n";
+
+/// No orphans, no untraced code, no diagnostics: those sections are omitted
+/// entirely (spec 011 §3.2 / §3.4).
+const EMPTY_SECTIONS_FIXTURE: &str = r#"{
+  "schemaVersion": "0.1.0",
+  "build": {
+    "indexerId": "spec-spine",
+    "indexerVersion": "0.2.0",
+    "repoRoot": ".",
+    "contentHash": "beef5678"
+  },
+  "packages": [
+    { "name": "alpha", "path": "crates/alpha", "kind": "rust-bin" }
+  ],
+  "traceability": {
+    "mappings": [
+      {
+        "specId": "001-alpha",
+        "implementingPaths": [{ "path": "crates/alpha", "source": "spec-edge" }]
+      }
+    ],
+    "orphanedSpecs": [],
+    "untracedCode": []
+  },
+  "diagnostics": { "warnings": [], "errors": [] }
+}"#;
+
+const EMPTY_SECTIONS_EXPECTED: &str = "# spec-spine codebase index\n\
+\n\
+- schemaVersion: 0.1.0\n\
+- contentHash: beef5678\n\
+\n\
+## Packages\n\
+\n\
+| name | path | kind | version | spec |\n\
+|---|---|---|---|---|\n\
+| alpha | crates/alpha | rust-bin | - | - |\n\
+\n\
+## Traceability\n\
+\n\
+| spec | status | paths | units |\n\
+|---|---|---|---|\n\
+| 001-alpha | - | 1 | 0 |\n";
+
+#[test]
+fn render_full_fixture_is_byte_exact() {
+    let index = load_index(FULL_FIXTURE.as_bytes()).unwrap();
+    assert_eq!(render_markdown(&Config::default(), &index), FULL_EXPECTED);
+}
+
+#[test]
+fn render_omits_empty_sections() {
+    let index = load_index(EMPTY_SECTIONS_FIXTURE.as_bytes()).unwrap();
+    assert_eq!(
+        render_markdown(&Config::default(), &index),
+        EMPTY_SECTIONS_EXPECTED
+    );
+}
+
+#[test]
+fn orphans_are_id_sorted() {
+    let index = load_index(FULL_FIXTURE.as_bytes()).unwrap();
+    assert_eq!(orphans(&index), ["003-orphan", "009-zzz"]);
+
+    let empty = load_index(EMPTY_SECTIONS_FIXTURE.as_bytes()).unwrap();
+    assert!(orphans(&empty).is_empty());
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -202,6 +202,8 @@ pub fn lint_json           (config_json: &str, repo_root: &str) -> Result<String
 pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn couple_json         (request_json: &str)                 -> Result<String, Error>;
 pub fn query_json          (request_json: &str)                 -> Result<String, Error>;
+pub fn render_json         (config_json: &str, index_json: &str) -> Result<String, Error>;
+pub fn orphans_json        (index_json: &str)                    -> Result<String, Error>;
 pub fn load_config_json    (toml_src: &str)                     -> Result<String, Error>;
 pub fn scaffold_init_json  (config_json: &str)                  -> Result<String, Error>;
 ```
@@ -214,6 +216,9 @@ pub fn scaffold_init_json  (config_json: &str)                  -> Result<String
 - `couple_json` request: `{ "config"?: Config, "repoRoot": string, "diff":
   DiffInput, "waiver"?: { "reason": string } }`.
 - `check_freshness_json` returns `{ "fresh": bool, "expected"?, "actual"? }`.
+- `render_json` / `orphans_json` (spec 011) take the committed `index.json`
+  text and return the markdown projection (a JSON-encoded string) and the
+  orphaned-spec ids (a JSON array) respectively.
 
 All emitted JSON is **pretty-printed with sorted keys, LF line endings, and a
 trailing newline** (diffability over compactness; see

--- a/specs/011-index-render-orphans/spec.md
+++ b/specs/011-index-render-orphans/spec.md
@@ -1,0 +1,108 @@
+---
+id: "011-index-render-orphans"
+title: "Index: implement the reserved render and orphans subcommands"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "004-codebase-index"
+establishes:
+  - "crates/spec-spine-core/src/render.rs"
+  - "crates/spec-spine-core/tests/render.rs"
+extends:
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  # §3.4's missing-index / orphans-form e2e tests live in 001's exit-code
+  # contract file, same additive shape as spec 010.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+summary: >
+  Implements the two subcommands spec 004's CLI reserved but stubbed:
+  `spec-spine index render` (a deterministic human-shaped markdown projection
+  of the committed index.json -- package inventory, traceability, diagnostics)
+  and `spec-spine index orphans` (the orphanedSpecs list, newline ids or a
+  --json array). Both are pure read-side projections of the committed
+  artifact; neither recomputes the index. Establishes the render module;
+  extends the index CLI dispatch.
+---
+
+# 011: `index render` and `index orphans`
+
+## 1. Purpose
+
+The committed `index.json` is machine truth; humans and agent session-init
+protocols need a governed human-shaped view of it without ad-hoc JSON parsing.
+OAP's Makefile and cross-agent init protocol call `render` on every session
+start, and its workflow rules document `orphans` as the governed way to list
+specs whose claims resolve nowhere. The subcommands already exist in the CLI
+grammar as reserved stubs; this spec gives them their one honest
+implementation: **projections of the committed artifact, never recomputation**
+(recomputation is `index`; freshness is `index check` -- three verbs, three
+jobs).
+
+## 2. Territory
+
+A new `render.rs` in `spec-spine-core` (markdown projection, plus the
+`orphans` accessor) with its tests; the `cmd_index.rs` dispatch gains the two
+live arms; `lib.rs` exports the projection API (and a `render_json` /
+`orphans_json` facade entry consistent with the existing JSON facade). The
+e2e exit-code tests of §3.4 additively extend 001's `cli.rs`.
+
+## 3. Behavior
+
+### 3.1 Common contract
+
+- Both subcommands **read the committed** `<derived_dir>/codebase-index/
+  index.json` via `load_index` (rejecting unknown MAJOR). Missing artifact ⇒
+  `Error::Io` with a message pointing at `spec-spine index` (exit 3).
+- Neither consults the working tree, recomputes hashes, nor warns about
+  staleness -- a stale-but-loadable index renders; freshness is `check`'s job.
+- Output is a pure function of `(config, index.json bytes)`: byte-identical
+  across platforms, LF line endings, trailing newline.
+
+### 3.2 `index render` -- the markdown projection
+
+Emits to stdout, in this order:
+
+1. **Header**: title (`branding.indexer_id`), the index `schemaVersion`, and
+   the `build.contentHash` (so a rendered view is traceable to the exact
+   artifact that produced it).
+2. **Package inventory**: one table over all discovered packages -- name, path,
+   kind, version, owning spec (the manifest-linkage spec id, or `-`). Sorted
+   by name, ties by path.
+3. **Traceability**: per-spec mapping summary (spec id, status, count of
+   implementing paths, count of resolved units), id-sorted; then
+   `orphanedSpecs` and `untracedCode` as flat lists (omit either section when
+   empty).
+4. **Diagnostics**: every `I-###` diagnostic with severity and message, sorted
+   by (code, file). Omit the section when empty.
+
+The section inventory above is the v1 contract: adopters MAY rely on the
+*presence and order* of these sections; the precise prose between them is not
+contractual. Exit `0` on success (diagnostics in the artifact do not fail a
+render), `3` on I/O / parse / schema.
+
+### 3.3 `index orphans`
+
+- Text mode: newline-delimited spec ids from `traceability.orphanedSpecs`,
+  id-sorted; empty list ⇒ empty output.
+- `--json`: a JSON array of id strings.
+- Exit `0` whether or not orphans exist (a query, not a gate; gating on
+  orphans is an adopter's CI policy choice, e.g.
+  `test -z "$(spec-spine index orphans)"`), `3` on I/O / parse / schema.
+
+### 3.4 Tests (minimum)
+
+- Golden-file test of the rendered markdown against a fixture index
+  (byte-exact, the determinism proof).
+- Render with empty orphans/untraced/diagnostics sections (omission rule).
+- Orphans text + JSON forms; missing-index error path for both subcommands.
+
+## 4. Out of scope
+
+Overlay layers (domain-specific render sections belong to overlay crates per
+`docs/overlay-contract.md` -- an overlay renders its own sibling view; this
+render is the generic core's view and takes no extension hooks in v1).
+Rendering the *registry* (the registry's human view is the spec corpus
+itself). Any staleness signaling inside render output.


### PR DESCRIPTION
Lands `specs/011-index-render-orphans` (PR 2 of 6 in the staged amendment series; strictly serial, after #7). Implements the two read-side subcommands spec 004 reserved, as pure projections of the committed `index.json` -- never recomputation (that's `index`), never freshness signaling (that's `index check`):

- `spec-spine index render`: deterministic markdown projection. Header carries `branding.indexer_id`, `schemaVersion` and `build.contentHash` (traceable to the exact artifact); then the package inventory table (name-sorted, path tiebreak), the per-spec traceability summary (id-sorted), orphaned/untraced flat lists and diagnostics sorted by (code, file) -- each trailing section omitted when empty. Section presence/order is the v1 contract; output is byte-identical across platforms (LF, trailing newline), proven by golden tests.
- `spec-spine index orphans`: id-sorted `traceability.orphanedSpecs`, newline-delimited or a `--json` string array; exit 0 whether or not orphans exist (a query, not a gate), 3 when the artifact is missing.

Implementation notes:
- Core establishes `render.rs` (`render_markdown`, `orphans`) plus golden tests in `crates/spec-spine-core/tests/render.rs`; `lib.rs` gains `render_json`/`orphans_json` facade entries; `cmd_index.rs` gains the two dispatch arms with a shared committed-artifact loader. `docs/api.md` updated.
- One premise correction vs the staged spec text: the CLI had no literal reserved stubs (the reservation was in spec 004's prose), so the arms are new `IndexAction` variants -- behavior exactly as specified.
- As with #7, the staged frontmatter under-declared territory: section 3.4's e2e exit-code tests live in 001's `tests/cli.rs`, so that additive extends edge was added and the Territory prose aligned. Em dashes normalized to `--`.
- Dogfooded against this repo's own committed index; rendering is clean.

Gates: `compile` (0 warnings), `index` (0 errors), `lint` (0/0/0), `couple --base origin/main --head HEAD` (6 paths, no drift). Full workspace test suite passes (21 suites).

**Review call for the maintainer:** spec lands with `implementation: complete`, `status: draft`; the draft -> approved flip is yours.

Merge ordering: rewrites the committed `.derived` artifacts; next staged spec (012) moves in only after this merges.
