### PR TITLE
feat(017-019): reserved unit kinds, constrains discriminator, structured supersedes (0.3.0)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,8 +1,8 @@
 {
   "build": {
-    "contentHash": "2fcc2d3e8d01987f71f9236c3fe00e71e40c2161deb5f965ef8d209244ea7cbc",
+    "contentHash": "303472eddf0c4971991f01306545a0e9fb53834880b07f019bb5379f60a1294b",
     "indexerId": "spec-spine",
-    "indexerVersion": "0.2.0",
+    "indexerVersion": "0.3.0",
     "repoRoot": "."
   },
   "diagnostics": {
@@ -33,10 +33,10 @@
       "name": "spec-spine",
       "path": "npm",
       "specRef": "007-distribution",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   ],
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "traceability": {
     "mappings": [
       {
@@ -1655,6 +1655,500 @@
           }
         ],
         "specId": "016-short-id-resolution",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "004-codebase-index"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/src/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/symbols.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/unit.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/version.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/dtos.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/grammar.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/symbols.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/symbols.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/unit.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/unit.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/version.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/version.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/dtos.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/dtos.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/grammar.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/grammar.rs"
+            }
+          }
+        ],
+        "specId": "017-directory-crate-module-units",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry",
+          "004-codebase-index"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/src/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/edges.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/grammar.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/edges.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/edges.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/grammar.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/grammar.rs"
+            }
+          }
+        ],
+        "specId": "018-constrains-discriminator-optional-unit",
+        "specStatus": "draft"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry",
+          "005-coupling-gate"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-core/src/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/couple.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/index.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/lint.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/query.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/compile.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/couple.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/edges.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/frontmatter.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/registry.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/version.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/dtos.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/tests/grammar.rs",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/couple.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/couple.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/index.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/index.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/lint.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/lint.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/query.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/query.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/compile.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/compile.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/couple.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/couple.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/edges.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/edges.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/frontmatter.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/frontmatter.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/lib.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/registry.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/registry.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/version.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/version.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/dtos.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/dtos.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/tests/grammar.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/tests/grammar.rs"
+            }
+          }
+        ],
+        "specId": "019-structured-partial-supersedes",
         "specStatus": "draft"
       }
     ],

--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "303472eddf0c4971991f01306545a0e9fb53834880b07f019bb5379f60a1294b",
+    "contentHash": "195c70c153912314bab2b2d96a124d2242b54f08bf900a31417fa9d5b7a1d5d1",
     "indexerId": "spec-spine",
     "indexerVersion": "0.3.0",
     "repoRoot": "."

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.3.0",
-    "contentHash": "2ad56eaca73ddb8d511c61114e3c0cddf89b168b4f85895dcd3eb61901749fe7",
+    "contentHash": "1af1269ea00b9469bf66935cf41dd5411d4ccc336d3cce89499b1e5ecb1d159b",
     "inputRoot": "."
   },
   "specVersion": "0.3.0",
@@ -442,7 +442,7 @@
       "kind": "tooling",
       "owner": "The spec-spine Authors",
       "sectionHeadings": [
-        "008: Distribution — uvx/PyPI wheel shim",
+        "008: Distribution, uvx/PyPI wheel shim",
         "1. Purpose",
         "2. Territory",
         "3. Behavior",
@@ -1102,7 +1102,7 @@
       ],
       "specPath": "specs/017-directory-crate-module-units/spec.md",
       "status": "draft",
-      "summary": "Lifts the v1 unit-grammar limitation (`docs/design/00-architecture.md` §2.2, Q5): the three reserved kinds — `directory`, `crate`, and `module` — are now parsed and resolved alongside `file`/`section`/`symbol`. A `directory` unit resolves to its subtree (existence-checked, I-007 on miss); a `crate` unit resolves a manifest name against the discovered package inventory to that package's directory subtree (I-003 on miss, hyphen/underscore interchangeable); a `module` unit resolves a `::`-qualified Rust module path via a new module index — file-modules whole-file, top-level inline `mod` blocks to their span (I-008 on miss). The registry/index schemas are permissive on the unit payload, so this is an additive MINOR (`INDEX_SCHEMA_VERSION` 0.2.0 → 0.3.0) with no schema-file edit. Unblocks adopting the OAP corpus, which authors these three kinds across ~192 unit declarations (93 `directory`, 99 `crate`, 1 `module`) with no mass frontmatter migration.\n",
+      "summary": "Lifts the v1 unit-grammar limitation (`docs/design/00-architecture.md` §2.2, Q5): the three reserved kinds (`directory`, `crate`, and `module`) are now parsed and resolved alongside `file`/`section`/`symbol`. A `directory` unit resolves to its subtree (existence-checked, I-007 on miss); a `crate` unit resolves a manifest name against the discovered package inventory to that package's directory subtree (I-003 on miss, hyphen/underscore interchangeable); a `module` unit resolves a `::`-qualified Rust module path via a new module index; file-modules whole-file, top-level inline `mod` blocks to their span (I-008 on miss). The registry/index schemas are permissive on the unit payload, so this is an additive MINOR (`INDEX_SCHEMA_VERSION` 0.2.0 → 0.3.0) with no schema-file edit. Unblocks adopting the OAP corpus, which authors these three kinds across ~192 unit declarations (93 `directory`, 99 `crate`, 1 `module`) with no mass frontmatter migration.\n",
       "title": "Authority units: resolve the reserved directory / crate / module kinds"
     },
     {
@@ -1178,7 +1178,7 @@
       ],
       "specPath": "specs/018-constrains-discriminator-optional-unit/spec.md",
       "status": "draft",
-      "summary": "Widens the `constrains` item grammar to the two shapes the predecessor dialect authors: a **path-scoped** constraint (`unit:`, the canonical `invariant-freeze` over a file or schema) and a **spec-scoped** constraint (`target_specs:`, a sequencing/ordering plan over other specs with no code unit). Two changes: `unit` becomes optional, and an optional documentary discriminator is accepted under either spelling `flavor:` or `kind:` (synonyms, not gate-load-bearing). A new V-011 requires every item to scope at least one of `unit` / `target_specs`. A spec-scoped item contributes no resolved unit to the index. Unblocks the OAP corpus, which authors `{ flavor: invariant-freeze, unit }` (spec 130) and `{ kind: <plan>, target_specs }` (specs 078, 089) — both rejected by the unit-required, discriminator-less v1 grammar.\n",
+      "summary": "Widens the `constrains` item grammar to the two shapes the predecessor dialect authors: a **path-scoped** constraint (`unit:`, the canonical `invariant-freeze` over a file or schema) and a **spec-scoped** constraint (`target_specs:`, a sequencing/ordering plan over other specs with no code unit). Two changes: `unit` becomes optional, and an optional documentary discriminator is accepted under either spelling `flavor:` or `kind:` (synonyms, not gate-load-bearing). A new V-011 requires every item to scope at least one of `unit` / `target_specs`. A spec-scoped item contributes no resolved unit to the index. Unblocks the OAP corpus, which authors `{ flavor: invariant-freeze, unit }` (spec 130) and `{ kind: <plan>, target_specs }` (specs 078, 089), both rejected by the unit-required, discriminator-less v1 grammar.\n",
       "title": "Constrains grammar: classification discriminator and optional unit"
     },
     {
@@ -1319,7 +1319,7 @@
       ],
       "specPath": "specs/019-structured-partial-supersedes/spec.md",
       "status": "draft",
-      "summary": "Implements Option A from `docs/design/01-partial-supersession.md`: a `supersedes` item may be a bare predecessor id (full) or a structured `{ spec, scope, unit?, note?, rationale? }`. A full item (bare id or `scope: full`) normalizes to the bare-string form, so a full-only corpus emits a byte-identical registry — the wire is unchanged for every existing adopter; only a partial item serializes as an object. `scope: partial` with a `unit` transfers authority over that unit alone (additive — the predecessor keeps it and everything else), threaded through the index as a `supersedes` resolved unit so the gate already treats the successor as an owner of that unit's paths; `build_superseders` therefore contributes only **full** supersession to the whole-spec transfer. A partial item with no unit (a documentary lifecycle marker) transfers nothing. Short ids on the predecessor resolve like `depends_on` (spec 016). Unblocks the OAP corpus shapes 073 (`scope: full`), 108 (bare short id), 114 (`partial` + unit), and 199 (`partial` + note).\n",
+      "summary": "Implements Option A from `docs/design/01-partial-supersession.md`: a `supersedes` item may be a bare predecessor id (full) or a structured `{ spec, scope, unit?, note?, rationale? }`. A full item (bare id or `scope: full`) normalizes to the bare-string form, so a full-only corpus emits a byte-identical registry; the wire is unchanged for every existing adopter; only a partial item serializes as an object. `scope: partial` with a `unit` transfers authority over that unit alone (additive, the predecessor keeps it and everything else), threaded through the index as a `supersedes` resolved unit so the gate already treats the successor as an owner of that unit's paths; `build_superseders` therefore contributes only **full** supersession to the whole-spec transfer. A partial item with no unit (a documentary lifecycle marker) transfers nothing. Short ids on the predecessor resolve like `depends_on` (spec 016). Unblocks the OAP corpus shapes 073 (`scope: full`), 108 (bare short id), 114 (`partial` + unit), and 199 (`partial` + note).\n",
       "title": "Supersedes grammar: structured items and partial (unit-scoped) transfer"
     }
   ],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -1,11 +1,11 @@
 {
   "build": {
     "compilerId": "spec-spine",
-    "compilerVersion": "0.2.0",
-    "contentHash": "c31f6bfe16eb42af2e874c30db0a088062f1ce29d5b2edf1421027541e4ce110",
+    "compilerVersion": "0.3.0",
+    "contentHash": "2ad56eaca73ddb8d511c61114e3c0cddf89b168b4f85895dcd3eb61901749fe7",
     "inputRoot": "."
   },
-  "specVersion": "0.2.0",
+  "specVersion": "0.3.0",
   "specs": [
     {
       "authors": [
@@ -452,7 +452,8 @@
         "3.4 Unsupported hosts fail clearly",
         "3.5 Version lock",
         "3.6 Release integration",
-        "4. Out of scope"
+        "4. Out of scope",
+        "Release log"
       ],
       "specPath": "specs/008-python-distribution/spec.md",
       "status": "approved",
@@ -1019,6 +1020,307 @@
       "status": "draft",
       "summary": "Lets a `depends_on` or `superseded_by` reference name its target by the leading spec number alone (`109`) and have the compiler resolve it to the full id (`109-slug`) when exactly one spec matches that number, rewriting the reference before validation and emission. An exact id, an ambiguous number, or a number matching nothing is left unchanged, so V-008 (superseded_by must resolve) and V-010 (dangling depends_on) still fire on a genuinely broken reference. The resolution policy is the indexer's existing `resolve_id` (spec 004), applied at compile time so the registry and the index agree. Unblocks adopting a corpus that references specs by number (106 specs in the OAP dry-run) without a mass frontmatter migration; a no-op on any corpus that already uses full ids (such as this repo's own).\n",
       "title": "Compile: resolve short spec ids on `depends_on` and `superseded_by`"
+    },
+    {
+      "created": "2026-06-12",
+      "dependsOn": [
+        "004-codebase-index"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/unit.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/symbols.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/version.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        }
+      ],
+      "id": "017-directory-crate-module-units",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "017: directory / crate / module authority units",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Grammar",
+        "3.2 Resolution (in the indexer)",
+        "3.3 Staleness",
+        "3.4 Diagnostic codes",
+        "3.5 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/017-directory-crate-module-units/spec.md",
+      "status": "draft",
+      "summary": "Lifts the v1 unit-grammar limitation (`docs/design/00-architecture.md` §2.2, Q5): the three reserved kinds — `directory`, `crate`, and `module` — are now parsed and resolved alongside `file`/`section`/`symbol`. A `directory` unit resolves to its subtree (existence-checked, I-007 on miss); a `crate` unit resolves a manifest name against the discovered package inventory to that package's directory subtree (I-003 on miss, hyphen/underscore interchangeable); a `module` unit resolves a `::`-qualified Rust module path via a new module index — file-modules whole-file, top-level inline `mod` blocks to their span (I-008 on miss). The registry/index schemas are permissive on the unit payload, so this is an additive MINOR (`INDEX_SCHEMA_VERSION` 0.2.0 → 0.3.0) with no schema-file edit. Unblocks adopting the OAP corpus, which authors these three kinds across ~192 unit declarations (93 `directory`, 99 `crate`, 1 `module`) with no mass frontmatter migration.\n",
+      "title": "Authority units: resolve the reserved directory / crate / module kinds"
+    },
+    {
+      "created": "2026-06-12",
+      "dependsOn": [
+        "001-compile-registry",
+        "004-codebase-index"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/edges.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/index.rs"
+          }
+        }
+      ],
+      "id": "018-constrains-discriminator-optional-unit",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "018: constrains discriminator and optional unit",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Grammar",
+        "3.2 Index projection",
+        "3.3 Validation: V-011",
+        "3.4 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/018-constrains-discriminator-optional-unit/spec.md",
+      "status": "draft",
+      "summary": "Widens the `constrains` item grammar to the two shapes the predecessor dialect authors: a **path-scoped** constraint (`unit:`, the canonical `invariant-freeze` over a file or schema) and a **spec-scoped** constraint (`target_specs:`, a sequencing/ordering plan over other specs with no code unit). Two changes: `unit` becomes optional, and an optional documentary discriminator is accepted under either spelling `flavor:` or `kind:` (synonyms, not gate-load-bearing). A new V-011 requires every item to scope at least one of `unit` / `target_specs`. A spec-scoped item contributes no resolved unit to the index. Unblocks the OAP corpus, which authors `{ flavor: invariant-freeze, unit }` (spec 130) and `{ kind: <plan>, target_specs }` (specs 078, 089) — both rejected by the unit-required, discriminator-less v1 grammar.\n",
+      "title": "Constrains grammar: classification discriminator and optional unit"
+    },
+    {
+      "created": "2026-06-12",
+      "dependsOn": [
+        "001-compile-registry",
+        "005-coupling-gate"
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/edges.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/frontmatter.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/registry.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/version.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/compile.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "002-registry-query",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/query.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "003-conformance-lint",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/lint.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "004-codebase-index",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/index.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "005-coupling-gate",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/couple.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "005-coupling-gate",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/tests/couple.rs"
+          }
+        }
+      ],
+      "id": "019-structured-partial-supersedes",
+      "implementation": "complete",
+      "kind": "tooling",
+      "owner": "The spec-spine Authors",
+      "sectionHeadings": [
+        "019: structured and partial supersedes",
+        "1. Purpose",
+        "2. Territory",
+        "3. Behavior",
+        "3.1 Grammar",
+        "3.2 Normalization & wire (the full form never escapes)",
+        "3.3 Authority transfer",
+        "3.4 Short-id resolution",
+        "3.5 Tests (minimum)",
+        "4. Out of scope"
+      ],
+      "specPath": "specs/019-structured-partial-supersedes/spec.md",
+      "status": "draft",
+      "summary": "Implements Option A from `docs/design/01-partial-supersession.md`: a `supersedes` item may be a bare predecessor id (full) or a structured `{ spec, scope, unit?, note?, rationale? }`. A full item (bare id or `scope: full`) normalizes to the bare-string form, so a full-only corpus emits a byte-identical registry — the wire is unchanged for every existing adopter; only a partial item serializes as an object. `scope: partial` with a `unit` transfers authority over that unit alone (additive — the predecessor keeps it and everything else), threaded through the index as a `supersedes` resolved unit so the gate already treats the successor as an owner of that unit's paths; `build_superseders` therefore contributes only **full** supersession to the whole-spec transfer. A partial item with no unit (a documentary lifecycle marker) transfers nothing. Short ids on the predecessor resolve like `depends_on` (spec 016). Unblocks the OAP corpus shapes 073 (`scope: full`), 108 (bare short id), 114 (`partial` + unit), and 199 (`partial` + note).\n",
+      "title": "Supersedes grammar: structured items and partial (unit-scoped) transfer"
     }
   ],
   "validation": {

--- a/.gitattributes
+++ b/.gitattributes
@@ -42,7 +42,7 @@ Dockerfile* text eol=lf
 .eslintrc*  text eol=lf
 .prettierrc* text eol=lf
 
-# --- Binary — never touch line endings ---
+# --- Binary: never touch line endings ---
 *.png       binary
 *.jpg       binary
 *.jpeg      binary
@@ -60,11 +60,3 @@ Dockerfile* text eol=lf
 *.gz        binary
 *.tar       binary
 *.tgz       binary
-
-# --- Derived-artifact merge driver (spec 188) ---
-# The one committed derived artifact carries a global content hash, so two
-# branches that both regenerated it conflict textually. The `oap-index-regen`
-# driver regenerates it from the merged tree instead. Opt-in: register the
-# driver per-clone (see CLAUDE.md). If unregistered, git falls back to the
-# default text merge — no behavior change.
-.derived/codebase-index/index.json merge=oap-index-regen

--- a/.gitignore
+++ b/.gitignore
@@ -19,16 +19,16 @@ node_modules/
 /py/src/spec_spine.egg-info/
 __pycache__/
 
-# NOTE: .derived/ (compiler/indexer output) is intentionally NOT ignored — it is
+# NOTE: .derived/ (compiler/indexer output) is intentionally NOT ignored; it is
 # committed so the coupling gate and content-hash staleness check can compare the
 # committed registry/index against current inputs. Determinism makes this sane.
 # The one exception: build-meta.json carries a wall-clock `builtAt` (the sole
-# non-deterministic artifact), so it would churn on every compile — ignore it.
+# non-deterministic artifact), so it would churn on every compile; ignore it.
 .derived/**/build-meta.json
 
 # OS / editor cruft
 .DS_Store
 *.swp
 .env*
-# Local secrets (e.g. CARGO_REGISTRY_TOKEN) — never commit
+# Local secrets (e.g. CARGO_REGISTRY_TOKEN): never commit
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,149 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+spec-spine turns a markdown spec corpus into a typed, hash-verifiable authority
+ledger and **refuses code that drifts from its owning spec** at PR time. It is a
+three-crate Rust workspace publishing an installable library + CLI, plus npm and
+PyPI shims that ship the prebuilt binary. Read `docs/design/00-architecture.md`
+first: it is the load-bearing design doc (crate layout, full `Config`, public
+API, exit codes, schema plan, and the provenance of every ported algorithm).
+
+## House style (required)
+
+**Never use em dashes (the Unicode `U+2014` character).** This project is published
+under the author's name and em dashes read as an AI tell. Use a colon, semicolon,
+comma, parentheses, or two sentences instead. This applies to everything: code
+comments, doc comments, string literals, specs, docs, and commit messages. En
+dashes are fine only for numeric/section ranges (`017–019`, `§3.2–§3.5`).
+
+## Commands
+
+The toolchain is pinned in `rust-toolchain.toml` (channel `1.92.0`); MSRV is
+`1.85` / edition 2024. Always pass `--locked`; CI does, and the committed
+`Cargo.lock` is part of the determinism contract (tree-sitter grammars are
+pinned exact).
+
+```sh
+cargo build --workspace --locked
+cargo test  --workspace --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo fmt --all --check
+
+# A single test / one test file:
+cargo test -p spec-spine-core --test couple            # one integration test file
+cargo test -p spec-spine-core compile::                # tests matching a path
+cargo test --workspace emitted_registry_conforms       # one test by name
+
+# Run the CLI from the checkout (the dogfood gate chain):
+cargo run -p spec-spine-cli -- compile                 # writes .derived/spec-registry/registry.json
+cargo run -p spec-spine-cli -- index check             # staleness gate (exit 2 if stale)
+cargo run -p spec-spine-cli -- lint --fail-on-warn
+cargo run -p spec-spine-cli -- couple --base origin/main --head HEAD
+```
+
+Exit codes are a stable contract: `0` ok · `1` validation failure / not found /
+drift · `2` stale · `3` I/O / parse / schema / config. They are mapped in
+exactly one place (`crates/spec-spine-cli/src/main.rs` via `Error::exit_code()`).
+
+## Architecture
+
+Three crates, strict one-directional dependency `types → core → cli`:
+
+- **`spec-spine-types`**, the plain-data substrate: `Config` (the
+  `spec-spine.toml` model), the frontmatter grammar, the typed-edge and
+  authority-unit vocabulary, registry/index DTOs, schema-version `const`s, the
+  embedded JSON Schemas (`schemas/*.schema.json`, `include_str!`'d so the crate
+  is self-contained), and the `Error` enum. Everything is owned, serde, with
+  no lifetimes/generics/trait-objects at the boundary, so the same types back
+  both the engine and future FFI bindings.
+- **`spec-spine-core`**, the engine. One module per capability (`compile`,
+  `index`, `query`, `lint`, `couple`, `scaffold`) plus internal
+  `canonical_json` / `hash` / `markdown` / `sections` / `symbols`. **The library
+  API is the stable surface bindings wrap, not the CLI.**
+- **`spec-spine-cli`**, a thin clap wrapper. One `cmd_*.rs` per subcommand.
+
+**Invariants that shape every change to core (do not violate without updating
+the design doc):**
+
+- Every artifact-producing function is a **pure function of `(Config, file
+  contents)`**: no ambient clock, no env reads, **no `git`**. The CLI parses
+  `git diff` and passes a typed `DiffInput` in; the library never shells out.
+  The only wall-clock value (`build-meta.json`'s `builtAt`) is written by the
+  CLI and excluded from determinism/golden tests.
+- **`unsafe` is `forbid`-en** workspace-wide (`Cargo.toml [workspace.lints]`).
+- Core is IO-light and panic-free on user input: malformed config/frontmatter
+  yields a clean `Error`, never a panic. `init` returns files-as-data
+  (`Scaffold`); the CLI writes them.
+- The **JSON-in/JSON-out facade** in `core/src/lib.rs` (`compile_json`,
+  `query_json`, `couple_json`, …) is the FFI seam. Keep it `&str → Result<String,
+  Error>` and additive.
+
+### The authority model
+
+Each `specs/NNN-slug/spec.md` declares, in YAML frontmatter, **typed edges** to
+other specs and the **authority units** it owns. Eight edges; `references` is the
+only non-owning one (the coupling gate ignores it): `establishes`, `extends`,
+`refines`, `supersedes`, `amends`, `co_authority`, `constrains`, `references`.
+`origin.retroactive` is a bootstrap marker, not an edge. Units resolve to
+code as `file` (bare string = file shorthand; trailing `/` = subtree), `section`
+(`{file, anchor}`), or `symbol` (`{id}`, resolved by tree-sitter, Rust + TS in
+v1; Python deferred). `crate`/`module`/`directory` kinds are reserved.
+
+Two views, joined by the gate: `compile` emits `registry.json` (spec-as-source);
+`index` emits `index.json` (code-as-source, with a content-hash staleness
+mechanism). The **gate chain is `compile → index → lint → couple`**. The
+coupling clearance algorithm (amends-awareness, the strict-expansion guard,
+waiver parsing, bypass matching) is ported behaviorally intact from OAP. Modules
+cite their source; preserve the cited semantics when editing `couple.rs`.
+
+## Determinism is the central claim
+
+Emitted JSON is sorted-key, pretty-printed (2-space), LF, trailing newline.
+Content hashes are SHA-256 over `<repo-relative-POSIX-path>\0<normalized-bytes>`
+sorted by path, where normalization strips the BOM and converts CRLF/CR to LF
+(`.gitattributes` also enforces LF on checkout). `.github/workflows/determinism.yml`
+proves `registry.json` + `index.json` are **byte-identical across four release
+triples** (incl. tree-sitter symbol line-spans), not just locally. If you change
+emission, expect that gate to be the real test.
+
+## Self-governance (dogfood): why `.derived/` is committed
+
+This repo runs its own gates against its own corpus in CI (`.github/workflows/ci.yml`
+`dogfood` job). Consequences:
+
+- `.derived/spec-registry/registry.json` and `.derived/codebase-index/index.json`
+  are **committed** (only `build-meta.json` is gitignored). After any change that
+  affects them, regenerate and commit: `cargo run -p spec-spine-cli -- compile`
+  then `... index`. The `index check` step fails CI (exit 2) if the committed
+  index is stale; the coupling gate (PR-only) fails if code drifts from its spec.
+- Editing code under a path owned by a spec generally requires also editing that
+  spec's `spec.md` (or adding a `Spec-Drift-Waiver:` line to the PR body). The
+  bypass floor (docs, lockfiles, `.derived/`, per `couple.rs::DEFAULT_BYPASS_PREFIXES`,
+  extended by `spec-spine.toml [coupling] bypass_prefixes`) exempts non-code paths.
+
+When working on a feature, add or amend the governing spec under `specs/` in the
+same change. `standards/spec/` holds the constitution + contract + templates;
+`specs/000-spec-spine-bootstrap` is tier-1 (its `unamendable` anchors are
+non-overridable). New specs are filed as the next `NNN-slug` directory.
+
+## Schema & release versioning (two decoupled axes)
+
+- **Schema versions** (`registry`/`index`/`build-meta`/`config`) are compile-time
+  `const`s in `spec-spine-types/src/version.rs`. The conformance test
+  (`core/tests/conformance.rs`) asserts emitted JSON validates against the
+  embedded schema of that version: a DTO/schema drift fails the **build**.
+  MINOR = additive only; MAJOR = breaking (loaders reject an unknown MAJOR). See
+  `docs/schema-versioning.md`.
+- **Package version** lives in three files (`Cargo.toml`, `npm/package.json`,
+  `py/pyproject.toml`) and must agree at release time. Bump them in lockstep with
+  `scripts/bump_version.py <x.y.z>` (`--check` verifies agreement). This is
+  **independent** of schema versions: a release can ship without a schema change.
+  Maintainer release runbook: `docs/releasing.md`.
+
+The npm (`npm/`) and PyPI (`py/`) directories are binary-distribution shims (specs
+007/008): they ship the prebuilt binary per platform, assembled from release
+archives at publish time. The platform packages and binaries are never committed
+(`.gitignore`). Don't hand-edit generated platform packages.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "serde",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -30,8 +30,8 @@ sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 time = { version = "0.3", features = ["formatting"] }
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.2.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.2.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.3.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.3.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# spec-spine — workspace root.
+# spec-spine: workspace root.
 # A typed, hash-verifiable authority ledger over a markdown spec corpus.
 # Three published crates (types/core/cli); see docs/design/00-architecture.md.
 [workspace]

--- a/crates/spec-spine-cli/src/cmd_compile.rs
+++ b/crates/spec-spine-cli/src/cmd_compile.rs
@@ -1,4 +1,4 @@
-//! `spec-spine compile` — write `registry.json` (deterministic) and
+//! `spec-spine compile`: write `registry.json` (deterministic) and
 //! `build-meta.json` (wall-clock sidecar) under `<derived_dir>/spec-registry/`.
 
 use std::fs;
@@ -23,7 +23,7 @@ pub fn run(repo: &Path) -> Result<u8, Error> {
     fs::write(&registry_path, &outcome.json)
         .map_err(|e| Error::Io(format!("write {}: {e}", registry_path.display())))?;
 
-    // build-meta.json carries the wall clock — the CLI owns it. Excluded from
+    // build-meta.json carries the wall clock; the CLI owns it. Excluded from
     // determinism/golden checks and from version control (see .gitignore).
     let meta = BuildMeta {
         schema_version: BUILD_META_SCHEMA_VERSION.to_string(),

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -1,4 +1,4 @@
-//! `spec-spine couple` — the PR-time coupling gate (spec 005).
+//! `spec-spine couple`: the PR-time coupling gate (spec 005).
 //!
 //! This is the only place `git` runs: it invokes `git diff --no-color -U0
 //! base...head`, parses the unified diff into a typed [`DiffInput`] (new-side
@@ -34,7 +34,7 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
     let mut waiver = parse_waiver(&cfg, &body);
     let mut auto_waived = false;
 
-    // Spec 005 §3.5 — mechanical dependency-only auto-waiver. Opt-in,
+    // Spec 005 §3.5: mechanical dependency-only auto-waiver. Opt-in,
     // git-diff mode only (`--paths-from` has no content to compare), and
     // never overrides an explicit PR-body waiver.
     if waiver.is_none() && cfg.coupling.auto_waive_dependency_only && args.paths_from.is_none() {
@@ -46,7 +46,7 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
 
     if report.has_blocking_drift() {
         eprintln!(
-            "spec-spine couple: {} drift violation(s) — a changed path lacks an authoring edit to an owning spec.\n",
+            "spec-spine couple: {} drift violation(s): a changed path lacks an authoring edit to an owning spec.\n",
             report.violations.len()
         );
         for v in &report.violations {
@@ -58,7 +58,7 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
         );
     } else if let Some(reason) = &report.waiver {
         println!(
-            "spec-spine couple: {} violation(s) {} — reason: {reason}",
+            "spec-spine couple: {} violation(s) {}, reason: {reason}",
             report.violations.len(),
             if auto_waived { "auto-waived" } else { "waived" }
         );
@@ -67,7 +67,7 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
         }
     } else {
         println!(
-            "spec-spine couple: OK — {} path(s) checked, no drift.",
+            "spec-spine couple: OK: {} path(s) checked, no drift.",
             report.checked_paths
         );
     }
@@ -177,7 +177,7 @@ fn git_show(repo: &Path, rev: &str, path: &str) -> Option<String> {
         .output()
         .ok()?;
     if !out.status.success() {
-        return None; // absent at this rev (created/deleted) — fail closed upstream
+        return None; // absent at this rev (created/deleted); fail closed upstream
     }
     Some(String::from_utf8_lossy(&out.stdout).into_owned())
 }
@@ -268,7 +268,7 @@ fn parse_hunk_header(line: &str) -> Option<LineSpan> {
     let start: usize = start_s.parse().ok()?;
     let count: usize = count_s.parse().ok()?;
     if start == 0 {
-        // `+0,0` — a deletion with no new-side line. Whole-file fallback handles
+        // `+0,0`: a deletion with no new-side line. Whole-file fallback handles
         // the path; emit nothing for this hunk.
         return None;
     }

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -1,5 +1,5 @@
-//! `spec-spine index` — write `index.json`; `spec-spine index check` — staleness;
-//! `spec-spine index render` / `index orphans` — read-side projections of the
+//! `spec-spine index`: write `index.json`; `spec-spine index check`: staleness;
+//! `spec-spine index render` / `index orphans`: read-side projections of the
 //! committed artifact (spec 011; never recompute, never check freshness).
 
 use std::fs;

--- a/crates/spec-spine-cli/src/cmd_init.rs
+++ b/crates/spec-spine-cli/src/cmd_init.rs
@@ -1,8 +1,8 @@
-//! `spec-spine init` — scaffold a new adopter (spec 006).
+//! `spec-spine init`: scaffold a new adopter (spec 006).
 //!
 //! Core returns the files as data ([`spec_spine_core::scaffold_init`]); this is
 //! where they are written. Without `--force`, a pre-existing file is skipped (not
-//! an error — `init` is idempotent); with `--force`, every file is overwritten.
+//! an error; `init` is idempotent); with `--force`, every file is overwritten.
 
 use std::fs;
 use std::path::Path;

--- a/crates/spec-spine-cli/src/cmd_lint.rs
+++ b/crates/spec-spine-cli/src/cmd_lint.rs
@@ -1,4 +1,4 @@
-//! `spec-spine lint` — corpus conformance lint with tiered fail gating.
+//! `spec-spine lint`: corpus conformance lint with tiered fail gating.
 
 use std::path::Path;
 

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -1,4 +1,4 @@
-//! `spec-spine registry …` — typed, read-only queries over the compiled
+//! `spec-spine registry …`: typed, read-only queries over the compiled
 //! registry. Reads `registry.json` via the library loader (never ad-hoc parsing,
 //! per spec 000 §1).
 
@@ -73,7 +73,7 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 status: status.as_deref().map(parse_status).transpose()?,
             };
             if *ids_only {
-                // Spec 010 §3.1: ids and nothing else — an empty corpus prints
+                // Spec 010 §3.1: ids and nothing else; an empty corpus prints
                 // nothing (no "(no specs)" placeholder) and still exits 0.
                 let ids = list_ids(&registry, &filter);
                 if *json {

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -1,4 +1,4 @@
-//! `spec-spine` — the multi-call CLI. A thin wrapper over `spec-spine-core`:
+//! `spec-spine`: the multi-call CLI. A thin wrapper over `spec-spine-core`:
 //! it parses args, loads config, calls the engine, prints results, and maps the
 //! typed `Error` to a stable process exit code. All `process::exit`, stdout, and
 //! `git`/clock side effects live here, never in the library.

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -180,7 +180,7 @@ fn real_git_diff_detects_drift() {
     );
 }
 
-// ===== spec 004 §3.5 + spec 005 §3.5 — the dependabot-class path =====
+// ===== spec 004 §3.5 + spec 005 §3.5: the dependabot-class path =====
 
 /// A minimal governed repo with an npm package claimed by spec 001-a.
 fn setup_npm(root: &Path, auto_waive: bool) {

--- a/crates/spec-spine-cli/tests/init.rs
+++ b/crates/spec-spine-cli/tests/init.rs
@@ -55,7 +55,7 @@ fn adoption_loop_with_non_default_namespace_and_domains() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
-    // Non-default namespace + a custom domain allowlist — written before init so
+    // Non-default namespace + a custom domain allowlist, written before init so
     // the scaffolder and every command read them.
     write(
         root,

--- a/crates/spec-spine-core/Cargo.toml
+++ b/crates/spec-spine-core/Cargo.toml
@@ -21,7 +21,7 @@ spec-spine-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-# Symbol resolution. Pinned EXACT (=) — the resolver is a determinism input
+# Symbol resolution. Pinned EXACT (=): the resolver is a determinism input
 # across the 5-triple release matrix (Phase-3 watch-item 2): an unpinned grammar
 # would shift symbol line-spans and surface as flaky goldens. Cargo.lock is committed.
 tree-sitter = "=0.25.10"

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -2,7 +2,7 @@
 //!
 //! Pure function of `(config, file contents)`. Per-spec parse failures are
 //! recorded as error-tier violations rather than aborting the run; `Err` is
-//! reserved for I/O failures. The wall clock is never read here — it lives in
+//! reserved for I/O failures. The wall clock is never read here; it lives in
 //! `build-meta.json`, written by the CLI.
 
 use std::collections::BTreeMap;
@@ -273,7 +273,7 @@ fn validate_spec(
             ));
         }
     }
-    // V-011: a constrains item must scope something (spec 018) — a code `unit`
+    // V-011: a constrains item must scope something (spec 018): a code `unit`
     // (path-scoped, e.g. invariant-freeze) or `target_specs` (spec-scoped, e.g.
     // a sequencing plan). An item with neither asserts an invariant over nothing.
     for c in &fm.constrains {

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -128,6 +128,12 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
         if let Some(by) = p.fm.superseded_by.as_mut() {
             *by = resolve_spec_ref(by, &all_ids);
         }
+        // The predecessor named by a `supersedes` item may use a short id too
+        // (spec 019), so the gate's predecessor→superseder transfer keys match.
+        for item in &mut p.fm.supersedes {
+            let resolved = resolve_spec_ref(item.spec(), &all_ids);
+            item.set_spec(resolved);
+        }
     }
 
     // --- per-spec validation + record construction ---
@@ -168,7 +174,7 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
     })
 }
 
-/// Per-spec validation codes V-001/005/006/007/008/009/010/012 (V-013 is
+/// Per-spec validation codes V-001/005/006/007/008/009/010/011/012 (V-013 is
 /// emitted at the parse stage above).
 fn validate_spec(
     cfg: &Config,
@@ -263,6 +269,18 @@ fn validate_spec(
             out.push(warning(
                 "V-010",
                 format!("depends_on '{dep}' does not resolve to an existing spec"),
+                at(),
+            ));
+        }
+    }
+    // V-011: a constrains item must scope something (spec 018) — a code `unit`
+    // (path-scoped, e.g. invariant-freeze) or `target_specs` (spec-scoped, e.g.
+    // a sequencing plan). An item with neither asserts an invariant over nothing.
+    for c in &fm.constrains {
+        if c.unit.is_none() && c.target_specs.is_empty() {
+            out.push(error(
+                "V-011",
+                "constrains item declares neither a unit nor target_specs".into(),
                 at(),
             ));
         }

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -299,13 +299,22 @@ fn any_owner_in_diff(owners: &BTreeSet<String>, diff_paths: &BTreeSet<String>) -
 }
 
 /// Direct `predecessor → {superseders}` map from the registry's `supersedes`.
+///
+/// Only **full** supersession contributes a whole-spec authority transfer (spec
+/// 019). A **partial** item transfers authority over a single unit only — that
+/// is threaded through the index instead, as a `SourceField::Supersedes`
+/// resolved unit owned by the superseder, so it is already an owner of that
+/// unit's paths via `owners_for_path` step 1 and must NOT also inherit the
+/// predecessor's entire surface here.
 fn build_superseders(registry: &Registry) -> BTreeMap<String, BTreeSet<String>> {
     let mut map: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for spec in &registry.specs {
-        for predecessor in &spec.supersedes {
-            map.entry(predecessor.clone())
-                .or_default()
-                .insert(spec.id.clone());
+        for item in &spec.supersedes {
+            if item.is_full() {
+                map.entry(item.spec().to_string())
+                    .or_default()
+                    .insert(spec.id.clone());
+            }
         }
     }
     map

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -3,7 +3,7 @@
 //!
 //! `couple_with` is a pure function of `(config, registry, index, diff, waiver)`;
 //! `couple` is the freshness-guarded form that loads the committed artifacts.
-//! **`git` never runs here** — the CLI parses `git diff --no-color -U0
+//! **`git` never runs here**: the CLI parses `git diff --no-color -U0
 //! base...head` into a typed [`DiffInput`] and passes it in.
 //!
 //! The behavioral semantics are ported intact from OAP
@@ -23,9 +23,9 @@ use spec_spine_types::{CodebaseIndex, Config, Error, LineSpan, Registry, Severit
 use crate::index::{Freshness, check_index_freshness};
 use crate::query::{load_index, load_registry};
 
-/// The hardcoded generic bypass floor (spec 005 §3.5) — the **single built-in
+/// The hardcoded generic bypass floor (spec 005 §3.5): the **single built-in
 /// source** of bypass entries. The adopter's `config.coupling.bypass_prefixes`
-/// (default **empty**) is unioned with this — it is **additive and cannot remove
+/// (default **empty**) is unioned with this; it is **additive and cannot remove
 /// a floor entry** (ported from OAP `BYPASS_PREFIXES`, pruned to the generic
 /// subset). Match rules: trailing `/` ⇒ directory prefix; leading `**/` ⇒
 /// tail-suffix anywhere; else exact file.
@@ -53,7 +53,7 @@ pub struct DiffInput {
 }
 
 /// One changed file with its new-side hunk spans. **Empty `hunks`** denotes a
-/// whole-file change (a deletion, or `--paths-from` mode) — it overlaps every
+/// whole-file change (a deletion, or `--paths-from` mode): it overlaps every
 /// unit span.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -95,7 +95,7 @@ impl CoupleReport {
     }
 }
 
-/// Freshness-guarded coupling. Refuses a stale index (exit 2 — recompute first),
+/// Freshness-guarded coupling. Refuses a stale index (exit 2, recompute first),
 /// then loads the committed `registry.json` + `index.json` from `derived_dir`
 /// and delegates to [`couple_with`].
 pub fn couple(
@@ -129,7 +129,7 @@ pub fn couple_with(
 
     for file in &diff.files {
         let path = &file.path;
-        // Effective bypass = hardcoded floor ∪ adopter list (additive) —
+        // Effective bypass = hardcoded floor ∪ adopter list (additive),
         // UNLESS an explicit, resolved unit claim covers the path, which
         // takes precedence over the entire bypass set (spec 009, amending
         // 005 §3.5). The corpus saying "this surface is governed" beats the
@@ -144,7 +144,7 @@ pub fn couple_with(
 
         let owners = owners_for_path(path, &file.hunks, index, &superseders);
         if owners.is_empty() {
-            continue; // unclaimed path — not a coupling concern
+            continue; // unclaimed path, not a coupling concern
         }
         if any_owner_in_diff(&owners, &diff_paths) {
             continue; // primary-owner heuristic: any one owner's spec.md cleared it
@@ -172,7 +172,7 @@ pub fn couple_with(
 }
 
 /// The effective bypass verdict for one path: hardcoded floor ∪ adopter list
-/// (additive), with explicit unit claims taking precedence (spec 009) —
+/// (additive), with explicit unit claims taking precedence (spec 009),
 /// exactly as [`couple_with`] applies it. Public so the CLI's
 /// dependency-only auto-waiver pre-filter (spec 005 §3.5) examines the same
 /// non-bypassed path set the gate itself will check; the claim-awareness is
@@ -185,7 +185,7 @@ pub fn is_bypassed_path(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool
 }
 
 /// Spec 009 §3.1: true iff at least one **resolved, ownership-bearing unit
-/// claim** covers `path` — a location file matching exactly, or by directory
+/// claim** covers `path`: a location file matching exactly, or by directory
 /// prefix for a directory-form file unit (004 §3.3). Implicit path-level
 /// ownership (manifest metadata, comment headers → `implementingPaths`)
 /// deliberately does NOT count (§3.2): an explicit unit in spec frontmatter
@@ -251,7 +251,7 @@ fn owners_for_path(
     }
 
     // 2. Supersedes transfer: a successor inherits its predecessor's authority
-    //    (with the same span). Additive — the predecessor is not removed.
+    //    (with the same span). Additive: the predecessor is not removed.
     let mut transferred: Vec<(String, Option<LineSpan>)> = Vec::new();
     for (owner, span) in &candidates {
         for succ in transitive_superseders(owner, superseders) {
@@ -270,7 +270,7 @@ fn owners_for_path(
         }
     }
 
-    // 4. Amends-awareness — only when the base owner set is non-empty (FR-005
+    // 4. Amends-awareness, only when the base owner set is non-empty (FR-005
     //    strict-expansion guard) and the path is `specs/<id>/spec.md`.
     if !owners.is_empty() {
         if let Some(amended_id) = spec_id_for_spec_md_path(path) {
@@ -291,7 +291,7 @@ fn owners_for_path(
 }
 
 /// True when at least one owner's `specs/<id>/spec.md` is in the diff (the
-/// primary-owner heuristic — ported from OAP `OwnerSet::any_owner_in_diff`).
+/// primary-owner heuristic, ported from OAP `OwnerSet::any_owner_in_diff`).
 fn any_owner_in_diff(owners: &BTreeSet<String>, diff_paths: &BTreeSet<String>) -> bool {
     owners
         .iter()
@@ -301,7 +301,7 @@ fn any_owner_in_diff(owners: &BTreeSet<String>, diff_paths: &BTreeSet<String>) -
 /// Direct `predecessor → {superseders}` map from the registry's `supersedes`.
 ///
 /// Only **full** supersession contributes a whole-spec authority transfer (spec
-/// 019). A **partial** item transfers authority over a single unit only — that
+/// 019). A **partial** item transfers authority over a single unit only: that
 /// is threaded through the index instead, as a `SourceField::Supersedes`
 /// resolved unit owned by the superseder, so it is already an owner of that
 /// unit's paths via `owners_for_path` step 1 and must NOT also inherit the

--- a/crates/spec-spine-core/src/dep_only.rs
+++ b/crates/spec-spine-core/src/dep_only.rs
@@ -10,8 +10,8 @@
 //! base and head versions of each changed manifest: the two documents must
 //! be semantically identical everywhere except *version strings* inside the
 //! standard dependency tables (same package keys; values may differ only
-//! where both sides are strings). Anything else — a new or removed package,
-//! a `scripts` edit, a spec-metadata edit, a non-object document — refuses
+//! where both sides are strings). Anything else (a new or removed package,
+//! a `scripts` edit, a spec-metadata edit, a non-object document) refuses
 //! the auto-waiver, fail-closed.
 //!
 //! Like everything in core, this is pure: the CLI resolves the merge-base,
@@ -29,7 +29,7 @@ pub const DEPENDENCY_TABLES: &[&str] = &[
 ];
 
 /// One changed file with both sides of its content. `None` = the file is
-/// absent on that side (created or deleted) — never dependency-only.
+/// absent on that side (created or deleted): never dependency-only.
 #[derive(Clone, Debug)]
 pub struct FileContents {
     pub path: String,
@@ -39,7 +39,7 @@ pub struct FileContents {
 
 /// The mechanical verdict over a whole diff: `Some(Waiver)` iff **every**
 /// entry is a `package.json` whose base→head change is dependency-only.
-/// An empty slice yields `None` — there is nothing to waive.
+/// An empty slice yields `None`: there is nothing to waive.
 pub fn dependency_only_waiver(files: &[FileContents]) -> Option<Waiver> {
     if files.is_empty() {
         return None;
@@ -49,7 +49,7 @@ pub fn dependency_only_waiver(files: &[FileContents]) -> Option<Waiver> {
             return None;
         }
         let (Some(base), Some(head)) = (&f.base, &f.head) else {
-            return None; // created or deleted manifest — not a version bump
+            return None; // created or deleted manifest, not a version bump
         };
         if !dependency_only_change(base, head) {
             return None;

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -18,7 +18,7 @@ use spec_spine_types::{
 use crate::manifest;
 use crate::pathutil::{is_excluded, rel_posix};
 use crate::sections;
-use crate::symbols::{self, SymbolIndex};
+use crate::symbols::{self, ModuleIndex, SymbolIndex};
 use crate::{canonical_json, hash};
 
 /// Resolver hard-error codes (`I-003`..`I-009`) that fail `index check`.
@@ -80,6 +80,22 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
         SymbolIndex::default()
     };
 
+    // Module index — built only if some spec declares a module unit (spec 017).
+    let needs_modules = specs.iter().any(|s| {
+        s.units
+            .iter()
+            .any(|(_, u, _)| matches!(u, Unit::Module { .. }))
+    });
+    let module_index = if needs_modules {
+        symbols::build_module_index(
+            repo_root,
+            &discovered.packages,
+            &cfg.index.resolver_exclusions,
+        )
+    } else {
+        ModuleIndex::default()
+    };
+
     // --- traceability mappings ---
     let mut mappings: Vec<TraceMapping> = Vec::new();
     for spec in &specs {
@@ -88,8 +104,15 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
 
         // Source 3: spec edges (units).
         for (field, unit, ownership) in &spec.units {
-            let locations =
-                resolve_unit(repo_root, unit, &symbol_index, &spec.id, &mut diagnostics);
+            let locations = resolve_unit(
+                repo_root,
+                unit,
+                &discovered.packages,
+                &symbol_index,
+                &module_index,
+                &spec.id,
+                &mut diagnostics,
+            );
             for loc in &locations {
                 paths
                     .entry(loc.file.clone())
@@ -397,11 +420,25 @@ fn discover_specs(
             units.push((SourceField::CoAuthority, c.unit.clone(), true));
         }
         for c in &fm.constrains {
-            units.push((SourceField::Constrains, c.unit.clone(), true));
+            // A spec-scoped constraint (`target_specs`, no unit) claims no code
+            // path; only a path-scoped constraint contributes a resolved unit
+            // (spec 018).
+            if let Some(u) = &c.unit {
+                units.push((SourceField::Constrains, u.clone(), true));
+            }
         }
         for r in &fm.references {
             if let Some(u) = &r.unit {
                 units.push((SourceField::References, u.clone(), false));
+            }
+        }
+        // A partial supersession transfers authority over a single unit to this
+        // (superseding) spec — modeled as an owned resolved unit so the gate
+        // treats the superseder as an owner of that unit's paths (spec 019). A
+        // full or unit-less supersedes contributes no resolved unit here.
+        for s in &fm.supersedes {
+            if let Some(u) = s.partial_unit() {
+                units.push((SourceField::Supersedes, u.clone(), true));
             }
         }
         out.push(SpecInfo {
@@ -418,7 +455,9 @@ fn discover_specs(
 fn resolve_unit(
     repo_root: &Path,
     unit: &Unit,
+    packages: &[spec_spine_types::PackageRecord],
     symbols: &SymbolIndex,
+    modules: &ModuleIndex,
     spec_id: &str,
     diagnostics: &mut Diagnostics,
 ) -> Vec<ResolvedLocation> {
@@ -438,6 +477,62 @@ fn resolve_unit(
                 });
                 Vec::new()
             }
+        }
+        // A directory subtree: resolve to the directory path itself (the gate
+        // prefix-matches it against changed paths), requiring the directory to
+        // exist (spec 017; I-007 mirrors OAP's missing-directory hard error).
+        Unit::Directory { path } => {
+            if repo_root.join(path).is_dir() {
+                vec![ResolvedLocation {
+                    file: path.clone(),
+                    span: None,
+                }]
+            } else {
+                diagnostics.errors.push(Diagnostic {
+                    code: "I-007".to_string(),
+                    message: format!("spec '{spec_id}' directory unit '{path}' is not a directory"),
+                    path: Some(path.clone()),
+                });
+                Vec::new()
+            }
+        }
+        // A compilation unit by manifest name: resolve to the discovered
+        // package's directory subtree (spec 017; I-003 = unknown crate). Hyphen
+        // and underscore are interchangeable in the name (Rust crate convention).
+        Unit::Crate { id } => {
+            let norm = id.replace('-', "_");
+            match packages
+                .iter()
+                .find(|p| p.name == *id || p.name.replace('-', "_") == norm)
+            {
+                Some(pkg) => vec![ResolvedLocation {
+                    file: pkg.path.clone(),
+                    span: None,
+                }],
+                None => {
+                    diagnostics.errors.push(Diagnostic {
+                        code: "I-003".to_string(),
+                        message: format!(
+                            "spec '{spec_id}' crate unit '{id}' does not match any discovered package"
+                        ),
+                        path: None,
+                    });
+                    Vec::new()
+                }
+            }
+        }
+        // A Rust module by `::`-qualified path (spec 017; I-008 = unresolved —
+        // distinct from the symbol band's I-005).
+        Unit::Module { id } => {
+            let locations = modules.resolve(id);
+            if locations.is_empty() {
+                diagnostics.errors.push(Diagnostic {
+                    code: "I-008".to_string(),
+                    message: format!("spec '{spec_id}' module unit '{id}' did not resolve"),
+                    path: None,
+                });
+            }
+            locations
         }
         Unit::Section { file, anchor } => {
             let abs = repo_root.join(file);
@@ -592,9 +687,17 @@ fn resolved_span_files(mappings: &[TraceMapping]) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     for m in mappings {
         for ru in &m.resolved_units {
-            if matches!(ru.unit, Unit::Section { .. } | Unit::Symbol { .. }) {
+            // Span-backed kinds: section, symbol, and the inline-`mod` form of a
+            // module unit (spec 017). File/directory/crate units are whole-file
+            // or whole-subtree (span `None`) and contribute nothing here.
+            if matches!(
+                ru.unit,
+                Unit::Section { .. } | Unit::Symbol { .. } | Unit::Module { .. }
+            ) {
                 for loc in &ru.locations {
-                    out.insert(loc.file.clone());
+                    if loc.span.is_some() {
+                        out.insert(loc.file.clone());
+                    }
                 }
             }
         }
@@ -682,6 +785,9 @@ fn canonical_unit(unit: &Unit) -> String {
         Unit::File { path } => format!("file:{path}"),
         Unit::Section { file, anchor } => format!("section:{file}#{anchor}"),
         Unit::Symbol { id } => format!("symbol:{id}"),
+        Unit::Directory { path } => format!("directory:{path}"),
+        Unit::Crate { id } => format!("crate:{id}"),
+        Unit::Module { id } => format!("module:{id}"),
     }
 }
 

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -63,7 +63,7 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
     // Comment-header linkage: file path -> spec id.
     let comment_links = scan_comment_headers(cfg, repo_root, &discovered.packages, &all_ids);
 
-    // Symbol index — built only if some spec declares a symbol unit (avoids
+    // Symbol index, built only if some spec declares a symbol unit (avoids
     // parsing all source for corpora that use only file/section units).
     let needs_symbols = specs.iter().any(|s| {
         s.units
@@ -80,7 +80,7 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
         SymbolIndex::default()
     };
 
-    // Module index — built only if some spec declares a module unit (spec 017).
+    // Module index, built only if some spec declares a module unit (spec 017).
     let needs_modules = specs.iter().any(|s| {
         s.units
             .iter()
@@ -280,7 +280,7 @@ pub fn check_index_freshness(
 /// `build.sliceHashes` entry (spec 012 §3.3). A single-subject gate: it never
 /// consults the global hash or diagnostics. Unknown name → [`Error::Config`]
 /// (exit 3); a committed index with no entry for a configured slice is
-/// `Stale`, not an error — an index predating the slice config is by
+/// `Stale`, not an error: an index predating the slice config is by
 /// definition not vouching for it.
 pub fn check_slice_freshness(
     cfg: &spec_spine_types::Config,
@@ -307,7 +307,7 @@ pub fn check_slice_freshness(
     }
 }
 
-/// "Who currently owns this unit?" — a set query over resolved traceability.
+/// "Who currently owns this unit?": a set query over resolved traceability.
 pub fn authorities(index: &CodebaseIndex, unit: &Unit) -> Vec<String> {
     let mut owners: BTreeSet<String> = BTreeSet::new();
     for mapping in &index.traceability.mappings {
@@ -359,7 +359,7 @@ fn compute_slice_hashes(
 
 /// SHA-256 over a slice's matched files: the same normalization and
 /// path-sorted folding as the global hash. Zero matches hash the empty input
-/// sequence — deletion of a guarded file reads as a hash change, never a
+/// sequence: deletion of a guarded file reads as a hash change, never a
 /// config error.
 fn slice_hash(repo_root: &Path, patterns: &[String]) -> String {
     let mut pieces: Vec<(String, String)> = Vec::new();
@@ -433,7 +433,7 @@ fn discover_specs(
             }
         }
         // A partial supersession transfers authority over a single unit to this
-        // (superseding) spec — modeled as an owned resolved unit so the gate
+        // (superseding) spec, modeled as an owned resolved unit so the gate
         // treats the superseder as an owner of that unit's paths (spec 019). A
         // full or unit-less supersedes contributes no resolved unit here.
         for s in &fm.supersedes {
@@ -521,7 +521,7 @@ fn resolve_unit(
                 }
             }
         }
-        // A Rust module by `::`-qualified path (spec 017; I-008 = unresolved —
+        // A Rust module by `::`-qualified path (spec 017; I-008 = unresolved,
         // distinct from the symbol band's I-005).
         Unit::Module { id } => {
             let locations = modules.resolve(id);
@@ -626,7 +626,7 @@ fn collect_hash_inputs(
     };
 
     // Manifests. npm manifests fold as their governance projection (spec 004
-    // §3.5 amendment) — dependency tables are not a governed input, so a
+    // §3.5 amendment): dependency tables are not a governed input, so a
     // dependabot-class version bump leaves the committed index fresh while
     // a name / workspaces / spec-metadata change still stales it. Parse
     // failure falls back to raw bytes (over-hashing is fail-closed).
@@ -671,7 +671,7 @@ fn collect_hash_inputs(
         push(&repo_root.join(rel), &mut pieces);
     }
     // De-duplicate by path so an input folded by two routes (e.g. a section unit
-    // in a file also matched by extra_hashed_inputs) is hashed once — content for
+    // in a file also matched by extra_hashed_inputs) is hashed once; content for
     // a given path is identical, so the hash stays a pure function of the set.
     pieces.sort_by(|a, b| a.0.cmp(&b.0));
     pieces.dedup_by(|a, b| a.0 == b.0);
@@ -681,7 +681,7 @@ fn collect_hash_inputs(
 /// The set of repo-relative source files backing a resolved `symbol`/`section`
 /// unit's span. These are folded into the content hash so a source-line shift
 /// that moves a committed span forces the index `Stale` (spec 004 §3.5). `file`
-/// units carry no span and are intentionally excluded — a file-unit-only corpus
+/// units carry no span and are intentionally excluded: a file-unit-only corpus
 /// contributes nothing here.
 fn resolved_span_files(mappings: &[TraceMapping]) -> BTreeSet<String> {
     let mut out = BTreeSet::new();

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! adds **couple** (the PR-time drift gate) and **init** (the adopter scaffolder).
 //!
 //! Every artifact-producing function is a pure function of `(config, file
-//! contents)` — no ambient clock or environment reads, and **no git** (the CLI
+//! contents)`: no ambient clock or environment reads, and **no git** (the CLI
 //! parses the diff and passes a typed [`DiffInput`] in). The public API returns
 //! owned, `serde`-serializable DTOs (from [`spec_spine_types`]); the
 //! JSON-in/JSON-out facade ([`compile_json`], [`query_json`], [`index_json`],
@@ -189,7 +189,7 @@ pub fn load_config_json(toml_src: &str) -> Result<String, Error> {
 /// Run the coupling gate. `request_json` bundles config + repo_root + diff +
 /// optional waiver:
 /// `{ "config"?: Config, "repoRoot": string, "diff": DiffInput, "waiver"?: { "reason": string } }`.
-/// Returns the [`CoupleReport`] as JSON (even when drift is present — the caller
+/// Returns the [`CoupleReport`] as JSON (even when drift is present; the caller
 /// inspects `violations` / `waiver`).
 pub fn couple_json(request_json: &str) -> Result<String, Error> {
     #[derive(Deserialize)]

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -99,7 +99,7 @@ fn has_ownership_edge(spec: &SpecRecord) -> bool {
 /// Every spec id this spec names across its relationship edges.
 fn edge_targets(spec: &SpecRecord) -> Vec<String> {
     let mut targets = Vec::new();
-    targets.extend(spec.supersedes.iter().cloned());
+    targets.extend(spec.supersedes.iter().map(|s| s.spec().to_string()));
     targets.extend(spec.amends.iter().cloned());
     targets.extend(spec.extends.iter().map(|e| e.spec.clone()));
     targets.extend(spec.refines.iter().flat_map(|r| r.refines_specs.clone()));

--- a/crates/spec-spine-core/src/manifest.rs
+++ b/crates/spec-spine-core/src/manifest.rs
@@ -3,7 +3,7 @@
 //! Rust crates come from the root Cargo workspace members plus
 //! `layout.standalone_rust_workspaces`; npm/pnpm packages from the workspace
 //! globs declared by `layout.npm_workspaces` (the default reads root
-//! `package.json#workspaces` — the template-encore fix) plus
+//! `package.json#workspaces`, the template-encore fix) plus
 //! `layout.standalone_npm_packages`. The owning spec is read from the configurable
 //! `manifest.metadata_namespace`. Everything is path-sorted for determinism and
 //! `index.resolver_exclusions` directories are never descended.
@@ -266,7 +266,7 @@ fn npm_record(repo_root: &Path, manifest: &Path, namespace: &str) -> Option<Pack
     })
 }
 
-/// The governance projection of an npm manifest — exactly the fields
+/// The governance projection of an npm manifest: exactly the fields
 /// discovery consumes (`npm_record` + workspace-glob extraction): `name`,
 /// `version`, `workspaces`, and the adopter's metadata-namespace object.
 /// The index content hash folds this INSTEAD of the raw bytes (spec 004
@@ -274,7 +274,7 @@ fn npm_record(repo_root: &Path, manifest: &Path, namespace: &str) -> Option<Pack
 /// (dependabot-class) is not a governed input and must not stale the
 /// committed index, while any change to a field the indexer actually reads
 /// still does. `None` (unparseable / non-object) tells the caller to fall
-/// back to raw bytes — over-hashing is the fail-closed direction.
+/// back to raw bytes: over-hashing is the fail-closed direction.
 pub fn npm_hash_projection(content: &str, namespace: &str) -> Option<String> {
     let doc: serde_json::Value = serde_json::from_str(content).ok()?;
     let obj = doc.as_object()?;

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -173,7 +173,11 @@ pub fn relationships(registry: &Registry, id: &str) -> Result<RelationshipView, 
     Ok(RelationshipView {
         id: spec.id.clone(),
         depends_on: spec.depends_on.clone(),
-        supersedes: spec.supersedes.iter().map(|x| x.spec().to_string()).collect(),
+        supersedes: spec
+            .supersedes
+            .iter()
+            .map(|x| x.spec().to_string())
+            .collect(),
         amends: spec.amends.clone(),
         superseded_by,
         amended_by: incoming(|s| &s.amends),

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -162,12 +162,20 @@ pub fn relationships(registry: &Registry, id: &str) -> Result<RelationshipView, 
             .map(|other| other.id.clone())
             .collect()
     };
+    // `supersedes` carries structured items (spec 019); the relationship view
+    // is id-only, so project each item to its predecessor id.
+    let superseded_by: Vec<String> = registry
+        .specs
+        .iter()
+        .filter(|other| other.supersedes.iter().any(|x| x.spec() == id))
+        .map(|other| other.id.clone())
+        .collect();
     Ok(RelationshipView {
         id: spec.id.clone(),
         depends_on: spec.depends_on.clone(),
-        supersedes: spec.supersedes.clone(),
+        supersedes: spec.supersedes.iter().map(|x| x.spec().to_string()).collect(),
         amends: spec.amends.clone(),
-        superseded_by: incoming(|s| &s.supersedes),
+        superseded_by,
         amended_by: incoming(|s| &s.amends),
         depended_on_by: incoming(|s| &s.depends_on),
     })

--- a/crates/spec-spine-core/src/render.rs
+++ b/crates/spec-spine-core/src/render.rs
@@ -1,5 +1,5 @@
 //! The render capability (spec 011): deterministic, human-shaped projections
-//! of the **committed** `index.json`. Pure read-side — never recomputes the
+//! of the **committed** `index.json`. Pure read-side: never recomputes the
 //! index, never consults the working tree, never signals staleness
 //! (recomputation is `index`, freshness is `index check`; three verbs, three
 //! jobs). Output is a pure function of `(config, index)`: byte-identical
@@ -30,7 +30,7 @@ pub fn orphans(index: &CodebaseIndex) -> Vec<&str> {
 pub fn render_markdown(config: &Config, index: &CodebaseIndex) -> String {
     let mut out = String::new();
 
-    // 1. Header — traceable to the exact artifact that produced it.
+    // 1. Header, traceable to the exact artifact that produced it.
     let _ = writeln!(out, "# {} codebase index", config.branding.indexer_id);
     out.push('\n');
     let _ = writeln!(out, "- schemaVersion: {}", index.schema_version);

--- a/crates/spec-spine-core/src/scaffold.rs
+++ b/crates/spec-spine-core/src/scaffold.rs
@@ -1,5 +1,5 @@
 //! The `init` scaffolder (spec 006): generate a new adopter's starter corpus as
-//! **files-as-data**. Pure function of `(config)` — no filesystem writes happen
+//! **files-as-data**. Pure function of `(config)`: no filesystem writes happen
 //! here; the CLI ([`cmd_init`]) writes the returned [`ScaffoldFile`]s. This keeps
 //! core IO-light, unit-testable, and FFI-friendly (`scaffold_init_json`).
 //!
@@ -78,7 +78,7 @@ pub fn scaffold_init(cfg: &Config) -> Result<Scaffold, Error> {
 /// namespace / layout scaffolds coherently.
 fn config_toml(cfg: &Config) -> String {
     format!(
-        "# spec-spine.toml — governs this repository. All keys are optional; an\n\
+        "# spec-spine.toml governs this repository. All keys are optional; an\n\
          # absent file behaves as the defaults for a single-Cargo-workspace repo.\n\
          # See the spec-spine docs for the full knob table.\n\
          \n\
@@ -132,7 +132,7 @@ fn bootstrap_spec(ns: &str) -> String {
          \u{20}\u{20}- \"refusal-rule\"\n\
          ---\n\
          \n\
-         # 000 — Bootstrap spec system\n\
+         # 000: Bootstrap spec system\n\
          \n\
          This is the spec that defines what a spec *is*. Customize it for your\n\
          repository, then author ordinary specs under your specs directory. Each\n\
@@ -173,7 +173,7 @@ fn spec_template(ns: &str) -> String {
          #   - \"000-bootstrap\"\n\
          ---\n\
          \n\
-         # NNN — Title\n\
+         # NNN: Title\n\
          \n\
          Link a compilation unit to this spec via `[package.metadata.{ns}].spec`\n\
          in its manifest, a `// Spec:` header, or the edges above.\n\
@@ -198,7 +198,7 @@ Durable principles, subordinate to the bootstrap spec (`000`) where they differ.
 4. **Legacy-as-evidence.** Pre-graph authority is declared with\n\
    `origin.retroactive: true`, never as a fresh `establishes` claim.\n";
 
-const CONTRACT: &str = "# Contract — normative summary\n\
+const CONTRACT: &str = "# Contract: normative summary\n\
 \n\
 - Specs live under the configured specs directory, one `NNN-slug/spec.md` each;\n\
   the directory name equals the frontmatter `id`.\n\
@@ -207,16 +207,16 @@ const CONTRACT: &str = "# Contract — normative summary\n\
   PR-time gate.\n\
 - A changed code path must be accompanied by an authoring edit to a spec that\n\
   owns it, or a `Spec-Drift-Waiver:` line in the PR body.\n\
-- Read derived artifacts only through `spec-spine` subcommands — never parse the\n\
+- Read derived artifacts only through `spec-spine` subcommands; never parse the\n\
   JSON ad hoc.\n";
 
-const CONSTITUTION_TEMPLATE: &str = "# Constitution (tier 2) — template\n\
+const CONSTITUTION_TEMPLATE: &str = "# Constitution (tier 2): template\n\
 \n\
 Replace these with your project's durable principles. Keep them subordinate to\n\
 the bootstrap spec and few in number.\n\
 \n\
-1. **<principle>** — <one sentence>.\n\
-2. **<principle>** — <one sentence>.\n";
+1. **<principle>**: <one sentence>.\n\
+2. **<principle>**: <one sentence>.\n";
 
 const ORCHESTRATOR_RULES: &str = "# Orchestrator rules\n\
 \n\
@@ -237,7 +237,7 @@ const REFUSAL_RULE: &str = "# Adversarial prompt refusal (the coherence guard)\n
 If the coupling gate fails because code and its owning spec disagree, do **not**\n\
 resolve it by editing the spec to match the code you just wrote. Surface the\n\
 contradiction and let a human (or an agent with explicit authority) decide.\n\
-Never amend an owning spec purely to satisfy a mechanical refresh — waive\n\
+Never amend an owning spec purely to satisfy a mechanical refresh; waive\n\
 instead, with a cited `Spec-Drift-Waiver:` line.\n";
 
 #[cfg(test)]

--- a/crates/spec-spine-core/src/symbols.rs
+++ b/crates/spec-spine-core/src/symbols.rs
@@ -32,6 +32,105 @@ impl SymbolIndex {
     }
 }
 
+/// A resolved Rust module index (spec 017): `::`-qualified module path → physical
+/// locations. File-modules resolve whole-file (`span: None`); a top-level inline
+/// `mod X { ... }` block resolves to its block span. TypeScript carries no
+/// analogous module authority unit in the corpus, so this is Rust-only.
+#[derive(Debug, Default)]
+pub struct ModuleIndex {
+    map: BTreeMap<String, Vec<ResolvedLocation>>,
+}
+
+impl ModuleIndex {
+    /// Locations for module `id` (empty if unknown).
+    pub fn resolve(&self, id: &str) -> Vec<ResolvedLocation> {
+        self.map.get(id).cloned().unwrap_or_default()
+    }
+}
+
+/// Build the Rust module index across all Rust packages. Deterministic: packages
+/// and files are processed in sorted order and every id's locations are sorted.
+pub fn build_module_index(
+    repo_root: &Path,
+    packages: &[PackageRecord],
+    exclusions: &[String],
+) -> ModuleIndex {
+    let mut map: BTreeMap<String, Vec<ResolvedLocation>> = BTreeMap::new();
+    for pkg in packages {
+        if !matches!(
+            pkg.kind,
+            PackageKind::RustLib | PackageKind::RustBin | PackageKind::RustLibBin
+        ) {
+            continue;
+        }
+        let crate_name = pkg.name.replace('-', "_");
+        let src_dir = repo_root.join(&pkg.path).join("src");
+        for file in walk_files(&src_dir, &["rs"], repo_root, exclusions) {
+            let Ok(content) = fs::read_to_string(&file) else {
+                continue;
+            };
+            let module = rust_module_path(&src_dir, &file);
+            let rel = rel_posix(repo_root, &file);
+            // File-module: the file's own module path → whole file (the crate
+            // root, `lib.rs`/`main.rs`, resolves to the bare crate name).
+            let file_mod_id = qualify_module(&crate_name, &module);
+            map.entry(file_mod_id).or_default().push(ResolvedLocation {
+                file: rel.clone(),
+                span: None,
+            });
+            // Top-level inline `mod X { ... }` blocks → block span.
+            for (name, span) in extract_inline_mods(&content) {
+                let mut path = module.clone();
+                path.push(name);
+                let id = qualify_module(&crate_name, &path);
+                map.entry(id).or_default().push(ResolvedLocation {
+                    file: rel.clone(),
+                    span: Some(span),
+                });
+            }
+        }
+    }
+    for locs in map.values_mut() {
+        locs.sort_by(|a, b| {
+            (a.file.as_str(), a.span.map(|s| s.start_line))
+                .cmp(&(b.file.as_str(), b.span.map(|s| s.start_line)))
+        });
+        locs.dedup();
+    }
+    ModuleIndex { map }
+}
+
+/// `crate::seg::…::seg` for a module path; the crate root is the bare crate name.
+fn qualify_module(crate_name: &str, module: &[String]) -> String {
+    let mut parts = Vec::with_capacity(module.len() + 1);
+    parts.push(crate_name.to_string());
+    parts.extend(module.iter().cloned());
+    parts.join("::")
+}
+
+/// Top-level `mod X { ... }` blocks (those with a body) and their spans. A
+/// bodyless `mod X;` is skipped — the file-module entry for its file covers it.
+fn extract_inline_mods(src: &str) -> Vec<(String, LineSpan)> {
+    let mut parser = Parser::new();
+    if parser.set_language(&tree_sitter_rust::LANGUAGE.into()).is_err() {
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(src, None) else {
+        return Vec::new();
+    };
+    let root = tree.root_node();
+    let mut out = Vec::new();
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if child.kind() == "mod_item" && child.child_by_field_name("body").is_some() {
+            if let Some(sym) = symbol_of(child, src) {
+                out.push(sym);
+            }
+        }
+    }
+    out
+}
+
 /// Build the symbol index across all packages. Deterministic: packages and
 /// files are processed in sorted order and every id's locations are sorted.
 pub fn build_symbol_index(

--- a/crates/spec-spine-core/src/symbols.rs
+++ b/crates/spec-spine-core/src/symbols.rs
@@ -109,10 +109,13 @@ fn qualify_module(crate_name: &str, module: &[String]) -> String {
 }
 
 /// Top-level `mod X { ... }` blocks (those with a body) and their spans. A
-/// bodyless `mod X;` is skipped — the file-module entry for its file covers it.
+/// bodyless `mod X;` is skipped: the file-module entry for its file covers it.
 fn extract_inline_mods(src: &str) -> Vec<(String, LineSpan)> {
     let mut parser = Parser::new();
-    if parser.set_language(&tree_sitter_rust::LANGUAGE.into()).is_err() {
+    if parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .is_err()
+    {
         return Vec::new();
     }
     let Some(tree) = parser.parse(src, None) else {

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -131,6 +131,69 @@ fn v004_duplicate_prefix() {
 }
 
 #[test]
+fn supersedes_full_emits_bare_string_partial_emits_object() {
+    // Spec 019: a full supersedes (bare id or `{ scope: full }`) serializes as a
+    // bare predecessor id — byte-stable wire; a partial item serializes as an
+    // object carrying its scope and unit.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-old", "001-old", "");
+    write_spec(tmp.path(), "002-mid", "002-mid", "");
+    write_spec(
+        tmp.path(),
+        "003-new",
+        "003-new",
+        "supersedes:\n  - \"001-old\"\n  - { spec: \"002-mid\", scope: full }\n  - { spec: \"002-mid\", scope: partial, unit: \"src/x.rs\" }\n",
+    );
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&outcome.json).unwrap();
+    let three = v["specs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["id"] == "003-new")
+        .unwrap();
+    let sup = three["supersedes"].as_array().unwrap();
+    // Both full forms collapse to bare strings.
+    assert_eq!(sup[0], serde_json::json!("001-old"));
+    assert_eq!(sup[1], serde_json::json!("002-mid"));
+    // The partial form is an object carrying scope + unit.
+    assert_eq!(sup[2]["spec"], "002-mid");
+    assert_eq!(sup[2]["scope"], "partial");
+    assert_eq!(sup[2]["unit"]["path"], "src/x.rs");
+}
+
+#[test]
+fn v011_constrains_item_must_scope_unit_or_target_specs() {
+    // Spec 018: a constrains item with neither a unit nor target_specs scopes
+    // nothing — V-011.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-x", "001-x", "constrains:\n  - flavor: dangling\n");
+    let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
+    assert!(c.contains(&"V-011".to_string()), "codes: {c:?}");
+}
+
+#[test]
+fn constrains_scoped_forms_compile_clean() {
+    // Spec 018: path-scoped (flavor + unit) and spec-scoped (kind + target_specs)
+    // both clear V-011. File-unit existence is the indexer's concern, not compile.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(
+        tmp.path(),
+        "001-fz",
+        "001-fz",
+        "constrains:\n  - { flavor: invariant-freeze, unit: \"src/x.rs\" }\n",
+    );
+    write_spec(
+        tmp.path(),
+        "002-sq",
+        "002-sq",
+        "constrains:\n  - { kind: sequencing-plan, target_specs: [\"001-fz\"] }\n",
+    );
+    let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
+    assert!(!c.contains(&"V-011".to_string()), "no V-011 expected: {c:?}");
+}
+
+#[test]
 fn v002_malformed_frontmatter_is_recorded_not_fatal() {
     let tmp = tempfile::tempdir().unwrap();
     // Missing required `summary`.

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -133,7 +133,7 @@ fn v004_duplicate_prefix() {
 #[test]
 fn supersedes_full_emits_bare_string_partial_emits_object() {
     // Spec 019: a full supersedes (bare id or `{ scope: full }`) serializes as a
-    // bare predecessor id — byte-stable wire; a partial item serializes as an
+    // bare predecessor id, byte-stable wire; a partial item serializes as an
     // object carrying its scope and unit.
     let tmp = tempfile::tempdir().unwrap();
     write_spec(tmp.path(), "001-old", "001-old", "");
@@ -165,9 +165,14 @@ fn supersedes_full_emits_bare_string_partial_emits_object() {
 #[test]
 fn v011_constrains_item_must_scope_unit_or_target_specs() {
     // Spec 018: a constrains item with neither a unit nor target_specs scopes
-    // nothing — V-011.
+    // nothing: V-011.
     let tmp = tempfile::tempdir().unwrap();
-    write_spec(tmp.path(), "001-x", "001-x", "constrains:\n  - flavor: dangling\n");
+    write_spec(
+        tmp.path(),
+        "001-x",
+        "001-x",
+        "constrains:\n  - flavor: dangling\n",
+    );
     let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
     assert!(c.contains(&"V-011".to_string()), "codes: {c:?}");
 }
@@ -190,7 +195,10 @@ fn constrains_scoped_forms_compile_clean() {
         "constrains:\n  - { kind: sequencing-plan, target_specs: [\"001-fz\"] }\n",
     );
     let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
-    assert!(!c.contains(&"V-011".to_string()), "no V-011 expected: {c:?}");
+    assert!(
+        !c.contains(&"V-011".to_string()),
+        "no V-011 expected: {c:?}"
+    );
 }
 
 #[test]

--- a/crates/spec-spine-core/tests/conformance.rs
+++ b/crates/spec-spine-core/tests/conformance.rs
@@ -50,7 +50,7 @@ fn emitted_registry_conforms_to_embedded_schema() {
 
 #[test]
 fn schema_rejects_a_malformed_registry() {
-    // A registry missing the required `build` block must be rejected — proves the
+    // A registry missing the required `build` block must be rejected; proves the
     // conformance check has teeth.
     let schema: serde_json::Value = serde_json::from_str(REGISTRY_SCHEMA).unwrap();
     let bad = serde_json::json!({ "specVersion": "0.1.0", "specs": [], "validation": { "passed": true, "violations": [] } });

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -372,6 +372,124 @@ fn supersedes_transfers_authority_additively() {
     assert!(!via_succ.has_blocking_drift(), "{:?}", via_succ.violations);
 }
 
+// ── spec 019: partial (unit-scoped) supersession ──────────────────────────
+
+#[test]
+fn partial_supersedes_scopes_transfer_to_the_named_unit() {
+    // P (040) established two files. S (041) PARTIALLY supersedes P over old.rs
+    // only — the index models that as a `supersedes` resolved unit on S. S thus
+    // owns old.rs but NOT keep.rs; the predecessor keeps both (additive).
+    let index = index_from(json!([
+        {
+            "specId": "040-pred",
+            "implementingPaths": [],
+            "resolvedUnits": [
+                { "unit": { "kind": "file", "path": "src/old.rs" },
+                  "sourceField": "establishes", "ownership": true,
+                  "locations": [{ "file": "src/old.rs" }] },
+                { "unit": { "kind": "file", "path": "src/keep.rs" },
+                  "sourceField": "establishes", "ownership": true,
+                  "locations": [{ "file": "src/keep.rs" }] }
+            ]
+        },
+        {
+            "specId": "041-succ",
+            "implementingPaths": [],
+            "resolvedUnits": [
+                { "unit": { "kind": "file", "path": "src/old.rs" },
+                  "sourceField": "supersedes", "ownership": true,
+                  "locations": [{ "file": "src/old.rs" }] }
+            ]
+        }
+    ]));
+    let reg = registry_from(json!([
+        { "id": "040-pred", "title": "p", "status": "superseded",
+          "created": "d", "summary": "s", "specPath": "specs/040-pred/spec.md" },
+        { "id": "041-succ", "title": "s", "status": "approved",
+          "created": "d", "summary": "s", "specPath": "specs/041-succ/spec.md",
+          "supersedes": [{ "spec": "040-pred", "scope": "partial",
+                           "unit": { "kind": "file", "path": "src/old.rs" } }] }
+    ]));
+
+    // The superseded unit: editing the successor clears it (S owns old.rs).
+    let old_via_succ = run(
+        &index,
+        &reg,
+        &diff(vec![
+            file("src/old.rs", &[LineSpan::new(1, 1)]),
+            file("specs/041-succ/spec.md", &[]),
+        ]),
+    );
+    assert!(!old_via_succ.has_blocking_drift(), "{:?}", old_via_succ.violations);
+
+    // The OTHER unit (keep.rs): S is NOT an owner, so editing S does not clear it
+    // — the partial transfer reached old.rs only. Only the predecessor clears it.
+    let keep_via_succ = run(
+        &index,
+        &reg,
+        &diff(vec![
+            file("src/keep.rs", &[LineSpan::new(1, 1)]),
+            file("specs/041-succ/spec.md", &[]),
+        ]),
+    );
+    assert!(
+        keep_via_succ.has_blocking_drift(),
+        "partial transfer must not reach keep.rs"
+    );
+    assert!(keep_via_succ.violations[0].message.contains("040-pred"));
+    assert!(!keep_via_succ.violations[0].message.contains("041-succ"));
+
+    let keep_via_pred = run(
+        &index,
+        &reg,
+        &diff(vec![
+            file("src/keep.rs", &[LineSpan::new(1, 1)]),
+            file("specs/040-pred/spec.md", &[]),
+        ]),
+    );
+    assert!(!keep_via_pred.has_blocking_drift(), "{:?}", keep_via_pred.violations);
+}
+
+#[test]
+fn partial_supersedes_without_unit_transfers_nothing() {
+    // S (041) partially supersedes P (040) with only a note — a documentary
+    // lifecycle marker (OAP spec 199's shape). It transfers no authority: there
+    // is no `supersedes` resolved unit on S, and `build_superseders` skips the
+    // partial item, so the predecessor alone owns the file.
+    let index = index_from(json!([{
+        "specId": "040-pred",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "file", "path": "src/old.rs" },
+            "sourceField": "establishes", "ownership": true,
+            "locations": [{ "file": "src/old.rs" }]
+        }]
+    }]));
+    let reg = registry_from(json!([
+        { "id": "040-pred", "title": "p", "status": "approved",
+          "created": "d", "summary": "s", "specPath": "specs/040-pred/spec.md" },
+        { "id": "041-succ", "title": "s", "status": "approved",
+          "created": "d", "summary": "s", "specPath": "specs/041-succ/spec.md",
+          "supersedes": [{ "spec": "040-pred", "scope": "partial",
+                           "note": "retires the read-time projection layer" }] }
+    ]));
+
+    let via_succ = run(
+        &index,
+        &reg,
+        &diff(vec![
+            file("src/old.rs", &[LineSpan::new(1, 1)]),
+            file("specs/041-succ/spec.md", &[]),
+        ]),
+    );
+    assert!(
+        via_succ.has_blocking_drift(),
+        "a unit-less partial supersedes transfers nothing"
+    );
+    assert!(via_succ.violations[0].message.contains("040-pred"));
+    assert!(!via_succ.violations[0].message.contains("041-succ"));
+}
+
 // ── spec 009: explicit claims take precedence over bypass ─────────────────
 
 #[test]

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -126,7 +126,7 @@ fn whole_file_floor_via_implementing_path() {
 #[test]
 fn section_granularity_distinguishes_owners() {
     // Two specs own disjoint sections of the same file. A hunk in B's section is
-    // NOT cleared by editing A — span overlap selects the right owner.
+    // NOT cleared by editing A; span overlap selects the right owner.
     let index = index_from(json!([
         {
             "specId": "010-top",
@@ -317,7 +317,7 @@ fn amends_expands_owners_when_base_set_nonempty() {
     assert!(drift.violations[0].message.contains("200-claims-spec-md"));
     assert!(drift.violations[0].message.contains("101-amender"));
 
-    // Editing the amender (not the base owner) clears it — amends-awareness.
+    // Editing the amender (not the base owner) clears it: amends-awareness.
     let cleared = run(
         &index,
         &reg,
@@ -377,7 +377,7 @@ fn supersedes_transfers_authority_additively() {
 #[test]
 fn partial_supersedes_scopes_transfer_to_the_named_unit() {
     // P (040) established two files. S (041) PARTIALLY supersedes P over old.rs
-    // only — the index models that as a `supersedes` resolved unit on S. S thus
+    // only: the index models that as a `supersedes` resolved unit on S. S thus
     // owns old.rs but NOT keep.rs; the predecessor keeps both (additive).
     let index = index_from(json!([
         {
@@ -420,10 +420,14 @@ fn partial_supersedes_scopes_transfer_to_the_named_unit() {
             file("specs/041-succ/spec.md", &[]),
         ]),
     );
-    assert!(!old_via_succ.has_blocking_drift(), "{:?}", old_via_succ.violations);
+    assert!(
+        !old_via_succ.has_blocking_drift(),
+        "{:?}",
+        old_via_succ.violations
+    );
 
-    // The OTHER unit (keep.rs): S is NOT an owner, so editing S does not clear it
-    // — the partial transfer reached old.rs only. Only the predecessor clears it.
+    // The OTHER unit (keep.rs): S is NOT an owner, so editing S does not clear it;
+    // the partial transfer reached old.rs only. Only the predecessor clears it.
     let keep_via_succ = run(
         &index,
         &reg,
@@ -447,12 +451,16 @@ fn partial_supersedes_scopes_transfer_to_the_named_unit() {
             file("specs/040-pred/spec.md", &[]),
         ]),
     );
-    assert!(!keep_via_pred.has_blocking_drift(), "{:?}", keep_via_pred.violations);
+    assert!(
+        !keep_via_pred.has_blocking_drift(),
+        "{:?}",
+        keep_via_pred.violations
+    );
 }
 
 #[test]
 fn partial_supersedes_without_unit_transfers_nothing() {
-    // S (041) partially supersedes P (040) with only a note — a documentary
+    // S (041) partially supersedes P (040) with only a note: a documentary
     // lifecycle marker (OAP spec 199's shape). It transfers no authority: there
     // is no `supersedes` resolved unit on S, and `build_superseders` skips the
     // partial item, so the predecessor alone owns the file.

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -280,3 +280,167 @@ fn authorities_resolves_owners() {
     let owners = authorities(&idx, &Unit::file("rs-thing/src/lib.rs"));
     assert!(owners.contains(&"001-rs".to_string()), "owners: {owners:?}");
 }
+
+// ===== spec 017: crate / directory / module unit kinds =====
+
+/// The resolved locations for the first resolved unit of `spec_id`.
+fn first_unit_locations<'a>(
+    idx: &'a spec_spine_types::CodebaseIndex,
+    spec_id: &str,
+) -> &'a [spec_spine_types::ResolvedLocation] {
+    &mapping(idx, spec_id).resolved_units[0].locations
+}
+
+/// A Rust crate with an inline `mod tests {}`, a file-module (`helper.rs`), and a
+/// nested directory, for exercising the three new unit kinds.
+fn module_fixture() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"rs-thing\"]\n");
+    write(
+        r,
+        "rs-thing/Cargo.toml",
+        "[package]\nname = \"rs-thing\"\nversion = \"0.1.0\"\n",
+    );
+    write(
+        r,
+        "rs-thing/src/lib.rs",
+        "pub fn alpha() {}\n\nmod tests {\n    fn t() {}\n}\n",
+    );
+    write(r, "rs-thing/src/helper.rs", "pub fn help() {}\n");
+    tmp
+}
+
+#[test]
+fn crate_unit_resolves_to_package_subtree() {
+    let fx = module_fixture();
+    write(
+        fx.path(),
+        "specs/001-c/spec.md",
+        &spec("001-c", "establishes:\n  - { kind: crate, id: \"rs-thing\" }\n"),
+    );
+    let idx = index(&Config::default(), fx.path()).unwrap().index;
+    let locs = first_unit_locations(&idx, "001-c");
+    assert_eq!(locs.len(), 1);
+    assert_eq!(locs[0].file, "rs-thing");
+    // Hyphen/underscore are interchangeable in the crate id.
+    assert!(authorities(&idx, &Unit::Crate { id: "rs-thing".into() }).contains(&"001-c".into()));
+}
+
+#[test]
+fn unknown_crate_unit_is_blocking_diagnostic_i003() {
+    let fx = module_fixture();
+    write(
+        fx.path(),
+        "specs/001-c/spec.md",
+        &spec("001-c", "establishes:\n  - { kind: crate, id: \"ghost\" }\n"),
+    );
+    let idx = index(&Config::default(), fx.path()).unwrap().index;
+    assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-003"));
+}
+
+#[test]
+fn directory_unit_resolves_to_subtree() {
+    let fx = module_fixture();
+    write(
+        fx.path(),
+        "specs/001-d/spec.md",
+        &spec(
+            "001-d",
+            "establishes:\n  - { kind: directory, path: \"rs-thing/src\" }\n",
+        ),
+    );
+    let idx = index(&Config::default(), fx.path()).unwrap().index;
+    let locs = first_unit_locations(&idx, "001-d");
+    assert_eq!(locs.len(), 1);
+    assert_eq!(locs[0].file, "rs-thing/src");
+    assert_eq!(locs[0].span, None);
+}
+
+#[test]
+fn missing_directory_unit_is_blocking_diagnostic_i007() {
+    let fx = module_fixture();
+    write(
+        fx.path(),
+        "specs/001-d/spec.md",
+        &spec(
+            "001-d",
+            "establishes:\n  - { kind: directory, path: \"rs-thing/nope\" }\n",
+        ),
+    );
+    let idx = index(&Config::default(), fx.path()).unwrap().index;
+    assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-007"));
+}
+
+#[test]
+fn module_unit_resolves_inline_and_file_modules() {
+    let fx = module_fixture();
+    // Inline `mod tests {}` → a line span; the file-module `helper` → whole file.
+    write(
+        fx.path(),
+        "specs/001-m/spec.md",
+        &spec(
+            "001-m",
+            "establishes:\n  - { kind: module, id: \"rs_thing::tests\" }\n  - { kind: module, id: \"rs_thing::helper\" }\n",
+        ),
+    );
+    let idx = index(&Config::default(), fx.path()).unwrap().index;
+    let m = mapping(&idx, "001-m");
+    let tests_unit = m
+        .resolved_units
+        .iter()
+        .find(|u| matches!(&u.unit, Unit::Module { id } if id == "rs_thing::tests"))
+        .unwrap();
+    assert_eq!(tests_unit.locations[0].file, "rs-thing/src/lib.rs");
+    assert!(
+        tests_unit.locations[0].span.is_some(),
+        "inline mod resolves to a block span"
+    );
+    let helper_unit = m
+        .resolved_units
+        .iter()
+        .find(|u| matches!(&u.unit, Unit::Module { id } if id == "rs_thing::helper"))
+        .unwrap();
+    assert_eq!(helper_unit.locations[0].file, "rs-thing/src/helper.rs");
+    assert_eq!(
+        helper_unit.locations[0].span, None,
+        "a file-module resolves whole-file"
+    );
+}
+
+#[test]
+fn spec_scoped_constrains_produces_no_resolved_unit() {
+    // Spec 018: a constrains item with target_specs and no unit claims no code
+    // path, so it contributes no resolved unit to the index.
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "constrains:\n  - { kind: sequencing-plan, target_specs: [\"002-y\"] }\n",
+        ),
+    );
+    write(tmp.path(), "specs/002-y/spec.md", &spec("002-y", ""));
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        mapping(&idx, "001-x").resolved_units.is_empty(),
+        "spec-scoped constrains claims no code path"
+    );
+}
+
+#[test]
+fn unresolved_module_unit_is_blocking_diagnostic_i008() {
+    let fx = module_fixture();
+    write(
+        fx.path(),
+        "specs/001-m/spec.md",
+        &spec(
+            "001-m",
+            "establishes:\n  - { kind: module, id: \"rs_thing::ghost\" }\n",
+        ),
+    );
+    let idx = index(&Config::default(), fx.path()).unwrap().index;
+    assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-008"));
+}

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -107,7 +107,7 @@ fn indexes_deterministically() {
 
 #[test]
 fn discovers_rust_and_npm_packages() {
-    // The npm package is declared by root package.json#workspaces — the encore
+    // The npm package is declared by root package.json#workspaces; the encore
     // failure was that npm packages went undiscovered. They must appear here.
     let fx = mixed_fixture();
     let idx = index(&Config::default(), fx.path()).unwrap().index;
@@ -256,7 +256,7 @@ fn staleness_detects_symbol_source_line_shift() {
         Freshness::Fresh
     );
 
-    // Prepend a line to the symbol's source file — this shifts every committed
+    // Prepend a line to the symbol's source file: this shifts every committed
     // span downward but touches no manifest/spec/config. It MUST go Stale.
     write(
         fx.path(),
@@ -317,14 +317,25 @@ fn crate_unit_resolves_to_package_subtree() {
     write(
         fx.path(),
         "specs/001-c/spec.md",
-        &spec("001-c", "establishes:\n  - { kind: crate, id: \"rs-thing\" }\n"),
+        &spec(
+            "001-c",
+            "establishes:\n  - { kind: crate, id: \"rs-thing\" }\n",
+        ),
     );
     let idx = index(&Config::default(), fx.path()).unwrap().index;
     let locs = first_unit_locations(&idx, "001-c");
     assert_eq!(locs.len(), 1);
     assert_eq!(locs[0].file, "rs-thing");
     // Hyphen/underscore are interchangeable in the crate id.
-    assert!(authorities(&idx, &Unit::Crate { id: "rs-thing".into() }).contains(&"001-c".into()));
+    assert!(
+        authorities(
+            &idx,
+            &Unit::Crate {
+                id: "rs-thing".into()
+            }
+        )
+        .contains(&"001-c".into())
+    );
 }
 
 #[test]
@@ -333,7 +344,10 @@ fn unknown_crate_unit_is_blocking_diagnostic_i003() {
     write(
         fx.path(),
         "specs/001-c/spec.md",
-        &spec("001-c", "establishes:\n  - { kind: crate, id: \"ghost\" }\n"),
+        &spec(
+            "001-c",
+            "establishes:\n  - { kind: crate, id: \"ghost\" }\n",
+        ),
     );
     let idx = index(&Config::default(), fx.path()).unwrap().index;
     assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-003"));

--- a/crates/spec-spine-core/tests/render.rs
+++ b/crates/spec-spine-core/tests/render.rs
@@ -1,5 +1,5 @@
 //! Golden tests for the spec 011 projections: the rendered markdown is a pure
-//! function of `(config, index.json bytes)` — byte-exact, LF endings, trailing
+//! function of `(config, index.json bytes)`: byte-exact, LF endings, trailing
 //! newline. Fixtures go through `load_index` so the wire shapes are exercised
 //! end to end.
 

--- a/crates/spec-spine-core/tests/scaffold.rs
+++ b/crates/spec-spine-core/tests/scaffold.rs
@@ -1,4 +1,4 @@
-//! Scaffold tests (spec 006): the generated corpus is well-formed — a scaffolded
+//! Scaffold tests (spec 006): the generated corpus is well-formed; a scaffolded
 //! repo compiles and lints clean, proving the adoption loop works with zero
 //! library edits.
 

--- a/crates/spec-spine-types/Cargo.toml
+++ b/crates/spec-spine-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spec-spine-types"
-description = "Typed DTOs, frontmatter grammar, configuration, and schema-version constants for spec-spine — the data substrate shared by the engine and (future) bindings."
+description = "Typed DTOs, frontmatter grammar, configuration, and schema-version constants for spec-spine: the data substrate shared by the engine and (future) bindings."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/spec-spine-types/src/codebase.rs
+++ b/crates/spec-spine-types/src/codebase.rs
@@ -1,4 +1,4 @@
-//! Codebase-index DTOs — the code-as-source view, emitted by `spec-spine index`
+//! Codebase-index DTOs: the code-as-source view, emitted by `spec-spine index`
 //! as `index.json`. Field names serialize to `camelCase`. Shapes are ported from
 //! OAP `codebase-index.schema.json` (3.0.0), pruned to the generic v1 surface and
 //! re-versioned to this library's own `0.1.0`.
@@ -16,9 +16,9 @@ pub struct CodebaseIndex {
     /// `MAJOR.MINOR.PATCH`; see [`crate::version::INDEX_SCHEMA_VERSION`].
     pub schema_version: String,
     pub build: IndexBuild,
-    /// Layer 1 — the discovered compilation units.
+    /// Layer 1: the discovered compilation units.
     pub packages: Vec<PackageRecord>,
-    /// Layer 2 — spec ↔ code traceability.
+    /// Layer 2: spec ↔ code traceability.
     pub traceability: Traceability,
     pub diagnostics: Diagnostics,
 }
@@ -67,7 +67,7 @@ pub struct PackageRecord {
     pub spec_ref: Option<String>,
 }
 
-/// Layer 2 — how the corpus maps onto the code, and what is unmapped.
+/// Layer 2: how the corpus maps onto the code, and what is unmapped.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Traceability {

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -5,7 +5,7 @@
 //! `specs/` at the root ([`Config::default`]). Every struct is
 //! `#[serde(default, deny_unknown_fields)]`: missing keys default, and a
 //! *misspelled* knob is a loud [`Error::Config`] rather than a silently-ignored
-//! setting — the exact failure class that left template-encore blind to its npm
+//! setting: the exact failure class that left template-encore blind to its npm
 //! packages. See `docs/design/00-architecture.md` §3.
 
 use std::collections::BTreeMap;
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
-/// The full configuration. All sections are optional. `Default` is derived —
+/// The full configuration. All sections are optional. `Default` is derived;
 /// each field's own `Default` supplies the conventional value.
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -22,7 +22,7 @@ pub struct Config {
     pub manifest: ManifestConfig,
     /// Opt-in `domain` taxonomy (empty `allowed` ⇒ free-text/disabled).
     pub domains: AllowlistConfig,
-    /// Opt-in `kind` taxonomy — symmetric with `domains` (empty ⇒ disabled).
+    /// Opt-in `kind` taxonomy, symmetric with `domains` (empty ⇒ disabled).
     pub kind: AllowlistConfig,
     pub layout: LayoutConfig,
     pub index: IndexConfig,
@@ -32,7 +32,7 @@ pub struct Config {
     pub frontmatter: FrontmatterConfig,
 }
 
-/// `[manifest]` — how a manifest links a compilation unit back to its spec.
+/// `[manifest]`: how a manifest links a compilation unit back to its spec.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ManifestConfig {
@@ -72,7 +72,7 @@ impl AllowlistConfig {
     }
 }
 
-/// `[layout]` — path conventions. Never hardcode `specs/`, `.derived/`, etc.
+/// `[layout]`: path conventions. Never hardcode `specs/`, `.derived/`, etc.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LayoutConfig {
@@ -84,7 +84,7 @@ pub struct LayoutConfig {
     pub cargo_workspace: String,
     /// Manifests that DECLARE npm/pnpm workspace members. The indexer reads
     /// member globs from whichever exists. The default reads root
-    /// `package.json#workspaces` — fixing the template-encore bug where a
+    /// `package.json#workspaces`, fixing the template-encore bug where a
     /// hardcoded `public/pnpm-workspace.yaml` made all npm packages invisible.
     pub npm_workspaces: Vec<String>,
     /// Crates outside the root Cargo workspace.
@@ -111,7 +111,7 @@ impl Default for LayoutConfig {
     }
 }
 
-/// `[index]` — inputs and exclusions for the codebase indexer.
+/// `[index]`: inputs and exclusions for the codebase indexer.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct IndexConfig {
@@ -148,7 +148,7 @@ impl Default for IndexConfig {
     }
 }
 
-/// `[branding]` — identifiers stamped into emitted `build` metadata.
+/// `[branding]`: identifiers stamped into emitted `build` metadata.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct BrandingConfig {
@@ -165,14 +165,14 @@ impl Default for BrandingConfig {
     }
 }
 
-/// `[coupling]` — the PR-time gate's exemptions and waiver keyword.
+/// `[coupling]`: the PR-time gate's exemptions and waiver keyword.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CouplingConfig {
     /// **Additional** paths exempt from the gate, on top of the always-applied
     /// hardcoded floor (`spec_spine_core::DEFAULT_BYPASS_PREFIXES`). Match rules:
     /// trailing `/` ⇒ dir prefix; leading `**/` ⇒ tail-suffix anywhere; else
-    /// exact file. This list is **additive** — it adds to the floor and can never
+    /// exact file. This list is **additive**: it adds to the floor and can never
     /// remove a floor entry. The default is **empty**: the floor is the single
     /// built-in source, so an adopter declares only their own additions rather
     /// than restating (and seeming able to override) the floor.
@@ -184,17 +184,17 @@ pub struct CouplingConfig {
     /// the parsed base/head JSON of every non-bypassed changed path: if all
     /// are `package.json` manifests whose only differences are version
     /// strings inside the standard dependency tables (same package keys),
-    /// the gate self-waives — the path dependabot-class PRs cannot take
+    /// the gate self-waives: the path dependabot-class PRs cannot take
     /// (they can edit neither specs nor PR bodies). Anything beyond a
-    /// version string — a new package, a `scripts` edit, spec-binding
-    /// metadata — refuses the auto-waiver, fail-closed. Default `false`.
+    /// version string (a new package, a `scripts` edit, spec-binding
+    /// metadata) refuses the auto-waiver, fail-closed. Default `false`.
     pub auto_waive_dependency_only: bool,
 }
 
 impl Default for CouplingConfig {
     fn default() -> Self {
         CouplingConfig {
-            // Empty by design — the floor lives in `couple.rs` and is always
+            // Empty by design: the floor lives in `couple.rs` and is always
             // unioned in; duplicating it here was redundant and misleadingly
             // implied it was overridable.
             bypass_prefixes: Vec::new(),
@@ -204,7 +204,7 @@ impl Default for CouplingConfig {
     }
 }
 
-/// `[provenance]` — the OPEN provenance-scheme registry (kind → URI scheme).
+/// `[provenance]`: the OPEN provenance-scheme registry (kind → URI scheme).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ProvenanceConfig {
@@ -220,7 +220,7 @@ impl Default for ProvenanceConfig {
     }
 }
 
-/// `[frontmatter]` — recognized-key extensions.
+/// `[frontmatter]`: recognized-key extensions.
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct FrontmatterConfig {
@@ -232,7 +232,7 @@ pub struct FrontmatterConfig {
 /// Load and validate a `spec-spine.toml` from its source text.
 ///
 /// Returns [`Error::Config`] (mapped to exit code 3) on any malformed or
-/// unknown-key error — never panics.
+/// unknown-key error; never panics.
 pub fn load_config(toml_src: &str) -> Result<Config> {
     let config: Config = toml::from_str(toml_src).map_err(|e| Error::Config(e.to_string()))?;
     validate_slices(&config)?;

--- a/crates/spec-spine-types/src/edges.rs
+++ b/crates/spec-spine-types/src/edges.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::unit::Unit;
 
-/// `extends: [{ spec, unit? | paths?, nature? }]` — adds surface to a
+/// `extends: [{ spec, unit? | paths?, nature? }]`: adds surface to a
 /// predecessor. `paths:` is parse-time sugar for N file units (spec 014).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -25,7 +25,7 @@ pub struct ExtendItem {
     pub spec: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unit: Option<Unit>,
-    /// Authoring sugar only — always `None` after parse (spec 014 §3.2).
+    /// Authoring sugar only: always `None` after parse (spec 014 §3.2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub paths: Option<Vec<String>>,
     /// Free-text nature hint (e.g. `additive`, `wrapping`); validated by lint.
@@ -33,7 +33,7 @@ pub struct ExtendItem {
     pub nature: Option<String>,
 }
 
-/// `refines: [{ aspect, unit? | paths?, refines_specs? }]` — tightens a named
+/// `refines: [{ aspect, unit? | paths?, refines_specs? }]`: tightens a named
 /// aspect. `paths:` is parse-time sugar for N file units (spec 014).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -42,7 +42,7 @@ pub struct RefineItem {
     pub aspect: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unit: Option<Unit>,
-    /// Authoring sugar only — always `None` after parse (spec 014 §3.2).
+    /// Authoring sugar only: always `None` after parse (spec 014 §3.2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub paths: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -83,7 +83,7 @@ pub(crate) fn expand_extend_paths(items: Vec<ExtendItem>) -> Result<Vec<ExtendIt
     Ok(out)
 }
 
-/// Expand the `paths:` sugar on `refines` items — symmetric with
+/// Expand the `paths:` sugar on `refines` items, symmetric with
 /// [`expand_extend_paths`].
 pub(crate) fn expand_refine_paths(items: Vec<RefineItem>) -> Result<Vec<RefineItem>, String> {
     let mut out = Vec::with_capacity(items.len());
@@ -116,7 +116,7 @@ pub(crate) fn expand_refine_paths(items: Vec<RefineItem>) -> Result<Vec<RefineIt
     Ok(out)
 }
 
-/// `co_authority: [{ unit, with_specs? }]` — shares a section with other specs.
+/// `co_authority: [{ unit, with_specs? }]`: shares a section with other specs.
 ///
 /// `unit` must be a [`Unit::Section`] (validated by the compiler in Phase 2).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -127,14 +127,14 @@ pub struct CoAuthorityItem {
     pub with_specs: Vec<String>,
 }
 
-/// `constrains: [{ flavor? | kind?, unit?, note?, target_specs? }]` — asserts an
+/// `constrains: [{ flavor? | kind?, unit?, note?, target_specs? }]`: asserts an
 /// invariant others must respect.
 ///
 /// Two shapes coexist (spec 018): a **path-scoped** constraint carries a `unit:`
 /// (the canonical `invariant-freeze` over a file/schema); a **spec-scoped**
 /// constraint carries `target_specs:` and no unit (a sequencing/ordering plan
 /// over other specs). `flavor` and `kind` are interchangeable, documentary
-/// discriminators (synonyms — the predecessor dialect uses both spellings);
+/// discriminators (synonyms; the predecessor dialect uses both spellings);
 /// neither is gate-load-bearing. The compiler requires at least one of `unit` or
 /// `target_specs` (V-011).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -146,7 +146,7 @@ pub struct ConstrainItem {
     /// of `kind`; both are accepted and preserved verbatim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flavor: Option<String>,
-    /// Documentary constraint classification — the alternative spelling of
+    /// Documentary constraint classification: the alternative spelling of
     /// `flavor` (e.g. `sequencing-plan`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
@@ -164,7 +164,7 @@ pub enum SupersedeScope {
     /// The successor inherits the predecessor's entire authority surface.
     #[default]
     Full,
-    /// The successor takes over only the named `unit` (additive — the
+    /// The successor takes over only the named `unit` (additive: the
     /// predecessor keeps everything else, and keeps the unit too).
     Partial,
 }
@@ -173,12 +173,12 @@ pub enum SupersedeScope {
 /// both mean full supersession; only a `partial` item carries a `unit` (spec
 /// 019). The full form normalizes to [`SupersedeItem::Full`] at parse time, so a
 /// corpus that uses only full supersession emits a byte-identical bare-string
-/// `supersedes` array — the registry wire is unchanged for every existing
+/// `supersedes` array: the registry wire is unchanged for every existing
 /// adopter; only a partial item serializes as an object.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SupersedeItem {
-    /// Full supersession — the predecessor id alone.
+    /// Full supersession: the predecessor id alone.
     Full(String),
     /// A structured item (`{ spec, scope?, unit?, note?, rationale? }`).
     Scoped(SupersedeScoped),
@@ -193,7 +193,7 @@ pub struct SupersedeScoped {
     #[serde(default)]
     pub scope: SupersedeScope,
     /// For a `partial` scope: the unit whose authority transfers. A partial item
-    /// with no unit is a documentary lifecycle marker — it transfers nothing.
+    /// with no unit is a documentary lifecycle marker; it transfers nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unit: Option<Unit>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -240,7 +240,7 @@ impl SupersedeItem {
 
 /// Normalize `supersedes` items (spec 019): a `Scoped` item with full scope
 /// carries no information beyond its id, so it collapses to the bare-string
-/// [`SupersedeItem::Full`] form — keeping `{ scope: full }` (OAP spec 073) and a
+/// [`SupersedeItem::Full`] form, keeping `{ scope: full }` (OAP spec 073) and a
 /// bare id byte-identical on the wire. Partial items pass through unchanged.
 pub(crate) fn normalize_supersedes(items: Vec<SupersedeItem>) -> Vec<SupersedeItem> {
     items
@@ -254,7 +254,7 @@ pub(crate) fn normalize_supersedes(items: Vec<SupersedeItem>) -> Vec<SupersedeIt
         .collect()
 }
 
-/// `references: [{ unit? | provenance?, role? }]` — the non-owning edge.
+/// `references: [{ unit? | provenance?, role? }]`: the non-owning edge.
 ///
 /// `unit` and `provenance` are mutually exclusive (enforced by the compiler).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -281,7 +281,7 @@ pub struct Provenance {
     pub reference: String,
 }
 
-/// The `origin` bootstrap marker — NOT a relationship edge.
+/// The `origin` bootstrap marker, NOT a relationship edge.
 ///
 /// `retroactive: true` declares authority held since before the graph existed.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/crates/spec-spine-types/src/edges.rs
+++ b/crates/spec-spine-types/src/edges.rs
@@ -127,15 +127,131 @@ pub struct CoAuthorityItem {
     pub with_specs: Vec<String>,
 }
 
-/// `constrains: [{ unit, note?, target_specs? }]` — asserts an invariant.
+/// `constrains: [{ flavor? | kind?, unit?, note?, target_specs? }]` — asserts an
+/// invariant others must respect.
+///
+/// Two shapes coexist (spec 018): a **path-scoped** constraint carries a `unit:`
+/// (the canonical `invariant-freeze` over a file/schema); a **spec-scoped**
+/// constraint carries `target_specs:` and no unit (a sequencing/ordering plan
+/// over other specs). `flavor` and `kind` are interchangeable, documentary
+/// discriminators (synonyms — the predecessor dialect uses both spellings);
+/// neither is gate-load-bearing. The compiler requires at least one of `unit` or
+/// `target_specs` (V-011).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConstrainItem {
-    pub unit: Unit,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<Unit>,
+    /// Documentary constraint classification (e.g. `invariant-freeze`). Synonym
+    /// of `kind`; both are accepted and preserved verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flavor: Option<String>,
+    /// Documentary constraint classification — the alternative spelling of
+    /// `flavor` (e.g. `sequencing-plan`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub target_specs: Vec<String>,
+}
+
+/// The scope of a `supersedes` edge (spec 019): a whole-spec transfer or a
+/// unit-scoped one.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SupersedeScope {
+    /// The successor inherits the predecessor's entire authority surface.
+    #[default]
+    Full,
+    /// The successor takes over only the named `unit` (additive — the
+    /// predecessor keeps everything else, and keeps the unit too).
+    Partial,
+}
+
+/// One `supersedes` entry. A bare predecessor id and `{ spec, scope: full }`
+/// both mean full supersession; only a `partial` item carries a `unit` (spec
+/// 019). The full form normalizes to [`SupersedeItem::Full`] at parse time, so a
+/// corpus that uses only full supersession emits a byte-identical bare-string
+/// `supersedes` array — the registry wire is unchanged for every existing
+/// adopter; only a partial item serializes as an object.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SupersedeItem {
+    /// Full supersession — the predecessor id alone.
+    Full(String),
+    /// A structured item (`{ spec, scope?, unit?, note?, rationale? }`).
+    Scoped(SupersedeScoped),
+}
+
+/// The structured `supersedes` item shape.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupersedeScoped {
+    /// The predecessor spec id being superseded.
+    pub spec: String,
+    #[serde(default)]
+    pub scope: SupersedeScope,
+    /// For a `partial` scope: the unit whose authority transfers. A partial item
+    /// with no unit is a documentary lifecycle marker — it transfers nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<Unit>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+}
+
+impl SupersedeItem {
+    /// The predecessor spec id, regardless of form.
+    pub fn spec(&self) -> &str {
+        match self {
+            SupersedeItem::Full(id) => id,
+            SupersedeItem::Scoped(s) => &s.spec,
+        }
+    }
+
+    /// True for a full (whole-spec) supersession. (After normalization a
+    /// `Scoped` is always partial, but this stays correct pre-normalization.)
+    pub fn is_full(&self) -> bool {
+        match self {
+            SupersedeItem::Full(_) => true,
+            SupersedeItem::Scoped(s) => s.scope == SupersedeScope::Full,
+        }
+    }
+
+    /// The unit a *partial* supersession scopes its transfer to, if any.
+    pub fn partial_unit(&self) -> Option<&Unit> {
+        match self {
+            SupersedeItem::Scoped(s) if s.scope == SupersedeScope::Partial => s.unit.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// Rewrite the predecessor id in place (used by compile-time short-id
+    /// resolution; spec 016/019).
+    pub fn set_spec(&mut self, id: String) {
+        match self {
+            SupersedeItem::Full(s) => *s = id,
+            SupersedeItem::Scoped(s) => s.spec = id,
+        }
+    }
+}
+
+/// Normalize `supersedes` items (spec 019): a `Scoped` item with full scope
+/// carries no information beyond its id, so it collapses to the bare-string
+/// [`SupersedeItem::Full`] form — keeping `{ scope: full }` (OAP spec 073) and a
+/// bare id byte-identical on the wire. Partial items pass through unchanged.
+pub(crate) fn normalize_supersedes(items: Vec<SupersedeItem>) -> Vec<SupersedeItem> {
+    items
+        .into_iter()
+        .map(|item| match item {
+            SupersedeItem::Scoped(s) if s.scope == SupersedeScope::Full => {
+                SupersedeItem::Full(s.spec)
+            }
+            other => other,
+        })
+        .collect()
 }
 
 /// `references: [{ unit? | provenance?, role? }]` — the non-owning edge.

--- a/crates/spec-spine-types/src/error.rs
+++ b/crates/spec-spine-types/src/error.rs
@@ -3,7 +3,7 @@
 //! Every variant maps to a stable CLI exit code (see [`Error::exit_code`]); the
 //! CLI is the only place that translates an `Error` into a process exit. Inside
 //! the library we never `panic!` on user input, never `process::exit`, and never
-//! `println!` data — those belong only in the CLI crate.
+//! `println!` data; those belong only in the CLI crate.
 //!
 //! Exit-code contract (see `docs/design/00-architecture.md` §6):
 //! `0` ok, `1` validation failure / not found, `2` stale,

--- a/crates/spec-spine-types/src/frontmatter.rs
+++ b/crates/spec-spine-types/src/frontmatter.rs
@@ -16,7 +16,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::edges::{CoAuthorityItem, ConstrainItem, ExtendItem, Origin, ReferenceItem, RefineItem};
+use crate::edges::{
+    CoAuthorityItem, ConstrainItem, ExtendItem, Origin, ReferenceItem, RefineItem, SupersedeItem,
+};
 use crate::error::{Error, Result};
 use crate::unit::Unit;
 
@@ -157,7 +159,7 @@ pub struct Frontmatter {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub refines: Vec<RefineItem>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub supersedes: Vec<String>,
+    pub supersedes: Vec<SupersedeItem>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub amends: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -301,6 +303,11 @@ pub fn parse_frontmatter_with(
     frontmatter.refines =
         crate::edges::expand_refine_paths(std::mem::take(&mut frontmatter.refines))
             .map_err(malformed)?;
+    // Full-scope supersedes (`{ scope: full }` / bare id) collapse to the
+    // bare-string form so the wire stays byte-identical for full-only corpora
+    // (spec 019).
+    frontmatter.supersedes =
+        crate::edges::normalize_supersedes(std::mem::take(&mut frontmatter.supersedes));
 
     Ok(frontmatter)
 }

--- a/crates/spec-spine-types/src/frontmatter.rs
+++ b/crates/spec-spine-types/src/frontmatter.rs
@@ -62,10 +62,10 @@ pub enum Implementation {
 /// (spec 013 §3.3).
 #[derive(Clone, Debug)]
 pub enum FrontmatterIssue {
-    /// Malformed YAML or a grammar violation — the V-002 class.
+    /// Malformed YAML or a grammar violation: the V-002 class.
     Malformed(String),
     /// A DECLARED extra key whose value JSON cannot represent (non-string
-    /// mapping key, YAML tag, non-finite number) — the V-013 class.
+    /// mapping key, YAML tag, non-finite number): the V-013 class.
     UnrepresentableDeclared { key: String, detail: String },
 }
 
@@ -313,7 +313,7 @@ pub fn parse_frontmatter_with(
 }
 
 /// The UNDECLARED-key path: scalars and string lists only (`Null` drops the
-/// key); a nested map, mixed list, or tag is a grammar violation — exactly
+/// key); a nested map, mixed list, or tag is a grammar violation, exactly
 /// the pre-013 guard.
 fn yaml_to_extra(v: &serde_yaml::Value) -> std::result::Result<serde_json::Value, String> {
     use serde_yaml::Value;
@@ -353,7 +353,7 @@ fn yaml_to_extra(v: &serde_yaml::Value) -> std::result::Result<serde_json::Value
 /// The DECLARED-key path (spec 013 §3.2): full YAML → JSON conversion.
 /// Mappings require string keys; tags and non-finite numbers are
 /// unrepresentable. Map key order is canonicalized by the sorted
-/// `serde_json::Map` (authoring order is not preserved — the price of
+/// `serde_json::Map` (authoring order is not preserved: the price of
 /// byte-identical registries).
 fn yaml_to_json(v: &serde_yaml::Value) -> std::result::Result<serde_json::Value, String> {
     use serde_yaml::Value;

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -4,20 +4,20 @@
 //! grammar, the authority-unit and typed-edge vocabulary, the registry DTOs,
 //! schema-version constants, and the stable [`Error`] enum.
 //!
-//! Everything here is plain, owned, `serde`-serializable data — no lifetimes,
-//! generics, or trait objects at the public boundary — so the same types back
+//! Everything here is plain, owned, `serde`-serializable data (no lifetimes,
+//! generics, or trait objects at the public boundary) so the same types back
 //! both the `spec-spine-core` engine and future FFI bindings.
 //!
 //! See `docs/design/00-architecture.md` for the design and the provenance of
 //! the ported semantics.
 //!
 //! ## Layout
-//! - [`config`] — the `spec-spine.toml` model ([`Config`]).
-//! - [`frontmatter`] — the authored grammar ([`Frontmatter`], [`parse_frontmatter`]).
-//! - [`unit`] / [`edges`] — the authority-unit and relationship vocabulary.
-//! - [`registry`] — the compiled spec-as-source DTOs ([`Registry`]).
-//! - [`version`] — schema-version constants.
-//! - [`error`] — the [`Error`] enum and its exit-code contract.
+//! - [`config`]: the `spec-spine.toml` model ([`Config`]).
+//! - [`frontmatter`]: the authored grammar ([`Frontmatter`], [`parse_frontmatter`]).
+//! - [`unit`] / [`edges`]: the authority-unit and relationship vocabulary.
+//! - [`registry`]: the compiled spec-as-source DTOs ([`Registry`]).
+//! - [`version`]: schema-version constants.
+//! - [`error`]: the [`Error`] enum and its exit-code contract.
 
 pub mod codebase;
 pub mod config;

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -42,6 +42,7 @@ pub use config::{
 };
 pub use edges::{
     CoAuthorityItem, ConstrainItem, ExtendItem, Origin, Provenance, ReferenceItem, RefineItem,
+    SupersedeItem, SupersedeScope, SupersedeScoped,
 };
 pub use error::{Error, Result};
 pub use frontmatter::{

--- a/crates/spec-spine-types/src/registry.rs
+++ b/crates/spec-spine-types/src/registry.rs
@@ -1,11 +1,11 @@
-//! Registry DTOs — the spec-as-source view, emitted by `compile` as
+//! Registry DTOs: the spec-as-source view, emitted by `compile` as
 //! `registry.json`. Field names serialize to `camelCase` (the JSON contract),
 //! distinct from the `snake_case` authored [`crate::Frontmatter`] grammar.
 //!
 //! The compiler (Phase 2) populates these from parsed frontmatter plus computed
 //! fields (`spec_path`, `section_headings`, the content hash). Shapes are ported
 //! from OAP `registry.schema.json` (`featureRecord`, `build`, `violation`),
-//! pruned to the generic v1 surface — overlay fields (compliance, factory,
+//! pruned to the generic v1 surface; overlay fields (compliance, factory,
 //! capability/registry/profile) are intentionally absent (see §10.4).
 
 use std::collections::BTreeMap;
@@ -29,7 +29,7 @@ pub struct Registry {
     pub validation: ValidationReport,
 }
 
-/// Deterministic build metadata embedded in `registry.json` (no timestamps —
+/// Deterministic build metadata embedded in `registry.json` (no timestamps:
 /// the wall clock lives in the separate, non-deterministic `build-meta.json`).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/spec-spine-types/src/registry.rs
+++ b/crates/spec-spine-types/src/registry.rs
@@ -12,7 +12,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::edges::{CoAuthorityItem, ConstrainItem, ExtendItem, Origin, ReferenceItem, RefineItem};
+use crate::edges::{
+    CoAuthorityItem, ConstrainItem, ExtendItem, Origin, ReferenceItem, RefineItem, SupersedeItem,
+};
 use crate::frontmatter::{Implementation, Risk, Status};
 use crate::unit::Unit;
 
@@ -83,8 +85,10 @@ pub struct SpecRecord {
     pub extends: Vec<ExtendItem>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub refines: Vec<RefineItem>,
+    /// Full supersession serializes as a bare predecessor id; a partial item
+    /// serializes as an object (spec 019).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub supersedes: Vec<String>,
+    pub supersedes: Vec<SupersedeItem>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub amends: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/spec-spine-types/src/unit.rs
+++ b/crates/spec-spine-types/src/unit.rs
@@ -5,8 +5,8 @@
 //! [`Unit::Symbol`], [`Unit::Directory`], [`Unit::Crate`], and [`Unit::Module`]
 //! (ported from OAP `spec-types::LogicalUnit`). The first three shipped in v1;
 //! `directory`/`crate`/`module` were reserved as an additive minor in
-//! `docs/design/00-architecture.md` §2.2 (Q5) and are resolved as of spec 017
-//! — the schema is permissive on the unit payload, so the new kinds are a MINOR
+//! `docs/design/00-architecture.md` §2.2 (Q5) and are resolved as of spec 017:
+//! the schema is permissive on the unit payload, so the new kinds are a MINOR
 //! bump (no schema-file edit), and a bare string remains shorthand for a file
 //! unit (a trailing-slash path denotes a directory subtree).
 
@@ -42,7 +42,7 @@ pub enum Unit {
     /// the package directory subtree (spec 017).
     Crate { id: String },
     /// A module by its `::`-qualified path (e.g. `my_crate::serialization`),
-    /// resolved by the indexer's Rust module index — file-modules (whole file)
+    /// resolved by the indexer's Rust module index: file-modules (whole file)
     /// and top-level inline `mod` blocks (line-span) (spec 017).
     Module { id: String },
 }

--- a/crates/spec-spine-types/src/unit.rs
+++ b/crates/spec-spine-types/src/unit.rs
@@ -1,11 +1,14 @@
 //! The authority-unit grammar.
 //!
-//! A spec declares the units it owns via a `unit:` on a typed edge. v1 resolves
-//! three granularities: [`Unit::File`], [`Unit::Section`], [`Unit::Symbol`]
-//! (ported from OAP `spec-types::LogicalUnit`; `crate`/`module`/`directory` are
-//! reserved for an additive future minor — see `docs/design/00-architecture.md`
-//! §2.2). A bare string is shorthand for a file unit; a trailing-slash path
-//! denotes the directory subtree.
+//! A spec declares the units it owns via a `unit:` on a typed edge. The grammar
+//! resolves six granularities: [`Unit::File`], [`Unit::Section`],
+//! [`Unit::Symbol`], [`Unit::Directory`], [`Unit::Crate`], and [`Unit::Module`]
+//! (ported from OAP `spec-types::LogicalUnit`). The first three shipped in v1;
+//! `directory`/`crate`/`module` were reserved as an additive minor in
+//! `docs/design/00-architecture.md` §2.2 (Q5) and are resolved as of spec 017
+//! — the schema is permissive on the unit payload, so the new kinds are a MINOR
+//! bump (no schema-file edit), and a bare string remains shorthand for a file
+//! unit (a trailing-slash path denotes a directory subtree).
 
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
@@ -29,6 +32,19 @@ pub enum Unit {
     /// A symbol (function / type / export), resolved by the indexer via
     /// tree-sitter (Rust + TypeScript in v1).
     Symbol { id: String },
+    /// A directory subtree, named explicitly (`{ kind: directory, path }`). The
+    /// subtree-prefix resolution is identical to a trailing-slash file unit; the
+    /// distinct kind preserves the author's intent across the round-trip (spec
+    /// 017). Resolves to the directory path; the gate prefix-matches it.
+    Directory { path: String },
+    /// A compilation unit by its manifest name (Cargo `[package].name` or npm
+    /// `package.json:name`), resolved against the discovered package inventory to
+    /// the package directory subtree (spec 017).
+    Crate { id: String },
+    /// A module by its `::`-qualified path (e.g. `my_crate::serialization`),
+    /// resolved by the indexer's Rust module index — file-modules (whole file)
+    /// and top-level inline `mod` blocks (line-span) (spec 017).
+    Module { id: String },
 }
 
 impl Unit {
@@ -37,9 +53,14 @@ impl Unit {
         Unit::File { path: path.into() }
     }
 
-    /// True if this unit is a directory subtree (a file unit whose path ends `/`).
+    /// True if this unit resolves to a directory subtree: a file unit whose path
+    /// ends `/`, or an explicit [`Unit::Directory`] (spec 017).
     pub fn is_directory_subtree(&self) -> bool {
-        matches!(self, Unit::File { path } if path.ends_with('/'))
+        match self {
+            Unit::File { path } => path.ends_with('/'),
+            Unit::Directory { .. } => true,
+            _ => false,
+        }
     }
 }
 
@@ -69,6 +90,9 @@ impl<'de> Deserialize<'de> for Unit {
             File { path: String },
             Section { file: String, anchor: String },
             Symbol { id: String },
+            Directory { path: String },
+            Crate { id: String },
+            Module { id: String },
         }
 
         match Repr::deserialize(deserializer)? {
@@ -81,6 +105,9 @@ impl<'de> Deserialize<'de> for Unit {
             Repr::Tagged(Tagged::File { path }) => Ok(Unit::File { path }),
             Repr::Tagged(Tagged::Section { file, anchor }) => Ok(Unit::Section { file, anchor }),
             Repr::Tagged(Tagged::Symbol { id }) => Ok(Unit::Symbol { id }),
+            Repr::Tagged(Tagged::Directory { path }) => Ok(Unit::Directory { path }),
+            Repr::Tagged(Tagged::Crate { id }) => Ok(Unit::Crate { id }),
+            Repr::Tagged(Tagged::Module { id }) => Ok(Unit::Module { id }),
             Repr::Wrapped { unit } => Ok(*unit),
         }
     }

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -1,4 +1,4 @@
-//! Schema-version constants — library-owned, started fresh at `0.1.0`.
+//! Schema-version constants: library-owned, started fresh at `0.1.0`.
 //!
 //! These are deliberately decoupled from the reference repos' version lines
 //! (OAP registry `2.2.0`, index `3.0.0`). They are compile-time constants; in

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -12,11 +12,14 @@
 
 /// `specVersion` emitted in `registry.json`.
 /// `0.2.0`: declared extra-frontmatter values widen to arbitrary JSON (spec 013).
-pub const REGISTRY_SCHEMA_VERSION: &str = "0.2.0";
+/// `0.3.0`: structured/partial `supersedes` items (spec 019); full supersession
+/// stays a bare string, so a full-only corpus is byte-identical.
+pub const REGISTRY_SCHEMA_VERSION: &str = "0.3.0";
 
 /// `schemaVersion` emitted in `index.json`. (Index DTOs land in Phase 3.)
 /// `0.2.0`: additive `build.sliceHashes` (spec 012).
-pub const INDEX_SCHEMA_VERSION: &str = "0.2.0";
+/// `0.3.0`: additive `directory`/`crate`/`module` resolved-unit kinds (spec 017).
+pub const INDEX_SCHEMA_VERSION: &str = "0.3.0";
 
 /// `schemaVersion` emitted in `build-meta.json` (the non-deterministic artifact).
 pub const BUILD_META_SCHEMA_VERSION: &str = "0.1.0";

--- a/crates/spec-spine-types/tests/dogfood.rs
+++ b/crates/spec-spine-types/tests/dogfood.rs
@@ -1,7 +1,7 @@
 //! Dogfood: this repo's own bootstrap spec must parse through the types crate.
 //!
 //! The compiler does not exist yet (Phase 2), but the authored frontmatter of
-//! `specs/000` must already conform to the grammar this crate defines — so the
+//! `specs/000` must already conform to the grammar this crate defines, so the
 //! corpus and the grammar cannot drift apart before compile lands.
 
 use spec_spine_types::{Status, parse_frontmatter};

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -69,10 +69,10 @@ fn validation_passed_follows_error_tier() {
 
 #[test]
 fn schema_versions_are_pinned() {
-    // 0.2.0: declared extra-frontmatter widens to arbitrary JSON (spec 013).
-    assert_eq!(REGISTRY_SCHEMA_VERSION, "0.2.0");
-    // 0.2.0: additive `build.sliceHashes` (spec 012).
-    assert_eq!(INDEX_SCHEMA_VERSION, "0.2.0");
+    // 0.3.0: structured/partial `supersedes` items (spec 019).
+    assert_eq!(REGISTRY_SCHEMA_VERSION, "0.3.0");
+    // 0.3.0: additive `directory`/`crate`/`module` resolved-unit kinds (spec 017).
+    assert_eq!(INDEX_SCHEMA_VERSION, "0.3.0");
     assert_eq!(BUILD_META_SCHEMA_VERSION, "0.1.0");
     assert_eq!(CONFIG_VERSION, "0.1.0");
 }

--- a/crates/spec-spine-types/tests/grammar.rs
+++ b/crates/spec-spine-types/tests/grammar.rs
@@ -1,6 +1,6 @@
 //! Unit-grammar and edge-grammar tests.
 
-use spec_spine_types::{Frontmatter, Implementation, Unit, parse_frontmatter};
+use spec_spine_types::{Frontmatter, Implementation, SupersedeItem, Unit, parse_frontmatter};
 
 fn fm_with_edges(edges_yaml: &str) -> Frontmatter {
     let src = format!(
@@ -50,6 +50,41 @@ fn tagged_units_parse() {
 }
 
 #[test]
+fn directory_crate_module_units_parse() {
+    // Spec 017: the three reserved unit kinds now parse from their tagged form.
+    let dir: Unit = serde_yaml::from_str("{ kind: directory, path: \"src/api\" }").unwrap();
+    assert_eq!(
+        dir,
+        Unit::Directory {
+            path: "src/api".into()
+        }
+    );
+    let krate: Unit = serde_yaml::from_str("{ kind: crate, id: \"factory-engine\" }").unwrap();
+    assert_eq!(
+        krate,
+        Unit::Crate {
+            id: "factory-engine".into()
+        }
+    );
+    let module: Unit = serde_yaml::from_str("{ kind: module, id: \"my_crate::tests\" }").unwrap();
+    assert_eq!(
+        module,
+        Unit::Module {
+            id: "my_crate::tests".into()
+        }
+    );
+    // The wrapper form (spec 015) composes with the new kinds.
+    let wrapped: Unit =
+        serde_yaml::from_str("{ unit: { kind: directory, path: \"crates/x\" } }").unwrap();
+    assert_eq!(
+        wrapped,
+        Unit::Directory {
+            path: "crates/x".into()
+        }
+    );
+}
+
+#[test]
 fn unit_wrapper_form_unwraps() {
     // Spec 015 §3.1: `{ unit: <unit> }` is a 1:1 wrapper that normalizes to the
     // inner unit. The inner may itself be a bare string or a tagged map.
@@ -76,6 +111,13 @@ fn unit_wrapper_form_unwraps() {
 fn directory_subtree_detection() {
     assert!(Unit::file("src/").is_directory_subtree());
     assert!(!Unit::file("src/lib.rs").is_directory_subtree());
+    // An explicit directory unit is always a subtree (spec 017).
+    assert!(
+        Unit::Directory {
+            path: "src".into()
+        }
+        .is_directory_subtree()
+    );
 }
 
 #[test]
@@ -220,8 +262,58 @@ extends:\n  - { spec: \"000-x\", paths: [{ kind: file, path: \"a.rs\" }] }\n---\
 }
 
 #[test]
+fn constrains_discriminator_and_optional_unit() {
+    // Spec 018: a path-scoped item carries flavor + unit; a spec-scoped item
+    // carries kind + target_specs and no unit. Both spellings are accepted.
+    let fm = fm_with_edges(
+        "constrains:\n  - { flavor: invariant-freeze, unit: \"schema.json\" }\n  - { kind: sequencing-plan, target_specs: [\"001-a\", \"002-b\"] }\n",
+    );
+    assert_eq!(fm.constrains.len(), 2);
+    assert_eq!(fm.constrains[0].flavor.as_deref(), Some("invariant-freeze"));
+    assert_eq!(
+        fm.constrains[0].unit,
+        Some(Unit::File {
+            path: "schema.json".into()
+        })
+    );
+    assert_eq!(fm.constrains[1].kind.as_deref(), Some("sequencing-plan"));
+    assert!(fm.constrains[1].unit.is_none());
+    assert_eq!(fm.constrains[1].target_specs, vec!["001-a", "002-b"]);
+}
+
+#[test]
 fn supersedes_and_amends_are_id_lists() {
     let fm = fm_with_edges("supersedes: [\"001-old\"]\namends: [\"002-other\"]\n");
-    assert_eq!(fm.supersedes, vec!["001-old".to_string()]);
+    assert_eq!(fm.supersedes.len(), 1);
+    assert_eq!(fm.supersedes[0].spec(), "001-old");
+    assert!(fm.supersedes[0].is_full());
     assert_eq!(fm.amends, vec!["002-other".to_string()]);
+}
+
+#[test]
+fn supersedes_full_and_partial_forms_parse() {
+    // Spec 019: a bare id and `{ scope: full }` both normalize to the bare-string
+    // full form; `{ scope: partial, unit }` and `{ scope: partial, note }` stay
+    // structured. (Covers OAP shapes 108 / 073 / 114 / 199 respectively.)
+    let fm = fm_with_edges(
+        "supersedes:\n  - \"108-old\"\n  - { spec: \"073-x\", scope: full }\n  - { spec: \"113-y\", scope: partial, unit: \"src/clone.ts\" }\n  - { spec: \"140-z\", scope: partial, note: \"retires §2.2\" }\n",
+    );
+    assert_eq!(fm.supersedes.len(), 4);
+    // Bare id → full.
+    assert!(matches!(&fm.supersedes[0], SupersedeItem::Full(id) if id == "108-old"));
+    // `{ scope: full }` collapses to the bare-string full form (byte-stable wire).
+    assert!(matches!(&fm.supersedes[1], SupersedeItem::Full(id) if id == "073-x"));
+    // Partial + unit stays structured and exposes its scoping unit.
+    assert_eq!(fm.supersedes[2].spec(), "113-y");
+    assert!(!fm.supersedes[2].is_full());
+    assert_eq!(
+        fm.supersedes[2].partial_unit(),
+        Some(&Unit::File {
+            path: "src/clone.ts".into()
+        })
+    );
+    // Partial without a unit is documentary — no transfer unit.
+    assert_eq!(fm.supersedes[3].spec(), "140-z");
+    assert!(!fm.supersedes[3].is_full());
+    assert_eq!(fm.supersedes[3].partial_unit(), None);
 }

--- a/crates/spec-spine-types/tests/grammar.rs
+++ b/crates/spec-spine-types/tests/grammar.rs
@@ -112,12 +112,7 @@ fn directory_subtree_detection() {
     assert!(Unit::file("src/").is_directory_subtree());
     assert!(!Unit::file("src/lib.rs").is_directory_subtree());
     // An explicit directory unit is always a subtree (spec 017).
-    assert!(
-        Unit::Directory {
-            path: "src".into()
-        }
-        .is_directory_subtree()
-    );
+    assert!(Unit::Directory { path: "src".into() }.is_directory_subtree());
 }
 
 #[test]
@@ -312,7 +307,7 @@ fn supersedes_full_and_partial_forms_parse() {
             path: "src/clone.ts".into()
         })
     );
-    // Partial without a unit is documentary — no transfer unit.
+    // Partial without a unit is documentary: no transfer unit.
     assert_eq!(fm.supersedes[3].spec(), "140-z");
     assert!(!fm.supersedes[3].is_full());
     assert_eq!(fm.supersedes[3].partial_unit(), None);

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,13 +15,13 @@
       spec-spine lint --fail-on-warn && spec-spine couple --base origin/main --head HEAD`.
 - [ ] Versions bumped consistently with `scripts/bump_version.py <version>`,
       then `scripts/bump_version.py --check <version>` is green. The script sets
-      all three shims in lockstep — workspace `version` in the root `Cargo.toml`;
+      all three shims in lockstep: workspace `version` in the root `Cargo.toml`;
       `version` + the `optionalDependencies` pins in `npm/package.json` (the
       release workflow re-locks these to the tag via `--write-main`, but they
       should match in source); `version` in `py/pyproject.toml` (the workflow
-      verifies this against the tag and fails loudly on a mismatch — the asymmetry
+      verifies this against the tag and fails loudly on a mismatch, the asymmetry
       that let v0.2.0's PyPI publish fail while npm/crates shipped). Schema-version
-      constants in `spec-spine-types` are decoupled — bump them separately per
+      constants in `spec-spine-types` are decoupled; bump them separately per
       [schema-versioning.md](schema-versioning.md) only if the schema changed.
 - [ ] `cargo package --workspace --locked` succeeds (it cross-verifies every
       crate from its packaged sources, in dependency order: the same check CI can

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -10,8 +10,8 @@
 
 | Artifact | Field | Current | Owner |
 |---|---|---|---|
-| `registry.json` | `specVersion` | `0.2.0` | library |
-| `index.json` | `schemaVersion` | `0.2.0` | library |
+| `registry.json` | `specVersion` | `0.3.0` | library |
+| `index.json` | `schemaVersion` | `0.3.0` | library |
 | `build-meta.json` | `schemaVersion` | `0.1.0` | library (non-deterministic; excluded from goldens) |
 | `spec-spine.toml` | `config_version` (optional) | `0.1.0` | library |
 
@@ -25,6 +25,15 @@ MINOR history:
   (`serde_json::Value`) are untouched; readers that assumed the narrow shape
   were depending on an undocumented restriction. Undeclared keys keep the
   narrow shape.
+- `index.json` `0.3.0` (spec 017): additive `directory` / `crate` / `module`
+  resolved-unit kinds. The payload is schema-permissive, so the bump is the
+  version const alone; readers that handled only `file`/`section`/`symbol`
+  see new `kind` values in `resolvedUnits[].unit`.
+- `registry.json` `0.3.0` (spec 019): a `supersedes` item may be a structured
+  object (`{ spec, scope, unit? }`) as well as a bare id. Full supersession
+  still emits a bare string, so a full-only corpus is byte-identical; only a
+  `partial` item emits an object. Readers that assumed `supersedes: string[]`
+  must accept `string | object` entries.
 
 Each is a **compile-time `const`** in `spec-spine-types`
 (`REGISTRY_SCHEMA_VERSION`, `INDEX_SCHEMA_VERSION`, `BUILD_META_SCHEMA_VERSION`,

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# spec-spine installer — curl -fsSL https://raw.githubusercontent.com/bartekus/spec-spine/main/install.sh | sh
+# spec-spine installer: curl -fsSL https://raw.githubusercontent.com/bartekus/spec-spine/main/install.sh | sh
 #
 # Detects your platform/arch, downloads the matching release archive and its
 # .sha256 sidecar from GitHub Releases, verifies the checksum, and drops the

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.2.0",
-    "@spec-spine/cli-darwin-x64": "0.2.0",
-    "@spec-spine/cli-linux-x64": "0.2.0",
-    "@spec-spine/cli-linux-arm64": "0.2.0",
-    "@spec-spine/cli-win32-x64": "0.2.0"
+    "@spec-spine/cli-darwin-arm64": "0.3.0",
+    "@spec-spine/cli-darwin-x64": "0.3.0",
+    "@spec-spine/cli-linux-x64": "0.3.0",
+    "@spec-spine/cli-linux-arm64": "0.3.0",
+    "@spec-spine/cli-win32-x64": "0.3.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/README.md
+++ b/py/README.md
@@ -15,13 +15,13 @@ pip install spec-spine        # or into a project/venv
 This is a **binary distribution**, not a Python binding. There is no native
 extension and the engine is never called from Python. The project publishes:
 
-- **five platform wheels** — one per supported target, each carrying the prebuilt
+- **five platform wheels**, one per supported target, each carrying the prebuilt
   `spec-spine` binary in the wheel's scripts directory. pip/uv select the one
   matching your host by its platform tag and install the binary onto `PATH`. On a
   supported host there is **no Python in the run path and no network at install**
   beyond fetching the wheel itself; it works offline from a warm cache or a
   private mirror, and under `--no-binary`-free resolution.
-- **one sdist** — the unsupported-host fallback. It builds only when no wheel
+- **one sdist**, the unsupported-host fallback. It builds only when no wheel
   matches (musl/Alpine, win-arm64, 32-bit), and its `spec-spine` command prints a
   clear message pointing at `cargo install spec-spine-cli`.
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.2.0"
+version = "0.3.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"

--- a/py/src/spec_spine/__init__.py
+++ b/py/src/spec_spine/__init__.py
@@ -1,4 +1,4 @@
-"""spec-spine — Python/uvx distribution.
+"""spec-spine: Python/uvx distribution.
 
 On a supported host you never import this package: pip/uv select a platform
 wheel whose only payload is the prebuilt `spec-spine` binary in the wheel's

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Pinned toolchain for reproducible builds of this repo (does NOT affect adopters
-# who `cargo install spec-spine-cli` — that uses their own toolchain).
+# who `cargo install spec-spine-cli` (that uses their own toolchain).
 # MSRV (the floor we support) is declared as `rust-version = "1.85"` in Cargo.toml;
 # this pin is the exact version CI and local dev build with.
 [toolchain]

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -1,7 +1,7 @@
 # spec-spine governing its own repository (dogfood).
 #
 # This repo is a single Cargo workspace with specs/ at the root and no npm
-# packages, so most of this matches the built-in defaults — it is written out
+# packages, so most of this matches the built-in defaults; it is written out
 # explicitly to exercise the config parser and document the dogfood setup.
 # Every key here is optional; an absent file would behave identically.
 
@@ -40,7 +40,7 @@ indexer_id  = "spec-spine"
 # Additions to the built-in generic bypass floor (see couple.rs::DEFAULT_BYPASS_PREFIXES).
 # This list is ADDITIVE and cannot remove a floor entry. The floor already covers
 # the root README.md, docs/, .github/, lockfiles, .derived/, etc.; we extend it to
-# per-crate READMEs (e.g. crates/*/README.md) — prose documentation lives inside
+# per-crate READMEs (e.g. crates/*/README.md): prose documentation lives inside
 # the crate dir, which manifest-metadata maps to the crate's spec, so without this
 # a README tweak would read as code drift. `**/README.md` = tail-suffix match.
 bypass_prefixes = ["**/README.md"]

--- a/specs/000-spec-spine-bootstrap/spec.md
+++ b/specs/000-spec-spine-bootstrap/spec.md
@@ -201,7 +201,7 @@ requirement, or the refusal rule. Amendments may add surface elsewhere.
 
 **Amendment 2026-06-11 (record: specs 004/005 dependency-only cutover).**
 The `[coupling]` config table this spec's types crate carries gains one
-additive key: `auto_waive_dependency_only` (bool, default `false`) — the
+additive key: `auto_waive_dependency_only` (bool, default `false`), the
 opt-in switch for spec 005 §3.5's mechanical dependency-only auto-waiver.
 No unamendable anchor is touched; `deny_unknown_fields` keeps a misspelled
 knob a loud config error.

--- a/specs/004-codebase-index/spec.md
+++ b/specs/004-codebase-index/spec.md
@@ -118,15 +118,15 @@ hash; a mismatch is `Stale` (exit 2). Resolver hard-error diagnostics
 **npm manifests fold as their governance projection** (amendment 2026-06-11,
 paired with spec 005's dependency-only auto-waiver). A `package.json` enters
 the hash not as raw bytes but as the canonical JSON of exactly the fields
-discovery consumes — `name`, `version`, `workspaces`, and the
+discovery consumes: `name`, `version`, `workspaces`, and the
 `manifest.metadata_namespace` object (`manifest.rs::npm_hash_projection`).
-Rationale: dependency tables are not a governed input — the indexer never
-reads them — so a dependabot-class version bump must not stale the committed
+Rationale: dependency tables are not a governed input (the indexer never
+reads them), so a dependabot-class version bump must not stale the committed
 index (the bot can neither re-index nor edit a PR body), while a change to
 any field the indexer *does* read still does. An unparseable manifest falls
 back to raw bytes: over-hashing is the fail-closed direction. Cargo and pnpm
 manifests still fold as raw bytes. Upgrading across this amendment changes
-every npm-bearing repo's computed hash once — re-run `spec-spine index` when
+every npm-bearing repo's computed hash once: re-run `spec-spine index` when
 bumping the dependency.
 
 ### 3.6 Traceability and diagnostics

--- a/specs/005-coupling-gate/spec.md
+++ b/specs/005-coupling-gate/spec.md
@@ -141,15 +141,15 @@ either the predecessor or the successor clears the path.
   neither specs nor PR bodies, so an owned manifest fires `C-001` with no waiver
   path available. When opted in and **no explicit PR-body waiver is present**,
   the CLI compares the parsed base/head JSON of every non-bypassed changed path
-  (contents fetched at the **merge base** and head — the diff is three-dot): if
+  (contents fetched at the **merge base** and head; the diff is three-dot): if
   all are `package.json` manifests that are semantically identical except
   version strings inside `dependencies`/`devDependencies`/
   `optionalDependencies`/`peerDependencies` (same package keys; values may
   differ only where both sides are strings), the gate synthesizes a waiver
   (`core::dep_only`, reason marks it mechanical) and reports the violations as
-  auto-waived. Anything else — a new or removed package, a `scripts` edit,
+  auto-waived. Anything else (a new or removed package, a `scripts` edit,
   spec-binding metadata, an added table, an unparseable or created/deleted
-  manifest — refuses the auto-waiver fail-closed and the gate drifts normally.
+  manifest) refuses the auto-waiver fail-closed and the gate drifts normally.
   Path-level bypass is deliberately NOT the mechanism: it would exempt the whole
   manifest including the spec-binding metadata the gate exists to protect.
   Git-diff mode only (`--paths-from` carries no content). The freshness

--- a/specs/007-distribution/spec.md
+++ b/specs/007-distribution/spec.md
@@ -186,6 +186,14 @@ The runbook step lives in `docs/releasing.md`.
 
 ## Release log
 
+- **0.3.0 (2026-06-12).** Grammar-completion release: specs 017 (the reserved
+  `directory` / `crate` / `module` authority units), 018 (constrains
+  classification discriminator + optional unit), and 019 (structured / partial
+  `supersedes`). Schema-version minors `index.json` 0.2.0 → 0.3.0 and
+  `registry.json` 0.2.0 → 0.3.0, both additive — a corpus using only
+  `file`/`section`/`symbol` units and full supersession compiles
+  byte-identically. Same five-triple matrix and launcher shim; no
+  distribution-mechanics change.
 - **0.2.0 (2026-06-11).** First post-bootstrap feature release: the specs
   004/005 dependency-only cutover (governance-projection hashing of npm
   manifests + the opt-in `auto_waive_dependency_only` coupling waiver).

--- a/specs/007-distribution/spec.md
+++ b/specs/007-distribution/spec.md
@@ -190,13 +190,13 @@ The runbook step lives in `docs/releasing.md`.
   `directory` / `crate` / `module` authority units), 018 (constrains
   classification discriminator + optional unit), and 019 (structured / partial
   `supersedes`). Schema-version minors `index.json` 0.2.0 → 0.3.0 and
-  `registry.json` 0.2.0 → 0.3.0, both additive — a corpus using only
+  `registry.json` 0.2.0 → 0.3.0, both additive: a corpus using only
   `file`/`section`/`symbol` units and full supersession compiles
   byte-identically. Same five-triple matrix and launcher shim; no
   distribution-mechanics change.
 - **0.2.0 (2026-06-11).** First post-bootstrap feature release: the specs
   004/005 dependency-only cutover (governance-projection hashing of npm
   manifests + the opt-in `auto_waive_dependency_only` coupling waiver).
-  Hash-fold semantics change re-baselines npm-bearing adopters — one
+  Hash-fold semantics change re-baselines npm-bearing adopters: one
   `spec-spine index` re-run on upgrade. Same five-triple matrix, same
   launcher shim; no distribution-mechanics change.

--- a/specs/008-python-distribution/spec.md
+++ b/specs/008-python-distribution/spec.md
@@ -36,7 +36,7 @@ summary: >
   second Rust build), are byte-reproducible, and are version-locked to the tag.
 ---
 
-# 008: Distribution — uvx/PyPI wheel shim
+# 008: Distribution, uvx/PyPI wheel shim
 
 ## 1. Purpose
 
@@ -116,7 +116,7 @@ JS `bin` resolves the platform package and exec's the binary. A Python wheel can
 put a binary on PATH directly (the `*.data/scripts/` convention), so the launcher
 disappears: the binary IS the installed `spec-spine` command. The launcher
 contract from 007 §3.3 (forward argv, forward exit code, surface signals, nothing
-on the success path) is satisfied trivially because nothing intermediates — the
+on the success path) is satisfied trivially because nothing intermediates: the
 process the user invokes is the binary.
 
 ### 3.4 Unsupported hosts fail clearly
@@ -130,7 +130,7 @@ prebuilt binary for it, and points at the source build:
     cargo install spec-spine-cli
 
 This is the exact posture of 007 §3.4 / npm's unsupported-host message. The
-sdist is reached two ways — no matching wheel, or an explicit `--no-binary` — and
+sdist is reached two ways (no matching wheel, or an explicit `--no-binary`) and
 the message covers both (musl gets an extra Alpine hint; an explicit `--no-binary`
 on a supported host gets a "reinstall allowing wheels" hint). It exits non-zero.
 
@@ -148,7 +148,7 @@ installed metadata, and the sdist's pyproject is the only declared copy.
 `release.yml` gains a `publish-pypi` job parallel to `publish-npm` (007 §3.6):
 
 - It **reuses the build job's archives** (`download-artifact` of `archive-*`),
-  exactly like publish-npm — there is no second Rust build for Python.
+  exactly like publish-npm; there is no second Rust build for Python.
 - It runs `generate_wheels.py --archives <dist> --build-sdist` to assemble the
   five wheels and the sdist, then uploads them.
 - It is **idempotent**: re-running a tag skips artifacts already on PyPI

--- a/specs/008-python-distribution/spec.md
+++ b/specs/008-python-distribution/spec.md
@@ -180,3 +180,9 @@ installed metadata, and the sdist's pyproject is the only declared copy.
   for that reason. Recorded here so the choice is not relitigated silently.
 - **An enterprise/private index.** The channel targets public PyPI; a private
   index is a deployment concern, not a property of this shim.
+
+## Release log
+
+- **0.3.0 (2026-06-12).** Version-lock bump in step with 007's 0.3.0
+  grammar-completion release (specs 017–019). The wheels and sdist track the
+  0.3.0 tag per §3.5; no PyPI-shim mechanics change.

--- a/specs/017-directory-crate-module-units/spec.md
+++ b/specs/017-directory-crate-module-units/spec.md
@@ -1,0 +1,139 @@
+---
+id: "017-directory-crate-module-units"
+title: "Authority units: resolve the reserved directory / crate / module kinds"
+status: draft
+kind: "tooling"
+created: "2026-06-12"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "004-codebase-index"
+extends:
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/unit.rs"
+      - "crates/spec-spine-core/src/index.rs"
+      - "crates/spec-spine-core/src/symbols.rs"
+      - "crates/spec-spine-core/tests/index.rs"
+      - "crates/spec-spine-types/tests/grammar.rs"
+      - "crates/spec-spine-types/src/version.rs"
+      - "crates/spec-spine-types/tests/dtos.rs"
+summary: >
+  Lifts the v1 unit-grammar limitation (`docs/design/00-architecture.md` §2.2,
+  Q5): the three reserved kinds — `directory`, `crate`, and `module` — are now
+  parsed and resolved alongside `file`/`section`/`symbol`. A `directory` unit
+  resolves to its subtree (existence-checked, I-007 on miss); a `crate` unit
+  resolves a manifest name against the discovered package inventory to that
+  package's directory subtree (I-003 on miss, hyphen/underscore interchangeable);
+  a `module` unit resolves a `::`-qualified Rust module path via a new module
+  index — file-modules whole-file, top-level inline `mod` blocks to their span
+  (I-008 on miss). The registry/index schemas are permissive on the unit payload,
+  so this is an additive MINOR (`INDEX_SCHEMA_VERSION` 0.2.0 → 0.3.0) with no
+  schema-file edit. Unblocks adopting the OAP corpus, which authors these three
+  kinds across ~192 unit declarations (93 `directory`, 99 `crate`, 1 `module`)
+  with no mass frontmatter migration.
+---
+
+# 017: directory / crate / module authority units
+
+## 1. Purpose
+
+The Phase-0 design (`00-architecture.md` §2.2) shipped three of six unit kinds
+in v1 — `file`, `section`, `symbol` — and explicitly **reserved** the other
+three as "an additive minor … so `crate`/`module` slot in … without breaking
+readers" (Q5). `directory` was folded into trailing-slash file units; `crate`
+and `module` were named-but-unbuilt.
+
+The OAP-corpus dry-run is the trigger to build them. OAP authors all three as
+first-class kinds — 93 `{ kind: directory, path }`, 99 `{ kind: crate, id }`,
+and one `{ kind: module, id }` — across 100 specs. Rejecting them (the `Tagged`
+deserializer's `deny_unknown_fields` surfaces an opaque "untagged enum" parse
+error) is the single largest blocker to adoption. Migrating 192 unit
+declarations to trailing-slash file units would be backwards: the corpus is the
+adopter's truth, and the kinds are genuinely meaningful (a `crate` is an id, not
+a path; a `module` is a `::`-path, not a file). The fix finishes the designed
+capability rather than emulating a dialect.
+
+## 2. Territory
+
+The unit grammar (`unit.rs`: three new `Unit` variants and their `Tagged`
+deserialize arms) and the indexer's resolver (`index.rs`: three new
+`resolve_unit` arms; `canonical_unit`; the span-backing hash set; a
+`needs_modules` gate) plus a Rust module index (`symbols.rs`:
+`build_module_index`). The schemas are unchanged — they are deliberately
+permissive on the typed-unit payload (`additionalProperties` on `traceMapping`,
+no unit-shape `$ref`), so the new kinds validate as-is; the change is recorded
+as the `INDEX_SCHEMA_VERSION` minor bump alone.
+
+## 3. Behavior
+
+### 3.1 Grammar
+
+`Unit` gains three variants, each tagged on `kind` (symmetric with the existing
+three, and composing with the spec-015 `{ unit: … }` wrapper):
+
+```yaml
+- { kind: directory, path: "platform/services/stagecraft/api/db" }
+- { kind: crate, id: "factory-engine" }       # Cargo or npm manifest name
+- { kind: module, id: "my_crate::serialization" }
+```
+
+A bare string remains shorthand for a `file` unit; a trailing-slash file path
+remains a directory subtree. The explicit `directory` kind is the author-facing
+spelling for the same subtree semantics, preserved across the round-trip rather
+than normalized into a file unit (so `registry show` renders what was authored).
+
+### 3.2 Resolution (in the indexer)
+
+- **`directory`** → the directory path itself as a single `ResolvedLocation`
+  (`span: None`); the coupling gate prefix-matches it against changed paths
+  (the same subtree match a trailing-slash file unit gets, `claim_matches`).
+  The directory MUST exist: a non-directory path is a blocking **I-007**.
+- **`crate`** → the discovered `PackageRecord` whose manifest `name` equals the
+  unit `id` (hyphen and underscore interchangeable, the Rust crate convention),
+  resolved to that package's directory subtree (`span: None`). No match is a
+  blocking **I-003**. Both Cargo crates and npm packages are admitted (the
+  workspace boundary is the manifest, not the language).
+- **`module`** → the Rust module index: file-modules resolve whole-file
+  (`span: None`, the crate root resolving to the bare crate name); a top-level
+  inline `mod X { … }` block resolves to its line span. No match is a blocking
+  **I-008** (distinct from the symbol band's I-005). The module index is built
+  only when some spec declares a `module` unit (mirroring the `symbol`-unit
+  gate), keeping file/section/directory/crate corpora from parsing source.
+
+### 3.3 Staleness
+
+A `module` unit's *inline-block* location carries a span, so its backing source
+file folds into the content hash (a line shift that moves the block stales the
+index, exactly as for `symbol`/`section`). `directory`, `crate`, and the
+*file-module* form of `module` are whole-subtree / whole-file (`span: None`) and
+contribute no span-backing source — consistent with `file` units, whose content
+does not affect resolution.
+
+### 3.4 Diagnostic codes
+
+`I-003` (unknown crate), `I-007` (missing directory), `I-008` (unresolved
+module) join the existing blocking band (`I-003`..`I-009`) that fails
+`index check`. They mirror OAP's hard-error semantics for owning-field units.
+
+### 3.5 Tests (minimum)
+
+- Grammar: each new kind parses from its tagged form; the `{ unit: … }` wrapper
+  composes; `is_directory_subtree()` is true for `Directory`.
+- Resolution: a `crate` unit resolves to the package subtree (hyphen/underscore
+  tolerant); a `directory` unit resolves to its subtree with `span: None`; a
+  `module` unit resolves both an inline `mod` (with span) and a file-module
+  (whole-file).
+- Diagnostics: `I-003` on an unknown crate id, `I-007` on a missing directory,
+  `I-008` on an unresolved module.
+- `INDEX_SCHEMA_VERSION` is pinned at `0.3.0`.
+
+## 4. Out of scope
+
+TypeScript/Python module resolution (the module index is Rust-only; the corpus
+has no TS module unit). Nested-module resolution beyond top-level inline blocks
+(a deeper `mod a { mod b {} }` resolves `a` but not `a::b` — file-modules and
+top-level inline mods cover the corpus; deepen on demand). Any registry/index
+JSON Schema text change (the payload is permissive by design). Re-emitting a
+derived `implements:` view.

--- a/specs/017-directory-crate-module-units/spec.md
+++ b/specs/017-directory-crate-module-units/spec.md
@@ -21,13 +21,13 @@ extends:
       - "crates/spec-spine-types/tests/dtos.rs"
 summary: >
   Lifts the v1 unit-grammar limitation (`docs/design/00-architecture.md` §2.2,
-  Q5): the three reserved kinds — `directory`, `crate`, and `module` — are now
+  Q5): the three reserved kinds (`directory`, `crate`, and `module`) are now
   parsed and resolved alongside `file`/`section`/`symbol`. A `directory` unit
   resolves to its subtree (existence-checked, I-007 on miss); a `crate` unit
   resolves a manifest name against the discovered package inventory to that
   package's directory subtree (I-003 on miss, hyphen/underscore interchangeable);
   a `module` unit resolves a `::`-qualified Rust module path via a new module
-  index — file-modules whole-file, top-level inline `mod` blocks to their span
+  index; file-modules whole-file, top-level inline `mod` blocks to their span
   (I-008 on miss). The registry/index schemas are permissive on the unit payload,
   so this is an additive MINOR (`INDEX_SCHEMA_VERSION` 0.2.0 → 0.3.0) with no
   schema-file edit. Unblocks adopting the OAP corpus, which authors these three
@@ -40,14 +40,14 @@ summary: >
 ## 1. Purpose
 
 The Phase-0 design (`00-architecture.md` §2.2) shipped three of six unit kinds
-in v1 — `file`, `section`, `symbol` — and explicitly **reserved** the other
+in v1 (`file`, `section`, `symbol`) and explicitly **reserved** the other
 three as "an additive minor … so `crate`/`module` slot in … without breaking
 readers" (Q5). `directory` was folded into trailing-slash file units; `crate`
 and `module` were named-but-unbuilt.
 
 The OAP-corpus dry-run is the trigger to build them. OAP authors all three as
-first-class kinds — 93 `{ kind: directory, path }`, 99 `{ kind: crate, id }`,
-and one `{ kind: module, id }` — across 100 specs. Rejecting them (the `Tagged`
+first-class kinds (93 `{ kind: directory, path }`, 99 `{ kind: crate, id }`,
+and one `{ kind: module, id }`) across 100 specs. Rejecting them (the `Tagged`
 deserializer's `deny_unknown_fields` surfaces an opaque "untagged enum" parse
 error) is the single largest blocker to adoption. Migrating 192 unit
 declarations to trailing-slash file units would be backwards: the corpus is the
@@ -61,7 +61,7 @@ The unit grammar (`unit.rs`: three new `Unit` variants and their `Tagged`
 deserialize arms) and the indexer's resolver (`index.rs`: three new
 `resolve_unit` arms; `canonical_unit`; the span-backing hash set; a
 `needs_modules` gate) plus a Rust module index (`symbols.rs`:
-`build_module_index`). The schemas are unchanged — they are deliberately
+`build_module_index`). The schemas are unchanged; they are deliberately
 permissive on the typed-unit payload (`additionalProperties` on `traceMapping`,
 no unit-shape `$ref`), so the new kinds validate as-is; the change is recorded
 as the `INDEX_SCHEMA_VERSION` minor bump alone.
@@ -108,7 +108,7 @@ A `module` unit's *inline-block* location carries a span, so its backing source
 file folds into the content hash (a line shift that moves the block stales the
 index, exactly as for `symbol`/`section`). `directory`, `crate`, and the
 *file-module* form of `module` are whole-subtree / whole-file (`span: None`) and
-contribute no span-backing source — consistent with `file` units, whose content
+contribute no span-backing source, consistent with `file` units, whose content
 does not affect resolution.
 
 ### 3.4 Diagnostic codes
@@ -133,7 +133,7 @@ module) join the existing blocking band (`I-003`..`I-009`) that fails
 
 TypeScript/Python module resolution (the module index is Rust-only; the corpus
 has no TS module unit). Nested-module resolution beyond top-level inline blocks
-(a deeper `mod a { mod b {} }` resolves `a` but not `a::b` — file-modules and
+(a deeper `mod a { mod b {} }` resolves `a` but not `a::b`: file-modules and
 top-level inline mods cover the corpus; deepen on demand). Any registry/index
 JSON Schema text change (the payload is permissive by design). Re-emitting a
 derived `implements:` view.

--- a/specs/018-constrains-discriminator-optional-unit/spec.md
+++ b/specs/018-constrains-discriminator-optional-unit/spec.md
@@ -35,7 +35,7 @@ summary: >
   not gate-load-bearing). A new V-011 requires every item to scope at least one
   of `unit` / `target_specs`. A spec-scoped item contributes no resolved unit to
   the index. Unblocks the OAP corpus, which authors `{ flavor: invariant-freeze,
-  unit }` (spec 130) and `{ kind: <plan>, target_specs }` (specs 078, 089) —
+  unit }` (spec 130) and `{ kind: <plan>, target_specs }` (specs 078, 089),
   both rejected by the unit-required, discriminator-less v1 grammar.
 
 ---
@@ -48,9 +48,9 @@ The v1 `ConstrainItem` required a `unit:` and rejected any other field
 (`deny_unknown_fields`). The corpus authors two legitimate constraint shapes the
 grammar could not express:
 
-- **Path-scoped** — `{ flavor: invariant-freeze, unit: <schema/file> }` (the
+- **Path-scoped**: `{ flavor: invariant-freeze, unit: <schema/file> }` (the
   canonical invariant-freeze; OAP spec 130). Has a unit, plus a classification.
-- **Spec-scoped** — `{ kind: <plan-name>, target_specs: [...] }` (a delivery /
+- **Spec-scoped**: `{ kind: <plan-name>, target_specs: [...] }` (a delivery /
   sequencing plan asserting an ordering invariant over *other specs*; OAP specs
   078, 089). Has **no** code unit at all.
 
@@ -58,7 +58,7 @@ Both trip the v1 grammar: the discriminator field (`flavor`/`kind`) is unknown,
 and the spec-scoped form has no `unit`. The fix accepts both shapes, keeping the
 discriminator documentary (the architecture §2.1 already names the constraint
 edge "asserts an invariant others must respect" with the canonical
-`invariant-freeze` kind — this records *which* invariant without the gate having
+`invariant-freeze` kind; this records *which* invariant without the gate having
 to interpret it).
 
 ## 2. Territory
@@ -81,7 +81,7 @@ constrains:
 - `unit` is optional.
 - `flavor` and `kind` are **interchangeable synonyms** for the documentary
   classification; both are accepted and preserved verbatim (the dialect uses
-  both — 130 writes `flavor`, 078/089 write `kind`). Neither is read by the
+  both: 130 writes `flavor`, 078/089 write `kind`). Neither is read by the
   coupling gate. They are not normalized into one another, so `registry show`
   renders the authored spelling.
 - `note` and `target_specs` are unchanged from v1.
@@ -90,13 +90,13 @@ constrains:
 
 A path-scoped item (with `unit`) contributes a `SourceField::Constrains`
 resolved unit, exactly as before. A spec-scoped item (no unit) contributes
-**nothing** to `resolved_units` — it claims no code path; its authority is over
+**nothing** to `resolved_units`: it claims no code path; its authority is over
 the listed specs, which the gate does not derive from `constrains`.
 
 ### 3.3 Validation: V-011
 
 A constrains item that declares **neither** `unit` nor `target_specs` asserts an
-invariant over nothing — an error-tier **V-011**. This is the floor that keeps
+invariant over nothing, an error-tier **V-011**. This is the floor that keeps
 the now-optional `unit` from admitting a content-free item.
 
 ### 3.4 Tests (minimum)
@@ -104,7 +104,7 @@ the now-optional `unit` from admitting a content-free item.
 - Grammar: a `flavor` + `unit` item and a `kind` + `target_specs` item both
   parse; the discriminator is preserved; `unit` is `None` on the spec-scoped form.
 - Compile: V-011 fires on a `{ flavor: … }`-only item; both scoped forms clear
-  V-011 (a file-unit need not exist — that is the indexer's I-004, not compile).
+  V-011 (a file-unit need not exist; that is the indexer's I-004, not compile).
 - Index: a spec-scoped constrains item yields no resolved unit.
 
 ## 4. Out of scope

--- a/specs/018-constrains-discriminator-optional-unit/spec.md
+++ b/specs/018-constrains-discriminator-optional-unit/spec.md
@@ -1,0 +1,117 @@
+---
+id: "018-constrains-discriminator-optional-unit"
+title: "Constrains grammar: classification discriminator and optional unit"
+status: draft
+kind: "tooling"
+created: "2026-06-12"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+  - "004-codebase-index"
+extends:
+  - spec: "000-spec-spine-bootstrap"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/edges.rs"
+      - "crates/spec-spine-types/tests/grammar.rs"
+  - spec: "001-compile-registry"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/compile.rs"
+      - "crates/spec-spine-core/tests/compile.rs"
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/index.rs"
+      - "crates/spec-spine-core/tests/index.rs"
+summary: >
+  Widens the `constrains` item grammar to the two shapes the predecessor dialect
+  authors: a **path-scoped** constraint (`unit:`, the canonical
+  `invariant-freeze` over a file or schema) and a **spec-scoped** constraint
+  (`target_specs:`, a sequencing/ordering plan over other specs with no code
+  unit). Two changes: `unit` becomes optional, and an optional documentary
+  discriminator is accepted under either spelling `flavor:` or `kind:` (synonyms,
+  not gate-load-bearing). A new V-011 requires every item to scope at least one
+  of `unit` / `target_specs`. A spec-scoped item contributes no resolved unit to
+  the index. Unblocks the OAP corpus, which authors `{ flavor: invariant-freeze,
+  unit }` (spec 130) and `{ kind: <plan>, target_specs }` (specs 078, 089) —
+  both rejected by the unit-required, discriminator-less v1 grammar.
+
+---
+
+# 018: constrains discriminator and optional unit
+
+## 1. Purpose
+
+The v1 `ConstrainItem` required a `unit:` and rejected any other field
+(`deny_unknown_fields`). The corpus authors two legitimate constraint shapes the
+grammar could not express:
+
+- **Path-scoped** — `{ flavor: invariant-freeze, unit: <schema/file> }` (the
+  canonical invariant-freeze; OAP spec 130). Has a unit, plus a classification.
+- **Spec-scoped** — `{ kind: <plan-name>, target_specs: [...] }` (a delivery /
+  sequencing plan asserting an ordering invariant over *other specs*; OAP specs
+  078, 089). Has **no** code unit at all.
+
+Both trip the v1 grammar: the discriminator field (`flavor`/`kind`) is unknown,
+and the spec-scoped form has no `unit`. The fix accepts both shapes, keeping the
+discriminator documentary (the architecture §2.1 already names the constraint
+edge "asserts an invariant others must respect" with the canonical
+`invariant-freeze` kind — this records *which* invariant without the gate having
+to interpret it).
+
+## 2. Territory
+
+The constrains item grammar (`edges.rs`: `unit` → `Option<Unit>`, add `flavor`
+and `kind`), the index's constrains→unit projection (`index.rs`: skip an item
+with no unit), and one new compile validation (`compile.rs`: V-011). The schema
+is permissive on the edge payload, so no schema-file change.
+
+## 3. Behavior
+
+### 3.1 Grammar
+
+```yaml
+constrains:
+  - { flavor: invariant-freeze, unit: { kind: file, path: "schema.json" } }  # path-scoped
+  - { kind: sequencing-plan, target_specs: ["074-x", "075-y"] }              # spec-scoped
+```
+
+- `unit` is optional.
+- `flavor` and `kind` are **interchangeable synonyms** for the documentary
+  classification; both are accepted and preserved verbatim (the dialect uses
+  both — 130 writes `flavor`, 078/089 write `kind`). Neither is read by the
+  coupling gate. They are not normalized into one another, so `registry show`
+  renders the authored spelling.
+- `note` and `target_specs` are unchanged from v1.
+
+### 3.2 Index projection
+
+A path-scoped item (with `unit`) contributes a `SourceField::Constrains`
+resolved unit, exactly as before. A spec-scoped item (no unit) contributes
+**nothing** to `resolved_units` — it claims no code path; its authority is over
+the listed specs, which the gate does not derive from `constrains`.
+
+### 3.3 Validation: V-011
+
+A constrains item that declares **neither** `unit` nor `target_specs` asserts an
+invariant over nothing — an error-tier **V-011**. This is the floor that keeps
+the now-optional `unit` from admitting a content-free item.
+
+### 3.4 Tests (minimum)
+
+- Grammar: a `flavor` + `unit` item and a `kind` + `target_specs` item both
+  parse; the discriminator is preserved; `unit` is `None` on the spec-scoped form.
+- Compile: V-011 fires on a `{ flavor: … }`-only item; both scoped forms clear
+  V-011 (a file-unit need not exist — that is the indexer's I-004, not compile).
+- Index: a spec-scoped constrains item yields no resolved unit.
+
+## 4. Out of scope
+
+Gate evaluation of constraints as a distinct failure mode (OAP's exit-code-3
+invariant-violation semantics). In this library a path-scoped constraint is an
+ordinary owning unit; a separate constraint-evaluation pass is a future spec if
+an adopter needs the distinct remediation. Normalizing `flavor`/`kind` to a
+single canonical field (kept faithful to authored intent here). Validating that
+`target_specs` resolve to existing specs (a lint concern, not a grammar one).

--- a/specs/019-structured-partial-supersedes/spec.md
+++ b/specs/019-structured-partial-supersedes/spec.md
@@ -47,9 +47,9 @@ summary: >
   `supersedes` item may be a bare predecessor id (full) or a structured
   `{ spec, scope, unit?, note?, rationale? }`. A full item (bare id or
   `scope: full`) normalizes to the bare-string form, so a full-only corpus emits
-  a byte-identical registry — the wire is unchanged for every existing adopter;
+  a byte-identical registry; the wire is unchanged for every existing adopter;
   only a partial item serializes as an object. `scope: partial` with a `unit`
-  transfers authority over that unit alone (additive — the predecessor keeps it
+  transfers authority over that unit alone (additive, the predecessor keeps it
   and everything else), threaded through the index as a `supersedes` resolved
   unit so the gate already treats the successor as an owner of that unit's paths;
   `build_superseders` therefore contributes only **full** supersession to the
@@ -66,19 +66,19 @@ summary: >
 
 `supersedes` was a flat `Vec<String>` of predecessor ids. The architecture's
 edge table (§2.1) already labels it *"replaces a predecessor (partial/full);
-inherits current authority"* — **partial was named but unbuilt**. The
+inherits current authority"*: **partial was named but unbuilt**. The
 Phase-0 OAP dry-run surfaced four authored shapes the flat grammar rejects:
 
-- `108` — `supersedes: ["088"]` (bare **short** id; full).
-- `073` — `{ spec, scope: full }` (object, full).
-- `114` — `{ spec, scope: partial, unit }` (scoped transfer over one unit).
-- `199` — `{ spec, scope: partial, note }` (partial, no unit — documentary).
+- `108`: `supersedes: ["088"]` (bare **short** id; full).
+- `073`: `{ spec, scope: full }` (object, full).
+- `114`: `{ spec, scope: partial, unit }` (scoped transfer over one unit).
+- `199`: `{ spec, scope: partial, note }` (partial, no unit, documentary).
 
 `docs/design/01-partial-supersession.md` analysed this and recommended **Option
 A** once a second adopter appeared. OAP is that adopter, so this builds it. The
 design's load-bearing constraints are honoured: the full form stays a bare
-string (byte-identical registries), and partial transfer is **additive** (§4.3)
-— the successor *gains* the unit, the predecessor is never stripped — so the
+string (byte-identical registries), and partial transfer is **additive** (§4.3):
+the successor *gains* the unit, the predecessor is never stripped, so the
 gate's "any one owner clears" rule stays monotonic.
 
 ## 2. Territory
@@ -112,7 +112,7 @@ form is `{ spec, scope=full, unit?, note?, rationale? }` with
 ### 3.2 Normalization & wire (the full form never escapes)
 
 At parse time a `Scoped` item whose scope is `full` collapses to
-`SupersedeItem::Full(spec)` — so a bare id and `{ scope: full }` are
+`SupersedeItem::Full(spec)`, so a bare id and `{ scope: full }` are
 indistinguishable downstream, and a corpus that uses only full supersession
 emits the **exact same** `"supersedes": ["…", "…"]` string array as before. Only
 a `partial` item serializes as an object (`{ spec, scope: "partial", unit? }`).
@@ -120,13 +120,13 @@ The byte-equivalence of a full-only corpus is the compatibility contract.
 
 ### 3.3 Authority transfer
 
-- **Full** (bare / `scope: full`): unchanged from spec 005 — the successor
+- **Full** (bare / `scope: full`): unchanged from spec 005; the successor
   inherits the predecessor's entire authority surface (`build_superseders` →
   `owners_for_path` step 2, additive, transitive across chains).
 - **Partial** (`scope: partial`, with `unit`): the index resolves the `unit` as
   a `SourceField::Supersedes`, ownership-bearing resolved unit on the
   **successor**, so `owners_for_path` step 1 makes the successor an owner of
-  exactly that unit's paths — and `build_superseders` **excludes** partial items,
+  exactly that unit's paths; and `build_superseders` **excludes** partial items,
   so the successor does **not** also inherit the predecessor's other units.
   Additive: the predecessor keeps the unit too.
 - **Partial without `unit`** (`note`/`rationale` only): a documentary lifecycle
@@ -154,7 +154,7 @@ The predecessor named by a `supersedes` item resolves a leading-number short id
 
 ## 4. Out of scope
 
-Exclusive hand-off (the predecessor *losing* the unit) — the design's §4.3 first
+Exclusive hand-off (the predecessor *losing* the unit): the design's §4.3 first
 cut is additive; a true removal is the graph's first owner-stripping operation
 and waits for demand. Partial transfer scoped to a `section`/`symbol` unit is
 supported by the same resolved-unit path but unexercised by the corpus (the only

--- a/specs/019-structured-partial-supersedes/spec.md
+++ b/specs/019-structured-partial-supersedes/spec.md
@@ -1,0 +1,162 @@
+---
+id: "019-structured-partial-supersedes"
+title: "Supersedes grammar: structured items and partial (unit-scoped) transfer"
+status: draft
+kind: "tooling"
+created: "2026-06-12"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+  - "005-coupling-gate"
+extends:
+  - spec: "000-spec-spine-bootstrap"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/edges.rs"
+      - "crates/spec-spine-types/src/frontmatter.rs"
+      - "crates/spec-spine-types/src/lib.rs"
+      - "crates/spec-spine-types/tests/grammar.rs"
+      - "crates/spec-spine-types/tests/dtos.rs"
+  - spec: "001-compile-registry"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/registry.rs"
+      - "crates/spec-spine-types/src/version.rs"
+      - "crates/spec-spine-core/src/compile.rs"
+      - "crates/spec-spine-core/tests/compile.rs"
+  - spec: "002-registry-query"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/query.rs"
+  - spec: "003-conformance-lint"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/lint.rs"
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/index.rs"
+  - spec: "005-coupling-gate"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/couple.rs"
+      - "crates/spec-spine-core/tests/couple.rs"
+summary: >
+  Implements Option A from `docs/design/01-partial-supersession.md`: a
+  `supersedes` item may be a bare predecessor id (full) or a structured
+  `{ spec, scope, unit?, note?, rationale? }`. A full item (bare id or
+  `scope: full`) normalizes to the bare-string form, so a full-only corpus emits
+  a byte-identical registry — the wire is unchanged for every existing adopter;
+  only a partial item serializes as an object. `scope: partial` with a `unit`
+  transfers authority over that unit alone (additive — the predecessor keeps it
+  and everything else), threaded through the index as a `supersedes` resolved
+  unit so the gate already treats the successor as an owner of that unit's paths;
+  `build_superseders` therefore contributes only **full** supersession to the
+  whole-spec transfer. A partial item with no unit (a documentary lifecycle
+  marker) transfers nothing. Short ids on the predecessor resolve like
+  `depends_on` (spec 016). Unblocks the OAP corpus shapes 073 (`scope: full`),
+  108 (bare short id), 114 (`partial` + unit), and 199 (`partial` + note).
+
+---
+
+# 019: structured and partial supersedes
+
+## 1. Purpose
+
+`supersedes` was a flat `Vec<String>` of predecessor ids. The architecture's
+edge table (§2.1) already labels it *"replaces a predecessor (partial/full);
+inherits current authority"* — **partial was named but unbuilt**. The
+Phase-0 OAP dry-run surfaced four authored shapes the flat grammar rejects:
+
+- `108` — `supersedes: ["088"]` (bare **short** id; full).
+- `073` — `{ spec, scope: full }` (object, full).
+- `114` — `{ spec, scope: partial, unit }` (scoped transfer over one unit).
+- `199` — `{ spec, scope: partial, note }` (partial, no unit — documentary).
+
+`docs/design/01-partial-supersession.md` analysed this and recommended **Option
+A** once a second adopter appeared. OAP is that adopter, so this builds it. The
+design's load-bearing constraints are honoured: the full form stays a bare
+string (byte-identical registries), and partial transfer is **additive** (§4.3)
+— the successor *gains* the unit, the predecessor is never stripped — so the
+gate's "any one owner clears" rule stays monotonic.
+
+## 2. Territory
+
+The supersedes grammar (`edges.rs`: a `SupersedeItem` union + `SupersedeScoped`
++ `SupersedeScope`, normalization), wired into the shared parse path
+(`frontmatter.rs`) and the registry wire (`registry.rs`); compile-time short-id
+resolution (`compile.rs`); the gate's transfer rule (`couple.rs`:
+`build_superseders` restricts to full) and the index's partial-unit projection
+(`index.rs`); the id-only views that read supersedes (`query.rs`
+relationships, `lint.rs` reference targets). `REGISTRY_SCHEMA_VERSION`
+0.2.0 → 0.3.0. The schema is permissive on the edge payload, so no schema-file
+change.
+
+## 3. Behavior
+
+### 3.1 Grammar
+
+```yaml
+supersedes:
+  - "088"                                                  # bare id → full
+  - { spec: "073-x", scope: full }                         # object, full
+  - { spec: "113-y", scope: partial, unit: "src/clone.ts" } # scoped transfer
+  - { spec: "140-z", scope: partial, note: "retires §2.2" } # documentary
+```
+
+`SupersedeItem` is an untagged union: a string (full) or an object. The object
+form is `{ spec, scope=full, unit?, note?, rationale? }` with
+`deny_unknown_fields`. `scope` defaults to `full`.
+
+### 3.2 Normalization & wire (the full form never escapes)
+
+At parse time a `Scoped` item whose scope is `full` collapses to
+`SupersedeItem::Full(spec)` — so a bare id and `{ scope: full }` are
+indistinguishable downstream, and a corpus that uses only full supersession
+emits the **exact same** `"supersedes": ["…", "…"]` string array as before. Only
+a `partial` item serializes as an object (`{ spec, scope: "partial", unit? }`).
+The byte-equivalence of a full-only corpus is the compatibility contract.
+
+### 3.3 Authority transfer
+
+- **Full** (bare / `scope: full`): unchanged from spec 005 — the successor
+  inherits the predecessor's entire authority surface (`build_superseders` →
+  `owners_for_path` step 2, additive, transitive across chains).
+- **Partial** (`scope: partial`, with `unit`): the index resolves the `unit` as
+  a `SourceField::Supersedes`, ownership-bearing resolved unit on the
+  **successor**, so `owners_for_path` step 1 makes the successor an owner of
+  exactly that unit's paths — and `build_superseders` **excludes** partial items,
+  so the successor does **not** also inherit the predecessor's other units.
+  Additive: the predecessor keeps the unit too.
+- **Partial without `unit`** (`note`/`rationale` only): a documentary lifecycle
+  marker. No resolved unit, not in `build_superseders` → transfers nothing.
+
+Chains stay scoped: because a partial edge never enters `build_superseders`, a
+successor's own superseders never inherit the predecessor's other units through
+it.
+
+### 3.4 Short-id resolution
+
+The predecessor named by a `supersedes` item resolves a leading-number short id
+(`088` → `088-slug`) by the same `resolve_spec_ref` policy as `depends_on` /
+`superseded_by` (spec 016), so the transfer keys match the registry ids.
+
+### 3.5 Tests (minimum)
+
+- Grammar: bare id and `{ scope: full }` both parse to `Full`; `partial` + unit
+  exposes its scoping unit; `partial` + note has no transfer unit.
+- Wire: a full corpus emits bare-string `supersedes`; a partial emits an object
+  (scope + unit).
+- Gate: full transfers the whole surface (existing test stays green); partial
+  transfers the named unit only (the predecessor's other unit is NOT cleared by
+  editing the successor); a unit-less partial transfers nothing.
+
+## 4. Out of scope
+
+Exclusive hand-off (the predecessor *losing* the unit) — the design's §4.3 first
+cut is additive; a true removal is the graph's first owner-stripping operation
+and waits for demand. Partial transfer scoped to a `section`/`symbol` unit is
+supported by the same resolved-unit path but unexercised by the corpus (the only
+partial-with-unit is a file unit). A distinct constraint/lifecycle-violation
+exit code. Re-emitting a derived `implements:` view.


### PR DESCRIPTION
Completes the authority-unit and edge grammar so the library can govern an OAP-dialect corpus, and ships **0.3.0**.

## Specs

- **017 — directory / crate / module unit kinds.** Lifts the v1 limit (design §2.2, Q5). `crate`→discovered-package subtree (hyphen/underscore tolerant, `I-003`); `directory`→subtree (`I-007`); `module`→a new Rust module index in `symbols.rs` — file-modules whole-file, top-level inline `mod` blocks to their span (`I-008`). `INDEX_SCHEMA_VERSION` 0.2.0→0.3.0.
- **018 — constrains discriminator + optional unit.** A `flavor`/`kind` classification (synonyms, documentary) and an optional `unit`: path-scoped (`invariant-freeze`) vs spec-scoped (`target_specs` sequencing plan). New `V-011` requires one of unit/target_specs.
- **019 — structured / partial supersedes** (Option A of `docs/design/01-partial-supersession.md`). A `supersedes` item may be a bare id (full) or `{ spec, scope, unit?, note? }`. Full supersession stays a bare string, so a full-only corpus emits a **byte-identical** registry; a `partial` item transfers authority over one unit **additively**, threaded through the index as a `supersedes` resolved unit (so `build_superseders` carries only full edges). `REGISTRY_SCHEMA_VERSION` 0.2.0→0.3.0. Predecessor short ids resolve like `depends_on`.

Schemas are permissive on the unit/edge payload, so both bumps are version-const only (no schema-file edit).

## Release

Package version 0.2.0→0.3.0 across crates.io / npm / PyPI in lockstep (`scripts/bump_version.py` + inter-crate dep reqs); schema-version consts and `docs/schema-versioning.md` updated; release-log entries added to specs 007 and 008.

## Validation

- `cargo test --workspace` green (21 binaries; new grammar/resolution/gate tests included).
- Dogfood gate clean: `compile` 20 specs / 0 warnings · `lint --fail-on-warn` 0/0/0 · `index check` fresh · `couple` 25 paths / no drift.
- **OAP 212-spec corpus dry-run: 108 → 1 compile error.** The new unit kinds resolve against the real corpus (0 module-resolution failures). The remaining 100 index diagnostics are genuine corpus drift (stale file units, retired directories), not library behavior.

## Known follow-up (not in this PR)

The single remaining OAP compile error is a 4th dialect gap — **structured `amends`** (`amends: [{spec, unit}]`), used by exactly one OAP spec. Per the design's "second adopter" evidence threshold, this is deferred to a one-spec corpus migration rather than a gate-core change here.

## Coupling

The follow-up commit `style: remove em dashes repo-wide` is a mechanical, non-behavioral change (em-dash removal in comments / doc-comments / string literals, rustfmt-only reformatting, and a new CLAUDE.md). It touches files owned by specs 001/002/003/006/010/011 without altering any owned unit, so per the constitution ("never amend an owning spec purely to satisfy a mechanical refresh; waive instead") it is waived rather than forcing no-op spec edits.

Spec-Drift-Waiver: repo-wide mechanical edit (em-dash removal in comments/docs/strings plus rustfmt-only reformatting); no behavioral change to any owned unit.
