### PR TITLE
fix(ci): run the coupling gate on pull_request only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,16 +52,20 @@ jobs:
         run: ./target/debug/spec-spine index check
       - name: Conformance lint (fail on warn)
         run: ./target/debug/spec-spine lint --fail-on-warn
+      # The coupling gate is a PR-time gate (spec 005 §1): it joins the spec and
+      # code views and refuses the *merge* when code drifts from its owning spec.
+      # It runs on pull_request only. A push to main has already merged (nothing
+      # left to refuse) and carries no PR body, so the Spec-Drift-Waiver line is
+      # unrecoverable: it lives in the PR description, not the squash commit
+      # message. A legitimately waived PR would otherwise resurface as a false
+      # drift failure on the post-merge main push.
       - name: Coupling gate (spec/code drift)
+        if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
-          fi
+          BASE="${{ github.event.pull_request.base.sha }}"
           echo "coupling base: $BASE → HEAD"
           printf '%s' "${PR_BODY:-}" > /tmp/pr-body.txt
           ./target/debug/spec-spine couple --base "$BASE" --head HEAD --pr-body /tmp/pr-body.txt


### PR DESCRIPTION
## What

Gate the dogfood job's **Coupling gate** step to `pull_request` events and remove the now-dead `HEAD~1` base branch.

## Why

[Run 27408627912](https://github.com/bartekus/spec-spine/actions/runs/27408627912/job/81003979824) (the post-merge `push` of #17) failed with 3 drift violations on `docs/releasing.md`, `npm/package.json`, `py/pyproject.toml` — the exact files #17 changed under a valid `Spec-Drift-Waiver:` line. The PR itself passed; only main went red after merge.

Root cause: the coupling step ran on **both** `pull_request` and `push: [main]`, but the push leg is structurally broken:

- The waiver is read from `${{ github.event.pull_request.body }}`, which is **empty on a `push` event**. The `Spec-Drift-Waiver:` line lives in the PR *description*, not the squash commit message, so it is unrecoverable post-merge.
- On push, `BASE = HEAD~1`, so the gate re-evaluates the just-merged diff with **no waiver** present. Every PR that legitimately waived drift lands green, then turns main red on the post-merge push.

This is also conceptually wrong: spec 005 §1 frames this as a **PR-time** gate that *"joins them at PR time"* and *"refuses the merge"*. By the time code is on main the merge has already happened — there is nothing left to refuse.

## Change

- `if: github.event_name == 'pull_request'` on the coupling step; drop the dead `HEAD~1` else-branch.
- `compile` / `index check` / `lint` still run on `push` as post-merge main invariants. Only the merge-refusal gate is now PR-scoped.

## Notes

- `.github/` is in the coupling bypass floor (`couple.rs::DEFAULT_BYPASS_PREFIXES`), so this change needs no owning-spec edit — verified locally: `couple --base main` reports `OK — 0 path(s) checked`.
- The committed index is unchanged (governance-projection hashing ignores this comment/conditional tweak); `index check` stays fresh.
- No spec behavior changes; spec 005 already describes the gate as PR-time.

Once merged, the post-merge `push` run no longer evaluates couple, so main goes green.