### PR TITLE
docs: refresh docs/ + comments to specs 009-022; prep v0.4.0

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "9cdcc709c54796d5eefc2ee4d7aac39b0b7a682b520e29e1deb153b74c8fa81b",
+    "contentHash": "f2619f3461d0c1bdf8435155bb4dae4bf1d92647afd7f0bc8831d339f06afa2c",
     "indexerId": "spec-spine",
     "indexerVersion": "0.4.0",
     "repoRoot": "."

--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,8 +1,8 @@
 {
   "build": {
-    "contentHash": "749bf9bc90524ba95676039e153ae2f99fabc012828362c8397147d2455fcb47",
+    "contentHash": "9cdcc709c54796d5eefc2ee4d7aac39b0b7a682b520e29e1deb153b74c8fa81b",
     "indexerId": "spec-spine",
-    "indexerVersion": "0.3.0",
+    "indexerVersion": "0.4.0",
     "repoRoot": "."
   },
   "diagnostics": {
@@ -33,7 +33,7 @@
       "name": "spec-spine",
       "path": "npm",
       "specRef": "007-distribution",
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   ],
   "schemaVersion": "0.3.0",

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.4.0",
-    "contentHash": "a1d5f836ef7a119e67d4dae17a1c5dac316e15568da8aeff3f866c02d2ab3359",
+    "contentHash": "f39e538802fca67588ff62dedd95ab8d996c4ed83a9c731b23af25f03caea38d",
     "inputRoot": "."
   },
   "specVersion": "0.3.0",
@@ -24,7 +24,7 @@
         "3. Frontmatter grammar",
         "4. The typed authority graph",
         "4.1 Edges: eight types, seven ownership-bearing",
-        "4.2 Authority units: file, section, symbol (v1)",
+        "4.2 Authority units: file, section, symbol, directory, crate, module",
         "4.3 Resolution and amends-awareness",
         "5. The compiled artifacts",
         "6. Determinism",

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "compilerId": "spec-spine",
-    "compilerVersion": "0.3.0",
+    "compilerVersion": "0.4.0",
     "contentHash": "a1d5f836ef7a119e67d4dae17a1c5dac316e15568da8aeff3f866c02d2ab3359",
     "inputRoot": "."
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "serde",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -31,8 +31,8 @@ sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 time = { version = "0.3", features = ["formatting"] }
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.3.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.3.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.4.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.4.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Installable Rust library + CLI; API-first, binding-ready, deterministic.
 spec-spine turns a markdown spec corpus into a governed, hash-verifiable
 authority ledger and **refuses code that drifts from its owning spec** at PR
 time. Each `specs/NNN-slug/spec.md` declares, in YAML frontmatter, typed edges to
-other specs and the authority units it owns (**file / section / symbol**). Two
+other specs and the authority units it owns (**file / section / symbol /
+directory / crate / module**). Two
 deterministic views are emitted and joined by a coupling gate:
 
 - **`registry.json`**: the *spec-as-source* view (the compiler's output).
@@ -58,7 +59,7 @@ install → init → annotate → wire-CI walkthrough.
 | Command | Capability |
 |---|---|
 | `spec-spine compile` | validate frontmatter, emit the deterministic registry |
-| `spec-spine index` / `index check` | emit the codebase index / check it for staleness |
+| `spec-spine index` / `index check` / `index render` / `index orphans` | emit the codebase index / check staleness / render it as markdown / list orphaned specs |
 | `spec-spine registry list\|show\|status-report\|relationships` | typed read-only queries |
 | `spec-spine lint [--fail-on-warn] [--fail-on-info]` | corpus well-formedness |
 | `spec-spine couple` | the PR-time coupling gate (refuses drift) |
@@ -97,7 +98,9 @@ operation has a JSON-in/JSON-out facade (`compile_json`, `query_json`, …); see
 - **Deterministic by construction.** Sorted-key, pretty-printed JSON with LF and
   a trailing newline; content hashes over LF/BOM-normalized, path-sorted bytes;
   tree-sitter grammars pinned exact. CI proves **byte-identical `registry.json` +
-  `index.json` across all five release triples**, not just locally.
+  `index.json` across four release triples**, not just locally (the fifth,
+  x86_64-apple-darwin, is built and shipped by the release workflow but omitted
+  from the determinism gate; its two dimensions are each proven by other legs).
 - **spec-spine governs itself.** This repo's own coupling gate runs against its
   own spec corpus in CI: a spec-spine that is not itself spec-governed would be
   hypocritical.

--- a/crates/spec-spine-cli/README.md
+++ b/crates/spec-spine-cli/README.md
@@ -9,13 +9,15 @@ pure.
 spec-spine init [--force]                  # scaffold a new adopter (config, standards, specs/000, rules)
 spec-spine compile                         # specs/*/spec.md -> .derived/spec-registry/registry.json
 spec-spine index                           # scan manifests + specs -> .derived/codebase-index/index.json
-spec-spine index check                     # staleness gate (exit 2 if stale)
-spec-spine registry list [--status S]      # list specs
-spec-spine registry show <id>              # show one spec
-spec-spine registry status-report          # counts by status
-spec-spine registry relationships <id>     # relationship neighborhood
+spec-spine index check [--slice NAME]      # staleness gate (exit 2 if stale)
+spec-spine index render                    # render the committed index as markdown (read-only)
+spec-spine index orphans [--json]          # list specs with no resolved code units
+spec-spine registry list [--status S] [--ids-only] [--json]   # list specs
+spec-spine registry show <id> [--json]     # show one spec
+spec-spine registry status-report [--nonzero-only] [--json]   # counts by status
+spec-spine registry relationships <id> [--json]   # relationship neighborhood
 spec-spine lint [--fail-on-warn] [--fail-on-info]   # corpus conformance
-spec-spine couple --base origin/main --head HEAD [--pr-body FILE]   # the PR-time drift gate
+spec-spine couple --base origin/main --head HEAD [--pr-body FILE] [--paths-from FILE]   # the PR-time drift gate
 ```
 
 `cargo install spec-spine-cli` installs the `spec-spine` binary. A global

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -1,8 +1,9 @@
 //! The index capability (spec 004): code-as-source view + staleness + authorities.
 //!
 //! Pure function of `(config, file contents)`. Discovers packages, links code to
-//! specs three ways, resolves the file/section/symbol grammar to physical
-//! locations, and emits a deterministic `index.json`. All discovery is
+//! specs three ways, resolves the unit grammar (file / section / symbol /
+//! directory / crate / module) to physical locations, and emits a deterministic
+//! `index.json`. All discovery is
 //! path-sorted before hashing and emission (watch-item 1).
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/spec-spine-core/src/scaffold.rs
+++ b/crates/spec-spine-core/src/scaffold.rs
@@ -149,8 +149,8 @@ fn bootstrap_spec(ns: &str) -> String {
          \n\
          Specs declare typed edges (`establishes`, `extends`, `refines`,\n\
          `supersedes`, `amends`, `co_authority`, `constrains`, `references`) and\n\
-         the units they own (file / section / symbol). Authority is derived by\n\
-         walking the graph.\n",
+         the units they own (file / section / symbol / directory / crate / module).\n\
+         Authority is derived by walking the graph.\n",
         ns = ns
     )
 }
@@ -169,6 +169,9 @@ fn spec_template(ns: &str) -> String {
          \u{20}\u{20}- \"path/to/file.rs\"                              # a file unit\n\
          \u{20}\u{20}# - {{ kind: section, file: \"Makefile\", anchor: \"build\" }}\n\
          \u{20}\u{20}# - {{ kind: symbol, id: \"my_crate::my_fn\" }}\n\
+         \u{20}\u{20}# - {{ kind: directory, path: \"crates/my-crate/\" }}\n\
+         \u{20}\u{20}# - {{ kind: crate, id: \"my-crate\" }}\n\
+         \u{20}\u{20}# - {{ kind: module, id: \"my_crate::serialization\" }}\n\
          # depends_on:\n\
          #   - \"000-bootstrap\"\n\
          ---\n\

--- a/crates/spec-spine-core/src/symbols.rs
+++ b/crates/spec-spine-core/src/symbols.rs
@@ -1,9 +1,11 @@
 //! Symbol resolution (spec 004 §3.3): build a deterministic index from
 //! `::`-qualified ids to physical `(file, line-span)` locations via tree-sitter.
 //!
-//! v1 indexes top-level items only (no `impl` methods, no inline `mod` bodies)
-//! for Rust (`.rs`) and TypeScript (`.ts`/`.tsx`). The tree-sitter core and
-//! grammar crates are pinned exactly so spans are identical across platforms.
+//! Symbol indexing covers top-level items only (no `impl` methods, no inline
+//! `mod` bodies) for Rust (`.rs`) and TypeScript (`.ts`/`.tsx`). The module index
+//! (spec 017) additionally resolves top-level inline `mod X { ... }` blocks to
+//! their block spans. The tree-sitter core and grammar crates are pinned exactly
+//! so spans are identical across platforms.
 
 use std::collections::BTreeMap;
 use std::fs;

--- a/crates/spec-spine-types/schemas/registry.schema.json
+++ b/crates/spec-spine-types/schemas/registry.schema.json
@@ -56,7 +56,7 @@
         },
         "extraFrontmatter": {
           "type": "object",
-          "description": "Adopter frontmatter transported by the compiler. Declared keys (frontmatter.extra_known_keys) carry any JSON value (spec 013, specVersion 0.2.0); undeclared keys are scalars or string arrays."
+          "description": "Adopter frontmatter transported by the compiler. Declared keys (frontmatter.extra_known_keys) carry any JSON value (spec 013; first shipped in specVersion 0.2.0); undeclared keys are scalars or string arrays."
         }
       }
     },

--- a/crates/spec-spine-types/src/codebase.rs
+++ b/crates/spec-spine-types/src/codebase.rs
@@ -1,7 +1,8 @@
 //! Codebase-index DTOs: the code-as-source view, emitted by `spec-spine index`
 //! as `index.json`. Field names serialize to `camelCase`. Shapes are ported from
 //! OAP `codebase-index.schema.json` (3.0.0), pruned to the generic v1 surface and
-//! re-versioned to this library's own `0.1.0`.
+//! re-versioned to this library's own schema line (currently `0.3.0`; see
+//! [`crate::version::INDEX_SCHEMA_VERSION`]).
 
 use std::collections::BTreeMap;
 

--- a/crates/spec-spine-types/src/edges.rs
+++ b/crates/spec-spine-types/src/edges.rs
@@ -4,8 +4,10 @@
 //! non-owning one (the coupling gate ignores it). `origin` is a bootstrap
 //! marker, **not** an edge (see `docs/design/00-architecture.md` §2.1).
 //!
-//! `establishes` is a bare `Vec<Unit>`; `supersedes`/`amends` are `Vec<String>`
-//! of spec ids; the remaining edges are lists of the item structs below. Each
+//! `establishes` is a bare `Vec<Unit>`; `supersedes` is `Vec<SupersedeItem>` (a
+//! bare predecessor id for full supersession, or a structured partial item,
+//! spec 019); `amends` is `Vec<String>` of spec ids; the remaining edges are
+//! lists of the item structs below. Each
 //! item uses `deny_unknown_fields` so a misspelled key produces a clear error
 //! rather than silently overflowing. `extends`/`refines` items accept the
 //! predecessor dialect's `paths:` list as authoring sugar (spec 014): the

--- a/crates/spec-spine-types/src/unit.rs
+++ b/crates/spec-spine-types/src/unit.rs
@@ -3,11 +3,11 @@
 //! A spec declares the units it owns via a `unit:` on a typed edge. The grammar
 //! resolves six granularities: [`Unit::File`], [`Unit::Section`],
 //! [`Unit::Symbol`], [`Unit::Directory`], [`Unit::Crate`], and [`Unit::Module`]
-//! (ported from OAP `spec-types::LogicalUnit`). The first three shipped in v1;
-//! `directory`/`crate`/`module` were reserved as an additive minor in
-//! `docs/design/00-architecture.md` §2.2 (Q5) and are resolved as of spec 017:
-//! the schema is permissive on the unit payload, so the new kinds are a MINOR
-//! bump (no schema-file edit), and a bare string remains shorthand for a file
+//! (ported from OAP `spec-types::LogicalUnit`). All six are implemented:
+//! `file`/`section`/`symbol` shipped first, and `directory`/`crate`/`module`
+//! landed in spec 017 (originally reserved in `docs/design/00-architecture.md`
+//! §2.2 Q5). They were a MINOR bump because the schema is permissive on the unit
+//! payload (no schema-file edit), and a bare string remains shorthand for a file
 //! unit (a trailing-slash path denotes a directory subtree).
 
 use serde::de::{self, Deserializer};
@@ -30,7 +30,7 @@ pub enum Unit {
     /// a `region:` marker, or a CI `jobs.<name>`.
     Section { file: String, anchor: String },
     /// A symbol (function / type / export), resolved by the indexer via
-    /// tree-sitter (Rust + TypeScript in v1).
+    /// tree-sitter (Rust `.rs` and TypeScript `.ts`/`.tsx`).
     Symbol { id: String },
     /// A directory subtree, named explicitly (`{ kind: directory, path }`). The
     /// subtree-prefix resolution is identical to a trailing-slash file unit; the

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -16,7 +16,7 @@
 /// stays a bare string, so a full-only corpus is byte-identical.
 pub const REGISTRY_SCHEMA_VERSION: &str = "0.3.0";
 
-/// `schemaVersion` emitted in `index.json`. (Index DTOs land in Phase 3.)
+/// `schemaVersion` emitted in `index.json`.
 /// `0.2.0`: additive `build.sliceHashes` (spec 012).
 /// `0.3.0`: additive `directory`/`crate`/`module` resolved-unit kinds (spec 017).
 pub const INDEX_SCHEMA_VERSION: &str = "0.3.0";

--- a/crates/spec-spine-types/tests/dogfood.rs
+++ b/crates/spec-spine-types/tests/dogfood.rs
@@ -1,8 +1,8 @@
 //! Dogfood: this repo's own bootstrap spec must parse through the types crate.
 //!
-//! The compiler does not exist yet (Phase 2), but the authored frontmatter of
-//! `specs/000` must already conform to the grammar this crate defines, so the
-//! corpus and the grammar cannot drift apart before compile lands.
+//! The authored frontmatter of `specs/000` must conform to the grammar this
+//! crate defines; a parse failure here means the corpus and the types drifted
+//! apart (this guards the grammar independently of the full compile pipeline).
 
 use spec_spine_types::{Status, parse_frontmatter};
 

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/bartekus/spec-spine/main/install.sh
 
 The script detects your platform/arch, downloads the matching release archive
 and its `.sha256` sidecar, verifies the checksum, and drops `spec-spine` on your
-`PATH`. Pin a version with `SPEC_SPINE_VERSION=v0.1.0` and a target dir with
+`PATH`. Pin a version with `SPEC_SPINE_VERSION=vX.Y.Z` (a published release tag) and a target dir with
 `SPEC_SPINE_BIN_DIR=~/.local/bin`.
 
 ### From source
@@ -79,8 +79,8 @@ spec-spine registry list    # see your specs
 ```
 
 Write your first real specs under `specs/NNN-slug/spec.md` using the template,
-declaring the **authority units** each spec owns (file / section / symbol) in its
-frontmatter edges.
+declaring the **authority units** each spec owns (file / section / symbol /
+directory / crate / module) in its frontmatter edges.
 
 ---
 
@@ -111,8 +111,9 @@ spec = "001-my-capability"
 
 The third direction, **spec edges**, is the `unit:` declarations inside each
 spec's frontmatter (`establishes` / `extends` / `refines` / `supersedes` /
-`amends` / `co_authority` / `constrains`). See the bootstrap spec and the
-template for the grammar.
+`amends` / `co_authority` / `constrains` / `references`; `references` is the
+only non-owning edge, ignored by the coupling gate). See the bootstrap spec and
+the template for the grammar.
 
 Build the code-as-source view and commit it:
 
@@ -197,9 +198,11 @@ divergence observed across the reference repos. Every sub-table is
 | `layout.standalone_rust_workspaces` / `standalone_npm_packages` | crates/packages outside the root workspace | `[]` |
 | `index.extra_hashed_inputs` | globs folded into the staleness content hash, beyond the always-hashed core | `["standards/**", ".github/workflows/**"]` |
 | `index.resolver_exclusions` | dir names pruned from symbol/section walks | `["target","node_modules",".derived","dist","build",".next"]` |
+| `index.slices` | named glob groups, each emitted as a `build.sliceHashes` entry and gated by `index check --slice <name>`; names match `[a-z0-9][a-z0-9-]*`, each list non-empty. Independent of the global `contentHash` | `{}` |
 | `branding.compiler_id` / `indexer_id` | ids stamped in emitted `build` metadata | `"spec-spine"` |
 | `coupling.bypass_prefixes` | **additions** to the built-in bypass floor (additive; cannot remove a floor entry) | `[]` |
 | `coupling.waiver_keyword` | the PR-body waiver keyword | `"Spec-Drift-Waiver:"` |
+| `coupling.auto_waive_dependency_only` | when `true` and no PR-body waiver is present, mechanically self-waives PRs where every non-bypassed changed path is a `package.json` with only dependency version-string changes (the dependabot-class path); fail-closed on anything more (spec 005 §3.5) | `false` |
 | `provenance.uri_schemes` | open kind→scheme map for provenance URIs | `{ knowledge = "knowledge://", code-fingerprint = "fingerprint://" }` |
 | `frontmatter.extra_known_keys` | recognized frontmatter keys added without forking the types crate | `[]` |
 
@@ -222,8 +225,10 @@ extra_hashed_inputs = ["standards/**", ".github/workflows/**", "schemas/**"]
 
 The bypass floor (always applied, cannot be removed) covers `.github/`, `docs/`,
 `README.md`, `CHANGELOG.md`, `LICENSE`, `CODEOWNERS`, `.gitignore`,
-`.gitattributes`, `standards/spec/constitution.md`, `.derived/`, and the common
-lockfiles. Your `coupling.bypass_prefixes` adds to it. Match rules: a trailing
+`.gitattributes`, `standards/spec/constitution.md`, `.derived/`, `**/Cargo.lock`,
+`**/package-lock.json`, and `**/pnpm-lock.yaml`. Your `coupling.bypass_prefixes`
+adds to it (other lockfiles, e.g. `yarn.lock`, are not covered by default).
+Match rules: a trailing
 `/` is a directory prefix, a leading `**/` is a tail-suffix match anywhere, and
 anything else is an exact path.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@ depend on `spec-spine-core` alone and reach everything via
 
 ```toml
 [dependencies]
-spec-spine-core = "0.1"
+spec-spine-core = "0.3"
 ```
 
 ---
@@ -47,7 +47,11 @@ Each is a pure function of `(Config, on-disk inputs under repo_root)`:
 
 ```rust
 use std::path::Path;
-use spec_spine_core::{compile, index, lint, couple, check_index_freshness};
+use spec_spine_core::{
+    compile, index, lint, couple, couple_with, parse_waiver,
+    check_index_freshness, check_slice_freshness,
+    DiffInput, DiffFile, Waiver,
+};
 
 pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error>;
 pub fn index  (cfg: &Config, repo_root: &Path) -> Result<IndexOutcome,   Error>;
@@ -65,6 +69,9 @@ pub fn couple_with(cfg: &Config, registry: &Registry, index: &CodebaseIndex,
 // Cheap staleness check: does the committed index.json's contentHash match
 // the current inputs?
 pub fn check_index_freshness(cfg: &Config, repo_root: &Path) -> Result<Freshness, Error>;
+
+// Per-slice staleness (spec 012): `name` is a configured `[index.slices]` key.
+pub fn check_slice_freshness(cfg: &Config, repo_root: &Path, name: &str) -> Result<Freshness, Error>;
 ```
 
 Returned outcomes carry both the typed struct and the canonical bytes the CLI
@@ -72,7 +79,7 @@ writes, so overlays and tests need not re-parse:
 
 ```rust
 pub struct CompileOutcome { pub registry: Registry,       pub json: String, pub validation_passed: bool }
-pub struct IndexOutcome   { pub index:    CodebaseIndex,   pub json: String, pub content_hash: String }
+pub struct IndexOutcome   { pub index:    CodebaseIndex,   pub json: String }  // hash: index.build.content_hash
 pub enum   Freshness      { Fresh, Stale { expected: String, actual: String } }
 ```
 
@@ -87,6 +94,16 @@ pub struct Waiver    { pub reason: String }
 
 // Build a Waiver from a PR body using the configured keyword:
 pub fn parse_waiver(cfg: &Config, pr_body: &str) -> Option<Waiver>;
+
+// Mechanical dependency-only auto-waiver (spec 005 §3.5), used when
+// `coupling.auto_waive_dependency_only` is set and no PR-body waiver is present:
+pub struct FileContents { pub path: String, pub base: String, pub head: String }
+pub fn dependency_only_waiver(files: &[FileContents]) -> Option<Waiver>;
+pub fn dependency_only_change(base: &str, head: &str) -> bool;  // both are package.json text
+pub fn is_package_json(path: &str) -> bool;
+
+// Is a path covered by the bypass floor (+ configured `coupling.bypass_prefixes`)?
+pub fn is_bypassed_path(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool;
 ```
 
 `couple` returns a `CoupleReport` **even on drift**: drift is data, not an
@@ -143,9 +160,10 @@ unknown MAJOR" means.
 Read-only queries over a loaded `Registry`:
 
 ```rust
-use spec_spine_core::{list, show, status_report, relationships, ListFilter};
+use spec_spine_core::{list, list_ids, show, status_report, relationships, ListFilter};
 
 pub fn list        (registry: &Registry, filter: &ListFilter)  -> Vec<&SpecRecord>;
+pub fn list_ids    (registry: &Registry, filter: &ListFilter)  -> Vec<&str>;  // idsOnly projection (spec 010)
 pub fn show        (registry: &Registry, id: &str)             -> Result<&SpecRecord, Error>;
 pub fn status_report(registry: &Registry)                      -> StatusReport;
 pub fn relationships(registry: &Registry, id: &str)            -> Result<RelationshipView, Error>;
@@ -216,9 +234,10 @@ pub fn scaffold_init_json  (config_json: &str)                  -> Result<String
 - `couple_json` request: `{ "config"?: Config, "repoRoot": string, "diff":
   DiffInput, "waiver"?: { "reason": string } }`.
 - `check_freshness_json` returns `{ "fresh": bool, "expected"?, "actual"? }`.
-- `render_json` / `orphans_json` (spec 011) take the committed `index.json`
-  text and return the markdown projection (a JSON-encoded string) and the
-  orphaned-spec ids (a JSON array) respectively.
+- `render_json` (spec 011) takes `config_json` and the committed `index.json`
+  text and returns the markdown projection (a JSON-encoded string).
+  `orphans_json` (spec 011) takes only the `index.json` text and returns the
+  orphaned-spec ids (a JSON array).
 
 All emitted JSON is **pretty-printed with sorted keys, LF line endings, and a
 trailing newline** (diffability over compactness; see

--- a/docs/bindings-plan.md
+++ b/docs/bindings-plan.md
@@ -32,7 +32,9 @@ The facade functions to wrap:
 | `lint_json(config_json, repo_root)` | `lint` |
 | `check_freshness_json(config_json, repo_root)` | `check_index_freshness` |
 | `couple_json(request_json)` | `couple` |
-| `query_json(request_json)` | `list` / `show` / `status_report` / `relationships` |
+| `query_json(request_json)` | `list` / `list_ids` / `show` / `status_report` / `relationships` |
+| `render_json(config_json, index_json)` | `render_markdown` (spec 011) |
+| `orphans_json(index_json)` | `orphans` (spec 011) |
 | `load_config_json(toml_src)` | `load_config` |
 | `scaffold_init_json(config_json)` | `scaffold_init` |
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -4,8 +4,8 @@
 > *how*, see [adoption-guide.md](adoption-guide.md) (using it),
 > [api.md](api.md) (the library), and
 > [design/00-architecture.md](design/00-architecture.md) (the design). Where this
-> document describes the full vision, the README's capability table marks what v1
-> actually ships.
+> document describes the model, the README's capability table and the release
+> notes track what each release actually ships.
 
 **A typed, hash-verifiable ledger of who-owns-what, sitting underneath a codebase
 so that many agents can work in parallel without trampling each other.**
@@ -141,7 +141,11 @@ The graph expresses ownership at finer granularity than "file." A unit can be:
 - a **section** within a file, a named anchor such as a particular build target
   or a Markdown heading,
 - a **symbol**, a function, a type, an exported binding (resolved via
-  tree-sitter).
+  tree-sitter for Rust and TypeScript; Python deferred),
+- a **directory** subtree (the explicit `{ kind: directory, path }` form,
+  complementing the trailing-slash file shorthand),
+- a **crate**, a compilation unit named by its manifest,
+- a **module**, a `::`-qualified module path.
 
 Section-scoped co-authority is the property that makes the canonical hard case
 tractable: a project-wide build file where many features each add targets.

--- a/docs/design/00-architecture.md
+++ b/docs/design/00-architecture.md
@@ -55,12 +55,13 @@ spec-spine/
 ├─ crates/
 │  ├─ spec-spine-types/             # DTOs, frontmatter grammar, Config, schema-version
 │  │  │                             #   consts, EMBEDDED JSON Schemas, the Error enum.
-│  │  └─ schemas/                   #   registry / index / config-hash / build-meta .schema.json
+│  │  └─ schemas/                   #   registry / index / build-meta .schema.json
 │  │                                #   (include_str!'d: the crate is self-contained)
-│  ├─ spec-spine-core/              # THE library: compile / index / query / lint / couple
+│  ├─ spec-spine-core/              # THE library: compile / index / query / lint / couple / render
 │  │                                #   + load_registry / load_index (overlay seam)
-│  │                                #   + scaffold_init + JSON facade. Internal canonical-json
-│  │                                #   + content-hash + tree-sitter symbol resolver modules.
+│  │                                #   + scaffold_init + JSON facade. Internal canonical-json,
+│  │                                #   content-hash, markdown, sections, symbols (tree-sitter),
+│  │                                #   manifest, pathutil, dep_only modules.
 │  └─ spec-spine-cli/               # thin clap wrapper → ONE `spec-spine` multi-call binary;
 │                                   #   git invocation, stdout/stderr, process::exit live HERE only.
 ├─ specs/                           # the library's own spec corpus (000 = bootstrap); dogfood
@@ -136,24 +137,26 @@ it does not; it is a **bootstrap marker**, not a relationship. The concept doc a
 `spec-spine.md` are authoritative: **eight edge types**, with `origin` tracked
 separately as frontmatter, not as a graph edge.)
 
-### 2.2 Authority unit grammar: v1 ships file / section / symbol
+### 2.2 Authority unit grammar: six kinds (file / section / symbol / directory / crate / module)
 
 A spec declares the units it owns via a `unit:` object on an edge. The full
-grammar (ported from OAP `LogicalUnit`, `spec-types/src/lib.rs`) is six kinds;
-**v1 resolves three**, per the build mandate (§1 of the prompt):
+grammar (ported from OAP `LogicalUnit`, `spec-types/src/lib.rs`) is six kinds.
+v1 shipped three (file / section / symbol); **spec 017 added the other three**
+(directory / crate / module) as the planned additive MINOR, so all six now
+resolve:
 
-| Unit kind | v1? | Shape | Resolution |
+| Unit kind | Status | Shape | Resolution |
 |---|---|---|---|
-| `file` | **v1** | `{ kind: file, path }` | literal path; trailing-`/` path ⇒ directory subtree (prefix match) |
-| `section` | **v1** | `{ kind: section, file, anchor }` | anchor parser by file type (Makefile target / Markdown heading slug / `region:` marker / workflow `jobs.<name>`) |
-| `symbol` | **v1** | `{ kind: symbol, id }` | tree-sitter (**Rust + TypeScript** in v1; Python deferred, Q4) → `(file, line-span)` |
-| `directory` | folded | n/a | expressed as a `file` unit with a trailing-slash path; **not a separate kind in v1** |
-| `crate` | deferred | `{ kind: crate, id }` | workspace-member validation; reserved (additive minor) |
-| `module` | deferred | `{ kind: module, id }` | tree-sitter module index; reserved (additive minor) |
+| `file` | v1 | `{ kind: file, path }` | literal path; trailing-`/` path ⇒ directory subtree (prefix match) |
+| `section` | v1 | `{ kind: section, file, anchor }` | anchor parser by file type (Makefile target / Markdown heading slug / `region:` marker / workflow `jobs.<name>` / bounded keypath, spec 022) |
+| `symbol` | v1 | `{ kind: symbol, id }` | tree-sitter (**Rust + TypeScript**; Python deferred, Q4) → `(file, line-span)` |
+| `directory` | spec 017 | `{ kind: directory, path }` | explicit subtree kind (same prefix-match semantics as a trailing-slash `file`) |
+| `crate` | spec 017 | `{ kind: crate, id }` | resolved by manifest name to the package directory subtree |
+| `module` | spec 017 | `{ kind: module, id }` | `::`-qualified module path, resolved via the module index |
 
 A bare string on an edge is shorthand for `{ kind: file, path }`. The `Unit`
-enum is designed additively so `crate`/`module` slot in as a MINOR schema bump
-later without breaking readers.
+enum was designed additively, so the three later kinds slotted in as a MINOR
+schema bump (spec 017) without breaking readers.
 
 ### 2.3 Three linkage directions (how code ↔ spec connect)
 
@@ -286,8 +289,8 @@ extra_known_keys = []
 #[serde(default, deny_unknown_fields)]   // deny_unknown_fields ⇒ typos are loud, not silent
 pub struct Config {
     pub manifest:    ManifestConfig,
-    pub domains:     DomainsConfig,   // { allowed: Vec<String> }
-    pub kind:        KindConfig,      // { allowed: Vec<String> }; symmetric with domains
+    pub domains:     AllowlistConfig, // { allowed: Vec<String> }
+    pub kind:        AllowlistConfig, // { allowed: Vec<String> }; symmetric with domains
     pub layout:      LayoutConfig,
     pub index:       IndexConfig,
     pub branding:    BrandingConfig,
@@ -348,7 +351,7 @@ pub fn check_index_freshness(cfg: &Config, repo_root: &Path) -> Result<Freshness
 
 ```rust
 pub struct CompileOutcome { pub registry: Registry, pub json: String, pub validation_passed: bool }
-pub struct IndexOutcome   { pub index: CodebaseIndex, pub json: String, pub content_hash: String }
+pub struct IndexOutcome   { pub index: CodebaseIndex, pub json: String }  // hash: index.build.content_hash
 pub enum   Freshness      { Fresh, Stale { expected: String, actual: String } }
 ```
 
@@ -380,14 +383,15 @@ extensibility model (OAP's enrichers do exactly this).
 ### 4.4 Typed query layer (over a loaded `Registry`)
 
 ```rust
-impl Registry {
-    pub fn list   (&self, filter: &ListFilter)  -> Vec<&SpecRecord>;
-    pub fn show   (&self, id: &SpecId)          -> Option<&SpecRecord>;
-    pub fn status_report(&self)                 -> StatusReport;          // counts by status
-    pub fn relationships(&self, id: &SpecId)    -> Option<RelationshipView>;
-}
-// Authority-by-unit needs both the registry (edges) and the index (resolved units):
-pub fn authorities(registry: &Registry, index: &CodebaseIndex, unit: &UnitRef) -> Vec<SpecId>;
+// Free functions in `spec_spine_core::query`, not inherent methods on Registry:
+pub fn list        (registry: &Registry, filter: &ListFilter) -> Vec<&SpecRecord>;
+pub fn list_ids    (registry: &Registry, filter: &ListFilter) -> Vec<&str>;   // idsOnly projection (spec 010)
+pub fn show        (registry: &Registry, id: &str)            -> Result<&SpecRecord, Error>;
+pub fn status_report(registry: &Registry)                     -> StatusReport; // counts by status
+pub fn relationships(registry: &Registry, id: &str)           -> Result<RelationshipView, Error>;
+
+// Authority-by-unit resolves over the index alone (the compiler pre-flattens edges into units):
+pub fn authorities(index: &CodebaseIndex, unit: &Unit) -> Vec<String>;  // → owning spec ids
 ```
 
 ### 4.5 The `Error` enum (stable variants → exit codes)
@@ -437,7 +441,7 @@ pub fn scaffold_init_json  (config_json: &str)                  -> Result<String
 ```
 spec-spine compile                                  # → .derived/spec-registry/registry.json (+ build-meta.json)
 spec-spine index   [check | render | orphans]       # check = staleness gate; default subcmd writes index.json
-spec-spine registry list|show|status-report|authorities|relationships
+spec-spine registry list|show|status-report|relationships
 spec-spine lint    [--fail-on-warn] [--fail-on-info]
 spec-spine couple  [--base origin/main] [--head HEAD] [--pr-body FILE] [--paths-from FILE]
 spec-spine init    [--force]
@@ -475,10 +479,14 @@ The references run registry `specVersion 2.2.0` and index `schemaVersion 3.0.0`.
 We **do not inherit those lines.** spec-spine starts every schema fresh at
 `0.1.0`, decoupled from any consumer's history.
 
-| Artifact | Field | v1 value | Owner |
+Each schema started at `0.1.0`; the values below are current (registry and
+index have since taken additive MINOR bumps as features shipped, e.g. spec 012
+hash slices, 013 passthrough, 017 unit kinds, 019 structured supersedes).
+
+| Artifact | Field | Current value | Owner |
 |---|---|---|---|
-| `registry.json` | `specVersion` | `0.1.0` | library |
-| `index.json` | `schemaVersion` | `0.1.0` | library |
+| `registry.json` | `specVersion` | `0.3.0` | library |
+| `index.json` | `schemaVersion` | `0.3.0` | library |
 | `spec-spine.toml` | `config_version` (optional) | `0.1.0` | library |
 | `build-meta.json` | `schemaVersion` | `0.1.0` | library (non-deterministic; excluded from golden) |
 
@@ -530,6 +538,10 @@ top-level `LICENSE`.
 **Recommendation: minimal-original** (per prompt §9 lean), not a re-derivation of
 the reference corpora. spec-spine governs itself from day one with a small, clean,
 purpose-built corpus.
+
+> Phase-0 outline of the original seven specs (000–006). The corpus has since
+> grown through ordinary governed development to 000–022 (23 specs, all
+> approved); `spec-spine registry list` is the live source of truth.
 
 ```
 specs/
@@ -602,8 +614,10 @@ The compiler is built to satisfy `000`; once built, it compiles its own corpus
 - **The symbol resolver is a determinism input** (Phase-0 checkpoint item 1).
   tree-sitter core and each grammar crate are pinned to **exact** versions
   (`=x.y.z`) with `Cargo.lock` committed; an unpinned grammar shifts symbol
-  line-spans and surfaces as flaky goldens late, across the 5-triple release
-  matrix. Phase 3 (specs 004/005) adds a **per-platform golden test for symbol
+  line-spans and surfaces as flaky goldens late. The release workflow builds
+  five triples; the determinism gate proves byte-identity across four of them
+  (`x86_64-apple-darwin` is omitted, its two dimensions each proven by another
+  leg). Phase 3 (specs 004/005) adds a **per-platform golden test for symbol
   line-spans** so a span drift fails CI on every target, not just locally.
 
 ### 10.2 Ported semantics → provenance map (cite-on-reuse)
@@ -664,8 +678,9 @@ forking.
   `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
   `x86_64-pc-windows-msvc`, each with a `.sha256` sidecar, plus an `install.sh`
   (`curl … | sh`) that detects platform/arch and drops the binary on `PATH`.
-- **SBOM** (CycloneDX per archive): nice-to-have; flagged as low-but-nonzero
-  workflow time; defer unless requested (§10 Q7).
+- **SBOM** (CycloneDX per archive): **shipped** (spec 021). The release workflow
+  emits a per-target CycloneDX SBOM plus build provenance, with a gate that
+  fails closed on a zero-component SBOM (§10 Q7).
 
 ---
 
@@ -726,9 +741,9 @@ as recommended unless you redirect.
 | Q2 | **CLI shape:** one multi-call binary vs five? | ✅ **One multi-call `spec-spine` binary** (confirmed) |
 | Q3 | **Bootstrap corpus:** minimal-original vs re-derive? | ✅ **Minimal-original** (6 capability specs + 000) (confirmed) |
 | Q4 | **v1 symbol-resolution languages?** | ✅ **Rust + TypeScript** in v1; **Python deferred** (confirmed). Expands Phase 3: two tree-sitter grammars. |
-| Q5 | Include `directory`/`crate`/`module` unit kinds in v1? | `directory` folded into trailing-slash `file` units; `crate`/`module` reserved for an additive minor |
+| Q5 | Include `directory`/`crate`/`module` unit kinds in v1? | v1 shipped file/section/symbol; ✅ **all three later added (spec 017)** as the planned additive MINOR: `directory` as an explicit kind, `crate`/`module` resolved via the package/module index |
 | Q6 | Registry/index JSON: pretty (diffable) vs compact (OAP)? | **Pretty**, sorted keys, LF, trailing newline |
-| Q7 | Per-archive CycloneDX SBOM in the release workflow? | Defer (low value/time ratio for v1); add on request |
+| Q7 | Per-archive CycloneDX SBOM in the release workflow? | ✅ **Shipped (spec 021):** per-target CycloneDX SBOM + build provenance, gated to fail closed on a zero-component SBOM |
 | Q8 | `index.extra_hashed_inputs` default base set contents? | `["standards/**", ".github/workflows/**"]` + always-hashed core (specs, manifests, config) |
 | Q9 | `manifest.metadata_namespace` default `"spec-spine"` ⇒ `[package.metadata.spec-spine]` (hyphenated TOML key, legal but unusual). Prefer `"spec"`? | Keep **`"spec-spine"`** (self-describing; hyphenated bare keys are valid TOML) |
 | Q10 | How much provenance/`references` semantics in v1? | Ship the `references` edge + open `provenance.uri_schemes` config + basic URI well-formedness; defer rich knowledge-graph semantics |

--- a/docs/design/01-partial-supersession.md
+++ b/docs/design/01-partial-supersession.md
@@ -1,6 +1,10 @@
 # 01: Partial supersession (structured `supersedes`)
 
-**Status:** open design question. Decision needed before any `017` is filed.
+**Status:** decided and shipped. Option A was implemented as spec
+`019-structured-partial-supersedes` (approved, complete). This document is the
+historical design analysis that preceded the decision; the analysis and
+algorithm sketch below match what was built, but the "open question" and staged
+recommendation framing is superseded (see the postscript at the end).
 **Origin:** the Phase-0 OAP corpus dry-run (read-only, throwaway config). Five
 specs author `supersedes` items in a structured `{ spec, scope: partial, unit }`
 form that this library's grammar does not accept. Unlike the other dry-run gaps
@@ -60,8 +64,9 @@ couple.rs`. The relevant pieces:
 - **Grammar / registry.** `supersedes: Vec<String>` -- a list of predecessor
   spec ids. The architecture edge table (§2.1) already labels the edge
   *"replaces a predecessor (partial/full); inherits current authority"*, so
-  "partial" is a **named-but-unbuilt** capability, not a foreign concept. Only
-  the full form is implemented.
+  "partial" was a **named-but-unbuilt** capability at the time of this analysis,
+  not a foreign concept. (Both forms are now implemented as of spec 019; this
+  section describes the pre-019 baseline.)
 - **`build_superseders`** (`couple.rs`): folds the registry into a
   `predecessor_id -> { superseder_ids }` map. The key is a bare id; there is no
   slot for a unit qualifier.
@@ -200,3 +205,24 @@ demand signal this small).
 4. **`scope: full` spelling:** if A is built, do we also accept an explicit
    `{ spec, scope: full }` object (symmetry), or keep full as bare-string-only
    to guarantee registry stability?
+
+## 9. Outcome (postscript)
+
+The decision was taken and **Option A shipped directly as spec
+`019-structured-partial-supersedes`** (approved, complete), not the staged
+Option-D-then-A path recommended in §7, and not under the `017` number used as a
+placeholder above (`017` became the unrelated directory/crate/module-units
+spec). The implementation matches the §5 sketch:
+
+- **Wire format** (`spec-spine-types/src/edges.rs`): `supersedes` is a
+  `Vec<SupersedeItem>`. A bare predecessor id and an explicit
+  `{ spec, scope: full }` both normalize to `SupersedeItem::Full`, so existing
+  registries stay byte-identical (answering open question 4: symmetry accepted,
+  full canonicalizes to the bare form). A partial item is
+  `{ spec, scope: partial, unit, note?, rationale? }` -> `SupersedeItem::Scoped`.
+- **Transfer semantics:** additive (open question 1) -- `build_superseders` in
+  `couple.rs` branches on `SupersedeItem::is_full()`, so a partial item transfers
+  only the scoped unit's authority rather than the predecessor's whole surface.
+
+This document is retained as the design analysis that justified that shape; the
+analysis stands, only its "open question" framing is historical.

--- a/docs/overlay-contract.md
+++ b/docs/overlay-contract.md
@@ -122,8 +122,10 @@ those through the compiler **without forking the types crate**, two ways:
   recognizes. They are accepted as first-class frontmatter rather than triggering
   an unknown-key diagnostic.
 - **`extra_frontmatter`** (DTO field): any frontmatter key not otherwise known
-  overflows into a capped `extra_frontmatter` map on the `SpecRecord` (scalar /
-  string-list values only). Your overlay reads it from the loaded `Registry`.
+  overflows into a capped `extra_frontmatter` map on the `SpecRecord`. Undeclared
+  keys are restricted to scalar and string-list values; keys you list in
+  `extra_known_keys` carry any JSON-representable YAML value, including arbitrary
+  nesting (spec 013). Your overlay reads it from the loaded `Registry`.
 
 The compiler validates and emits these deterministically alongside the generic
 fields; the overlay picks them up from the typed `Registry`. Neither path

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,6 +13,11 @@
 - [ ] Working tree clean and green: `cargo test --workspace --locked`.
 - [ ] Self-governance green: `spec-spine compile && spec-spine index check &&
       spec-spine lint --fail-on-warn && spec-spine couple --base origin/main --head HEAD`.
+- [ ] If the spec-020 derived-artifact merge driver is enabled on this clone
+      (`./.githooks/enable-merge-driver.sh`), the binary is current
+      (`cargo build --release --locked`) before merging the release-prep branch:
+      the driver regenerates the committed artifacts by shelling out to
+      `spec-spine compile && index`.
 - [ ] Versions bumped consistently with `scripts/bump_version.py <version>`,
       then `scripts/bump_version.py --check <version>` is green. The script sets
       all three shims in lockstep: workspace `version` in the root `Cargo.toml`;
@@ -54,14 +59,15 @@ All three crates are publish-clean by construction: full metadata
 The release workflow (`.github/workflows/release.yml`) is tag-gated:
 
 ```sh
-git tag v0.1.0
-git push origin v0.1.0
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 That builds a per-triple archive (with a `.sha256` sidecar) for all five
 supported targets, `x86_64`/`aarch64` `apple-darwin`, `x86_64`/`aarch64`
-`unknown-linux-gnu`, `x86_64-pc-windows-msvc`, each natively on a matching
-GitHub-hosted runner, and attaches them to the GitHub Release.
+`unknown-linux-gnu`, `x86_64-pc-windows-msvc`, each on a GitHub-hosted runner
+(`x86_64-apple-darwin` cross-compiles on the Apple Silicon runner), and attaches
+them to the GitHub Release.
 [`install.sh`](../install.sh) (`curl | sh`) consumes those assets.
 
 ### Supply-chain artifacts (spec 021)
@@ -99,7 +105,7 @@ The shape (esbuild / biome / turbo model):
   (`npm/bin/spec-spine.js`);
 - five **platform packages** `@spec-spine/cli-<os>-<cpu>`, each carrying one
   prebuilt binary, `os`/`cpu`-gated and listed as `optionalDependencies` of the
-  main package, **version-locked** to the tag (npm `0.1.0` ⇔ `v0.1.0` assets).
+  main package, **version-locked** to the tag (npm `X.Y.Z` ⇔ `vX.Y.Z` assets).
 
 There is **no `postinstall`**, so it installs under `npm ci --ignore-scripts` and
 offline. The `npm/scripts/generate-platform-packages.js` generator assembles the
@@ -190,9 +196,12 @@ platform wheel, installs it into a throwaway env with uv or pip, and runs
 
 `.github/workflows/determinism.yml` proves the emitted `registry.json` and
 `index.json` (including tree-sitter symbol line-spans) are **byte-identical
-across all five triples**: the empirical backstop for the
-"identical-on-every-triple" claim, beyond merely pinning the grammars exact. Keep
-it green; a span drift on any platform fails this gate.
+across four triples** (`x86_64-apple-darwin` is intentionally omitted: its two
+dimensions, x86_64 and apple-darwin, are each proven by another leg, and the
+deprecated Intel macOS runner queues badly): the empirical backstop for the
+"identical-on-every-triple" claim, beyond merely pinning the grammars exact. The
+release workflow still builds and ships all five archives. Keep this gate green;
+a span drift on any platform fails it.
 
 ## Schema / version bumps
 

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -131,8 +131,8 @@ an unknown field fails loudly, which is the intended safety net.
 Determinism + pinning is how an adopter gets reproducible governance:
 
 - **crates.io:** pin the CLI version, `cargo install spec-spine-cli --version
-  =0.1.0`, or commit a `Cargo.lock`/`--locked` in CI.
-- **Prebuilt binary:** pin the release tag, `SPEC_SPINE_VERSION=v0.1.0
+  =X.Y.Z`, or commit a `Cargo.lock`/`--locked` in CI.
+- **Prebuilt binary:** pin the release tag, `SPEC_SPINE_VERSION=vX.Y.Z
   install.sh` (see [adoption-guide.md](adoption-guide.md)).
 - The binary **embeds** the schema version; every emitted artifact **carries** it
   (`specVersion` / `schemaVersion`). So a committed `registry.json` /

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.3.0",
-    "@spec-spine/cli-darwin-x64": "0.3.0",
-    "@spec-spine/cli-linux-x64": "0.3.0",
-    "@spec-spine/cli-linux-arm64": "0.3.0",
-    "@spec-spine/cli-win32-x64": "0.3.0"
+    "@spec-spine/cli-darwin-arm64": "0.4.0",
+    "@spec-spine/cli-darwin-x64": "0.4.0",
+    "@spec-spine/cli-linux-x64": "0.4.0",
+    "@spec-spine/cli-linux-arm64": "0.4.0",
+    "@spec-spine/cli-win32-x64": "0.4.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.3.0"
+version = "0.4.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -5,6 +5,10 @@ The release version lives in three committed files, and a release tag publishes
 all three (crates.io, npm, PyPI) under the same number. They MUST agree:
 
   - Cargo.toml           [workspace.package] version  (crates.io)
+                         + the internal [workspace.dependencies] pins for the
+                           sibling crates (a 0.x MINOR bump crosses the caret
+                           boundary, so `^0.3.0` would stop matching `0.4.0` and
+                           break `cargo build`/`cargo package` if left stale)
   - npm/package.json     version + the 5 optionalDependencies pins  (npm)
   - py/pyproject.toml    [project] version  (PyPI)
 
@@ -41,6 +45,13 @@ PYPROJECT = ROOT / "py" / "pyproject.toml"
 # [workspace.package] version (dependency versions are inline `{ version = ... }`,
 # never at column 0); in pyproject.toml it is the [project] version.
 _TOML_VERSION = re.compile(r'(?m)^(version\s*=\s*)"[^"]*"')
+# The internal sibling-crate pins in Cargo.toml's [workspace.dependencies]:
+# `spec-spine-types = { version = "x.y.z", path = ... }`. Matched by the
+# dependency-name prefix at column 0, so this never collides with the
+# [workspace.package] `version =` line above.
+_CARGO_INTERNAL_DEP = re.compile(
+    r'(?m)^(spec-spine-(?:types|core)\s*=\s*\{\s*version\s*=\s*)"[^"]*"'
+)
 # package.json: the single top-level "version" key (opt-dep keys are package
 # names, never the literal "version").
 _JSON_VERSION = re.compile(r'("version"\s*:\s*)"[^"]*"')
@@ -71,6 +82,10 @@ def read_cargo() -> str:
     return m.group(0).split('"')[1] if m else die("no version in Cargo.toml")
 
 
+def read_cargo_internal_deps() -> set[str]:
+    return {m.group(0).split('"')[1] for m in _CARGO_INTERNAL_DEP.finditer(CARGO.read_text())}
+
+
 def read_pyproject() -> str:
     m = _TOML_VERSION.search(PYPROJECT.read_text())
     return m.group(0).split('"')[1] if m else die("no version in pyproject.toml")
@@ -86,8 +101,11 @@ def read_npm() -> tuple[str, set[str]]:
 def current_versions() -> dict[str, str]:
     npm_v, npm_pins = read_npm()
     pin_repr = next(iter(npm_pins)) if len(npm_pins) == 1 else f"MIXED{sorted(npm_pins)}"
+    dep_pins = read_cargo_internal_deps()
+    dep_repr = next(iter(dep_pins)) if len(dep_pins) == 1 else f"MIXED{sorted(dep_pins)}"
     return {
         "Cargo.toml": read_cargo(),
+        "Cargo.toml (internal deps)": dep_repr,
         "npm/package.json (version)": npm_v,
         "npm/package.json (pins)": pin_repr,
         "py/pyproject.toml": read_pyproject(),
@@ -97,7 +115,11 @@ def current_versions() -> dict[str, str]:
 # --- commands ----------------------------------------------------------------
 
 def do_bump(version: str) -> None:
-    CARGO.write_text(_sub_once(_TOML_VERSION, CARGO.read_text(), version, "version in Cargo.toml"))
+    cargo = _sub_once(_TOML_VERSION, CARGO.read_text(), version, "version in Cargo.toml")
+    cargo, ndeps = _CARGO_INTERNAL_DEP.subn(rf'\g<1>"{version}"', cargo)
+    if ndeps != 2:
+        die(f"expected 2 internal [workspace.dependencies] pins in Cargo.toml, rewrote {ndeps}")
+    CARGO.write_text(cargo)
 
     pkg = PACKAGE_JSON.read_text()
     pkg = _sub_once(_JSON_VERSION, pkg, version, 'top-level "version" in package.json')

--- a/specs/000-spec-spine-bootstrap/spec.md
+++ b/specs/000-spec-spine-bootstrap/spec.md
@@ -114,18 +114,26 @@ over any unit is *derived by walking the graph*, never declared directly.
 
 `origin` is a bootstrap marker, **not** an edge. The graph has eight edge types.
 
-### 4.2 Authority units: file, section, symbol (v1)
+### 4.2 Authority units: file, section, symbol, directory, crate, module
 
-Ownership resolves at three granularities, declared via a `unit:` on an edge:
+Ownership resolves at six granularities, declared via a `unit:` on an edge:
 
 - **file**: `{ kind: file, path }` (a bare string is shorthand for this; a
   trailing-slash path denotes the directory subtree).
 - **section**: `{ kind: section, file, anchor }` (a Makefile target, a Markdown
-  heading slug, a `region:` marker, a CI `jobs.<name>`).
+  heading slug, a `region:` marker, a CI `jobs.<name>`, or a bounded keypath into
+  a structured file).
 - **symbol**: `{ kind: symbol, id }` (a function/type/export, resolved by the
-  indexer; Rust and TypeScript in v1).
+  indexer; Rust and TypeScript).
+- **directory**: `{ kind: directory, path }` (a subtree named explicitly;
+  resolution is identical to a trailing-slash file unit).
+- **crate**: `{ kind: crate, id }` (a compilation unit by its manifest name,
+  resolved to that package's directory subtree).
+- **module**: `{ kind: module, id }` (a `::`-qualified module path, resolved by
+  the indexer's module index).
 
-(`crate`, `module`, `directory` are reserved for additive future minors.)
+The schema is permissive on the unit payload, so `directory`/`crate`/`module`
+were added as an additive minor with no schema-file edit.
 
 ### 4.3 Resolution and amends-awareness
 


### PR DESCRIPTION
## What

Refresh documentation and code comments to match shipped behavior (specs 009-022), and prepare the v0.4.0 package release.

Three commits:

1. **docs: sync docs/ and CLI README with shipped specs 009-022** - the prose docs predated specs 009-022. Corrected: 3 unit kinds to 6 (spec 017); determinism claim from "five" release triples to four (x86_64-apple-darwin is omitted from the gate); partial-supersedes marked shipped (spec 019); SBOMs marked shipped (spec 021); added missing Config knobs (`index.slices`, `coupling.auto_waive_dependency_only`) and the `references` edge; `index render`/`orphans` and projection flags; API-doc fixes (`IndexOutcome` has no `content_hash`, `render_json` takes two args, `AllowlistConfig`, free-function query layer).
2. **docs: correct stale code comments and adopter scaffold text** - module doc-comments and the `spec-spine init` scaffold still described the pre-017/019 model. Comment, doc-string, and embedded-string only; no behavior change.
3. **chore(release): prepare v0.4.0** - bump the package version (the three shims + internal `[workspace.dependencies]` pins), regenerate the committed derived artifacts, and fix `bump_version.py` so a 0.x MINOR bump also bumps the internal pins (it previously broke `cargo build`). 0.4.0 ships the spec 022 keypath-section-anchors feature that v0.3.0 binaries lack. Schema versions unchanged.

## Verification

`cargo test --workspace --locked`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `spec-spine compile`, `index check` (fresh), and `lint --fail-on-warn` (clean) all pass.

## Coupling

Spec-Drift-Waiver: Mechanical refresh only. Every flagged path is a stale comment / doc-string / embedded-string correction bringing text in line with already-shipped behavior (specs 009-022), plus the v0.4.0 package-version bump (npm/package.json, py/pyproject.toml) and a docs/releasing.md accuracy fix. No owning spec's authority claims and no runtime behavior change; per .claude/rules/adversarial-prompt-refusal.md a mechanical comment/version refresh must not amend the owning specs.
