### PR TITLE
feat: explicit unit claims take precedence over the bypass floor (spec 009)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "d8e816a14bde66dd963bc19a7c021ac884d23c07c7f35ee89e3d82d936289b2f",
+    "contentHash": "f20918d9dbe4c1a09d9eb9c264477b874c1c9f5c77258dd5e4d2415e2c17d215",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -834,6 +834,88 @@
         ],
         "specId": "008-python-distribution",
         "specStatus": "approved"
+      },
+      {
+        "amends": [
+          "005-coupling-gate"
+        ],
+        "dependsOn": [
+          "005-coupling-gate"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-cli/src/cmd_couple.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/tests/couple.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/couple.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/couple.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/cmd_couple.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/tests/couple.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/tests/couple.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/couple.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/couple.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/couple.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/couple.rs"
+            }
+          }
+        ],
+        "specId": "009-coupling-floor-claim-precedence",
+        "specStatus": "draft"
       },
       {
         "dependsOn": [

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "351f33e0a59799d43e73a5f875bcb65a7a38a5dc0be6faa874d774380cc2280a",
+    "contentHash": "13e773e6aaee7c1b0aff3f88096223dade5812b542fbd193bd1e6f1817235153",
     "inputRoot": "."
   },
   "specVersion": "0.2.0",
@@ -458,6 +458,70 @@
       "status": "approved",
       "summary": "The Python parallel of 007's npm shim: a uvx/PyPI channel so a Python or polyglot team can `uvx spec-spine ...` (or `uv tool install spec-spine`) and get the CLI with no Rust toolchain. Where npm uses a main launcher package + five os/cpu-gated platform packages, Python collapses the same idea into one PyPI project + five per-platform wheels (+ one sdist): the wheel platform tag IS the selector, and the prebuilt binary ships in the wheel's data/scripts dir so pip/uv place it directly on PATH. There is no Python in the run path, no postinstall, no network at install, and no archive extraction at install: it works offline and under --no-build-isolation. Unsupported hosts (musl/Alpine, win-arm64, 32-bit) match no wheel and fall to the sdist, whose only artifact is a `spec-spine` console entry point that names the host and points at `cargo install spec-spine-cli` -- exact parity with 007 §3.4. Wheels are assembled from the same release archives the build job already produces (no second Rust build), are byte-reproducible, and are version-locked to the tag.\n",
       "title": "Distribution: uvx/PyPI wheel shim"
+    },
+    {
+      "amends": [
+        "005-coupling-gate"
+      ],
+      "created": "2026-06-11",
+      "dependsOn": [
+        "005-coupling-gate"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "005-coupling-gate",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/couple.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "005-coupling-gate",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/couple.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "005-coupling-gate",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "005-coupling-gate",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/tests/couple.rs"
+          }
+        }
+      ],
+      "id": "009-coupling-floor-claim-precedence",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "009: Explicit unit claims take precedence over the bypass floor",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 The precedence rule",
+        "3.2 What does NOT override bypass",
+        "3.3 Precedence over adopter additions too",
+        "3.4 Effect on this repo's own corpus",
+        "3.5 Determinism and report shape",
+        "3.6 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/009-coupling-floor-claim-precedence/spec.md",
+      "status": "draft",
+      "summary": "Amends 005 §3.5: a path covered by an explicit unit claim (a file, section, or symbol declared in some spec's ownership-bearing edge and resolved into the index) is NEVER bypassed, even when it matches the hardcoded floor or an adopter's additive bypass list. Implicit path-level ownership (manifest floors, comment headers) keeps deferring to bypass. Closes the silent- weakening hole where an adopter who governs workflow YAML or specific docs by explicit claim would have those claims ignored because `.github/` and `docs/` sit on the immutable floor.\n",
+      "title": "Coupling gate: explicit unit claims take precedence over the bypass floor"
     },
     {
       "created": "2026-06-11",

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 
 use spec_spine_core::{
     DiffFile, DiffInput, FileContents, couple, dependency_only_waiver, is_bypassed_path,
-    parse_waiver,
+    load_index, parse_waiver,
 };
 use spec_spine_types::{Config, Error, LineSpan};
 
@@ -103,16 +103,32 @@ fn build_diff_input(repo: &Path, args: &CoupleArgs) -> Result<DiffInput, Error> 
 /// diff is three-dot, so the base side is `merge-base(base, head)`, not the
 /// base branch tip) and at `head`. Any git failure refuses the auto-waiver
 /// fail-closed rather than erroring the gate.
+///
+/// The bypass verdict is claim-aware (spec 009): it reads the committed
+/// index so a claim-overridden floor path counts as a candidate and refuses
+/// the waiver, matching exactly the path set the gate evaluates. An
+/// unreadable index refuses fail-closed (the gate itself will report the
+/// real error).
 fn try_dependency_only_waiver(
     repo: &Path,
     cfg: &Config,
     args: &CoupleArgs,
     diff: &DiffInput,
 ) -> Result<Option<spec_spine_core::Waiver>, Error> {
+    let index_path = repo
+        .join(&cfg.layout.derived_dir)
+        .join("codebase-index")
+        .join("index.json");
+    let Some(index) = std::fs::read(&index_path)
+        .ok()
+        .and_then(|bytes| load_index(&bytes).ok())
+    else {
+        return Ok(None);
+    };
     let candidates: Vec<&DiffFile> = diff
         .files
         .iter()
-        .filter(|f| !is_bypassed_path(cfg, &f.path))
+        .filter(|f| !is_bypassed_path(cfg, &index, &f.path))
         .collect();
     // Cheap pre-filter before any git spawn: the waiver can only ever apply
     // when every non-bypassed path is a package.json manifest.

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -344,3 +344,59 @@ fn script_edit_refuses_the_auto_waiver() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+#[test]
+fn claimed_floor_path_refuses_the_auto_waiver() {
+    // Spec 009 x 005 §3.5 interplay: a dependency-only bump PLUS an edit to a
+    // floor path that a spec explicitly claims must NOT be mechanically
+    // waived. With a claim-unaware pre-filter the workflow edit would hide
+    // behind the floor, every remaining candidate would be a manifest, and
+    // the dep-only waiver would excuse the workflow's C-001 -- fail-open.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_npm(root, true);
+    write(root, ".github/workflows/release.yml", "name: release\n");
+    write(
+        root,
+        "specs/002-wf/spec.md",
+        "---\nid: \"002-wf\"\ntitle: \"W\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \".github/workflows/release.yml\"\n---\n# 002-wf\n## body\n",
+    );
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // The PR: a dep bump AND a workflow edit, index refreshed (the workflow
+    // is a hashed input), no spec edit, no PR body.
+    write(
+        root,
+        "pkg-a/package.json",
+        "{ \"name\": \"pkg-a\", \"version\": \"1.0.0\",\n  \
+         \"spec-spine\": { \"spec\": \"001-a\" },\n  \
+         \"scripts\": { \"build\": \"tsc\" },\n  \
+         \"dependencies\": { \"zod\": \"3.23.1\" } }\n",
+    );
+    write(
+        root,
+        ".github/workflows/release.yml",
+        "name: release\non: push\n",
+    );
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump+workflow"]);
+
+    let out = couple_git(root);
+    assert_eq!(
+        code(&out),
+        1,
+        "a claimed floor path must refuse the auto-waiver and drift: {}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("002-wf"),
+        "the workflow's owner must be named: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -129,9 +129,14 @@ pub fn couple_with(
 
     for file in &diff.files {
         let path = &file.path;
-        // Effective bypass = hardcoded floor ∪ adopter list (additive).
-        if is_bypass(path, DEFAULT_BYPASS_PREFIXES)
-            || is_bypass(path, &cfg.coupling.bypass_prefixes)
+        // Effective bypass = hardcoded floor ∪ adopter list (additive) —
+        // UNLESS an explicit, resolved unit claim covers the path, which
+        // takes precedence over the entire bypass set (spec 009, amending
+        // 005 §3.5). The corpus saying "this surface is governed" beats the
+        // blanket scaffolding exemption.
+        if !explicitly_claimed(path, index)
+            && (is_bypass(path, DEFAULT_BYPASS_PREFIXES)
+                || is_bypass(path, &cfg.coupling.bypass_prefixes))
         {
             continue;
         }
@@ -167,11 +172,33 @@ pub fn couple_with(
 }
 
 /// The effective bypass verdict for one path: hardcoded floor ∪ adopter list
-/// (additive), exactly as [`couple_with`] applies it. Public so the CLI's
+/// (additive), with explicit unit claims taking precedence (spec 009) —
+/// exactly as [`couple_with`] applies it. Public so the CLI's
 /// dependency-only auto-waiver pre-filter (spec 005 §3.5) examines the same
-/// non-bypassed path set the gate itself will check.
-pub fn is_bypassed_path(cfg: &Config, path: &str) -> bool {
-    is_bypass(path, DEFAULT_BYPASS_PREFIXES) || is_bypass(path, &cfg.coupling.bypass_prefixes)
+/// non-bypassed path set the gate itself will check; the claim-awareness is
+/// what keeps a claim-overridden floor path from slipping past that
+/// pre-filter into a mechanical waiver.
+pub fn is_bypassed_path(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool {
+    !explicitly_claimed(path, index)
+        && (is_bypass(path, DEFAULT_BYPASS_PREFIXES)
+            || is_bypass(path, &cfg.coupling.bypass_prefixes))
+}
+
+/// Spec 009 §3.1: true iff at least one **resolved, ownership-bearing unit
+/// claim** covers `path` — a location file matching exactly, or by directory
+/// prefix for a directory-form file unit (004 §3.3). Implicit path-level
+/// ownership (manifest metadata, comment headers → `implementingPaths`)
+/// deliberately does NOT count (§3.2): an explicit unit in spec frontmatter
+/// is an author saying *this exact surface is governed*; a crate floor is a
+/// blanket safety net that keeps deferring to bypass.
+fn explicitly_claimed(path: &str, index: &CodebaseIndex) -> bool {
+    index.traceability.mappings.iter().any(|m| {
+        m.resolved_units.iter().filter(|ru| ru.ownership).any(|ru| {
+            ru.locations
+                .iter()
+                .any(|loc| claim_matches(&loc.file, path))
+        })
+    })
 }
 
 /// Parse a waiver from the PR body using the configured keyword. Returns the

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -371,3 +371,212 @@ fn supersedes_transfers_authority_additively() {
     );
     assert!(!via_succ.has_blocking_drift(), "{:?}", via_succ.violations);
 }
+
+// ── spec 009: explicit claims take precedence over bypass ─────────────────
+
+#[test]
+fn explicit_claim_overrides_the_floor() {
+    // .github/ sits on the hardcoded floor, but 007-d claims the workflow
+    // file explicitly -> evaluated: drifts alone, clears with the owner.
+    let index = index_from(json!([{
+        "specId": "007-d",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "file", "path": ".github/workflows/release.yml" },
+            "sourceField": "establishes", "ownership": true,
+            "locations": [{ "file": ".github/workflows/release.yml" }]
+        }]
+    }]));
+    let reg = empty_registry();
+
+    let drift = run(
+        &index,
+        &reg,
+        &diff(vec![file(".github/workflows/release.yml", &[])]),
+    );
+    assert!(drift.has_blocking_drift());
+    assert_eq!(drift.checked_paths, 1);
+    assert!(drift.violations[0].message.contains("007-d"));
+
+    let cleared = run(
+        &index,
+        &reg,
+        &diff(vec![
+            file(".github/workflows/release.yml", &[]),
+            file("specs/007-d/spec.md", &[]),
+        ]),
+    );
+    assert!(!cleared.has_blocking_drift(), "{:?}", cleared.violations);
+
+    // A sibling workflow nobody claims stays floor-bypassed.
+    let sibling = run(
+        &index,
+        &reg,
+        &diff(vec![file(".github/workflows/ci.yml", &[])]),
+    );
+    assert!(!sibling.has_blocking_drift());
+    assert_eq!(sibling.checked_paths, 0);
+}
+
+#[test]
+fn implicit_ownership_does_not_override_bypass() {
+    // Spec 009 §3.2: manifest-floor / comment-header ownership (the
+    // implementingPaths sources) keeps deferring to bypass.
+    let index = index_from(json!([{
+        "specId": "001-a",
+        "implementingPaths": [
+            { "path": ".github", "source": "manifest-metadata" },
+            { "path": "docs/guide.md", "source": "comment-header" }
+        ],
+        "resolvedUnits": []
+    }]));
+    let reg = empty_registry();
+    let report = run(
+        &index,
+        &reg,
+        &diff(vec![
+            file(".github/workflows/ci.yml", &[]),
+            file("docs/guide.md", &[]),
+        ]),
+    );
+    assert!(!report.has_blocking_drift());
+    assert_eq!(report.checked_paths, 0, "implicit ownership stays bypassed");
+}
+
+#[test]
+fn claim_overrides_adopter_bypass_for_exactly_the_claimed_file() {
+    // Spec 009 §3.3: the rule overrides config additions too; the specific
+    // intent (the claim) beats the broad one (the bypass pattern).
+    let index = index_from(json!([{
+        "specId": "002-docs",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "file", "path": "crates/x/README.md" },
+            "sourceField": "constrains", "ownership": true,
+            "locations": [{ "file": "crates/x/README.md" }]
+        }]
+    }]));
+    let reg = empty_registry();
+    let mut cfg = Config::default();
+    cfg.coupling
+        .bypass_prefixes
+        .push("**/README.md".to_string());
+
+    let claimed = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("crates/x/README.md", &[])]),
+        None,
+    )
+    .unwrap();
+    assert!(claimed.has_blocking_drift());
+    assert!(claimed.violations[0].message.contains("002-docs"));
+
+    let sibling = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("crates/y/README.md", &[])]),
+        None,
+    )
+    .unwrap();
+    assert!(!sibling.has_blocking_drift());
+    assert_eq!(sibling.checked_paths, 0, "unclaimed siblings stay bypassed");
+}
+
+#[test]
+fn directory_form_claim_overrides_for_the_subtree() {
+    let index = index_from(json!([{
+        "specId": "008-py",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "file", "path": "docs/runbooks/" },
+            "sourceField": "establishes", "ownership": true,
+            "locations": [{ "file": "docs/runbooks/" }]
+        }]
+    }]));
+    let reg = empty_registry();
+
+    let inside = run(
+        &index,
+        &reg,
+        &diff(vec![file("docs/runbooks/restore.md", &[])]),
+    );
+    assert!(inside.has_blocking_drift());
+    assert_eq!(inside.checked_paths, 1);
+
+    let outside = run(&index, &reg, &diff(vec![file("docs/guide.md", &[])]));
+    assert!(!outside.has_blocking_drift());
+    assert_eq!(outside.checked_paths, 0);
+}
+
+#[test]
+fn section_claim_under_floor_is_evaluated_with_span_semantics() {
+    // A co_authority section unit on jobs.<name> of a floored workflow: the
+    // path is evaluated; span overlap then decides ownership as usual.
+    let index = index_from(json!([{
+        "specId": "118-wf",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "section", "file": ".github/workflows/release.yml", "anchor": "publish" },
+            "sourceField": "co_authority", "ownership": true,
+            "locations": [{ "file": ".github/workflows/release.yml", "span": { "startLine": 10, "endLine": 20 } }]
+        }]
+    }]));
+    let reg = empty_registry();
+
+    let inside = run(
+        &index,
+        &reg,
+        &diff(vec![file(
+            ".github/workflows/release.yml",
+            &[LineSpan::new(12, 14)],
+        )]),
+    );
+    assert!(inside.has_blocking_drift());
+    assert!(inside.violations[0].message.contains("118-wf"));
+
+    // A hunk outside the span: evaluated (not bypassed) but unowned -> clean.
+    let outside = run(
+        &index,
+        &reg,
+        &diff(vec![file(
+            ".github/workflows/release.yml",
+            &[LineSpan::new(30, 31)],
+        )]),
+    );
+    assert!(!outside.has_blocking_drift(), "{:?}", outside.violations);
+    assert_eq!(outside.checked_paths, 1, "evaluated, not bypassed");
+}
+
+#[test]
+fn is_bypassed_path_is_claim_aware() {
+    // The CLI's auto-waiver pre-filter must see the same path set the gate
+    // checks (spec 005 §3.5 x spec 009).
+    let index = index_from(json!([{
+        "specId": "007-d",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "file", "path": ".github/workflows/release.yml" },
+            "sourceField": "establishes", "ownership": true,
+            "locations": [{ "file": ".github/workflows/release.yml" }]
+        }]
+    }]));
+    let cfg = Config::default();
+    assert!(!spec_spine_core::is_bypassed_path(
+        &cfg,
+        &index,
+        ".github/workflows/release.yml"
+    ));
+    assert!(spec_spine_core::is_bypassed_path(
+        &cfg,
+        &index,
+        ".github/workflows/ci.yml"
+    ));
+    assert!(!spec_spine_core::is_bypassed_path(
+        &cfg,
+        &index,
+        "src/lib.rs"
+    ));
+}

--- a/specs/009-coupling-floor-claim-precedence/spec.md
+++ b/specs/009-coupling-floor-claim-precedence/spec.md
@@ -1,0 +1,132 @@
+---
+id: "009-coupling-floor-claim-precedence"
+title: "Coupling gate: explicit unit claims take precedence over the bypass floor"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "005-coupling-gate"
+amends:
+  - "005-coupling-gate"
+extends:
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/tests/couple.rs", nature: additive }
+  # The 005 §3.5 auto-waiver pre-filter must see the same claim-aware bypass
+  # verdict as the gate (is_bypassed_path gains the index parameter), so the
+  # CLI wiring and its e2e contract file are touched too. Both additive.
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/src/cmd_couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/tests/couple.rs", nature: additive }
+summary: >
+  Amends 005 §3.5: a path covered by an explicit unit claim (a file, section,
+  or symbol declared in some spec's ownership-bearing edge and resolved into
+  the index) is NEVER bypassed, even when it matches the hardcoded floor or an
+  adopter's additive bypass list. Implicit path-level ownership (manifest
+  floors, comment headers) keeps deferring to bypass. Closes the silent-
+  weakening hole where an adopter who governs workflow YAML or specific docs
+  by explicit claim would have those claims ignored because `.github/` and
+  `docs/` sit on the immutable floor.
+---
+
+# 009: Explicit unit claims take precedence over the bypass floor
+
+## 1. Purpose
+
+Spec 005 §3.5 makes the bypass floor absolute: `config.coupling.bypass_prefixes`
+is additive-only and "cannot remove a floor entry". That is the right contract
+for *unclaimed* prose and scaffolding -- but it silently disables the gate for
+an adopter whose specs **explicitly claim** units beneath a floor prefix.
+
+The motivating adopter is OAP, where workflow YAML is governed truth: specs
+declare `co_authority` over `jobs.<name>` sections of `.github/workflows/*.yml`
+(OAP spec 118 / 152 lineage), and this repo's own corpus already does the same
+thing -- specs 007/008 declare `establishes` / `extends` units on
+`.github/workflows/release.yml`, which today the floor renders unenforceable.
+A gate that ignores an explicit, resolved authority claim is worse than one
+that lacks the claim: the corpus *says* the path is governed and the gate
+silently disagrees.
+
+The fix is a precedence rule, not a removable floor. The floor stays immutable
+as a *default*; an explicit claim overrides it for exactly the claimed surface.
+
+## 2. Territory
+
+`spec-spine-core`'s `couple.rs` (the bypass decision inside the pure engine)
+and its tests; plus the 005 §3.5 auto-waiver pre-filter in `cmd_couple.rs`,
+whose `is_bypassed_path` verdict becomes claim-aware (it reads the committed
+index) so a claim-overridden floor path cannot slip past the manifest-only
+candidate check into a mechanical waiver. No user-facing CLI surface change;
+no config knob change; no schema change.
+
+## 3. Behavior
+
+### 3.1 The precedence rule
+
+For a changed path `P`:
+
+1. Compute `explicitly_claimed(P)`: true iff the committed index contains at
+   least one **resolved unit** (kind `file`, `section`, or `symbol`, from any
+   ownership-bearing edge: `establishes` / `extends` / `refines` /
+   `co_authority` / `constrains` / `supersedes`-transferred) whose location
+   file equals `P` (file units with a trailing-slash directory path match `P`
+   by directory prefix, per 004 §3.3).
+2. If `explicitly_claimed(P)`, the bypass check is **skipped entirely**: `P`
+   proceeds to owner derivation and clearance exactly as a non-bypassed path
+   (005 §3.2–§3.5). Violations emit `C-001` as usual.
+3. Otherwise the effective bypass set (floor ∪ config additions) applies
+   unchanged.
+
+### 3.2 What does NOT override bypass
+
+**Implicit path-level ownership does not override.** The two path-level
+linkage sources from 004 §3.2 -- manifest metadata (`[package.metadata.<ns>]
+.spec`, the whole-crate coverage floor) and `// Spec:` comment headers -- keep
+deferring to bypass. This preserves the floor's purpose and this repo's own
+dogfood config: `**/README.md` stays bypassed even though every crate README
+sits inside a manifest-floored directory. The dividing line is intent: an
+explicit unit in spec frontmatter is an author saying *this exact surface is
+governed*; a crate floor is a blanket safety net.
+
+### 3.3 Precedence over adopter additions too
+
+The rule overrides the **entire** effective bypass set, including
+`config.coupling.bypass_prefixes` entries, not just the hardcoded floor. An
+adopter who both bypasses a pattern and explicitly claims a unit under it has
+stated two intents; the specific one (the claim) wins. This needs no new
+config: un-claiming the unit restores the bypass.
+
+### 3.4 Effect on this repo's own corpus
+
+Once this lands, `.github/workflows/release.yml` stops being bypassed (specs
+007/008 claim it explicitly), so future `release.yml` edits MUST be
+accompanied by an edit to 007 or 008 (or a waiver). This is the intended
+behavior and serves as the live acceptance test: the dogfood corpus is the
+first adopter of the rule.
+
+### 3.5 Determinism and report shape
+
+`couple_with` stays a pure function of `(config, registry, index, diff,
+waiver)`. The `CoupleReport` gains no new fields; a path un-bypassed by this
+rule is indistinguishable in the report from any other evaluated path. (A
+debug-level note in human output -- "bypass overridden by explicit claim from
+<spec-id>" -- is RECOMMENDED for the violation rendering, not required.)
+
+### 3.6 Tests (minimum)
+
+- Floor path with an explicit file unit claim → evaluated, drifts without the
+  owning spec in the diff, clears with it.
+- Floor path with only manifest-floor ownership → still bypassed.
+- Adopter-added bypass (`**/README.md`) with an explicit claim on one specific
+  README → that README evaluated; sibling READMEs still bypassed.
+- Directory-form file unit (`py/` style) claiming under a floor prefix →
+  subtree evaluated.
+- Section unit on a workflow `jobs.<name>` under `.github/` → evaluated.
+
+## 4. Out of scope
+
+Removing or configuring floor entries (the floor stays immutable; this spec
+makes it *yield to claims*, not *editable*). Constraint-specific exit codes or
+evaluation semantics for `constrains` beyond its existing ownership-bearing
+role. Diff-side section attribution changes (the hunk-to-span matching of 005
+§3.2 is untouched -- only the bypass short-circuit moves).


### PR DESCRIPTION
Lands `specs/009-coupling-floor-claim-precedence` (PR 6 of 6, the last of the staged amendment series; deliberately last because it changes gate semantics for this repo's own corpus).

**The precedence rule** (amends 005 section 3.5): a changed path covered by an explicit, resolved, ownership-bearing unit claim -- a file, section, or symbol declared in some spec's frontmatter and resolved into the committed index -- is **never bypassed**, even when it matches the hardcoded floor or an adopter's additive bypass list. The floor stays immutable as a *default*; the claim overrides it for exactly the claimed surface. Implicit path-level ownership (manifest floors, `// Spec:` comment headers) keeps deferring to bypass: a crate floor is a blanket safety net, an explicit unit is an author saying *this exact surface is governed*.

- Overrides the **entire** effective bypass set, config additions included (section 3.3): tested with `**/README.md` bypassed and one specific README claimed -- only that one is evaluated.
- Directory-form units claim their subtree; section units get evaluated with the usual span semantics (a hunk outside the owned span is evaluated-but-unowned, so clean).
- `couple_with` stays pure; `CoupleReport` shape unchanged; no config knob; no schema change.

**The 005-section-3.5 interplay (PR #5's auto-waiver), the soundness fix worth review attention:** the dep-only waiver's pre-filter used `is_bypassed_path` to pick its candidates. Claim-unaware, a claim-overridden floor path would hide behind the floor, every remaining candidate would be a manifest, and the mechanical waiver would excuse that path's C-001 -- fail-open. `is_bypassed_path` now takes the committed index and applies the same claim-aware verdict as the gate (its documented contract, "the same non-bypassed path set the gate itself will check", is now true again). E2e-tested: a dep bump + an edit to a claimed workflow file refuses the auto-waiver and exits 1 naming the workflow's owner. An unreadable index refuses the waiver fail-closed. This is a signature change to a pub fn introduced in #5 (0.x).

**Dogfood effect, the live acceptance test (section 3.4):** from this merge on, `.github/workflows/release.yml` stops being bypassed in this repo, because specs 007/008 claim it explicitly. Future `release.yml` edits MUST carry an edit to 007 or 008 (or a waiver). That is the intended behavior.

Gates: `compile` (15 specs, 0 warnings), `index` (0 errors), `lint` (0/0/0), `couple --base origin/main --head HEAD` (5 paths, no drift). Full workspace suite passes; new coverage: 6 core gate tests + 1 CLI e2e.

**Review call for the maintainer:** spec lands with `implementation: complete`, `status: draft`; the draft -> approved flip is yours.

This completes the staged series: 010, 011, 012, 013, 014, 009 all landed. The spec-spine-amendments staging dir now holds only its README.