### PR TITLE
feat: resolve short spec ids on depends_on and superseded_by (spec 016)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "bc3bfc8472dd56a49b87bb19549f741f17d3270dcc6e0decae576b706be3fe32",
+    "contentHash": "2fcc2d3e8d01987f71f9236c3fe00e71e40c2161deb5f965ef8d209244ea7cbc",
     "indexerId": "spec-spine",
     "indexerVersion": "0.2.0",
     "repoRoot": "."
@@ -1610,6 +1610,51 @@
           }
         ],
         "specId": "015-establishes-wrapper-na-alias",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/src/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/compile.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/compile.rs"
+            }
+          }
+        ],
+        "specId": "016-short-id-resolution",
         "specStatus": "draft"
       }
     ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.2.0",
-    "contentHash": "74db4d970d9838accc015217f05f163d06fe1f1199aa0959c30809ebbe236c87",
+    "contentHash": "c31f6bfe16eb42af2e874c30db0a088062f1ce29d5b2edf1421027541e4ce110",
     "inputRoot": "."
   },
   "specVersion": "0.2.0",
@@ -976,6 +976,49 @@
       "status": "draft",
       "summary": "Two pieces of authoring sugar for the predecessor dialect, both normalized away at parse so nothing new reaches registry.json. (1) An authority unit may be written as a single-key `{ unit: <unit> }` wrapper -- a third 1:1 representation alongside the existing bare-string and tagged-map forms -- which the Unit deserializer unwraps to its inner unit. The corpus uses this on `establishes` items (one wrapper per item, `unit` the only field). (2) `implementation: n/a` is accepted as a deserialize-only alias for the canonical `n-a`, which stays the only spelling ever emitted. Neither changes the registry schema or any consumer; both unblock adopting a corpus authored in the OAP dialect (389 wrapped establishes items across ~97 specs; 5 specs using `n/a`) without a mass frontmatter migration.\n",
       "title": "Frontmatter sugar: `unit:`-wrapped establishes items and the `n/a` implementation alias"
+    },
+    {
+      "created": "2026-06-11",
+      "dependsOn": [
+        "001-compile-registry"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/compile.rs"
+          }
+        }
+      ],
+      "id": "016-short-id-resolution",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "016: resolve short spec ids on `depends_on` and `superseded_by`",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Resolution policy",
+        "3.2 Scope: which references resolve",
+        "3.3 Ordering, determinism, and the canonical no-op",
+        "3.4 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/016-short-id-resolution/spec.md",
+      "status": "draft",
+      "summary": "Lets a `depends_on` or `superseded_by` reference name its target by the leading spec number alone (`109`) and have the compiler resolve it to the full id (`109-slug`) when exactly one spec matches that number, rewriting the reference before validation and emission. An exact id, an ambiguous number, or a number matching nothing is left unchanged, so V-008 (superseded_by must resolve) and V-010 (dangling depends_on) still fire on a genuinely broken reference. The resolution policy is the indexer's existing `resolve_id` (spec 004), applied at compile time so the registry and the index agree. Unblocks adopting a corpus that references specs by number (106 specs in the OAP dry-run) without a mass frontmatter migration; a no-op on any corpus that already uses full ids (such as this repo's own).\n",
+      "title": "Compile: resolve short spec ids on `depends_on` and `superseded_by`"
     }
   ],
   "validation": {

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -115,6 +115,21 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
         .collect();
     detect_duplicates(&id_paths, &mut violations);
 
+    // --- short-id resolution (spec 016): rewrite a depends_on / superseded_by
+    // reference that names a spec by its leading number (`109`) to the full id
+    // (`109-slug`), before validation (V-008/V-010) and record construction see
+    // it. A genuinely dangling or ambiguous reference is left unchanged, so its
+    // V-code still fires. Resolution is a pure function of the id set, so the
+    // registry stays deterministic.
+    for p in &mut parsed {
+        for dep in &mut p.fm.depends_on {
+            *dep = resolve_spec_ref(dep, &all_ids);
+        }
+        if let Some(by) = p.fm.superseded_by.as_mut() {
+            *by = resolve_spec_ref(by, &all_ids);
+        }
+    }
+
     // --- per-spec validation + record construction ---
     let mut records: Vec<SpecRecord> = Vec::new();
     for p in parsed {
@@ -319,6 +334,26 @@ fn build_record(fm: Frontmatter, spec_path: String, body: &str) -> SpecRecord {
         amendment_record: fm.amendment_record,
         origin: fm.origin,
         extra_frontmatter: fm.extra_frontmatter,
+    }
+}
+
+/// Resolve a short spec reference (`109`) to the full id (`109-slug`) by its
+/// leading numeric segment, when exactly one spec matches. An exact id, an
+/// ambiguous prefix, or no match returns the input unchanged (so V-008/V-010
+/// still fire on a genuinely dangling reference). Mirrors the indexer's
+/// `resolve_id` (spec 004) so compile-time and index-time resolution agree;
+/// kept local to avoid coupling the compile gate (001) to the indexer's file.
+fn resolve_spec_ref(short: &str, all_ids: &std::collections::BTreeSet<String>) -> String {
+    if all_ids.contains(short) {
+        return short.to_string();
+    }
+    let matches: Vec<&String> = all_ids
+        .iter()
+        .filter(|id| id.split('-').next() == Some(short))
+        .collect();
+    match matches.as_slice() {
+        [only] => (*only).clone(),
+        _ => short.to_string(),
     }
 }
 

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -432,3 +432,68 @@ fn establishes_wrapper_and_na_alias_are_byte_equivalent() {
     );
     assert_eq!(a.registry.validation, b.registry.validation);
 }
+
+#[test]
+fn short_id_depends_on_resolves_to_full_id() {
+    // Spec 016: a depends_on naming a spec by its leading number resolves to
+    // the full id; the record carries the resolved id and no V-010 fires.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-base", "001-base", "");
+    write_spec(tmp.path(), "002-a", "002-a", "depends_on: [\"001\"]\n");
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(
+        !codes(&outcome).contains(&"V-010".to_string()),
+        "a resolvable short id must not warn"
+    );
+    let rec = outcome
+        .registry
+        .specs
+        .iter()
+        .find(|s| s.id == "002-a")
+        .unwrap();
+    assert_eq!(rec.depends_on, vec!["001-base".to_string()]);
+}
+
+#[test]
+fn short_id_superseded_by_resolves() {
+    // Spec 016: superseded_by accepts the short form; resolution clears V-008
+    // and the record carries the full id.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "002-new", "002-new", "");
+    let spec_dir = tmp.path().join("specs").join("001-old");
+    fs::create_dir_all(&spec_dir).unwrap();
+    fs::write(
+        spec_dir.join("spec.md"),
+        "---\nid: \"001-old\"\ntitle: t\nstatus: superseded\ncreated: \"2026-06-08\"\nsummary: s\nsuperseded_by: \"002\"\n---\n",
+    )
+    .unwrap();
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(
+        !codes(&outcome).contains(&"V-008".to_string()),
+        "a resolvable short superseded_by must not error"
+    );
+    let rec = outcome
+        .registry
+        .specs
+        .iter()
+        .find(|s| s.id == "001-old")
+        .unwrap();
+    assert_eq!(rec.superseded_by, Some("002-new".to_string()));
+}
+
+#[test]
+fn dangling_short_id_is_left_unchanged_and_still_warns() {
+    // Spec 016: a reference that matches no spec resolves to itself, so the
+    // existing dangling-reference V-code still fires.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "depends_on: [\"999\"]\n");
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    assert!(codes(&outcome).contains(&"V-010".to_string()));
+    let rec = outcome
+        .registry
+        .specs
+        .iter()
+        .find(|s| s.id == "001-a")
+        .unwrap();
+    assert_eq!(rec.depends_on, vec!["999".to_string()]);
+}

--- a/specs/016-short-id-resolution/spec.md
+++ b/specs/016-short-id-resolution/spec.md
@@ -1,0 +1,111 @@
+---
+id: "016-short-id-resolution"
+title: "Compile: resolve short spec ids on `depends_on` and `superseded_by`"
+status: draft
+kind: "tooling"
+created: "2026-06-11"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+extends:
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+summary: >
+  Lets a `depends_on` or `superseded_by` reference name its target by the
+  leading spec number alone (`109`) and have the compiler resolve it to the full
+  id (`109-slug`) when exactly one spec matches that number, rewriting the
+  reference before validation and emission. An exact id, an ambiguous number, or
+  a number matching nothing is left unchanged, so V-008 (superseded_by must
+  resolve) and V-010 (dangling depends_on) still fire on a genuinely broken
+  reference. The resolution policy is the indexer's existing `resolve_id` (spec
+  004), applied at compile time so the registry and the index agree. Unblocks
+  adopting a corpus that references specs by number (106 specs in the OAP
+  dry-run) without a mass frontmatter migration; a no-op on any corpus that
+  already uses full ids (such as this repo's own).
+---
+
+# 016: resolve short spec ids on `depends_on` and `superseded_by`
+
+## 1. Purpose
+
+The predecessor dialect commonly references a spec by its number alone --
+`depends_on: ["109"]`, `superseded_by: "042"` -- rather than its full
+`NNN-slug` id. This library's compiler matches a reference against the literal
+id set, so a numeric short form resolves to nothing: a `depends_on` short id
+raises V-010 (dangling, warning) and a `superseded_by` short id raises V-008
+(does not resolve, error), the latter failing the corpus. The Phase-0 dry-run
+found 106 specs using the short form.
+
+The id is unambiguous: V-004 already forbids two specs sharing a numeric
+prefix, so a number identifies at most one spec. Resolving it is therefore a
+deterministic convenience, not a semantic guess. The indexer already does
+exactly this (`index.rs::resolve_id`, spec 004) when it resolves `amends`
+references for the trace graph; this spec applies the same policy at compile
+time, on the two fields whose short ids currently break validation, so the
+emitted registry carries full ids and the two gates stop flagging a reference
+that is merely abbreviated.
+
+## 2. Territory
+
+The compile resolution pass and its helper (`compile.rs`), plus tests
+(`tests/compile.rs`). The resolution function is a local mirror of
+`index.rs::resolve_id` rather than a shared call, to keep the compile gate (001)
+from taking a code dependency on the indexer's file (004); the two are pinned
+equal by behavior and a citing comment, not by linkage. No change to the
+registry schema, the JSON Schema artifact, the indexer, lint, or couple.
+Additive.
+
+## 3. Behavior
+
+### 3.1 Resolution policy
+
+For a reference string `r` against the set of all compiled spec ids:
+
+1. If `r` is exactly an existing id, keep it.
+2. Otherwise, collect every id whose leading dash-segment (the text before the
+   first `-`) equals `r`. If exactly one matches, resolve `r` to it.
+3. Otherwise (no match, or -- only possible under an existing V-004 violation --
+   more than one), keep `r` unchanged.
+
+This is `index.rs::resolve_id` verbatim. Note it matches the **whole** leading
+segment, not an arbitrary character prefix: `109` resolves `109-foo`, but `10`
+resolves nothing, and a wrong full slug (`109-typo`) resolves nothing rather
+than silently snapping to `109-foo`.
+
+### 3.2 Scope: which references resolve
+
+Only `depends_on` (each entry) and `superseded_by`. These are the two fields a
+short id currently breaks (V-010, V-008). `supersedes` and `amends` are out of
+scope here: they raise no compile V-code on a short id today, and the indexer
+already resolves `amends` for its own graph (spec 004). Edge `unit:` targets are
+paths, not spec ids, and are untouched.
+
+### 3.3 Ordering, determinism, and the canonical no-op
+
+Resolution runs once, after the full id set is known and before per-spec
+validation and record construction, so both the V-codes and the emitted records
+see the resolved value. It is a pure function of the id set, so the registry
+stays deterministic. A reference that is already a full id is returned
+unchanged, so a corpus that uses full ids throughout -- including this
+repository's own -- compiles to a byte-identical registry (this spec adds its
+own record and nothing else).
+
+### 3.4 Tests (minimum)
+
+- A short `depends_on` resolves to the full id, the record carries the resolved
+  id, and no V-010 fires.
+- A short `superseded_by` on a superseded spec resolves, clearing V-008, with
+  the full id in the record.
+- A reference matching no spec is left unchanged and still raises its V-code.
+
+## 4. Out of scope
+
+Resolution of `supersedes`/`amends` (no compile V-code today; `amends` already
+resolved at index time -- file a follow-up only if an adopter shows a need).
+Arbitrary-prefix or fuzzy matching (the policy is exact-segment, single-match,
+by design). Cross-field reference rewriting in the index beyond what spec 004
+already does. Any registry schema change. The structured `supersedes` form
+(`{ spec, scope: partial, unit }`) surfaced by the same dry-run: that is
+partial-supersession semantics, taken to design separately, not an id-spelling
+concern.


### PR DESCRIPTION
Files spec 016 and implements it. A `depends_on` or `superseded_by` reference
may name its target by the leading spec number (`109`); the compiler resolves
it to the full id (`109-slug`) when exactly one spec matches.

## What changes

- A resolution pass in `compile.rs` runs after the id set is known and before
  validation + record construction, rewriting each `depends_on` entry and
  `superseded_by` via a local `resolve_spec_ref`. The helper is a verbatim
  mirror of the indexer's `resolve_id` (spec 004), kept local so the compile
  gate (001) takes no code dependency on the indexer's file (004); the two are
  pinned equal by a citing comment.
- An exact id, an ambiguous number, or a number matching nothing is left
  unchanged — so V-010 (dangling `depends_on`) and V-008 (`superseded_by` must
  resolve) still fire on a genuinely broken reference.
- Scope is `depends_on` + `superseded_by` only (the two fields a short id
  breaks today). `supersedes`/`amends` are out of scope; `amends` is already
  resolved at index time.

No registry-schema change, no JSON Schema change, no indexer/lint/couple change.
Deterministic (pure function of the id set) and a **no-op on any corpus already
using full ids** — including this repo's own, so the only registry delta is the
new 016 record.

## Status

- `status: draft` — left for the maintainer's approve flip (not flipped
  autonomously).
- `implementation: complete`.

## Gates (local, mirror CI)

- `compile` — 17 specs, 0 warnings
- `index check` — fresh
- `lint --fail-on-warn` — 0/0/0
- `couple --base origin/main --head HEAD` — OK, 3 paths checked, no drift
- `cargo test --workspace` — all green (compile +3); `clippy -D warnings` clean; `fmt --check` clean