### PR TITLE
feat: paths list sugar on extends/refines items (spec 014)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "7329f79dd935383da0416f962ace3c1d570375250e88993433b4d90cab609b04",
+    "contentHash": "d8e816a14bde66dd963bc19a7c021ac884d23c07c7f35ee89e3d82d936289b2f",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -1353,6 +1353,102 @@
           }
         ],
         "specId": "013-declared-extra-frontmatter-passthrough",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/src/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/edges.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/frontmatter.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/grammar.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/edges.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/edges.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/frontmatter.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/frontmatter.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/grammar.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/grammar.rs"
+            }
+          }
+        ],
+        "specId": "014-edge-paths-grammar-sugar",
         "specStatus": "draft"
       }
     ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "0680d4d3508e790e1d569e4b25bdcd80b509e6c5dcb53a11b1eb58e6e48f1bd4",
+    "contentHash": "351f33e0a59799d43e73a5f875bcb65a7a38a5dc0be6faa874d774380cc2280a",
     "inputRoot": "."
   },
   "specVersion": "0.2.0",
@@ -786,6 +786,73 @@
       "status": "draft",
       "summary": "Widens the value domain of DECLARED extra-frontmatter keys (`config.frontmatter.extra_known_keys`) from scalars + string-lists to any JSON-representable YAML value (nested maps, mixed lists), carried verbatim into SpecRecord.extra_frontmatter under canonical-JSON normalization. Undeclared keys keep the existing scalar/string-list restriction and the V-007 cap -- the anti-bulk-YAML guard is untouched. Registry schema MINOR. This is the load-bearing half of the overlay contract: overlays cannot consume domain frontmatter the compiler drops.\n",
       "title": "Frontmatter: declared extra keys carry arbitrary YAML, verbatim"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "001-compile-registry"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/edges.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/frontmatter.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/compile.rs"
+          }
+        }
+      ],
+      "id": "014-edge-paths-grammar-sugar",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "014: `paths:` list sugar on extends/refines items",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Accepted forms",
+        "3.2 Normalization (the sugar never escapes)",
+        "3.3 Equivalence guarantee",
+        "3.4 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/014-edge-paths-grammar-sugar/spec.md",
+      "status": "draft",
+      "summary": "Authoring sugar for the predecessor dialect: an `extends:` or `refines:` item may declare `paths: [<file>, ...]` instead of a single `unit:`; the compiler expands each path to a file unit at parse time, emitting N normalized single-unit edges into the registry. Consumers see exactly one edge shape -- `paths:` never reaches registry.json. `unit:` and `paths:` on the same item is malformed (V-002). Unblocks adopting a corpus authored in the OAP dialect (140+ extends-bearing specs) without a mass frontmatter migration.\n",
+      "title": "Edge grammar: `paths:` list sugar on extends/refines items"
     }
   ],
   "validation": {

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -310,3 +310,90 @@ fn v008_superseded_requires_resolvable_superseded_by() {
         .expect("V-008 expected");
     assert_eq!(v.severity, Severity::Error);
 }
+
+#[test]
+fn paths_sugar_is_byte_equivalent_to_single_unit_items() {
+    // Spec 014 §3.3, the acceptance test: the same corpus authored with
+    // `paths: [a, b]` and as N single-`unit` items compiles to identical
+    // registries. Only `build.contentHash` may differ (it hashes the authored
+    // spec bytes, which differ by construction); every emitted record and the
+    // validation report must match byte-for-byte.
+    let sugar = tempfile::tempdir().unwrap();
+    write_spec(
+        sugar.path(),
+        "001-a",
+        "001-a",
+        "extends:\n  - { spec: \"000-x\", paths: [\"a.rs\", \"b.rs\"], nature: additive }\nrefines:\n  - { aspect: \"det\", paths: [\"c.rs\", \"d/\"] }\n",
+    );
+    let desugared = tempfile::tempdir().unwrap();
+    write_spec(
+        desugared.path(),
+        "001-a",
+        "001-a",
+        "extends:\n  - { spec: \"000-x\", unit: \"a.rs\", nature: additive }\n  - { spec: \"000-x\", unit: \"b.rs\", nature: additive }\nrefines:\n  - { aspect: \"det\", unit: \"c.rs\" }\n  - { aspect: \"det\", unit: \"d/\" }\n",
+    );
+
+    let cfg = Config::default();
+    let a = compile(&cfg, sugar.path()).unwrap();
+    let b = compile(&cfg, desugared.path()).unwrap();
+    assert_eq!(
+        serde_json::to_string(&a.registry.specs).unwrap(),
+        serde_json::to_string(&b.registry.specs).unwrap(),
+        "expanded records must be byte-identical"
+    );
+    assert_eq!(a.registry.validation, b.registry.validation);
+}
+
+#[test]
+fn paths_sugar_grammar_violations_are_v002() {
+    // unit: + paths: on one item.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        "extends:\n  - { spec: \"000-x\", unit: \"a.rs\", paths: [\"b.rs\"] }\n",
+    );
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(codes(&outcome).contains(&"V-002".to_string()));
+    assert!(outcome.registry.specs.is_empty(), "the spec is skipped");
+
+    // Empty paths: list.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        "refines:\n  - { aspect: \"a\", paths: [] }\n",
+    );
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(codes(&outcome).contains(&"V-002".to_string()));
+}
+
+#[test]
+fn oap_dialect_refines_fixture_compiles_clean() {
+    // Spec 014 §3.4: a fixture modeled on the real OAP shape -- `refines`
+    // with an aspect, refines_specs, and two paths -- compiles clean.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-base", "001-base", "");
+    write_spec(
+        tmp.path(),
+        "002-tighten",
+        "002-tighten",
+        "refines:\n  - aspect: \"hash-determinism\"\n    refines_specs: [\"001-base\"]\n    paths: [\"src/hash.rs\", \"src/canonical_json.rs\"]\n",
+    );
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(outcome.validation_passed, "{:?}", codes(&outcome));
+    let spec = outcome
+        .registry
+        .specs
+        .iter()
+        .find(|s| s.id == "002-tighten")
+        .unwrap();
+    assert_eq!(spec.refines.len(), 2, "expanded to one item per path");
+    assert!(
+        spec.refines
+            .iter()
+            .all(|r| r.unit.is_some() && r.paths.is_none())
+    );
+}

--- a/crates/spec-spine-types/src/edges.rs
+++ b/crates/spec-spine-types/src/edges.rs
@@ -6,14 +6,18 @@
 //!
 //! `establishes` is a bare `Vec<Unit>`; `supersedes`/`amends` are `Vec<String>`
 //! of spec ids; the remaining edges are lists of the item structs below. Each
-//! item uses `deny_unknown_fields` so the legacy `paths:` form (replaced by
-//! `unit:`) produces a clear error rather than silently overflowing.
+//! item uses `deny_unknown_fields` so a misspelled key produces a clear error
+//! rather than silently overflowing. `extends`/`refines` items accept the
+//! predecessor dialect's `paths:` list as authoring sugar (spec 014): the
+//! parser expands it to N single-`unit` items, so the sugar never reaches
+//! `registry.json`.
 
 use serde::{Deserialize, Serialize};
 
 use crate::unit::Unit;
 
-/// `extends: [{ spec, unit?, nature? }]` — adds surface to a predecessor.
+/// `extends: [{ spec, unit? | paths?, nature? }]` — adds surface to a
+/// predecessor. `paths:` is parse-time sugar for N file units (spec 014).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExtendItem {
@@ -21,12 +25,16 @@ pub struct ExtendItem {
     pub spec: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unit: Option<Unit>,
+    /// Authoring sugar only — always `None` after parse (spec 014 §3.2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paths: Option<Vec<String>>,
     /// Free-text nature hint (e.g. `additive`, `wrapping`); validated by lint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nature: Option<String>,
 }
 
-/// `refines: [{ aspect, unit?, refines_specs? }]` — tightens a named aspect.
+/// `refines: [{ aspect, unit? | paths?, refines_specs? }]` — tightens a named
+/// aspect. `paths:` is parse-time sugar for N file units (spec 014).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RefineItem {
@@ -34,8 +42,78 @@ pub struct RefineItem {
     pub aspect: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unit: Option<Unit>,
+    /// Authoring sugar only — always `None` after parse (spec 014 §3.2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paths: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub refines_specs: Vec<String>,
+}
+
+/// Expand the `paths:` sugar on `extends` items (spec 014 §3.2): one item per
+/// path, in authored order, every other field copied. `unit` + `paths`
+/// together, or an empty `paths` list, is a grammar error (the V-002 class).
+pub(crate) fn expand_extend_paths(items: Vec<ExtendItem>) -> Result<Vec<ExtendItem>, String> {
+    let mut out = Vec::with_capacity(items.len());
+    for mut item in items {
+        let Some(paths) = item.paths.take() else {
+            out.push(item);
+            continue;
+        };
+        if item.unit.is_some() {
+            return Err(format!(
+                "extends item for spec '{}' cannot carry both unit: and paths:",
+                item.spec
+            ));
+        }
+        if paths.is_empty() {
+            return Err(format!(
+                "extends item for spec '{}' has an empty paths: list",
+                item.spec
+            ));
+        }
+        for path in paths {
+            out.push(ExtendItem {
+                spec: item.spec.clone(),
+                unit: Some(Unit::File { path }),
+                paths: None,
+                nature: item.nature.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Expand the `paths:` sugar on `refines` items — symmetric with
+/// [`expand_extend_paths`].
+pub(crate) fn expand_refine_paths(items: Vec<RefineItem>) -> Result<Vec<RefineItem>, String> {
+    let mut out = Vec::with_capacity(items.len());
+    for mut item in items {
+        let Some(paths) = item.paths.take() else {
+            out.push(item);
+            continue;
+        };
+        if item.unit.is_some() {
+            return Err(format!(
+                "refines item for aspect '{}' cannot carry both unit: and paths:",
+                item.aspect
+            ));
+        }
+        if paths.is_empty() {
+            return Err(format!(
+                "refines item for aspect '{}' has an empty paths: list",
+                item.aspect
+            ));
+        }
+        for path in paths {
+            out.push(RefineItem {
+                aspect: item.aspect.clone(),
+                unit: Some(Unit::File { path }),
+                paths: None,
+                refines_specs: item.refines_specs.clone(),
+            });
+        }
+    }
+    Ok(out)
 }
 
 /// `co_authority: [{ unit, with_specs? }]` — shares a section with other specs.

--- a/crates/spec-spine-types/src/frontmatter.rs
+++ b/crates/spec-spine-types/src/frontmatter.rs
@@ -288,6 +288,16 @@ pub fn parse_frontmatter_with(
         frontmatter.extra_frontmatter.insert(key.to_string(), json);
     }
 
+    // `paths:` sugar on extends/refines items (spec 014): expanded here, in
+    // the shared parse path, so every consumer (compile, index, lint, couple)
+    // sees only single-unit edges.
+    frontmatter.extends =
+        crate::edges::expand_extend_paths(std::mem::take(&mut frontmatter.extends))
+            .map_err(malformed)?;
+    frontmatter.refines =
+        crate::edges::expand_refine_paths(std::mem::take(&mut frontmatter.refines))
+            .map_err(malformed)?;
+
     Ok(frontmatter)
 }
 

--- a/crates/spec-spine-types/tests/grammar.rs
+++ b/crates/spec-spine-types/tests/grammar.rs
@@ -95,10 +95,64 @@ fn extends_item_parses() {
 }
 
 #[test]
-fn legacy_paths_field_on_edge_is_rejected() {
-    // deny_unknown_fields on edge items: the retired `paths:` form fails loudly.
+fn extends_paths_sugar_expands_to_file_units() {
+    // Spec 014 §3.1/§3.2: the predecessor dialect's `paths:` list is sugar
+    // for N single-unit items, expanded at parse time in authored order.
+    let fm = fm_with_edges(
+        "extends:\n  - { spec: \"000-x\", paths: [\"a.rs\", \"src/api/\"], nature: additive }\n",
+    );
+    assert_eq!(fm.extends.len(), 2);
+    assert_eq!(
+        fm.extends[0].unit,
+        Some(Unit::File {
+            path: "a.rs".into()
+        })
+    );
+    assert_eq!(fm.extends[0].nature.as_deref(), Some("additive"));
+    // Directory form (trailing slash) is plain file-unit semantics.
+    assert_eq!(
+        fm.extends[1].unit,
+        Some(Unit::File {
+            path: "src/api/".into()
+        })
+    );
+    assert!(
+        fm.extends.iter().all(|e| e.paths.is_none()),
+        "the sugar never escapes the parser"
+    );
+}
+
+#[test]
+fn refines_paths_sugar_expands_symmetrically() {
+    let fm = fm_with_edges(
+        "refines:\n  - { aspect: \"determinism\", refines_specs: [\"001-a\"], paths: [\"a.rs\", \"b.rs\"] }\n",
+    );
+    assert_eq!(fm.refines.len(), 2);
+    for r in &fm.refines {
+        assert_eq!(r.aspect, "determinism");
+        assert_eq!(r.refines_specs, vec!["001-a".to_string()]);
+        assert!(r.paths.is_none());
+    }
+}
+
+#[test]
+fn unit_and_paths_together_is_rejected() {
     let src = "---\nid: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
-extends:\n  - { spec: \"000\", paths: [\"a.rs\"] }\n---\n";
+extends:\n  - { spec: \"000-x\", unit: \"a.rs\", paths: [\"b.rs\"] }\n---\n";
+    assert!(parse_frontmatter(src).is_err());
+}
+
+#[test]
+fn empty_paths_list_is_rejected() {
+    let src = "---\nid: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
+refines:\n  - { aspect: \"a\", paths: [] }\n---\n";
+    assert!(parse_frontmatter(src).is_err());
+}
+
+#[test]
+fn non_string_paths_entry_is_rejected() {
+    let src = "---\nid: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
+extends:\n  - { spec: \"000-x\", paths: [{ kind: file, path: \"a.rs\" }] }\n---\n";
     assert!(parse_frontmatter(src).is_err());
 }
 

--- a/specs/014-edge-paths-grammar-sugar/spec.md
+++ b/specs/014-edge-paths-grammar-sugar/spec.md
@@ -1,0 +1,114 @@
+---
+id: "014-edge-paths-grammar-sugar"
+title: "Edge grammar: `paths:` list sugar on extends/refines items"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+extends:
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/edges.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  # The expansion runs in the shared parse path (parse_frontmatter_with), so
+  # compile, index, lint and couple all see only single-unit edges; the
+  # grammar and compile test files carry the coverage.
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/frontmatter.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/grammar.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+summary: >
+  Authoring sugar for the predecessor dialect: an `extends:` or `refines:`
+  item may declare `paths: [<file>, ...]` instead of a single `unit:`; the
+  compiler expands each path to a file unit at parse time, emitting N
+  normalized single-unit edges into the registry. Consumers see exactly one
+  edge shape -- `paths:` never reaches registry.json. `unit:` and `paths:` on
+  the same item is malformed (V-002). Unblocks adopting a corpus authored in
+  the OAP dialect (140+ extends-bearing specs) without a mass frontmatter
+  migration.
+---
+
+# 014: `paths:` list sugar on extends/refines items
+
+## 1. Purpose
+
+This library's grammar descends from OAP's, but tightened one degree: an
+`extends`/`refines` item carries a single `unit:`. The ancestor dialect lets
+one item claim several files at once (`extends: [{spec: X, paths: [a, b]}]`,
+`refines: [{aspect: A, paths: [a, b]}]`), and OAP's corpus uses that form
+across 140+ extends-bearing and 60+ refines-bearing specs. Requiring a
+mass-migration commit in the adopter's corpus as the price of adoption is
+backwards -- the corpus is the adopter's truth; the compiler should meet it.
+The fix is sugar, not semantics: `paths:` is an authoring convenience that the
+compiler normalizes away, so every downstream consumer (query, index, couple,
+overlays) continues to see exactly one edge shape.
+
+## 2. Territory
+
+The edge item grammar (`edges.rs`: accept the alternative field and expand
+it) wired into the shared parse entry (`frontmatter.rs`), so the V-002
+mapping in `compile.rs` and every downstream consumer (index, lint, couple)
+see only single-unit edges with no changes of their own. Additive; no change
+to `establishes` (whose bare-string list form already covers the multi-path
+case), no change to registry consumers.
+
+## 3. Behavior
+
+### 3.1 Accepted forms
+
+On an `extends:` item -- exactly one of:
+
+```yaml
+extends:
+  - { spec: "001-x", unit: "src/lib.rs", nature: additive }            # existing
+  - { spec: "001-x", unit: { kind: section, file: "Makefile", anchor: "ci" } }
+  - { spec: "001-x", paths: ["src/lib.rs", "src/api/"], nature: additive }  # new
+```
+
+On a `refines:` item, symmetrically: `paths:` as the alternative to `unit:`,
+with `aspect` (and `refines_specs`) carried unchanged.
+
+- `paths:` MUST be a non-empty list of strings; each string uses **file-unit
+  semantics only** (literal path; trailing `/` = directory subtree, per 004
+  §3.3). Section/symbol units have no plural form -- a multi-section claim is
+  written as multiple items.
+- An item with **both** `unit:` and `paths:`, or with an empty `paths:` list,
+  is malformed frontmatter: `V-002`, error tier, spec skipped (001 §3.1).
+
+### 3.2 Normalization (the sugar never escapes)
+
+At parse time each `paths:` item expands to N items, one per path, each with
+`unit: { kind: file, path: <p> }` and every other field (`spec`, `nature`,
+`aspect`, `refines_specs`) copied. Expansion preserves authored path order;
+the registry's existing edge sorting then applies. `registry.json` therefore
+contains **only** single-unit edges -- its schema, the JSON Schema artifact,
+and every consumer are untouched (no schema bump; verify the embedded schema
+does not need a text edit precisely because the wire shape is unchanged).
+
+Lint (`L-001`, `L-004`) and the index/coupling pipeline run post-expansion and
+need no changes; tests assert that, they don't re-implement it.
+
+### 3.3 Equivalence guarantee
+
+A corpus authored with `paths: [a, b]` MUST compile to a registry
+byte-identical to the same corpus authored as two single-`unit` items in the
+same order. This is the whole contract; the golden test for it is the
+acceptance test.
+
+### 3.4 Tests (minimum)
+
+- The byte-equivalence golden of §3.3, for both `extends` and `refines`.
+- Directory-form path inside `paths:`.
+- `V-002` on `unit` + `paths` together; on empty `paths`; on a non-string
+  entry.
+- An OAP-dialect fixture spec (modeled on a real shape: `refines` with
+  `aspect` + two paths) compiles clean.
+
+## 4. Out of scope
+
+Plural forms for `section`/`symbol` units (write multiple items). `paths:` on
+`co_authority` or `constrains` (their items are unit-singular by design;
+extend only if the Phase-0 corpus dry-run proves an adopter needs it -- file a
+follow-up, don't widen here). Any registry schema change. Emission of a
+derived `implements:` union view (an adopter-side migration concern, noted in
+the amendments README).


### PR DESCRIPTION
Lands `specs/014-edge-paths-grammar-sugar` (PR 5 of 6 in the staged amendment series; strictly serial, after #10). Authoring sugar for the predecessor dialect, unblocking adoption of a corpus authored in the OAP form (140+ extends-bearing, 60+ refines-bearing specs) without a mass frontmatter migration.

- An `extends:`/`refines:` item may declare `paths: [<file>, ...]` instead of a single `unit:`. Each path uses file-unit semantics (trailing `/` = directory subtree, as today). Expansion to N single-unit items happens at parse time, authored order preserved, all other fields (`spec`, `nature`, `aspect`, `refines_specs`) copied.
- **The sugar never escapes**: expansion lives in the shared `parse_frontmatter_with` path, so compile, index, lint, couple and every registry consumer see exactly one edge shape. `registry.json` is untouched -- no schema bump, and I verified the embedded JSON schema needs no text edit since the wire shape is unchanged.
- `unit:` + `paths:` together, an empty `paths:` list, or a non-string entry is malformed frontmatter (V-002, spec skipped, exit 1).
- The §3.3 acceptance golden is in: a corpus authored with `paths: [a, b]` compiles to records **byte-identical** to the same corpus authored as N single-unit items (only `build.contentHash` differs, since it hashes the authored spec bytes). Plus the OAP-shaped fixture (`refines` with aspect + refines_specs + two paths) compiling clean.

Implementation notes:
- One deliberate locus change vs the staged spec's Territory prose: it named `compile.rs` for "compile-time expansion", but its own §3.2 says "at parse time" -- and parse time is correct, because the indexer's spec discovery uses the same parser. Expansion in compile.rs alone would have produced registries with expanded edges while the index silently missed every `paths:`-form unit. `compile.rs` needed zero changes (the V-002 mapping already existed); the Territory prose was aligned and the frontmatter/test extends edges declared.
- The pre-014 test asserting the `paths:` form is *rejected* (`legacy_paths_field_on_edge_is_rejected`) was replaced by the expansion tests -- that reversal is this spec's entire point.

Gates: `compile` (14 specs, 0 warnings), `index` (0 errors), `lint` (0/0/0), `couple --base origin/main --head HEAD` (5 paths, no drift). Full workspace test suite passes.

**Review call for the maintainer:** spec lands with `implementation: complete`, `status: draft`; the draft -> approved flip is yours.

Phase 0 (the read-only OAP corpus dry-run) is being run alongside this PR; results land in the PR conversation / session report. Next staged spec (009, the last) moves in only after this merges.