### PR TITLE
feat: named index hash slices and check --slice (spec 012)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "b46eef307d927c10909686cf437219833b5c1d20ae32cf9405edb3f3e173857a",
+    "contentHash": "092cbef54cd939c31306c7568f97617c9be0c9bb3934176765ebb57be7ce71f3",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -36,7 +36,7 @@
       "version": "0.2.0"
     }
   ],
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.2.0",
   "traceability": {
     "mappings": [
       {
@@ -1008,6 +1008,170 @@
           }
         ],
         "specId": "011-index-render-orphans",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "004-codebase-index"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-cli/src/cmd_index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/tests/cli.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/schemas/codebase-index.schema.json",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/codebase.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/config.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/version.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/dtos.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/cmd_index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/cmd_index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/tests/cli.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/tests/cli.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/lib.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/schemas/codebase-index.schema.json"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/schemas/codebase-index.schema.json"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/codebase.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/codebase.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/config.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/config.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/version.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/version.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/dtos.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/dtos.rs"
+            }
+          }
+        ],
+        "specId": "012-index-hash-slices",
         "specStatus": "draft"
       }
     ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "12206dab05175cc88634065ded1f8d3dabab78939bb461c6abd8158f975fa921",
+    "contentHash": "30c652918abc589c763a2b4d3eb05441f1b663fd845a00e0b11315a69d93a3d8",
     "inputRoot": "."
   },
   "specVersion": "0.1.0",
@@ -578,6 +578,106 @@
       "status": "draft",
       "summary": "Implements the two subcommands spec 004's CLI reserved but stubbed: `spec-spine index render` (a deterministic human-shaped markdown projection of the committed index.json -- package inventory, traceability, diagnostics) and `spec-spine index orphans` (the orphanedSpecs list, newline ids or a --json array). Both are pure read-side projections of the committed artifact; neither recomputes the index. Establishes the render module; extends the index CLI dispatch.\n",
       "title": "Index: implement the reserved render and orphans subcommands"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "004-codebase-index"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/config.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/codebase.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/version.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/schemas/codebase-index.schema.json"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        }
+      ],
+      "id": "012-index-hash-slices",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "012: Named hash slices",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Config",
+        "3.2 Emission",
+        "3.3 `index check --slice <name>`",
+        "3.4 Determinism",
+        "3.5 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/012-index-hash-slices/spec.md",
+      "status": "draft",
+      "summary": "Named sub-hashes of the index's input set: an adopter declares glob groups under `[index.slices]`, the indexer emits a per-slice content hash into `build.sliceHashes` (additive index-schema MINOR), and `spec-spine index check --slice <name>` gates on exactly that slice -- fresh (0), stale (2), config/IO error (3). Generalizes the narrow high-value staleness gate OAP runs over its agent-config files (settings/MCP JSON) without hardcoding any adopter's file list into the core.\n",
+      "title": "Index: named hash slices and `index check --slice <name>`"
     }
   ],
   "validation": {

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 
 use clap::Subcommand;
 use spec_spine_core::{
-    Freshness, check_index_freshness, index, load_index, orphans, render_markdown,
+    Freshness, check_index_freshness, check_slice_freshness, index, load_index, orphans,
+    render_markdown,
 };
 use spec_spine_types::{CodebaseIndex, Config, Error};
 
@@ -16,7 +17,11 @@ use crate::load_repo_config;
 #[derive(Subcommand)]
 pub enum IndexAction {
     /// Check the committed index against current inputs (the staleness gate).
-    Check,
+    Check {
+        /// Gate one named [index.slices] slice instead of the global hash.
+        #[arg(long, value_name = "NAME")]
+        slice: Option<String>,
+    },
     /// Render the committed index as markdown (a projection; never recomputes).
     Render,
     /// List orphaned specs from the committed index.
@@ -66,18 +71,27 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
             }
             Ok(0)
         }
-        Some(IndexAction::Check) => match check_index_freshness(&cfg, repo)? {
-            Freshness::Fresh => {
-                println!("index is fresh");
-                Ok(0)
+        Some(IndexAction::Check { slice }) => {
+            let (freshness, subject) = match slice {
+                Some(name) => (
+                    check_slice_freshness(&cfg, repo, name)?,
+                    format!("slice '{name}'"),
+                ),
+                None => (check_index_freshness(&cfg, repo)?, "index".to_string()),
+            };
+            match freshness {
+                Freshness::Fresh => {
+                    println!("{subject} is fresh");
+                    Ok(0)
+                }
+                Freshness::Stale { expected, actual } => {
+                    eprintln!("{subject} is STALE (run `spec-spine index` to refresh)");
+                    eprintln!("  expected content-hash: {expected}");
+                    eprintln!("  actual content-hash:   {actual}");
+                    Ok(2)
+                }
             }
-            Freshness::Stale { expected, actual } => {
-                eprintln!("index is STALE (run `spec-spine index` to refresh)");
-                eprintln!("  expected content-hash: {expected}");
-                eprintln!("  actual content-hash:   {actual}");
-                Ok(2)
-            }
-        },
+        }
         None => {
             let outcome = index(&cfg, repo)?;
             let out_dir = repo.join(&cfg.layout.derived_dir).join("codebase-index");

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -24,6 +24,126 @@ fn code(out: &std::process::Output) -> i32 {
 }
 
 #[test]
+fn index_slice_hashes_and_check() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "approved");
+    fs::create_dir_all(tmp.path().join("conf")).unwrap();
+    fs::write(tmp.path().join("conf/a.json"), "{\"a\":1}\n").unwrap();
+    fs::write(tmp.path().join("conf/b.json"), "{\"b\":2}\n").unwrap();
+    let run = |args: &[&str]| {
+        let out = bin().arg("--repo").arg(tmp.path()).args(args).output();
+        out.unwrap()
+    };
+    let index_json =
+        || fs::read_to_string(tmp.path().join(".derived/codebase-index/index.json")).unwrap();
+
+    // No slices configured: field absent; --slice is a config error (3).
+    assert_eq!(code(&run(&["index"])), 0);
+    assert!(!index_json().contains("sliceHashes"));
+    assert_eq!(
+        code(&run(&["index", "check", "--slice", "agent-config"])),
+        3,
+        "unknown slice name -> 3"
+    );
+
+    // Slices configured AFTER the committed index: missing entry -> stale.
+    fs::write(
+        tmp.path().join("spec-spine.toml"),
+        "[index.slices]\nzz-last = [\"conf/b.json\"]\nagent-config = [\"conf/a.json\", \"conf/missing.json\"]\n",
+    )
+    .unwrap();
+    assert_eq!(
+        code(&run(&["index", "check", "--slice", "agent-config"])),
+        2,
+        "an index predating the slice config is not vouching for it"
+    );
+
+    // Rebuild: entries emitted key-sorted; both slices fresh.
+    assert_eq!(code(&run(&["index"])), 0);
+    let raw = index_json();
+    assert!(raw.contains("sliceHashes"));
+    assert!(
+        raw.find("agent-config").unwrap() < raw.find("zz-last").unwrap(),
+        "sliceHashes keys are sorted"
+    );
+    assert_eq!(
+        code(&run(&["index", "check", "--slice", "agent-config"])),
+        0
+    );
+    assert_eq!(code(&run(&["index", "check", "--slice", "zz-last"])), 0);
+    assert_eq!(code(&run(&["index", "check"])), 0);
+
+    // Independence: a slice-only file's edit trips its slice, not the global
+    // gate and not the other slice.
+    fs::write(tmp.path().join("conf/a.json"), "{\"a\":99}\n").unwrap();
+    assert_eq!(code(&run(&["index", "check"])), 0, "global gate unaffected");
+    assert_eq!(
+        code(&run(&["index", "check", "--slice", "agent-config"])),
+        2
+    );
+    assert_eq!(code(&run(&["index", "check", "--slice", "zz-last"])), 0);
+
+    // ...and vice versa: a global-input edit leaves the slices fresh.
+    write_spec(tmp.path(), "001-a", "001-a", "draft");
+    assert_eq!(
+        code(&run(&["index", "check"])),
+        2,
+        "spec.md is global input"
+    );
+    assert_eq!(code(&run(&["index", "check", "--slice", "zz-last"])), 0);
+
+    // Deletion of a guarded file is a hash change, not a config error.
+    assert_eq!(code(&run(&["index"])), 0);
+    fs::remove_file(tmp.path().join("conf/b.json")).unwrap();
+    assert_eq!(code(&run(&["index", "check", "--slice", "zz-last"])), 2);
+
+    // Unknown name with slices configured is still 3.
+    assert_eq!(code(&run(&["index", "check", "--slice", "nope"])), 3);
+}
+
+#[test]
+fn invalid_slice_config_exits_3() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "approved");
+
+    // Name outside [a-z0-9][a-z0-9-]*.
+    fs::write(
+        tmp.path().join("spec-spine.toml"),
+        "[index.slices]\n\"Bad_Name\" = [\"conf/*.json\"]\n",
+    )
+    .unwrap();
+    assert_eq!(
+        code(
+            &bin()
+                .arg("--repo")
+                .arg(tmp.path())
+                .arg("index")
+                .output()
+                .unwrap()
+        ),
+        3
+    );
+
+    // Empty glob list.
+    fs::write(
+        tmp.path().join("spec-spine.toml"),
+        "[index.slices]\nok = []\n",
+    )
+    .unwrap();
+    assert_eq!(
+        code(
+            &bin()
+                .arg("--repo")
+                .arg(tmp.path())
+                .arg("index")
+                .output()
+                .unwrap()
+        ),
+        3
+    );
+}
+
+#[test]
 fn compile_ok_then_queries() {
     let tmp = tempfile::tempdir().unwrap();
     write_spec(tmp.path(), "001-a", "001-a", "approved");

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -195,6 +195,7 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
             indexer_version: env!("CARGO_PKG_VERSION").to_string(),
             repo_root: ".".to_string(),
             content_hash,
+            slice_hashes: compute_slice_hashes(cfg, repo_root),
         },
         packages: discovered.packages,
         traceability: Traceability {
@@ -216,17 +217,7 @@ pub fn check_index_freshness(
     cfg: &spec_spine_types::Config,
     repo_root: &Path,
 ) -> Result<Freshness, Error> {
-    let index_path = repo_root
-        .join(&cfg.layout.derived_dir)
-        .join("codebase-index")
-        .join("index.json");
-    let bytes = fs::read(&index_path).map_err(|e| {
-        Error::Io(format!(
-            "read {} (run `spec-spine index` first?): {e}",
-            index_path.display()
-        ))
-    })?;
-    let committed = crate::load_index(&bytes)?;
+    let committed = read_committed_index(cfg, repo_root)?;
 
     // Blocking resolver diagnostics also fail freshness.
     if committed
@@ -262,6 +253,37 @@ pub fn check_index_freshness(
     }
 }
 
+/// Recompute one named slice and compare it to the committed
+/// `build.sliceHashes` entry (spec 012 §3.3). A single-subject gate: it never
+/// consults the global hash or diagnostics. Unknown name → [`Error::Config`]
+/// (exit 3); a committed index with no entry for a configured slice is
+/// `Stale`, not an error — an index predating the slice config is by
+/// definition not vouching for it.
+pub fn check_slice_freshness(
+    cfg: &spec_spine_types::Config,
+    repo_root: &Path,
+    name: &str,
+) -> Result<Freshness, Error> {
+    let Some(patterns) = cfg.index.slices.get(name) else {
+        return Err(Error::Config(format!(
+            "unknown slice '{name}' (declare it under [index.slices] in spec-spine.toml)"
+        )));
+    };
+    let committed = read_committed_index(cfg, repo_root)?;
+    let actual = slice_hash(repo_root, patterns);
+    match committed.build.slice_hashes.get(name) {
+        Some(expected) if *expected == actual => Ok(Freshness::Fresh),
+        Some(expected) => Ok(Freshness::Stale {
+            expected: expected.clone(),
+            actual,
+        }),
+        None => Ok(Freshness::Stale {
+            expected: "(no committed sliceHashes entry)".to_string(),
+            actual,
+        }),
+    }
+}
+
 /// "Who currently owns this unit?" — a set query over resolved traceability.
 pub fn authorities(index: &CodebaseIndex, unit: &Unit) -> Vec<String> {
     let mut owners: BTreeSet<String> = BTreeSet::new();
@@ -281,6 +303,54 @@ pub fn authorities(index: &CodebaseIndex, unit: &Unit) -> Vec<String> {
 }
 
 // ===== helpers =====
+
+/// Read and parse the committed `index.json`.
+fn read_committed_index(
+    cfg: &spec_spine_types::Config,
+    repo_root: &Path,
+) -> Result<CodebaseIndex, Error> {
+    let index_path = repo_root
+        .join(&cfg.layout.derived_dir)
+        .join("codebase-index")
+        .join("index.json");
+    let bytes = fs::read(&index_path).map_err(|e| {
+        Error::Io(format!(
+            "read {} (run `spec-spine index` first?): {e}",
+            index_path.display()
+        ))
+    })?;
+    crate::load_index(&bytes)
+}
+
+/// One `build.sliceHashes` entry per configured slice (spec 012 §3.2).
+fn compute_slice_hashes(
+    cfg: &spec_spine_types::Config,
+    repo_root: &Path,
+) -> BTreeMap<String, String> {
+    cfg.index
+        .slices
+        .iter()
+        .map(|(name, patterns)| (name.clone(), slice_hash(repo_root, patterns)))
+        .collect()
+}
+
+/// SHA-256 over a slice's matched files: the same normalization and
+/// path-sorted folding as the global hash. Zero matches hash the empty input
+/// sequence — deletion of a guarded file reads as a hash change, never a
+/// config error.
+fn slice_hash(repo_root: &Path, patterns: &[String]) -> String {
+    let mut pieces: Vec<(String, String)> = Vec::new();
+    for pattern in patterns {
+        for file in glob_files(repo_root, pattern) {
+            if let Ok(content) = fs::read_to_string(&file) {
+                pieces.push((rel_posix(repo_root, &file), content));
+            }
+        }
+    }
+    pieces.sort_by(|a, b| a.0.cmp(&b.0));
+    pieces.dedup_by(|a, b| a.0 == b.0);
+    hash::content_hash(pieces)
+}
 
 fn discover_specs(
     cfg: &spec_spine_types::Config,

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -46,7 +46,9 @@ pub use dep_only::{
     DEPENDENCY_TABLES, FileContents, dependency_only_change, dependency_only_waiver,
     is_package_json,
 };
-pub use index::{Freshness, IndexOutcome, authorities, check_index_freshness, index};
+pub use index::{
+    Freshness, IndexOutcome, authorities, check_index_freshness, check_slice_freshness, index,
+};
 pub use lint::{LintReport, lint};
 pub use query::{
     ListFilter, RelationshipView, StatusReport, StatusReportNonzero, list, list_ids, load_index,

--- a/crates/spec-spine-types/schemas/codebase-index.schema.json
+++ b/crates/spec-spine-types/schemas/codebase-index.schema.json
@@ -16,7 +16,12 @@
         "indexerId": { "type": "string", "minLength": 1 },
         "indexerVersion": { "type": "string", "minLength": 1 },
         "repoRoot": { "type": "string" },
-        "contentHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        "contentHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "sliceHashes": {
+          "type": "object",
+          "propertyNames": { "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "additionalProperties": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
       }
     },
     "packages": {

--- a/crates/spec-spine-types/src/codebase.rs
+++ b/crates/spec-spine-types/src/codebase.rs
@@ -3,6 +3,8 @@
 //! OAP `codebase-index.schema.json` (3.0.0), pruned to the generic v1 surface and
 //! re-versioned to this library's own `0.1.0`.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::unit::Unit;
@@ -30,6 +32,11 @@ pub struct IndexBuild {
     pub repo_root: String,
     /// SHA-256 over the normalized, path-sorted manifest + spec + extra inputs.
     pub content_hash: String,
+    /// Per-slice content hashes (spec 012): one entry per `[index.slices]`
+    /// key, same normalization as `content_hash`. Absent when no slices are
+    /// configured; loaders tolerate absence (additive MINOR).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub slice_hashes: BTreeMap<String, String>,
 }
 
 /// The kind of a discovered compilation unit.

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -120,6 +120,12 @@ pub struct IndexConfig {
     pub extra_hashed_inputs: Vec<String>,
     /// Directory names pruned from symbol/section resolution walks.
     pub resolver_exclusions: Vec<String>,
+    /// `[index.slices]` (spec 012): named glob groups, each emitted as a
+    /// `build.sliceHashes` entry and gated by `index check --slice <name>`.
+    /// Names match `[a-z0-9][a-z0-9-]*`; each list is non-empty, with
+    /// `extra_hashed_inputs` pattern semantics. Slices are independent of the
+    /// global hash: listing a file here does NOT fold it into `contentHash`.
+    pub slices: BTreeMap<String, Vec<String>>,
 }
 
 impl Default for IndexConfig {
@@ -129,6 +135,7 @@ impl Default for IndexConfig {
                 "standards/**".to_string(),
                 ".github/workflows/**".to_string(),
             ],
+            slices: BTreeMap::new(),
             resolver_exclusions: vec![
                 "target".to_string(),
                 "node_modules".to_string(),
@@ -227,5 +234,30 @@ pub struct FrontmatterConfig {
 /// Returns [`Error::Config`] (mapped to exit code 3) on any malformed or
 /// unknown-key error — never panics.
 pub fn load_config(toml_src: &str) -> Result<Config> {
-    toml::from_str(toml_src).map_err(|e| Error::Config(e.to_string()))
+    let config: Config = toml::from_str(toml_src).map_err(|e| Error::Config(e.to_string()))?;
+    validate_slices(&config)?;
+    Ok(config)
+}
+
+/// `[index.slices]` grammar (spec 012 §3.1): names match
+/// `[a-z0-9][a-z0-9-]*`, glob lists are non-empty.
+fn validate_slices(config: &Config) -> Result<()> {
+    for (name, globs) in &config.index.slices {
+        let mut chars = name.chars();
+        let head_ok = chars
+            .next()
+            .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+        let tail_ok = chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+        if !(head_ok && tail_ok) {
+            return Err(Error::Config(format!(
+                "[index.slices] name '{name}' must match [a-z0-9][a-z0-9-]*"
+            )));
+        }
+        if globs.is_empty() {
+            return Err(Error::Config(format!(
+                "[index.slices] '{name}' must list at least one glob"
+            )));
+        }
+    }
+    Ok(())
 }

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -14,7 +14,8 @@
 pub const REGISTRY_SCHEMA_VERSION: &str = "0.1.0";
 
 /// `schemaVersion` emitted in `index.json`. (Index DTOs land in Phase 3.)
-pub const INDEX_SCHEMA_VERSION: &str = "0.1.0";
+/// `0.2.0`: additive `build.sliceHashes` (spec 012).
+pub const INDEX_SCHEMA_VERSION: &str = "0.2.0";
 
 /// `schemaVersion` emitted in `build-meta.json` (the non-deterministic artifact).
 pub const BUILD_META_SCHEMA_VERSION: &str = "0.1.0";

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -68,9 +68,10 @@ fn validation_passed_follows_error_tier() {
 }
 
 #[test]
-fn schema_versions_start_fresh_at_0_1_0() {
+fn schema_versions_are_pinned() {
     assert_eq!(REGISTRY_SCHEMA_VERSION, "0.1.0");
-    assert_eq!(INDEX_SCHEMA_VERSION, "0.1.0");
+    // 0.2.0: additive `build.sliceHashes` (spec 012).
+    assert_eq!(INDEX_SCHEMA_VERSION, "0.2.0");
     assert_eq!(BUILD_META_SCHEMA_VERSION, "0.1.0");
     assert_eq!(CONFIG_VERSION, "0.1.0");
 }

--- a/specs/012-index-hash-slices/spec.md
+++ b/specs/012-index-hash-slices/spec.md
@@ -1,0 +1,117 @@
+---
+id: "012-index-hash-slices"
+title: "Index: named hash slices and `index check --slice <name>`"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "004-codebase-index"
+extends:
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/codebase.rs", nature: additive }
+  # The MINOR bump touches the version constant and the embedded JSON schema;
+  # the re-export and e2e tests touch 001's surface. All additive, same shape
+  # as specs 010/011.
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/version.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/schemas/codebase-index.schema.json", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/dtos.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+summary: >
+  Named sub-hashes of the index's input set: an adopter declares glob groups
+  under `[index.slices]`, the indexer emits a per-slice content hash into
+  `build.sliceHashes` (additive index-schema MINOR), and `spec-spine index
+  check --slice <name>` gates on exactly that slice -- fresh (0), stale (2),
+  config/IO error (3). Generalizes the narrow high-value staleness gate OAP
+  runs over its agent-config files (settings/MCP JSON) without hardcoding any
+  adopter's file list into the core.
+---
+
+# 012: Named hash slices
+
+## 1. Purpose
+
+The full `index check` is the right default gate, but some inputs deserve a
+*dedicated* gate with their own CI job and failure message: files whose quiet
+drift is a governance event, not a freshness event. The motivating consumer is
+OAP's config-slice gate (its specs 184/188): a narrow check over
+`.claude/settings.json` + `.mcp.json` that fails PRs independently of -- and
+with a sharper message than -- the broad staleness check. Today that exists as
+a hardcoded `check-config` subcommand in OAP's fork-ancestor indexer. The
+library generalizes it: **slices are adopter config, not core vocabulary.**
+
+## 2. Territory
+
+Config grammar (`config.rs`: the `[index.slices]` table), the index DTO
+(`codebase.rs`: `build.sliceHashes`), slice hashing + checking (`index.rs`),
+and the CLI flag (`cmd_index.rs`). The MINOR bump rides through `version.rs`
+and the embedded index JSON schema; the new check surfaces through 001's
+`lib.rs` re-export list and its e2e test file. All additive.
+
+## 3. Behavior
+
+### 3.1 Config
+
+```toml
+[index.slices]
+agent-config = [".claude/settings.json", ".mcp.json"]
+workflows    = [".github/workflows/**"]
+```
+
+- Each key is a slice name (`[a-z0-9][a-z0-9-]*`); each value is a non-empty
+  glob list with the same pattern semantics as `index.extra_hashed_inputs`.
+- Slices are **independent** of the global hash: a slice's files need not
+  appear in the global input set, and listing them in a slice does NOT add
+  them to it. An adopter wanting both gates lists the globs in both knobs.
+  (Stated explicitly so nobody "deduplicates" the overlap away.)
+- Default: no slices. Absent table ⇒ behavior identical to pre-012.
+
+### 3.2 Emission
+
+- `spec-spine index` computes, per slice, SHA-256 over the slice's matched
+  files using the **same normalization and path-sorted folding** as
+  `build.contentHash` (004 §3.5), and emits
+  `build.sliceHashes: { "<name>": "<hex>" }` (key-sorted; omitted entirely
+  when no slices are configured).
+- A slice matching zero files is valid (hash of the empty input sequence) --
+  deletion of a guarded file must read as a hash *change*, not a config error.
+- Index schema: **MINOR bump** (additive optional field; loaders tolerate
+  absence per `docs/schema-versioning.md`).
+
+### 3.3 `index check --slice <name>`
+
+- Recomputes only the named slice over the current tree and compares against
+  the committed `build.sliceHashes.<name>`.
+- Exit `0` fresh; `2` stale (mismatch, OR the committed index has no entry for
+  a configured slice -- an index predating the slice config is by definition
+  not vouching for it); `3` when the name is not in `[index.slices]`, or on
+  I/O / parse / schema failure.
+- Plain `index check` (no flag) is unchanged: it gates the global hash only.
+  It does NOT additionally verify slices -- one gate per invocation keeps CI
+  failure messages single-subject (the adopter wires one job per slice).
+- `--slice` takes exactly one name; repeat the invocation for multiple slices.
+
+### 3.4 Determinism
+
+Slice hashes are pure functions of `(config, file contents)`; byte-identical
+across the release matrix, proven by the same fixture style as the global
+hash.
+
+### 3.5 Tests (minimum)
+
+- Emission: configured slices appear key-sorted; no config ⇒ field absent.
+- Check: fresh, content-drift stale, file-deletion stale, missing-entry stale,
+  unknown-name error.
+- Independence: a slice-only file's edit does not trip plain `index check`,
+  and vice versa.
+
+## 4. Out of scope
+
+Hardcoded slice names or any adopter's file list in core. Multi-slice or
+all-slices check forms (`--slice a --slice b`, `check --all-slices`) -- defer
+until a real consumer needs them. Folding slices into the coupling gate's
+freshness guard (005 keeps consulting the global hash only).


### PR DESCRIPTION
Lands `specs/012-index-hash-slices` (PR 3 of 6 in the staged amendment series; strictly serial, after #8). Named sub-hashes of the index input set, generalizing OAP's hardcoded `check-config` gate without adopting its file list -- slices are adopter config, not core vocabulary.

- **Config** (`[index.slices]`): each key is a slice name (`[a-z0-9][a-z0-9-]*`), each value a non-empty glob list with `extra_hashed_inputs` pattern semantics. Validated at config load (exit 3 on violation). Absent table = behavior identical to pre-012.
- **Emission**: `spec-spine index` computes per-slice SHA-256 with the same normalization and path-sorted folding as `contentHash`, emitted as `build.sliceHashes` (key-sorted via BTreeMap + canonical JSON; omitted entirely when no slices configured). Index schema bumped 0.1.0 -> 0.2.0 (additive MINOR; loaders tolerate absence, JSON schema updated).
- **Gate** (`index check --slice <name>`): recomputes only the named slice; exit 0 fresh, 2 stale -- including the committed-index-has-no-entry case (an index predating the slice config is not vouching for it) -- and 3 for an unknown name or IO/parse/schema failure. Plain `index check` is unchanged and consults the global hash only (one gate per invocation, single-subject CI messages).
- **Independence is tested both ways**: a slice-only file edit does not trip the global gate, and a global-input edit (spec.md) does not trip a slice. Deletion of a guarded file reads as a hash change (empty input sequence is hashable), never a config error.

Implementation notes:
- Touched surfaces beyond the four units the staged spec declared: `version.rs` + the embedded index JSON schema (the MINOR bump), 001's `lib.rs` (re-export of `check_slice_freshness`) and `tests/cli.rs` (e2e), and `tests/dtos.rs` (the pinned-versions conformance test now expects 0.2.0). All declared as additive extends edges in the spec frontmatter; the Territory prose was aligned. Em dashes normalized to `--`.
- `check_index_freshness` and the new slice check now share a `read_committed_index` helper (pure refactor).
- This repo configures no slices itself, so its regenerated `index.json` carries schemaVersion 0.2.0 with no `sliceHashes` field -- the absence path is dogfooded here, the presence path in e2e tests.

Gates: `compile` (0 warnings), `index` + `index check` (fresh), `lint` (0/0/0), `couple --base origin/main --head HEAD` (10 paths, no drift). Full workspace test suite passes (21 suites).

**Review call for the maintainer:** spec lands with `implementation: complete`, `status: draft`; the draft -> approved flip is yours.

Merge ordering: rewrites the committed `.derived` artifacts; next staged spec (013) moves in only after this merges.