### PR TITLE
feat: establishes unit-wrapper sugar and the n/a implementation alias (spec 015)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "37de583a36d30d2b79a6985516769513879dc53b9d181984ed2f2455199aa143",
+    "contentHash": "bc3bfc8472dd56a49b87bb19549f741f17d3270dcc6e0decae576b706be3fe32",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -1532,6 +1532,85 @@
         ],
         "specId": "014-edge-paths-grammar-sugar",
         "specStatus": "approved"
+      },
+      {
+        "dependsOn": [
+          "000-spec-spine-bootstrap"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/tests/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/frontmatter.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/unit.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/grammar.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/frontmatter.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/frontmatter.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/unit.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/unit.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/grammar.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/grammar.rs"
+            }
+          }
+        ],
+        "specId": "015-establishes-wrapper-na-alias",
+        "specStatus": "draft"
       }
     ],
     "orphanedSpecs": [],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "310703fd8da32d4466a5c783f911c2792ac353c4591c84e73b3fac63a54c7e1e",
+    "contentHash": "74db4d970d9838accc015217f05f163d06fe1f1199aa0959c30809ebbe236c87",
     "inputRoot": "."
   },
   "specVersion": "0.2.0",
@@ -917,6 +917,65 @@
       "status": "approved",
       "summary": "Authoring sugar for the predecessor dialect: an `extends:` or `refines:` item may declare `paths: [<file>, ...]` instead of a single `unit:`; the compiler expands each path to a file unit at parse time, emitting N normalized single-unit edges into the registry. Consumers see exactly one edge shape -- `paths:` never reaches registry.json. `unit:` and `paths:` on the same item is malformed (V-002). Unblocks adopting a corpus authored in the OAP dialect (140+ extends-bearing specs) without a mass frontmatter migration.\n",
       "title": "Edge grammar: `paths:` list sugar on extends/refines items"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "000-spec-spine-bootstrap"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/unit.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/frontmatter.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/compile.rs"
+          }
+        }
+      ],
+      "id": "015-establishes-wrapper-na-alias",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "015: `unit:`-wrapped establishes items and the `n/a` implementation alias",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 The `unit:` wrapper (a third 1:1 unit representation)",
+        "3.2 The `n/a` implementation alias",
+        "3.3 Normalization and equivalence (the sugar never escapes)",
+        "3.4 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/015-establishes-wrapper-na-alias/spec.md",
+      "status": "draft",
+      "summary": "Two pieces of authoring sugar for the predecessor dialect, both normalized away at parse so nothing new reaches registry.json. (1) An authority unit may be written as a single-key `{ unit: <unit> }` wrapper -- a third 1:1 representation alongside the existing bare-string and tagged-map forms -- which the Unit deserializer unwraps to its inner unit. The corpus uses this on `establishes` items (one wrapper per item, `unit` the only field). (2) `implementation: n/a` is accepted as a deserialize-only alias for the canonical `n-a`, which stays the only spelling ever emitted. Neither changes the registry schema or any consumer; both unblock adopting a corpus authored in the OAP dialect (389 wrapped establishes items across ~97 specs; 5 specs using `n/a`) without a mass frontmatter migration.\n",
+      "title": "Frontmatter sugar: `unit:`-wrapped establishes items and the `n/a` implementation alias"
     }
   ],
   "validation": {

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -397,3 +397,38 @@ fn oap_dialect_refines_fixture_compiles_clean() {
             .all(|r| r.unit.is_some() && r.paths.is_none())
     );
 }
+
+#[test]
+fn establishes_wrapper_and_na_alias_are_byte_equivalent() {
+    // Spec 015 §3.3, the acceptance test: a corpus authored in the predecessor
+    // dialect -- each `establishes` item `{ unit: ... }`-wrapped, and
+    // `implementation: n/a` -- compiles to a registry byte-identical to the
+    // canonical spelling (bare/tagged units, `implementation: n-a`). Only
+    // `build.contentHash` may differ (it hashes the authored bytes, which
+    // differ by construction); every emitted record and the validation report
+    // must match byte-for-byte.
+    let sugar = tempfile::tempdir().unwrap();
+    write_spec(
+        sugar.path(),
+        "001-a",
+        "001-a",
+        "implementation: n/a\nestablishes:\n  - { unit: \"a.rs\" }\n  - { unit: { kind: symbol, id: \"crate::f\" } }\n",
+    );
+    let canonical = tempfile::tempdir().unwrap();
+    write_spec(
+        canonical.path(),
+        "001-a",
+        "001-a",
+        "implementation: n-a\nestablishes:\n  - \"a.rs\"\n  - { kind: symbol, id: \"crate::f\" }\n",
+    );
+
+    let cfg = Config::default();
+    let a = compile(&cfg, sugar.path()).unwrap();
+    let b = compile(&cfg, canonical.path()).unwrap();
+    assert_eq!(
+        serde_json::to_string(&a.registry.specs).unwrap(),
+        serde_json::to_string(&b.registry.specs).unwrap(),
+        "wrapped/aliased records must be byte-identical to canonical"
+    );
+    assert_eq!(a.registry.validation, b.registry.validation);
+}

--- a/crates/spec-spine-types/src/frontmatter.rs
+++ b/crates/spec-spine-types/src/frontmatter.rs
@@ -41,13 +41,17 @@ pub enum Risk {
 }
 
 /// Implementation progress (optional descriptive metadata).
+///
+/// The canonical "not applicable" spelling is `n-a` (kebab-case, the family the
+/// other variants share); `n/a` is accepted as a deserialize-only alias (spec
+/// 015) for the predecessor dialect, and normalizes back to `n-a` on emission.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Implementation {
     Pending,
     InProgress,
     Complete,
-    #[serde(rename = "n-a")]
+    #[serde(rename = "n-a", alias = "n/a")]
     Na,
     Deferred,
 }

--- a/crates/spec-spine-types/src/unit.rs
+++ b/crates/spec-spine-types/src/unit.rs
@@ -13,8 +13,10 @@ use serde::{Deserialize, Serialize};
 /// An authority unit: the granularity at which a spec claims ownership.
 ///
 /// Serializes internally-tagged on `kind` (e.g. `{ "kind": "file", "path": ... }`).
-/// Deserializes from either that tagged map **or** a bare string (= a file unit),
-/// so authors can write `establishes: ["src/lib.rs"]` as shorthand.
+/// Deserializes from that tagged map, a bare string (= a file unit), **or** a
+/// `{ unit: <unit> }` wrapper (spec 015 sugar), so authors can write
+/// `establishes: ["src/lib.rs"]` or `establishes: [{ unit: "src/lib.rs" }]`
+/// interchangeably; all three normalize to the same unit.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum Unit {
@@ -46,12 +48,20 @@ impl<'de> Deserialize<'de> for Unit {
     where
         D: Deserializer<'de>,
     {
-        // Accept either a bare string (-> file unit) or the tagged map form.
+        // Accept a bare string (-> file unit), the tagged map form, or the
+        // `{ unit: <unit> }` wrapper (spec 015).
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum Repr {
             Bare(String),
             Tagged(Tagged),
+            // A predecessor dialect authors every `establishes` item as a
+            // single-key `unit:` map. The wrapper carries no information beyond
+            // the unit it wraps, so it normalizes away to that inner unit -- a
+            // third 1:1 representation alongside the bare-string and tagged
+            // forms, resolved by recursing through this same impl (so the inner
+            // unit may itself be bare or tagged, and inherits its validation).
+            Wrapped { unit: Box<Unit> },
         }
         #[derive(Deserialize)]
         #[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
@@ -71,6 +81,7 @@ impl<'de> Deserialize<'de> for Unit {
             Repr::Tagged(Tagged::File { path }) => Ok(Unit::File { path }),
             Repr::Tagged(Tagged::Section { file, anchor }) => Ok(Unit::Section { file, anchor }),
             Repr::Tagged(Tagged::Symbol { id }) => Ok(Unit::Symbol { id }),
+            Repr::Wrapped { unit } => Ok(*unit),
         }
     }
 }

--- a/crates/spec-spine-types/tests/grammar.rs
+++ b/crates/spec-spine-types/tests/grammar.rs
@@ -1,6 +1,6 @@
 //! Unit-grammar and edge-grammar tests.
 
-use spec_spine_types::{Frontmatter, Unit, parse_frontmatter};
+use spec_spine_types::{Frontmatter, Implementation, Unit, parse_frontmatter};
 
 fn fm_with_edges(edges_yaml: &str) -> Frontmatter {
     let src = format!(
@@ -50,6 +50,29 @@ fn tagged_units_parse() {
 }
 
 #[test]
+fn unit_wrapper_form_unwraps() {
+    // Spec 015 §3.1: `{ unit: <unit> }` is a 1:1 wrapper that normalizes to the
+    // inner unit. The inner may itself be a bare string or a tagged map.
+    let bare: Unit = serde_yaml::from_str("{ unit: \"src/lib.rs\" }").unwrap();
+    assert_eq!(
+        bare,
+        Unit::File {
+            path: "src/lib.rs".into()
+        }
+    );
+    let tagged: Unit =
+        serde_yaml::from_str("{ unit: { kind: symbol, id: \"crate::f\" } }").unwrap();
+    assert_eq!(
+        tagged,
+        Unit::Symbol {
+            id: "crate::f".into()
+        }
+    );
+    // The inner unit inherits its own validation (empty path still rejected).
+    assert!(serde_yaml::from_str::<Unit>("{ unit: \"\" }").is_err());
+}
+
+#[test]
 fn directory_subtree_detection() {
     assert!(Unit::file("src/").is_directory_subtree());
     assert!(!Unit::file("src/lib.rs").is_directory_subtree());
@@ -82,6 +105,46 @@ fn establishes_accepts_mixed_forms() {
         Unit::Symbol {
             id: "crate::f".into()
         }
+    );
+}
+
+#[test]
+fn establishes_accepts_unit_wrapper() {
+    // Spec 015 §3.1: the predecessor dialect wraps each establishes item in a
+    // single-key `unit:` map. Wrapped and bare forms parse to the same units,
+    // and may be mixed within one list.
+    let fm = fm_with_edges(
+        "establishes:\n  - { unit: \"src/whole.rs\" }\n  - \"src/bare.rs\"\n  - { unit: { kind: section, file: \"Makefile\", anchor: \"ci\" } }\n",
+    );
+    assert_eq!(
+        fm.establishes,
+        vec![
+            Unit::File {
+                path: "src/whole.rs".into()
+            },
+            Unit::File {
+                path: "src/bare.rs".into()
+            },
+            Unit::Section {
+                file: "Makefile".into(),
+                anchor: "ci".into()
+            },
+        ]
+    );
+}
+
+#[test]
+fn implementation_na_slash_is_alias_for_na() {
+    // Spec 015 §3.2: `n/a` is a deserialize-only alias for the canonical `n-a`,
+    // which is the only spelling ever emitted.
+    let slash = fm_with_edges("implementation: n/a\n");
+    let kebab = fm_with_edges("implementation: n-a\n");
+    assert_eq!(slash.implementation, Some(Implementation::Na));
+    assert_eq!(slash.implementation, kebab.implementation);
+    assert_eq!(
+        serde_json::to_string(&Implementation::Na).unwrap(),
+        "\"n-a\"",
+        "Na must emit canonically as n-a"
     );
 }
 

--- a/specs/015-establishes-wrapper-na-alias/spec.md
+++ b/specs/015-establishes-wrapper-na-alias/spec.md
@@ -1,0 +1,139 @@
+---
+id: "015-establishes-wrapper-na-alias"
+title: "Frontmatter sugar: `unit:`-wrapped establishes items and the `n/a` implementation alias"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "000-spec-spine-bootstrap"
+extends:
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/unit.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/frontmatter.rs", nature: additive }
+  # Both behaviors live in the shared parse layer (the Unit deserializer and the
+  # Implementation enum), so compile, index, lint and couple see only canonical
+  # units and the canonical `n-a` spelling; the grammar and compile test files
+  # carry the coverage.
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/grammar.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+summary: >
+  Two pieces of authoring sugar for the predecessor dialect, both normalized
+  away at parse so nothing new reaches registry.json. (1) An authority unit may
+  be written as a single-key `{ unit: <unit> }` wrapper -- a third 1:1
+  representation alongside the existing bare-string and tagged-map forms --
+  which the Unit deserializer unwraps to its inner unit. The corpus uses this on
+  `establishes` items (one wrapper per item, `unit` the only field). (2)
+  `implementation: n/a` is accepted as a deserialize-only alias for the
+  canonical `n-a`, which stays the only spelling ever emitted. Neither changes
+  the registry schema or any consumer; both unblock adopting a corpus authored
+  in the OAP dialect (389 wrapped establishes items across ~97 specs; 5 specs
+  using `n/a`) without a mass frontmatter migration.
+---
+
+# 015: `unit:`-wrapped establishes items and the `n/a` implementation alias
+
+## 1. Purpose
+
+This library's grammar descends from OAP's. The Phase-0 corpus dry-run surfaced
+two spellings the ancestor dialect uses that this grammar did not yet accept,
+both of which are pure surface convenience carrying no information the canonical
+form lacks:
+
+1. **The `unit:` wrapper.** Where this library writes an `establishes` item as a
+   bare unit (`establishes: ["src/lib.rs"]` or a tagged `{ kind, ... }` map), the
+   ancestor wraps each item in a single-key map: `establishes: [{ unit: "src/lib.rs" }]`.
+   The dry-run found this on 389 items across ~97 specs, and in every one `unit`
+   is the only key -- the wrapper is redundant punctuation.
+2. **The `n/a` alias.** This library spells "not applicable" `n-a` (the
+   kebab-case family its other `implementation` values use); the ancestor writes
+   `n/a`. The dry-run found 5 specs using the slash form.
+
+Requiring a mass-migration commit in the adopter's corpus as the price of
+adoption is backwards: the corpus is the adopter's truth and the compiler should
+meet it where the difference is spelling, not meaning. The fix is sugar, not
+semantics -- both forms normalize to the canonical representation at parse time,
+so every downstream consumer (query, index, couple, overlays) continues to see
+exactly one unit shape and one `implementation` spelling.
+
+## 2. Territory
+
+The Unit deserializer (`unit.rs`: accept the wrapper as a third representation)
+and the `Implementation` enum (`frontmatter.rs`: a serde alias on the `n-a`
+variant), both in the shared parse entry the whole pipeline funnels through. No
+change to `compile.rs`, `index`, `lint`, `couple`, the registry schema, or the
+JSON Schema artifact. Additive.
+
+The wrapper is defined at the unit level, so it is uniformly accepted wherever a
+`Unit` is parsed (it would also unwrap on a `co_authority`/`constrains`/
+`references` item's `unit:` value), not special-cased to `establishes`. This is
+the simplest correct implementation -- one 1:1 representation rule rather than an
+edge-specific carve-out -- and is harmless: the wrapper is only ever authored on
+`establishes`, and on any edge it still normalizes to the same single unit.
+
+## 3. Behavior
+
+### 3.1 The `unit:` wrapper (a third 1:1 unit representation)
+
+A `Unit` already deserializes from either a bare string (= a file unit) or a
+tagged `{ kind, ... }` map (000 §4.2). This adds a third accepted form:
+
+```yaml
+establishes:
+  - "src/lib.rs"                                   # existing: bare string
+  - { kind: symbol, id: "crate::run" }             # existing: tagged map
+  - { unit: "src/lib.rs" }                         # new: wrapper over a bare string
+  - { unit: { kind: section, file: "Makefile", anchor: "ci" } }  # new: wrapper over a tagged map
+```
+
+- The wrapper is a map whose single key is `unit:`; its value is itself a unit
+  in any accepted form (bare or tagged). The deserializer recurses through the
+  same impl, so the inner unit inherits its own validation -- e.g. an empty
+  wrapped path (`{ unit: "" }`) is rejected exactly as a bare `""` is.
+- The wrapper is 1:1 (one wrapper -> one unit), unlike 014's `paths:` list
+  (1:N), which is why it lives in the `Unit` deserializer beside the bare/tagged
+  forms rather than as a frontmatter normalize step.
+
+### 3.2 The `n/a` implementation alias
+
+`implementation: n/a` is accepted as a deserialize-only alias for the
+`Implementation::Na` variant whose canonical spelling is `n-a`. Both spellings
+parse to the same value; `n-a` remains the only spelling ever serialized into
+`registry.json`. No other `implementation` value gains an alias.
+
+### 3.3 Normalization and equivalence (the sugar never escapes)
+
+Both behaviors resolve entirely inside the parse layer. A `{ unit: X }` wrapper
+becomes the unit `X`; `n/a` becomes `Na`. `registry.json` therefore contains
+**only** bare/tagged units (never a wrapper) and **only** `n-a` (never `n/a`) --
+its schema, the JSON Schema artifact, and every consumer are untouched (no
+schema bump; the wire shape is unchanged precisely because the sugar normalizes
+away before emission).
+
+The contract: a corpus authored in the predecessor dialect (every `establishes`
+item `{ unit: ... }`-wrapped, `implementation: n/a`) MUST compile to a registry
+byte-identical to the same corpus authored canonically (bare/tagged units,
+`implementation: n-a`), modulo `build.contentHash` (which hashes the authored
+spec bytes, and those differ by construction). This byte-equivalence golden is
+the acceptance test.
+
+### 3.4 Tests (minimum)
+
+- The §3.3 byte-equivalence golden: a wrapped + `n/a` corpus compiles to a
+  registry byte-identical to the canonical spelling.
+- The wrapper unwraps over both a bare-string and a tagged inner unit, mixed
+  within one `establishes` list with un-wrapped items.
+- A wrapped empty path (`{ unit: "" }`) is still rejected.
+- `implementation: n/a` and `n-a` parse to the same value, and `Na` serializes
+  back as `n-a`.
+
+## 4. Out of scope
+
+Aliases for any other `implementation` value, or for `status`/`risk` (the
+dry-run surfaced only `n/a`; widen only on evidence). A wrapper form for the
+edge item structs themselves (`extends`/`refines`/`constrains` items are
+`{ spec/aspect, unit, ... }` maps by design, not bare units -- their `unit:`
+field already is the unit). Any registry schema change. The structured
+`supersedes` form (`{ spec, scope: partial, unit }`) the dry-run also surfaced:
+that is partial-supersession **semantics**, not spelling, and is being taken to
+design separately rather than widened into the grammar here.


### PR DESCRIPTION
Files spec 015 and implements it. Two pieces of authoring sugar for the
predecessor (OAP) dialect, both normalized away at parse so nothing new
reaches `registry.json`.

## What changes

1. **`unit:` wrapper** — a `Unit` now deserializes from a `{ unit: <unit> }`
   wrapper as well as the existing bare-string and tagged-map forms. It is a
   1:1 representation (one wrapper to one unit), so it lives in the `Unit`
   deserializer beside the bare/tagged forms (unlike 014's `paths:`, which is
   1:N and lives in a frontmatter normalize step). The inner unit recurses
   through the same impl, so it may itself be bare or tagged and inherits its
   own validation. The corpus uses this on `establishes` (389 items, ~97
   specs); it is accepted uniformly wherever a unit is parsed.
2. **`n/a` alias** — `implementation: n/a` is a deserialize-only alias for the
   canonical `Implementation::Na`, whose only emitted spelling stays `n-a`.

No `compile.rs`/index/lint/couple change, no registry-schema change, no JSON
Schema text change — the wire shape is unchanged because the sugar normalizes
away before emission. The §3.3 acceptance test asserts byte-equivalence: a
wrapped + `n/a` corpus compiles to a registry byte-identical to the canonical
spelling.

## Status

- `status: draft` — left for the maintainer's approve flip (the 000–008
  convention; not flipped autonomously).
- `implementation: complete`.

## Gates (local, mirror CI)

- `compile` — 16 specs, 0 warnings
- `index check` — fresh
- `lint --fail-on-warn` — 0/0/0
- `couple --base origin/main --head HEAD` — OK, 5 paths checked, no drift
- `cargo test --workspace` — all green (grammar +3, compile +1); `clippy -D warnings` clean; `fmt --check` clean