### PR TITLE
feat: declared extra-frontmatter passthrough (spec 013)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "092cbef54cd939c31306c7568f97617c9be0c9bb3934176765ebb57be7ce71f3",
+    "contentHash": "7329f79dd935383da0416f962ace3c1d570375250e88993433b4d90cab609b04",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -1172,6 +1172,187 @@
           }
         ],
         "specId": "012-index-hash-slices",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/src/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/schemas/registry.schema.json",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/frontmatter.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/registry.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/version.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/dtos.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/frontmatter.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/schemas/registry.schema.json"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/schemas/registry.schema.json"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/frontmatter.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/frontmatter.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/lib.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/registry.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/registry.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/version.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/version.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/dtos.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/dtos.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/frontmatter.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/frontmatter.rs"
+            }
+          }
+        ],
+        "specId": "013-declared-extra-frontmatter-passthrough",
         "specStatus": "draft"
       }
     ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,10 +2,10 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "30c652918abc589c763a2b4d3eb05441f1b663fd845a00e0b11315a69d93a3d8",
+    "contentHash": "0680d4d3508e790e1d569e4b25bdcd80b509e6c5dcb53a11b1eb58e6e48f1bd4",
     "inputRoot": "."
   },
-  "specVersion": "0.1.0",
+  "specVersion": "0.2.0",
   "specs": [
     {
       "authors": [
@@ -678,6 +678,114 @@
       "status": "draft",
       "summary": "Named sub-hashes of the index's input set: an adopter declares glob groups under `[index.slices]`, the indexer emits a per-slice content hash into `build.sliceHashes` (additive index-schema MINOR), and `spec-spine index check --slice <name>` gates on exactly that slice -- fresh (0), stale (2), config/IO error (3). Generalizes the narrow high-value staleness gate OAP runs over its agent-config files (settings/MCP JSON) without hardcoding any adopter's file list into the core.\n",
       "title": "Index: named hash slices and `index check --slice <name>`"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "001-compile-registry"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/frontmatter.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/registry.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/version.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/schemas/registry.schema.json"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/frontmatter.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/compile.rs"
+          }
+        }
+      ],
+      "id": "013-declared-extra-frontmatter-passthrough",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "013: Declared extra-frontmatter passthrough",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 The declared/undeclared split",
+        "3.2 Normalization (determinism)",
+        "3.3 Unrepresentable values: `V-013`",
+        "3.4 Schema impact",
+        "3.5 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/013-declared-extra-frontmatter-passthrough/spec.md",
+      "status": "draft",
+      "summary": "Widens the value domain of DECLARED extra-frontmatter keys (`config.frontmatter.extra_known_keys`) from scalars + string-lists to any JSON-representable YAML value (nested maps, mixed lists), carried verbatim into SpecRecord.extra_frontmatter under canonical-JSON normalization. Undeclared keys keep the existing scalar/string-list restriction and the V-007 cap -- the anti-bulk-YAML guard is untouched. Registry schema MINOR. This is the load-bearing half of the overlay contract: overlays cannot consume domain frontmatter the compiler drops.\n",
+      "title": "Frontmatter: declared extra keys carry arbitrary YAML, verbatim"
     }
   ],
   "validation": {

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -10,8 +10,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use spec_spine_types::{
-    Build, Config, Error, Frontmatter, REGISTRY_SCHEMA_VERSION, Registry, Severity, SpecRecord,
-    Status, ValidationReport, Violation, parse_frontmatter, split_frontmatter,
+    Build, Config, Error, Frontmatter, FrontmatterIssue, REGISTRY_SCHEMA_VERSION, Registry,
+    Severity, SpecRecord, Status, ValidationReport, Violation, parse_frontmatter_with,
+    split_frontmatter,
 };
 
 use crate::{canonical_json, hash, markdown};
@@ -75,7 +76,7 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
         let spec_path = rel_posix(repo_root, spec_md);
         hash_pieces.push((spec_path.clone(), raw.clone()));
 
-        match parse_frontmatter(&raw) {
+        match parse_frontmatter_with(&raw, &cfg.frontmatter.extra_known_keys) {
             Ok(fm) => {
                 let body = split_frontmatter(&raw).map(|(_, b)| b).unwrap_or_default();
                 parsed.push(Parsed {
@@ -85,9 +86,21 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
                     body,
                 });
             }
-            Err(e) => violations.push(error(
+            // V-013 (spec 013 §3.3): a DECLARED extra key carrying a value
+            // JSON cannot represent. Same skip-and-continue semantics as
+            // V-002 (001 §3.1).
+            Err(FrontmatterIssue::UnrepresentableDeclared { key, detail }) => {
+                violations.push(error(
+                    "V-013",
+                    format!(
+                        "declared extra-frontmatter key '{key}' carries an unrepresentable YAML value: {detail}"
+                    ),
+                    Some(spec_path),
+                ));
+            }
+            Err(FrontmatterIssue::Malformed(m)) => violations.push(error(
                 "V-002",
-                format!("malformed frontmatter: {e}"),
+                format!("malformed frontmatter: {m}"),
                 Some(spec_path),
             )),
         }
@@ -140,7 +153,8 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
     })
 }
 
-/// Per-spec validation codes V-001/005/006/007/008/009/010/012.
+/// Per-spec validation codes V-001/005/006/007/008/009/010/012 (V-013 is
+/// emitted at the parse stage above).
 fn validate_spec(
     cfg: &Config,
     dirname: &str,

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use spec_spine_types::{
     CodebaseIndex, Diagnostic, Diagnostics, Error, INDEX_SCHEMA_VERSION, ImplementingPath,
     IndexBuild, ResolvedLocation, ResolvedUnit, SourceField, TraceMapping, TraceSource,
-    Traceability, Unit, parse_frontmatter,
+    Traceability, Unit, parse_frontmatter_with,
 };
 
 use crate::manifest;
@@ -374,8 +374,10 @@ fn discover_specs(
         let Ok(raw) = fs::read_to_string(&spec_md) else {
             continue;
         };
-        let Ok(fm) = parse_frontmatter(&raw) else {
-            continue; // compile reports the V-002; the index skips it
+        // Declared-key awareness (spec 013): a nested value under a declared
+        // extra key must not knock the spec out of the index.
+        let Ok(fm) = parse_frontmatter_with(&raw, &cfg.frontmatter.extra_known_keys) else {
+            continue; // compile reports the V-002/V-013; the index skips it
         };
         let mut units: Vec<(SourceField, Unit, bool)> = Vec::new();
         for u in &fm.establishes {

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -176,6 +176,105 @@ fn v007_extra_frontmatter_count_cap_with_exemption() {
 }
 
 #[test]
+fn declared_nested_extra_roundtrips_deterministically() {
+    // Spec 013 §3.5: a compliance-shaped declared key survives compile ->
+    // registry byte-identically across two runs.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        "compliance:\n  reviewed: true\n  owasp:\n    - \"A01\"\n    - \"A03\"\n",
+    );
+    let mut cfg = Config::default();
+    cfg.frontmatter.extra_known_keys = vec!["compliance".into()];
+
+    let first = compile(&cfg, tmp.path()).unwrap();
+    let second = compile(&cfg, tmp.path()).unwrap();
+    assert!(first.validation_passed);
+    assert_eq!(first.json, second.json, "byte-identical across two runs");
+    assert_eq!(
+        first.registry.specs[0].extra_frontmatter.get("compliance"),
+        Some(&serde_json::json!({"owasp": ["A01", "A03"], "reviewed": true}))
+    );
+}
+
+#[test]
+fn declared_map_key_order_is_canonicalized() {
+    // Spec 013 §3.2/§3.5: two authoring orders, one registry value.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cfg = Config::default();
+    cfg.frontmatter.extra_known_keys = vec!["compliance".into()];
+
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        "compliance:\n  zz: 1\n  aa: 2\n",
+    );
+    let one = compile(&cfg, tmp.path()).unwrap().registry.specs[0]
+        .extra_frontmatter
+        .clone();
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        "compliance:\n  aa: 2\n  zz: 1\n",
+    );
+    let two = compile(&cfg, tmp.path()).unwrap().registry.specs[0]
+        .extra_frontmatter
+        .clone();
+    assert_eq!(one, two);
+}
+
+#[test]
+fn undeclared_nested_extra_keeps_pre013_guard() {
+    // Guard regression (spec 013 §3.5): an UNDECLARED nested map is rejected
+    // exactly as pre-013 (V-002, spec skipped).
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "custom_obj:\n  nested: 1\n");
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(codes(&outcome).contains(&"V-002".to_string()));
+    assert!(!outcome.validation_passed);
+    assert!(outcome.registry.specs.is_empty(), "the spec is skipped");
+}
+
+#[test]
+fn v013_unrepresentable_declared_value() {
+    // A non-string map key under a DECLARED key -> V-013, skip-and-continue.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "compliance:\n  1: \"x\"\n");
+    write_spec(tmp.path(), "002-ok", "002-ok", "");
+    let mut cfg = Config::default();
+    cfg.frontmatter.extra_known_keys = vec!["compliance".into()];
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+    assert!(codes(&outcome).contains(&"V-013".to_string()));
+    assert!(!outcome.validation_passed);
+    assert!(outcome.registry.specs.iter().any(|s| s.id == "002-ok"));
+    assert!(!outcome.registry.specs.iter().any(|s| s.id == "001-a"));
+}
+
+#[test]
+fn v007_cap_unchanged_in_presence_of_declared_keys() {
+    // Spec 013 §3.5: the undeclared cap is counted and enforced exactly as
+    // before, with declared keys present and exempt.
+    let tmp = tempfile::tempdir().unwrap();
+    let n = MAX_UNDECLARED_EXTRA_FRONTMATTER + 1;
+    let mut extra = String::from("compliance:\n  reviewed: true\n");
+    for i in 0..n {
+        extra.push_str(&format!("x_key_{i}: {i}\n"));
+    }
+    write_spec(tmp.path(), "001-a", "001-a", &extra);
+    let mut cfg = Config::default();
+    cfg.frontmatter.extra_known_keys = vec!["compliance".into()];
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+    assert!(
+        codes(&outcome).contains(&"V-007".to_string()),
+        "undeclared cap still fires"
+    );
+}
+
+#[test]
 fn v005_domain_allowlist_when_enabled() {
     let tmp = tempfile::tempdir().unwrap();
     write_spec(tmp.path(), "001-a", "001-a", "domain: \"galaxy\"\n");

--- a/crates/spec-spine-types/schemas/registry.schema.json
+++ b/crates/spec-spine-types/schemas/registry.schema.json
@@ -53,6 +53,10 @@
         "risk": { "enum": ["low", "medium", "high", "critical"] },
         "implementation": {
           "enum": ["pending", "in-progress", "complete", "n-a", "deferred"]
+        },
+        "extraFrontmatter": {
+          "type": "object",
+          "description": "Adopter frontmatter transported by the compiler. Declared keys (frontmatter.extra_known_keys) carry any JSON value (spec 013, specVersion 0.2.0); undeclared keys are scalars or string arrays."
         }
       }
     },

--- a/crates/spec-spine-types/src/frontmatter.rs
+++ b/crates/spec-spine-types/src/frontmatter.rs
@@ -1,13 +1,16 @@
 //! The spec frontmatter grammar: the typed `Frontmatter` struct, the value
 //! enums, the `extra_frontmatter` overflow, and the parse entry points.
 //!
-//! Parsing is config-free and pure. The `---`-delimited block is split out
+//! Parsing is pure. The `---`-delimited block is split out
 //! ([`split_frontmatter`]), the known keys are deserialized into [`Frontmatter`],
 //! and every key not in [`KNOWN_KEYS`] overflows into `extra_frontmatter` as a
-//! scalar or string-list (ported from OAP/aide `spec-types`). Whether an extra
-//! key is *warned about* is a lint concern driven by
-//! `config.frontmatter.extra_known_keys`, not a parse concern — so this module
-//! needs no `Config`.
+//! `serde_json::Value`. The value domain splits on declaration (spec 013):
+//! a key listed in `config.frontmatter.extra_known_keys` (passed to
+//! [`parse_frontmatter_with`]) carries **any JSON-representable YAML value**,
+//! transported verbatim under canonical-JSON normalization; an undeclared key
+//! keeps the original scalar / string-list restriction (the anti-bulk-YAML
+//! guard, ported from OAP/aide `spec-types`). [`parse_frontmatter`] is the
+//! declared-nothing form, byte-compatible with pre-013 behavior.
 
 use std::collections::BTreeMap;
 
@@ -49,18 +52,26 @@ pub enum Implementation {
     Deferred,
 }
 
-/// A scalar or string-list value carried in `extra_frontmatter`.
-///
-/// The grammar caps extra frontmatter to scalars and string lists; a complex
-/// (nested map / mixed list) value under an unknown key is a parse error.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ExtraValue {
-    Bool(bool),
-    Int(i64),
-    Float(f64),
-    Str(String),
-    List(Vec<String>),
+/// A failed frontmatter parse, classified for the compiler's V-code mapping
+/// (spec 013 §3.3).
+#[derive(Clone, Debug)]
+pub enum FrontmatterIssue {
+    /// Malformed YAML or a grammar violation — the V-002 class.
+    Malformed(String),
+    /// A DECLARED extra key whose value JSON cannot represent (non-string
+    /// mapping key, YAML tag, non-finite number) — the V-013 class.
+    UnrepresentableDeclared { key: String, detail: String },
+}
+
+impl From<FrontmatterIssue> for Error {
+    fn from(issue: FrontmatterIssue) -> Self {
+        match issue {
+            FrontmatterIssue::Malformed(m) => Error::Parse(m),
+            FrontmatterIssue::UnrepresentableDeclared { key, detail } => Error::Parse(format!(
+                "declared extra-frontmatter key '{key}' carries an unrepresentable YAML value: {detail}"
+            )),
+        }
+    }
 }
 
 /// Every frontmatter key modeled as a struct field. Keys outside this set
@@ -170,7 +181,7 @@ pub struct Frontmatter {
 
     // --- overflow (populated by parse_frontmatter, never by serde) ---
     #[serde(skip)]
-    pub extra_frontmatter: BTreeMap<String, ExtraValue>,
+    pub extra_frontmatter: BTreeMap<String, serde_json::Value>,
 }
 
 /// Split a `spec.md` source into its `(frontmatter_yaml, body)` halves.
@@ -216,79 +227,150 @@ pub fn split_frontmatter(src: &str) -> Result<(String, String)> {
     Ok((frontmatter, body))
 }
 
-/// Parse the frontmatter block of a `spec.md` into a typed [`Frontmatter`].
+/// Parse the frontmatter block of a `spec.md` into a typed [`Frontmatter`],
+/// treating every extra key as undeclared (pre-013 behavior, kept for
+/// config-free callers).
 ///
-/// Pure and config-free. Returns [`Error::Parse`] for a malformed block, a
-/// missing required key, an invalid enum value, or a non-scalar value under an
-/// unknown (overflow) key.
+/// Returns [`Error::Parse`] for a malformed block, a missing required key, an
+/// invalid enum value, or a non-scalar value under an unknown (overflow) key.
 pub fn parse_frontmatter(src: &str) -> Result<Frontmatter> {
-    let (yaml, _body) = split_frontmatter(src)?;
+    parse_frontmatter_with(src, &[]).map_err(Into::into)
+}
+
+/// Parse with declared-key awareness (spec 013): a key listed in `declared`
+/// (the adopter's `frontmatter.extra_known_keys`) carries any
+/// JSON-representable YAML value, transported verbatim; an undeclared key
+/// keeps the scalar / string-list restriction. A top-level `null` value drops
+/// the key on either path.
+pub fn parse_frontmatter_with(
+    src: &str,
+    declared: &[String],
+) -> std::result::Result<Frontmatter, FrontmatterIssue> {
+    let malformed = |m: String| FrontmatterIssue::Malformed(m);
+    let (yaml, _body) = split_frontmatter(src).map_err(|e| {
+        malformed(match e {
+            Error::Parse(m) => m,
+            other => other.to_string(),
+        })
+    })?;
 
     let value: serde_yaml::Value = serde_yaml::from_str(&yaml)
-        .map_err(|e| Error::Parse(format!("invalid YAML frontmatter: {e}")))?;
+        .map_err(|e| malformed(format!("invalid YAML frontmatter: {e}")))?;
 
     let mapping = value
         .as_mapping()
-        .ok_or_else(|| Error::Parse("frontmatter must be a YAML mapping".into()))?;
+        .ok_or_else(|| malformed("frontmatter must be a YAML mapping".into()))?;
 
     // Known keys (unknown keys are ignored here; collected below).
     let mut frontmatter: Frontmatter = serde_yaml::from_value(value.clone())
-        .map_err(|e| Error::Parse(format!("invalid frontmatter: {e}")))?;
+        .map_err(|e| malformed(format!("invalid frontmatter: {e}")))?;
 
     // Overflow: every key not in KNOWN_KEYS becomes an extra_frontmatter entry.
     for (k, v) in mapping {
         let key = match k.as_str() {
             Some(s) => s,
-            None => return Err(Error::Parse("frontmatter keys must be strings".into())),
+            None => return Err(malformed("frontmatter keys must be strings".into())),
         };
         if KNOWN_KEYS.contains(&key) {
             continue;
         }
-        if let Some(extra) = yaml_to_extra(v)? {
-            frontmatter.extra_frontmatter.insert(key.to_string(), extra);
+        let json = if declared.iter().any(|d| d == key) {
+            yaml_to_json(v).map_err(|detail| FrontmatterIssue::UnrepresentableDeclared {
+                key: key.to_string(),
+                detail,
+            })?
+        } else {
+            yaml_to_extra(v).map_err(malformed)?
+        };
+        if json.is_null() {
+            continue;
         }
+        frontmatter.extra_frontmatter.insert(key.to_string(), json);
     }
 
     Ok(frontmatter)
 }
 
-/// Convert a YAML scalar / string-list into an [`ExtraValue`]. `Null` yields
-/// `None` (the key is dropped); a nested map or mixed list is a parse error.
-fn yaml_to_extra(v: &serde_yaml::Value) -> Result<Option<ExtraValue>> {
+/// The UNDECLARED-key path: scalars and string lists only (`Null` drops the
+/// key); a nested map, mixed list, or tag is a grammar violation — exactly
+/// the pre-013 guard.
+fn yaml_to_extra(v: &serde_yaml::Value) -> std::result::Result<serde_json::Value, String> {
     use serde_yaml::Value;
-    Ok(match v {
-        Value::Null => None,
-        Value::Bool(b) => Some(ExtraValue::Bool(*b)),
+    match v {
+        Value::Null => Ok(serde_json::Value::Null),
+        Value::Bool(b) => Ok(serde_json::Value::Bool(*b)),
         Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Some(ExtraValue::Int(i))
+                Ok(serde_json::Value::from(i))
             } else if let Some(f) = n.as_f64() {
-                Some(ExtraValue::Float(f))
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .ok_or_else(|| "unsupported numeric extra-frontmatter value".to_string())
             } else {
-                return Err(Error::Parse(
-                    "unsupported numeric extra-frontmatter value".into(),
-                ));
+                Err("unsupported numeric extra-frontmatter value".to_string())
             }
         }
-        Value::String(s) => Some(ExtraValue::Str(s.clone())),
+        Value::String(s) => Ok(serde_json::Value::String(s.clone())),
         Value::Sequence(seq) => {
             let mut list = Vec::with_capacity(seq.len());
             for item in seq {
                 match item.as_str() {
-                    Some(s) => list.push(s.to_string()),
+                    Some(s) => list.push(serde_json::Value::String(s.to_string())),
                     None => {
-                        return Err(Error::Parse(
-                            "extra-frontmatter lists must contain only strings".into(),
-                        ));
+                        return Err("extra-frontmatter lists must contain only strings".to_string());
                     }
                 }
             }
-            Some(ExtraValue::List(list))
+            Ok(serde_json::Value::Array(list))
         }
-        Value::Mapping(_) | Value::Tagged(_) => {
-            return Err(Error::Parse(
-                "extra-frontmatter values must be scalars or string lists, not nested maps".into(),
-            ));
+        Value::Mapping(_) | Value::Tagged(_) => Err(
+            "extra-frontmatter values must be scalars or string lists, not nested maps".to_string(),
+        ),
+    }
+}
+
+/// The DECLARED-key path (spec 013 §3.2): full YAML → JSON conversion.
+/// Mappings require string keys; tags and non-finite numbers are
+/// unrepresentable. Map key order is canonicalized by the sorted
+/// `serde_json::Map` (authoring order is not preserved — the price of
+/// byte-identical registries).
+fn yaml_to_json(v: &serde_yaml::Value) -> std::result::Result<serde_json::Value, String> {
+    use serde_yaml::Value;
+    match v {
+        Value::Null => Ok(serde_json::Value::Null),
+        Value::Bool(b) => Ok(serde_json::Value::Bool(*b)),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(serde_json::Value::from(i))
+            } else if let Some(u) = n.as_u64() {
+                Ok(serde_json::Value::from(u))
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .ok_or_else(|| format!("non-finite number {f} is not JSON-representable"))
+            } else {
+                Err("unsupported YAML number".to_string())
+            }
         }
-    })
+        Value::String(s) => Ok(serde_json::Value::String(s.clone())),
+        Value::Sequence(seq) => seq
+            .iter()
+            .map(yaml_to_json)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map(serde_json::Value::Array),
+        Value::Mapping(map) => {
+            let mut out = serde_json::Map::new();
+            for (mk, mv) in map {
+                let Some(key) = mk.as_str() else {
+                    return Err("non-string mapping key is not JSON-representable".to_string());
+                };
+                out.insert(key.to_string(), yaml_to_json(mv)?);
+            }
+            Ok(serde_json::Value::Object(out))
+        }
+        Value::Tagged(tagged) => Err(format!(
+            "YAML tag '{}' is not JSON-representable",
+            tagged.tag
+        )),
+    }
 }

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -45,8 +45,8 @@ pub use edges::{
 };
 pub use error::{Error, Result};
 pub use frontmatter::{
-    ExtraValue, Frontmatter, Implementation, KNOWN_KEYS, Risk, Status, parse_frontmatter,
-    split_frontmatter,
+    Frontmatter, FrontmatterIssue, Implementation, KNOWN_KEYS, Risk, Status, parse_frontmatter,
+    parse_frontmatter_with, split_frontmatter,
 };
 pub use registry::{Build, BuildMeta, Registry, Severity, SpecRecord, ValidationReport, Violation};
 pub use schema::{BUILD_META_SCHEMA, INDEX_SCHEMA, REGISTRY_SCHEMA};

--- a/crates/spec-spine-types/src/registry.rs
+++ b/crates/spec-spine-types/src/registry.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::edges::{CoAuthorityItem, ConstrainItem, ExtendItem, Origin, ReferenceItem, RefineItem};
-use crate::frontmatter::{ExtraValue, Implementation, Risk, Status};
+use crate::frontmatter::{Implementation, Risk, Status};
 use crate::unit::Unit;
 
 /// The compiled registry: `registry.json`.
@@ -111,8 +111,10 @@ pub struct SpecRecord {
     pub origin: Option<Origin>,
 
     // --- overflow ---
+    /// Declared keys carry any JSON value (spec 013); undeclared keys are
+    /// scalars or string arrays.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra_frontmatter: BTreeMap<String, ExtraValue>,
+    pub extra_frontmatter: BTreeMap<String, serde_json::Value>,
 }
 
 /// Non-deterministic build metadata sidecar (`build-meta.json`). The wall-clock

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -11,7 +11,8 @@
 //! loaders reject an unknown MAJOR. Under `0.x`, MINOR may break (SemVer `0.x`).
 
 /// `specVersion` emitted in `registry.json`.
-pub const REGISTRY_SCHEMA_VERSION: &str = "0.1.0";
+/// `0.2.0`: declared extra-frontmatter values widen to arbitrary JSON (spec 013).
+pub const REGISTRY_SCHEMA_VERSION: &str = "0.2.0";
 
 /// `schemaVersion` emitted in `index.json`. (Index DTOs land in Phase 3.)
 /// `0.2.0`: additive `build.sliceHashes` (spec 012).

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -69,7 +69,8 @@ fn validation_passed_follows_error_tier() {
 
 #[test]
 fn schema_versions_are_pinned() {
-    assert_eq!(REGISTRY_SCHEMA_VERSION, "0.1.0");
+    // 0.2.0: declared extra-frontmatter widens to arbitrary JSON (spec 013).
+    assert_eq!(REGISTRY_SCHEMA_VERSION, "0.2.0");
     // 0.2.0: additive `build.sliceHashes` (spec 012).
     assert_eq!(INDEX_SCHEMA_VERSION, "0.2.0");
     assert_eq!(BUILD_META_SCHEMA_VERSION, "0.1.0");

--- a/crates/spec-spine-types/tests/frontmatter.rs
+++ b/crates/spec-spine-types/tests/frontmatter.rs
@@ -1,6 +1,10 @@
-//! Frontmatter tests: split, required keys, enums, extra-frontmatter overflow.
+//! Frontmatter tests: split, required keys, enums, extra-frontmatter overflow,
+//! and the declared-key passthrough (spec 013).
 
-use spec_spine_types::{Error, ExtraValue, Status, parse_frontmatter, split_frontmatter};
+use serde_json::json;
+use spec_spine_types::{
+    Error, FrontmatterIssue, Status, parse_frontmatter, parse_frontmatter_with, split_frontmatter,
+};
 
 const MINIMAL: &str = "---\n\
 id: \"001-thing\"\n\
@@ -76,22 +80,57 @@ custom_tags: [\"a\", \"b\"]\n\
 custom_note: \"hello\"\n\
 ---\n";
     let fm = parse_frontmatter(src).unwrap();
-    assert_eq!(
-        fm.extra_frontmatter.get("custom_flag"),
-        Some(&ExtraValue::Bool(true))
-    );
-    assert_eq!(
-        fm.extra_frontmatter.get("custom_count"),
-        Some(&ExtraValue::Int(7))
-    );
+    assert_eq!(fm.extra_frontmatter.get("custom_flag"), Some(&json!(true)));
+    assert_eq!(fm.extra_frontmatter.get("custom_count"), Some(&json!(7)));
     assert_eq!(
         fm.extra_frontmatter.get("custom_tags"),
-        Some(&ExtraValue::List(vec!["a".into(), "b".into()]))
+        Some(&json!(["a", "b"]))
     );
     assert_eq!(
         fm.extra_frontmatter.get("custom_note"),
-        Some(&ExtraValue::Str("hello".into()))
+        Some(&json!("hello"))
     );
+}
+
+#[test]
+fn declared_key_carries_nested_yaml_verbatim() {
+    // Modeled on OAP's `compliance:` shape (spec 013 §3.5).
+    let src = "---\n\
+id: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
+compliance:\n  reviewed: true\n  owasp:\n    - \"A01\"\n    - { control: \"A03\", note: 7 }\n\
+---\n";
+    let declared = vec!["compliance".to_string()];
+    let fm = parse_frontmatter_with(src, &declared).unwrap();
+    assert_eq!(
+        fm.extra_frontmatter.get("compliance"),
+        Some(&json!({
+            "reviewed": true,
+            "owasp": ["A01", { "control": "A03", "note": 7 }],
+        }))
+    );
+
+    // The same source without the declaration keeps the pre-013 guard.
+    assert!(matches!(
+        parse_frontmatter(src).unwrap_err(),
+        Error::Parse(_)
+    ));
+}
+
+#[test]
+fn declared_key_with_non_string_map_key_is_unrepresentable() {
+    let src = "---\n\
+id: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
+compliance:\n  1: \"x\"\n\
+---\n";
+    let declared = vec!["compliance".to_string()];
+    let err = parse_frontmatter_with(src, &declared).unwrap_err();
+    match err {
+        FrontmatterIssue::UnrepresentableDeclared { key, detail } => {
+            assert_eq!(key, "compliance");
+            assert!(detail.contains("non-string mapping key"));
+        }
+        other => panic!("expected UnrepresentableDeclared, got {other:?}"),
+    }
 }
 
 #[test]

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -8,12 +8,23 @@
 
 ## The versioned artifacts
 
-| Artifact | Field | v1 value | Owner |
+| Artifact | Field | Current | Owner |
 |---|---|---|---|
-| `registry.json` | `specVersion` | `0.1.0` | library |
-| `index.json` | `schemaVersion` | `0.1.0` | library |
+| `registry.json` | `specVersion` | `0.2.0` | library |
+| `index.json` | `schemaVersion` | `0.2.0` | library |
 | `build-meta.json` | `schemaVersion` | `0.1.0` | library (non-deterministic; excluded from goldens) |
 | `spec-spine.toml` | `config_version` (optional) | `0.1.0` | library |
+
+MINOR history:
+
+- `index.json` `0.2.0` (spec 012): additive `build.sliceHashes` -- per-slice
+  content hashes for `index check --slice <name>`.
+- `registry.json` `0.2.0` (spec 013): `extraFrontmatter` values under
+  **declared** keys (`frontmatter.extra_known_keys`) widen from
+  `string | string[]` + scalars to arbitrary JSON. Generic readers
+  (`serde_json::Value`) are untouched; readers that assumed the narrow shape
+  were depending on an undocumented restriction. Undeclared keys keep the
+  narrow shape.
 
 Each is a **compile-time `const`** in `spec-spine-types`
 (`REGISTRY_SCHEMA_VERSION`, `INDEX_SCHEMA_VERSION`, `BUILD_META_SCHEMA_VERSION`,

--- a/specs/013-declared-extra-frontmatter-passthrough/spec.md
+++ b/specs/013-declared-extra-frontmatter-passthrough/spec.md
@@ -1,0 +1,122 @@
+---
+id: "013-declared-extra-frontmatter-passthrough"
+title: "Frontmatter: declared extra keys carry arbitrary YAML, verbatim"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+extends:
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/frontmatter.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/registry.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  # The declared-aware parse entry must also be used by the indexer's spec
+  # discovery (a nested declared value must not knock a spec out of the
+  # index); the MINOR bump rides through version.rs, the embedded registry
+  # JSON schema and the pinned-versions test; the types export list and the
+  # parser/compile test files carry the surface. All additive, same shape as
+  # specs 010-012.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/version.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/schemas/registry.schema.json", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/dtos.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/frontmatter.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+summary: >
+  Widens the value domain of DECLARED extra-frontmatter keys
+  (`config.frontmatter.extra_known_keys`) from scalars + string-lists to any
+  JSON-representable YAML value (nested maps, mixed lists), carried verbatim
+  into SpecRecord.extra_frontmatter under canonical-JSON normalization.
+  Undeclared keys keep the existing scalar/string-list restriction and the
+  V-007 cap -- the anti-bulk-YAML guard is untouched. Registry schema MINOR.
+  This is the load-bearing half of the overlay contract: overlays cannot
+  consume domain frontmatter the compiler drops.
+---
+
+# 013: Declared extra-frontmatter passthrough
+
+## 1. Purpose
+
+The overlay contract (`docs/overlay-contract.md`) names `extra_known_keys` +
+`extra_frontmatter` as the seam by which an adopter's domain frontmatter
+reaches its overlay crate without forking the types. But the current value
+restriction -- scalars and string-lists only -- makes the seam too narrow for
+real overlays: OAP's `compliance:` key (the OWASP control-to-spec mapping its
+compliance-report overlay is built on, present on 33 specs) is a nested map
+and would be rejected or mangled. A declared key is an explicit adopter
+statement of intent; for declared keys the compiler's job is faithful
+transport, not shape policing. For **undeclared** keys the restriction and cap
+remain exactly as-is -- they are the guard against frontmatter becoming an
+unaudited bulk-YAML channel (spec 000's authoring-boundary posture), and this
+spec does not soften that by one bit.
+
+## 2. Territory
+
+The frontmatter parser's unknown-key handling (`frontmatter.rs`), the
+`extra_frontmatter` value type on `SpecRecord` (`registry.rs`), and the
+compile-time validation that polices the declared/undeclared split
+(`compile.rs`). All additive on the types crate (floor-owned by 000) and on
+001's compile engine.
+
+## 3. Behavior
+
+### 3.1 The declared/undeclared split
+
+| Key is… | Accepted values | Cap | On violation |
+|---|---|---|---|
+| listed in `extra_known_keys` | any JSON-representable YAML value | exempt from the cap (unchanged) | `V-013` (see §3.3) |
+| not listed | scalar or list-of-strings (unchanged) | counts toward the V-007 cap (unchanged) | `V-007` band (unchanged) |
+
+### 3.2 Normalization (determinism)
+
+Declared-key values are converted YAML → JSON once, at parse time:
+
+- Mappings ⇒ JSON objects; **key order is canonical-JSON sorted** on emission
+  (authoring order is not preserved -- document this; it is the price of
+  byte-identical registries).
+- Sequences ⇒ JSON arrays, order preserved.
+- Scalars ⇒ JSON string/number/bool/null per YAML core schema resolution.
+- The in-memory representation is a `serde_json::Value`; the registry emits it
+  through the existing canonical-JSON serializer, so the determinism contract
+  (sorted keys, LF, trailing newline) holds with no new machinery.
+
+### 3.3 Unrepresentable values: `V-013`
+
+A declared key whose value cannot be represented as JSON -- a non-string
+mapping key, a YAML tag, an anchor/alias cycle -- is an **error-tier**
+violation, new code `V-013` ("declared extra-frontmatter key carries an
+unrepresentable YAML value"), recorded against the spec like any V-code (the
+spec is skipped, compile continues, exit 1 -- 001 §3.1 semantics).
+*Implementation note: V-013 is the next free code in the V band at time of
+writing (V-001..V-010, V-012 assigned); if the band has moved by landing time,
+take the next free code and amend this paragraph in the same PR.*
+
+### 3.4 Schema impact
+
+`registry.json`'s `extra_frontmatter` value type widens from
+`string | string[]` to arbitrary JSON. This is a **MINOR** bump per
+`docs/schema-versioning.md`: the field was already adopter-shaped and loaders
+that read it generically (`serde_json::Value`) are untouched; loaders that
+assumed the narrow shape were depending on an undocumented restriction.
+Record the widening in the schema-versioning table and the embedded JSON
+Schema in `spec-spine-types`.
+
+### 3.5 Tests (minimum)
+
+- A declared nested-map key (model it on a `compliance:`-shaped fixture)
+  survives compile → registry round-trip byte-identically across two runs.
+- Map-key sorting: two authoring orders, one registry output.
+- Undeclared nested map still rejected exactly as pre-013 (guard regression).
+- V-013 on a non-string map key under a declared key.
+- Cap behavior unchanged for undeclared keys in the presence of declared ones.
+
+## 4. Out of scope
+
+Widening **undeclared** keys (explicitly preserved as-is). Semantic validation
+of declared values (shape contracts for domain keys belong to the overlay that
+consumes them, per the overlay contract -- the core transports, the overlay
+validates). New first-class frontmatter fields (a declared key that earns
+core semantics graduates by its own spec, not through this channel).


### PR DESCRIPTION
Lands `specs/013-declared-extra-frontmatter-passthrough` (PR 4 of 6 in the staged amendment series; strictly serial, after #9). The load-bearing half of the overlay contract: overlays cannot consume domain frontmatter the compiler drops.

- **Declared keys** (`frontmatter.extra_known_keys`) now carry **any JSON-representable YAML value** -- nested maps, mixed lists -- transported verbatim into `SpecRecord.extraFrontmatter` as `serde_json::Value`. Map key order is canonical-JSON sorted on emission (authoring order is not preserved; the price of byte-identical registries, and tested: two authoring orders, one registry value).
- **Undeclared keys are untouched**: the scalar/string-list restriction and the V-007 cap hold exactly as pre-013, guard-regression tested, including the cap firing correctly in the presence of declared keys.
- **New V-013** (error tier): a declared key whose value JSON cannot represent (non-string mapping key, YAML tag, non-finite number). Skip-and-continue semantics identical to V-002; the code was verified still free in the V band per the spec's implementation note.
- **Registry schema 0.1.0 -> 0.2.0** (MINOR): `extraFrontmatter` values widen to arbitrary JSON. Recorded in `docs/schema-versioning.md` (a MINOR-history section was added; the table also now shows index 0.2.0, which #9 had bumped without updating the doc) and made explicit in the embedded registry JSON schema.

Implementation notes:
- `parse_frontmatter_with(src, declared)` is the new declared-aware entry point; `parse_frontmatter(src)` keeps the pre-013 contract for config-free callers. Both compile **and the indexer's spec discovery** use the declared-aware form -- otherwise a nested declared value would knock a spec out of the index while compiling fine.
- The `ExtraValue` enum is replaced by `serde_json::Value` (one representation instead of two); the untagged wire format for narrow values is byte-identical, so pre-013 registries round-trip unchanged. This removes a public type from `spec-spine-types` -- a 0.x source-level break, flagged here deliberately.
- Touched surfaces beyond the three units the staged spec declared (indexer parse site, types export list, version constant, registry JSON schema, pinned-versions test, parser/compile test files) are all declared as additive extends edges, same pattern as #7/#8/#9.

Gates: `compile` (13 specs, 0 warnings), `index` (0 errors), `lint` (0/0/0), `couple --base origin/main --head HEAD` (11 paths, no drift). Full workspace test suite passes; new coverage spans the types parser tests and the core compile integration tests.

**Review call for the maintainer:** spec lands with `implementation: complete`, `status: draft`; the draft -> approved flip is yours.

Merge ordering: rewrites the committed `.derived` artifacts; next staged spec (014) moves in only after this merges.