### PR TITLE
chore: single version-bump script + fix main 0.2.0 drift

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,13 +13,16 @@
 - [ ] Working tree clean and green: `cargo test --workspace --locked`.
 - [ ] Self-governance green: `spec-spine compile && spec-spine index check &&
       spec-spine lint --fail-on-warn && spec-spine couple --base origin/main --head HEAD`.
-- [ ] Versions bumped consistently (workspace `version` in the root `Cargo.toml`;
-      `version` in `npm/package.json` and its `optionalDependencies` pins, which
-      the release workflow re-locks to the tag but should match in source;
-      `version` in `py/pyproject.toml`, which the release workflow verifies
-      against the tag and fails loudly on a mismatch;
-      schema-version constants in `spec-spine-types` per
-      [schema-versioning.md](schema-versioning.md) if the schema changed).
+- [ ] Versions bumped consistently with `scripts/bump_version.py <version>`,
+      then `scripts/bump_version.py --check <version>` is green. The script sets
+      all three shims in lockstep — workspace `version` in the root `Cargo.toml`;
+      `version` + the `optionalDependencies` pins in `npm/package.json` (the
+      release workflow re-locks these to the tag via `--write-main`, but they
+      should match in source); `version` in `py/pyproject.toml` (the workflow
+      verifies this against the tag and fails loudly on a mismatch — the asymmetry
+      that let v0.2.0's PyPI publish fail while npm/crates shipped). Schema-version
+      constants in `spec-spine-types` are decoupled — bump them separately per
+      [schema-versioning.md](schema-versioning.md) only if the schema changed.
 - [ ] `cargo package --workspace --locked` succeeds (it cross-verifies every
       crate from its packaged sources, in dependency order: the same check CI can
       run).

--- a/npm/package.json
+++ b/npm/package.json
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.1.0",
-    "@spec-spine/cli-darwin-x64": "0.1.0",
-    "@spec-spine/cli-linux-x64": "0.1.0",
-    "@spec-spine/cli-linux-arm64": "0.1.0",
-    "@spec-spine/cli-win32-x64": "0.1.0"
+    "@spec-spine/cli-darwin-arm64": "0.2.0",
+    "@spec-spine/cli-darwin-x64": "0.2.0",
+    "@spec-spine/cli-linux-x64": "0.2.0",
+    "@spec-spine/cli-linux-arm64": "0.2.0",
+    "@spec-spine/cli-win32-x64": "0.2.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -18,8 +18,9 @@ name = "spec-spine"
 # Single source of truth at publish time is the git tag; generate_wheels.py and
 # the sdist build are both invoked with --version / SETUPTOOLS_SCM-free explicit
 # version by release.yml, and the lock check fails on a tag/version mismatch
-# (§3.5 parity). 0.1.0 here tracks the workspace version.
-version = "0.1.0"
+# (§3.5 parity). Tracks the workspace version; bumped in lockstep with
+# Cargo.toml and npm/package.json by scripts/bump_version.py.
+version = "0.2.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Bump the package version in lockstep across all three distribution shims.
+
+The release version lives in three committed files, and a release tag publishes
+all three (crates.io, npm, PyPI) under the same number. They MUST agree:
+
+  - Cargo.toml           [workspace.package] version  (crates.io)
+  - npm/package.json     version + the 5 optionalDependencies pins  (npm)
+  - py/pyproject.toml    [project] version  (PyPI)
+
+History (why this script exists): v0.2.0 bumped Cargo + npm but missed
+pyproject, so the PyPI release failed on generate_wheels.py's version lock
+(spec 008 §3.5) while npm published fine -- the npm generator runs with
+--write-main and silently rewrites a stale version to the tag, so only PyPI
+enforces. This script removes the chance to bump one and forget another.
+
+NOTE: this bumps the *package* version only. Schema-version constants in
+spec-spine-types are deliberately decoupled (a release can ship without a
+schema change); bump those separately per docs/schema-versioning.md.
+
+Usage:
+  scripts/bump_version.py 0.2.0      # set all four locations to 0.2.0
+  scripts/bump_version.py v0.2.0     # leading 'v' is stripped
+  scripts/bump_version.py --check    # verify all locations agree (no writes)
+  scripts/bump_version.py --check 0.2.0   # ...and that they equal 0.2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CARGO = ROOT / "Cargo.toml"
+PACKAGE_JSON = ROOT / "npm" / "package.json"
+PYPROJECT = ROOT / "py" / "pyproject.toml"
+
+# The first top-level `version = "..."` line. In Cargo.toml that is the
+# [workspace.package] version (dependency versions are inline `{ version = ... }`,
+# never at column 0); in pyproject.toml it is the [project] version.
+_TOML_VERSION = re.compile(r'(?m)^(version\s*=\s*)"[^"]*"')
+# package.json: the single top-level "version" key (opt-dep keys are package
+# names, never the literal "version").
+_JSON_VERSION = re.compile(r'("version"\s*:\s*)"[^"]*"')
+# The 5 platform pins under optionalDependencies.
+_JSON_PIN = re.compile(r'("@spec-spine/cli-[^"]+"\s*:\s*)"[^"]*"')
+
+
+def die(msg: str) -> "None":
+    print(f"bump-version: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def normalize(v: str) -> str:
+    return v[1:] if v.startswith("v") else v
+
+
+def _sub_once(pattern: re.Pattern, text: str, version: str, what: str) -> str:
+    new, n = pattern.subn(rf'\g<1>"{version}"', text, count=1)
+    if n != 1:
+        die(f"expected exactly one {what} to rewrite, found {n}")
+    return new
+
+
+# --- readers (also used by --check) ------------------------------------------
+
+def read_cargo() -> str:
+    m = _TOML_VERSION.search(CARGO.read_text())
+    return m.group(0).split('"')[1] if m else die("no version in Cargo.toml")
+
+
+def read_pyproject() -> str:
+    m = _TOML_VERSION.search(PYPROJECT.read_text())
+    return m.group(0).split('"')[1] if m else die("no version in pyproject.toml")
+
+
+def read_npm() -> tuple[str, set[str]]:
+    text = PACKAGE_JSON.read_text()
+    vm = _JSON_VERSION.search(text)
+    pins = {m.group(0).split('"')[3] for m in _JSON_PIN.finditer(text)}
+    return (vm.group(0).split('"')[3] if vm else die("no version in package.json"), pins)
+
+
+def current_versions() -> dict[str, str]:
+    npm_v, npm_pins = read_npm()
+    pin_repr = next(iter(npm_pins)) if len(npm_pins) == 1 else f"MIXED{sorted(npm_pins)}"
+    return {
+        "Cargo.toml": read_cargo(),
+        "npm/package.json (version)": npm_v,
+        "npm/package.json (pins)": pin_repr,
+        "py/pyproject.toml": read_pyproject(),
+    }
+
+
+# --- commands ----------------------------------------------------------------
+
+def do_bump(version: str) -> None:
+    CARGO.write_text(_sub_once(_TOML_VERSION, CARGO.read_text(), version, "version in Cargo.toml"))
+
+    pkg = PACKAGE_JSON.read_text()
+    pkg = _sub_once(_JSON_VERSION, pkg, version, 'top-level "version" in package.json')
+    pkg, npins = _JSON_PIN.subn(rf'\g<1>"{version}"', pkg)
+    if npins != 5:
+        die(f"expected 5 optionalDependencies pins in package.json, rewrote {npins}")
+    PACKAGE_JSON.write_text(pkg)
+
+    PYPROJECT.write_text(_sub_once(_TOML_VERSION, PYPROJECT.read_text(), version, "version in pyproject.toml"))
+
+    # Read back and prove they all agree -- a regex that silently no-ops on a
+    # restructured file would otherwise pass unnoticed.
+    if not check(version, quiet=True):
+        die("post-write verification failed (locations disagree after bump)")
+    print(f"bumped all locations to {version}")
+    for name, v in current_versions().items():
+        print(f"  {name}: {v}")
+
+
+def check(expected: str | None, quiet: bool = False) -> bool:
+    versions = current_versions()
+    distinct = set(versions.values())
+    ok = len(distinct) == 1 and (expected is None or distinct == {expected})
+    if not quiet:
+        for name, v in versions.items():
+            print(f"  {name}: {v}")
+        if ok:
+            print(f"OK: all locations agree on {distinct.pop()}")
+        elif len(distinct) != 1:
+            print("MISMATCH: version locations disagree", file=sys.stderr)
+        else:
+            print(f"MISMATCH: locations agree on {distinct.pop()} but expected {expected}", file=sys.stderr)
+    return ok
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="bump-version", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("version", nargs="?", help="target version, e.g. 0.2.0 (leading 'v' ok)")
+    p.add_argument("--check", action="store_true",
+                   help="verify all locations agree (and equal VERSION if given); no writes")
+    args = p.parse_args(argv)
+
+    if args.check:
+        return 0 if check(normalize(args.version) if args.version else None) else 1
+    if not args.version:
+        p.error("a version is required (or pass --check to verify)")
+    do_bump(normalize(args.version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Adds `scripts/bump_version.py` — a single source for the lockstep version bump
across all three distribution shims — and brings `main` to a consistent `0.2.0`.

## Why

The v0.2.0 release bumped `Cargo.toml` and `npm/package.json` but missed
`py/pyproject.toml`, so the PyPI publish hard-failed on `generate_wheels.py`'s
§3.5 version lock while npm and crates.io shipped (the npm generator's
`--write-main` rewrites a stale version to the tag, so only PyPI enforced).
The fix tag still left `main` drifted: `py/pyproject.toml` and the
`npm/package.json` `optionalDependencies` pins were `0.1.0` while the Cargo
workspace and npm `version` were `0.2.0`.

## Changes

- `scripts/bump_version.py <version>` sets all four locations at once
  (Cargo workspace `version`, npm `version` + 5 `optionalDependencies` pins,
  `py/pyproject.toml` `version`); `--check` verifies they agree.
- Ran it to `0.2.0`, fixing the `main` drift (npm pins + pyproject).
- `docs/releasing.md` now points at the script; the pyproject comment no longer
  hardcodes a version.

Schema-version constants in `spec-spine-types` are intentionally untouched
(decoupled from the package version per `docs/schema-versioning.md`).

Spec-Drift-Waiver: Release-mechanics version bump only. `npm/package.json`
(spec 007), `py/pyproject.toml` (spec 008), and `docs/releasing.md` (spec 007)
change version strings / release-checklist prose with no change to the
distribution specs' intent; no authoring edit to those specs is warranted.
