### PR TITLE
feat(023): ledger seal (signed, reproducible corpus attestation)

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "f2619f3461d0c1bdf8435155bb4dae4bf1d92647afd7f0bc8831d339f06afa2c",
+    "contentHash": "5875c27106572d9703b092482847c9a13e08c4d744ab81aa43d9c7b084a38863",
     "indexerId": "spec-spine",
     "indexerVersion": "0.4.0",
     "repoRoot": "."
@@ -2254,6 +2254,207 @@
         ],
         "specId": "022-keypath-section-anchors",
         "specStatus": "approved"
+      },
+      {
+        "dependsOn": [
+          "001-compile-registry",
+          "003-conformance-lint",
+          "004-codebase-index",
+          "005-coupling-gate"
+        ],
+        "implementingPaths": [
+          {
+            "path": "crates/spec-spine-cli/Cargo.toml",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/src/cmd_attest.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/src/main.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/src/seal.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-cli/src/verify_attestation.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/attest.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-core/tests/attest.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/attest.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "crates/spec-spine-types/src/lib.rs",
+            "source": "spec-edge"
+          },
+          {
+            "path": "docs/design/00-architecture.md",
+            "source": "spec-edge"
+          }
+        ],
+        "resolvedUnits": [
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/cmd_attest.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/cmd_attest.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/seal.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/seal.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/verify_attestation.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/attest.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/attest.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/tests/attest.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/tests/attest.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/attest.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "establishes",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/attest.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/Cargo.toml"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/Cargo.toml"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-cli/src/main.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-cli/src/main.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-core/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-core/src/lib.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "crates/spec-spine-types/src/lib.rs"
+              }
+            ],
+            "ownership": true,
+            "sourceField": "extends",
+            "unit": {
+              "kind": "file",
+              "path": "crates/spec-spine-types/src/lib.rs"
+            }
+          },
+          {
+            "locations": [
+              {
+                "file": "docs/design/00-architecture.md"
+              }
+            ],
+            "ownership": false,
+            "sourceField": "references",
+            "unit": {
+              "kind": "file",
+              "path": "docs/design/00-architecture.md"
+            }
+          }
+        ],
+        "specId": "023-ledger-seal",
+        "specStatus": "draft"
       }
     ],
     "orphanedSpecs": [],

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.4.0",
-    "contentHash": "f39e538802fca67588ff62dedd95ab8d996c4ed83a9c731b23af25f03caea38d",
+    "contentHash": "151b3ffd22070b1ccada01fb35929ceede25c87a42e0f2cc594bf9c861b959ee",
     "inputRoot": "."
   },
   "specVersion": "0.3.0",
@@ -1432,6 +1432,106 @@
       "status": "approved",
       "summary": "Widens the section-anchor grammar (`sections.rs`, spec 004 §3.3) so a `{ kind: section, file, anchor }` unit can name a bounded mapping keypath inside a first-party structured-config file: a workflow YAML (`on`, `permissions`, `env`, `jobs.<name>`, `jobs.<name>.permissions`), a `Cargo.toml` table path (`workspace`, `package.metadata.oap`), or a `package.json` member (`scripts`, `dependencies`). The anchor field is already a free string (`Unit::Section`), so this is a permissive-payload additive change with no frontmatter or JSON-schema edit, mirroring spec 017. The motivating cases are ASI security boundaries: `permissions:` (GITHUB_TOKEN scope) and `on`/`on.merge_group` (the trigger and merge-queue contract). Section ownership of those keys means any token-scope escalation or trigger change forces the owning spec's review. A hard file-eligibility predicate keeps the grammar pointed at surfaces spec-spine has a first-party reason to parse and off foreign tool schemas (deny.toml, Helm values, k8s manifests), which their owners rev independently. This retires the `# region:`-in-structured-config escape hatch for the eligible surfaces: a structural keypath is computed from the document tree and cannot silently drift from the block it claims, the way a hand-placed region marker can.\n",
       "title": "Bounded keypath section anchors for first-party structured config"
+    },
+    {
+      "authors": [
+        "The spec-spine Authors"
+      ],
+      "created": "2026-06-16",
+      "dependsOn": [
+        "001-compile-registry",
+        "003-conformance-lint",
+        "004-codebase-index",
+        "005-coupling-gate"
+      ],
+      "establishes": [
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/attest.rs"
+        },
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/attest.rs"
+        },
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/attest.rs"
+        },
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/seal.rs"
+        },
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_attest.rs"
+        },
+        {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      ],
+      "extends": [
+        {
+          "nature": "additive",
+          "spec": "000-spec-spine-bootstrap",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-types/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-core/src/lib.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/src/main.rs"
+          }
+        },
+        {
+          "nature": "additive",
+          "spec": "001-compile-registry",
+          "unit": {
+            "kind": "file",
+            "path": "crates/spec-spine-cli/Cargo.toml"
+          }
+        }
+      ],
+      "id": "023-ledger-seal",
+      "implementation": "complete",
+      "kind": "tooling",
+      "references": [
+        {
+          "role": "context",
+          "unit": {
+            "kind": "file",
+            "path": "docs/design/00-architecture.md"
+          }
+        }
+      ],
+      "risk": "medium",
+      "sectionHeadings": [
+        "023: Ledger Seal",
+        "1. Purpose",
+        "2. Territory",
+        "3. Object shape",
+        "4. Functional requirements",
+        "5. Acceptance criteria",
+        "6. Out of scope",
+        "7. Naming (deliberate)",
+        "8. Sequencing"
+      ],
+      "specPath": "specs/023-ledger-seal/spec.md",
+      "status": "draft",
+      "summary": "spec-spine self-describes as a typed, hash-verifiable authority ledger over a markdown spec corpus. A hash-verifiable ledger is an attestation missing only two things: a signature and a verify. This spec completes that sentence. It adds a CorpusAttestation, a deterministic, pure-function payload over the inputs manifest, the registry hash, and the compile/lint (and optionally coupling) verdicts, plus a detached Ed25519 seal over its hash, and a two-mode verify-attestation (recompute, which any third party can run with no key, and signature, which is opt-in). The reproducible recompute mode is the property a run certificate can never have, because runs are side-effecting; this object is the signed, archival, independently-verifiable form of a verdict spec-spine already computes and then throws away into a CI log. It is deliberately NOT called a certificate: that word stays with run-provenance (signed testimony of a non-reproducible event). This is an attestation (recomputable truth).\n",
+      "title": "Ledger Seal (signed, reproducible attestation over the spec corpus)"
     }
   ],
   "validation": {

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ __pycache__/
 # The one exception: build-meta.json carries a wall-clock `builtAt` (the sole
 # non-deterministic artifact), so it would churn on every compile; ignore it.
 .derived/**/build-meta.json
+# The ledger-seal attestation (spec 023) is an on-demand artifact (and the seal
+# carries a wall-clock `signedAt`); it is not part of the committed dogfood set.
+.derived/attestation/
 
 # OS / editor cruft
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -92,6 +92,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -210,6 +216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +238,43 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -256,6 +305,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -299,6 +372,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -393,6 +472,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -837,6 +927,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +974,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ref-cast"
@@ -972,6 +1081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1113,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1092,6 +1216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1251,7 @@ name = "spec-spine-cli"
 version = "0.4.0"
 dependencies = [
  "clap",
+ "ed25519-dalek",
  "serde",
  "serde_json",
  "spec-spine-core",
@@ -1156,6 +1290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1316,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1211,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1685,6 +1835,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ toml_edit = "0.22"
 sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 time = { version = "0.3", features = ["formatting"] }
+# Detached Ed25519 seal over a corpus attestation (spec 023). CLI-only: the pure
+# core and the type substrate stay crypto-free and key-free.
+ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
 spec-spine-types = { version = "0.4.0", path = "crates/spec-spine-types" }
 spec-spine-core = { version = "0.4.0", path = "crates/spec-spine-core" }

--- a/crates/spec-spine-cli/Cargo.toml
+++ b/crates/spec-spine-cli/Cargo.toml
@@ -28,6 +28,9 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }
+# Ed25519 detached seal over a corpus attestation (spec 023, FR-003): signing
+# and signature verification live here so the core stays key-free.
+ed25519-dalek = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/spec-spine-cli/src/cmd_attest.rs
+++ b/crates/spec-spine-cli/src/cmd_attest.rs
@@ -1,0 +1,103 @@
+//! `spec-spine attest`: emit a reproducible corpus attestation under
+//! `<derived_dir>/attestation/`, and optionally seal it (spec 023).
+//!
+//! The attestation itself is pure (built in `spec-spine-core::attest`); this
+//! command is the IO + clock shell: it writes the artifact and, under `--sign`,
+//! the wall-clock-dated detached seal.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use spec_spine_core::{AttestOptions, attest};
+use spec_spine_types::Error;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::load_repo_config;
+use crate::seal;
+
+/// Parsed `attest` arguments.
+pub struct AttestArgs {
+    pub with_coupling: bool,
+    pub sign: bool,
+    pub key: Option<PathBuf>,
+    pub key_id: Option<String>,
+}
+
+/// Writes `attestation.json` (always) and `attestation.sig` (under `--sign`).
+/// Exit `0` on success; a `--sign` with no `--key` is a visible config error
+/// (FR-006: a mode that cannot run fails, never skip-as-pass).
+pub fn run(repo: &Path, args: &AttestArgs) -> Result<u8, Error> {
+    let cfg = load_repo_config(repo)?;
+
+    // FR-006 (fail-closed, no side effects on a usage error): when signing,
+    // resolve the key BEFORE building or writing the attestation, so a missing
+    // or invalid key fails before any artifact lands on disk.
+    let signer = if args.sign {
+        let key_path = args.key.as_ref().ok_or_else(|| {
+            Error::Config(
+                "attest --sign requires --key <path> (a 32-byte ed25519 signing key, raw or hex)"
+                    .to_string(),
+            )
+        })?;
+        let signing_key = seal::load_signing_key(key_path)?;
+        let key_id = args
+            .key_id
+            .clone()
+            .unwrap_or_else(|| seal::default_key_id(&signing_key));
+        Some((signing_key, key_id))
+    } else {
+        None
+    };
+
+    let outcome = attest(
+        &cfg,
+        repo,
+        AttestOptions {
+            with_coupling: args.with_coupling,
+        },
+    )?;
+
+    let out_dir = repo.join(&cfg.layout.derived_dir).join("attestation");
+    fs::create_dir_all(&out_dir)
+        .map_err(|e| Error::Io(format!("create {}: {e}", out_dir.display())))?;
+    let attestation_path = out_dir.join("attestation.json");
+    fs::write(&attestation_path, &outcome.json)
+        .map_err(|e| Error::Io(format!("write {}: {e}", attestation_path.display())))?;
+
+    let scope = if args.with_coupling {
+        "specs+code"
+    } else {
+        "spec-corpus"
+    };
+    println!("attested {scope} -> {}", attestation_path.display());
+    println!("  attestationHash: {}", outcome.attestation_hash);
+
+    if let Some((signing_key, key_id)) = signer {
+        let ledger_seal = seal::sign(
+            &outcome.attestation_hash,
+            &signing_key,
+            key_id,
+            now_rfc3339(),
+        )?;
+        let seal_json = serde_json::to_string_pretty(&ledger_seal)
+            .map_err(|e| Error::Schema(e.to_string()))?
+            + "\n";
+        let seal_path = out_dir.join("attestation.sig");
+        fs::write(&seal_path, seal_json)
+            .map_err(|e| Error::Io(format!("write {}: {e}", seal_path.display())))?;
+        println!(
+            "sealed -> {} (alg ed25519, keyId {})",
+            seal_path.display(),
+            ledger_seal.key_id
+        );
+    }
+
+    Ok(0)
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "unknown".to_string())
+}

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -3,12 +3,15 @@
 //! typed `Error` to a stable process exit code. All `process::exit`, stdout, and
 //! `git`/clock side effects live here, never in the library.
 
+mod cmd_attest;
 mod cmd_compile;
 mod cmd_couple;
 mod cmd_index;
 mod cmd_init;
 mod cmd_lint;
 mod cmd_registry;
+mod seal;
+mod verify_attestation;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -75,6 +78,39 @@ enum Command {
         #[arg(long)]
         force: bool,
     },
+    /// Emit a reproducible corpus attestation; optionally seal it (spec 023).
+    Attest {
+        /// Also record the coupling (specs-and-code-in-sync) verdict.
+        #[arg(long)]
+        with_coupling: bool,
+        /// Produce a detached Ed25519 seal over the attestation hash.
+        #[arg(long)]
+        sign: bool,
+        /// The ed25519 signing key (32-byte seed; raw or hex). Required with --sign.
+        #[arg(long, value_name = "PATH")]
+        key: Option<PathBuf>,
+        /// Override the seal's key id (defaults to the hex public key).
+        #[arg(long, value_name = "ID")]
+        key_id: Option<String>,
+    },
+    /// Verify a corpus attestation by recompute and/or detached signature.
+    VerifyAttestation {
+        /// Re-read the corpus and check it reproduces the attestation (no key).
+        #[arg(long)]
+        recompute: bool,
+        /// Check the detached seal against a supplied public key.
+        #[arg(long)]
+        signature: bool,
+        /// The attestation file (defaults to <derived>/attestation/attestation.json).
+        #[arg(long, value_name = "PATH")]
+        attestation: Option<PathBuf>,
+        /// The ed25519 public key (32 bytes; raw or hex). Required with --signature.
+        #[arg(long, value_name = "PATH")]
+        public_key: Option<PathBuf>,
+        /// The detached seal file (defaults to the attestation's sibling .sig).
+        #[arg(long, value_name = "PATH")]
+        seal: Option<PathBuf>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -107,6 +143,36 @@ fn main() -> ExitCode {
             },
         ),
         Command::Init { force } => cmd_init::run(&repo, *force),
+        Command::Attest {
+            with_coupling,
+            sign,
+            key,
+            key_id,
+        } => cmd_attest::run(
+            &repo,
+            &cmd_attest::AttestArgs {
+                with_coupling: *with_coupling,
+                sign: *sign,
+                key: key.clone(),
+                key_id: key_id.clone(),
+            },
+        ),
+        Command::VerifyAttestation {
+            recompute,
+            signature,
+            attestation,
+            public_key,
+            seal,
+        } => verify_attestation::run(
+            &repo,
+            &verify_attestation::VerifyArgs {
+                recompute: *recompute,
+                signature: *signature,
+                attestation: attestation.clone(),
+                public_key: public_key.clone(),
+                seal: seal.clone(),
+            },
+        ),
     };
 
     match result {

--- a/crates/spec-spine-cli/src/seal.rs
+++ b/crates/spec-spine-cli/src/seal.rs
@@ -1,0 +1,178 @@
+//! The detached Ed25519 seal over a corpus attestation (spec 023, FR-003).
+//!
+//! Signing is a **post-pass over an already-emitted hash**: this module is the
+//! only place in spec-spine that handles a key, deliberately kept in the CLI so
+//! the pure core (`spec-spine-core::attest`) and the type substrate stay
+//! crypto-free and key-free. The signed message is the 32 raw bytes of the
+//! attestation hash; `key_id` and `signed_at` live in the [`LedgerSeal`]
+//! envelope, never in the attested payload.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use spec_spine_types::{Error, LedgerSeal};
+
+/// Load an Ed25519 signing key (a 32-byte seed) from `path`. Accepts the raw 32
+/// bytes or a 64-char lowercase/uppercase hex string (with optional trailing
+/// whitespace).
+pub fn load_signing_key(path: &Path) -> Result<SigningKey, Error> {
+    let raw = fs::read(path)
+        .map_err(|e| Error::Io(format!("read signing key {}: {e}", path.display())))?;
+    let seed = parse_key_bytes(&raw, "signing key")?;
+    Ok(SigningKey::from_bytes(&seed))
+}
+
+/// Load an Ed25519 public key (32 bytes, raw or hex) from `path`.
+pub fn load_verifying_key(path: &Path) -> Result<VerifyingKey, Error> {
+    let raw = fs::read(path)
+        .map_err(|e| Error::Io(format!("read public key {}: {e}", path.display())))?;
+    let bytes = parse_key_bytes(&raw, "public key")?;
+    VerifyingKey::from_bytes(&bytes)
+        .map_err(|e| Error::Config(format!("invalid ed25519 public key: {e}")))
+}
+
+/// The default `key_id` for a signing key: the lowercase-hex public key.
+pub fn default_key_id(signing_key: &SigningKey) -> String {
+    hex_encode(signing_key.verifying_key().as_bytes())
+}
+
+/// Sign `attestation_hash` (lowercase hex of the 32-byte hash) with `signing_key`,
+/// producing the detached [`LedgerSeal`]. `signed_at` is the CLI-supplied
+/// wall-clock instant (RFC3339); the core never reads the clock.
+pub fn sign(
+    attestation_hash: &str,
+    signing_key: &SigningKey,
+    key_id: String,
+    signed_at: String,
+) -> Result<LedgerSeal, Error> {
+    let digest = hex_decode(attestation_hash)?;
+    let signature = signing_key.sign(&digest);
+    Ok(LedgerSeal {
+        alg: "ed25519".to_string(),
+        key_id,
+        signed_at,
+        sig: hex_encode(&signature.to_bytes()),
+    })
+}
+
+/// Verify a [`LedgerSeal`] over `attestation_hash` against `verifying_key`.
+/// Returns `Ok(true)` for a valid signature, `Ok(false)` for a mismatch, and
+/// `Err` only when the seal is structurally unusable (unknown alg, malformed
+/// hex). Uses `verify_strict` (rejects non-canonical / weak-key signatures).
+pub fn verify(
+    attestation_hash: &str,
+    seal: &LedgerSeal,
+    verifying_key: &VerifyingKey,
+) -> Result<bool, Error> {
+    if seal.alg != "ed25519" {
+        return Err(Error::Config(format!(
+            "unsupported seal algorithm '{}' (only ed25519 is supported)",
+            seal.alg
+        )));
+    }
+    let digest = hex_decode(attestation_hash)?;
+    let sig_bytes = hex_decode(&seal.sig)?;
+    let sig_arr: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| Error::Parse("ed25519 signature must be 64 bytes".to_string()))?;
+    let signature = Signature::from_bytes(&sig_arr);
+    Ok(verifying_key.verify_strict(&digest, &signature).is_ok())
+}
+
+// --- small hex + key-bytes helpers (kept local; the core's hash.rs is private) ---
+
+/// Parse a 32-byte key from raw bytes or a 64-char hex string.
+fn parse_key_bytes(raw: &[u8], what: &str) -> Result<[u8; 32], Error> {
+    if let Ok(text) = std::str::from_utf8(raw) {
+        let trimmed = text.trim();
+        if trimmed.len() == 64 && trimmed.bytes().all(|b| b.is_ascii_hexdigit()) {
+            let bytes = hex_decode(trimmed)?;
+            return bytes
+                .try_into()
+                .map_err(|_| Error::Config(format!("{what} must be 32 bytes")));
+        }
+    }
+    if raw.len() == 32 {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(raw);
+        return Ok(arr);
+    }
+    Err(Error::Config(format!(
+        "{what} must be 32 raw bytes or a 64-character hex string"
+    )))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn hex_decode(s: &str) -> Result<Vec<u8>, Error> {
+    let s = s.trim();
+    if s.len() % 2 != 0 {
+        return Err(Error::Parse("hex string has an odd length".to_string()));
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&s[i..i + 2], 16)
+                .map_err(|e| Error::Parse(format!("invalid hex: {e}")))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A fixed seed keeps the test deterministic (no RNG): the attestation is
+    // pure, and so is this round-trip.
+    fn fixed_key() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    const HASH: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    #[test]
+    fn sign_then_verify_round_trips() {
+        let key = fixed_key();
+        let seal = sign(
+            HASH,
+            &key,
+            default_key_id(&key),
+            "2026-06-16T00:00:00Z".to_string(),
+        )
+        .unwrap();
+        assert_eq!(seal.alg, "ed25519");
+        assert!(verify(HASH, &seal, &key.verifying_key()).unwrap());
+    }
+
+    #[test]
+    fn a_tampered_hash_fails_verification() {
+        let key = fixed_key();
+        let seal = sign(HASH, &key, "k".to_string(), "t".to_string()).unwrap();
+        let other = "00".repeat(32);
+        assert!(!verify(&other, &seal, &key.verifying_key()).unwrap());
+    }
+
+    #[test]
+    fn a_wrong_key_fails_verification() {
+        let key = fixed_key();
+        let seal = sign(HASH, &key, "k".to_string(), "t".to_string()).unwrap();
+        let wrong = SigningKey::from_bytes(&[9u8; 32]);
+        assert!(!verify(HASH, &seal, &wrong.verifying_key()).unwrap());
+    }
+
+    #[test]
+    fn key_bytes_parse_hex_and_raw() {
+        let hex = "00".repeat(32);
+        assert_eq!(parse_key_bytes(hex.as_bytes(), "k").unwrap(), [0u8; 32]);
+        assert_eq!(parse_key_bytes(&[1u8; 32], "k").unwrap(), [1u8; 32]);
+        assert!(parse_key_bytes(b"short", "k").is_err());
+    }
+}

--- a/crates/spec-spine-cli/src/verify_attestation.rs
+++ b/crates/spec-spine-cli/src/verify_attestation.rs
@@ -1,0 +1,128 @@
+//! `spec-spine verify-attestation`: two independent verification modes (spec 023
+//! FR-004), either or both selectable in one invocation.
+//!
+//! `--recompute` re-reads the corpus and checks it reproduces the attestation:
+//! no key, no signature, offline, runnable by any third party. It is the load
+//! bearing property the run certificate structurally cannot have. `--signature`
+//! checks the detached seal against a supplied public key. A mode that cannot
+//! run fails visibly (FR-006); skip-as-pass is forbidden.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use spec_spine_core::{VerifyOutcome, attestation_hash, verify_recompute};
+use spec_spine_types::{Config, CorpusAttestation, Error, LedgerSeal};
+
+use crate::load_repo_config;
+use crate::seal;
+
+/// Parsed `verify-attestation` arguments.
+pub struct VerifyArgs {
+    pub recompute: bool,
+    pub signature: bool,
+    pub attestation: Option<PathBuf>,
+    pub public_key: Option<PathBuf>,
+    pub seal: Option<PathBuf>,
+}
+
+/// Exit `0` only if every selected mode passes; `1` on any mismatch or version
+/// mismatch (a named, non-pass outcome). A missing mode or missing key is a
+/// visible config error (exit 3), never a silent pass.
+pub fn run(repo: &Path, args: &VerifyArgs) -> Result<u8, Error> {
+    if !args.recompute && !args.signature {
+        return Err(Error::Config(
+            "verify-attestation requires at least one mode: --recompute and/or --signature"
+                .to_string(),
+        ));
+    }
+
+    let cfg = load_repo_config(repo)?;
+    let attestation_path = args
+        .attestation
+        .clone()
+        .unwrap_or_else(|| default_attestation_path(repo, &cfg));
+    let attestation = load_attestation(&attestation_path)?;
+
+    let mut failed = false;
+
+    if args.recompute {
+        match verify_recompute(&cfg, repo, &attestation)? {
+            VerifyOutcome::Match => {
+                println!("recompute: MATCH (the corpus reproduces this attestation)");
+            }
+            VerifyOutcome::VersionMismatch { expected, actual } => {
+                eprintln!(
+                    "recompute: VERSION MISMATCH (attested under {expected}, this tool is {actual}); \
+                     recompute under {expected} to verify"
+                );
+                failed = true;
+            }
+            VerifyOutcome::ContentMismatch { differences } => {
+                eprintln!(
+                    "recompute: CONTENT MISMATCH ({} field(s) diverged):",
+                    differences.len()
+                );
+                for d in &differences {
+                    eprintln!("  - {d}");
+                }
+                failed = true;
+            }
+        }
+    }
+
+    if args.signature {
+        let pk_path = args.public_key.as_ref().ok_or_else(|| {
+            Error::Config(
+                "verify-attestation --signature requires --public-key <path> (a 32-byte ed25519 public key)"
+                    .to_string(),
+            )
+        })?;
+        let verifying_key = seal::load_verifying_key(pk_path)?;
+        let seal_path = args
+            .seal
+            .clone()
+            .unwrap_or_else(|| attestation_path.with_file_name("attestation.sig"));
+        let ledger_seal = load_seal(&seal_path)?;
+        // Recompute the hash from the loaded payload: a tampered byte changes it
+        // and the seal stops verifying.
+        let hash = attestation_hash(&attestation)?;
+        if seal::verify(&hash, &ledger_seal, &verifying_key)? {
+            println!("signature: VALID (sealed by keyId {})", ledger_seal.key_id);
+        } else {
+            eprintln!(
+                "signature: INVALID (the seal does not verify against the supplied public key)"
+            );
+            failed = true;
+        }
+    }
+
+    Ok(if failed { 1 } else { 0 })
+}
+
+fn default_attestation_path(repo: &Path, cfg: &Config) -> PathBuf {
+    repo.join(&cfg.layout.derived_dir)
+        .join("attestation")
+        .join("attestation.json")
+}
+
+fn load_attestation(path: &Path) -> Result<CorpusAttestation, Error> {
+    let bytes = fs::read(path).map_err(|e| {
+        Error::Io(format!(
+            "read attestation {} (run `spec-spine attest` first?): {e}",
+            path.display()
+        ))
+    })?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| Error::Parse(format!("invalid attestation {}: {e}", path.display())))
+}
+
+fn load_seal(path: &Path) -> Result<LedgerSeal, Error> {
+    let bytes = fs::read(path).map_err(|e| {
+        Error::Io(format!(
+            "read seal {} (run `spec-spine attest --sign` first?): {e}",
+            path.display()
+        ))
+    })?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| Error::Parse(format!("invalid seal {}: {e}", path.display())))
+}

--- a/crates/spec-spine-core/src/attest.rs
+++ b/crates/spec-spine-core/src/attest.rs
@@ -1,0 +1,259 @@
+//! The attest capability (spec 023): a pure, reproducible attestation over the
+//! spec corpus state.
+//!
+//! `attest` freezes a verdict spec-spine already computes (`compile`, `lint`,
+//! and optionally `couple`) into a [`CorpusAttestation`]: a pure function of
+//! `(config, file contents)` with no clock, no env, and **no key**. Re-running
+//! it on an unchanged corpus at the same tool version yields a byte-identical
+//! payload, which is exactly what makes `verify_recompute` runnable by any third
+//! party with no key and no trust in the signer. Signing is a separate, key-only
+//! post-pass that lives in the CLI (`seal.rs`); this module never touches a key.
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+use spec_spine_types::{
+    ATTESTATION_SCHEMA_VERSION, CompileVerdict, CorpusAttestation, CoupleVerdict, Error,
+    LintVerdict, Severity, ToolStamp, Verdicts,
+};
+
+use crate::canonical_json;
+use crate::compile::compile;
+use crate::index::index;
+use crate::lint::lint;
+
+/// Resolver diagnostics that mark code as out of sync with its claiming spec.
+/// A **local mirror** of `index.rs::BLOCKING_CODES` (kept equal by value and
+/// this comment, not by linkage, so the attest capability does not take a code
+/// dependency on the indexer's private constant): the same set that
+/// `check_index_freshness` treats as a hard failure.
+const BLOCKING_RESOLVER_CODES: &[&str] = &[
+    "I-003", "I-004", "I-005", "I-006", "I-007", "I-008", "I-009",
+];
+
+/// Inputs to a [`attest`] run beyond `(config, file contents)`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AttestOptions {
+    /// Record the coupling (specs-and-code-in-sync) verdict as well (FR-002).
+    /// Without it the attestation covers spec-corpus state only.
+    pub with_coupling: bool,
+}
+
+/// The result of an [`attest`] run: the typed attestation, its canonical JSON,
+/// and the hash a consumer references and a seal signs.
+pub struct AttestOutcome {
+    pub attestation: CorpusAttestation,
+    /// Canonical `CorpusAttestation` JSON (sorted keys, 2-space, trailing LF).
+    pub json: String,
+    /// SHA-256 (lowercase hex) over [`AttestOutcome::json`]. Emitted alongside,
+    /// never inside, the attestation: it is the chain handle a consumer
+    /// references and the message a [`crate::types::LedgerSeal`] signs.
+    pub attestation_hash: String,
+}
+
+/// The outcome of a `--recompute` verification (FR-004/FR-005).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VerifyOutcome {
+    /// The recomputed attestation is byte-identical to the supplied one.
+    Match,
+    /// The attestation was produced by a different tool version; recompute is
+    /// not meaningful. A distinct, named outcome: never a false content
+    /// mismatch, never a skip-as-pass (FR-005).
+    VersionMismatch { expected: String, actual: String },
+    /// The corpus recomputes to a different attestation. Each entry names a
+    /// field that diverged (FR-004).
+    ContentMismatch { differences: Vec<String> },
+}
+
+/// Build a [`CorpusAttestation`] over the corpus under `repo_root`.
+///
+/// Pure function of `(config, file contents)`: it runs `compile` and `lint`
+/// (and `index` under `--with-coupling`), all themselves pure, and hashes their
+/// canonical outputs. No clock, no env, no key.
+pub fn attest(
+    cfg: &spec_spine_types::Config,
+    repo_root: &Path,
+    opts: AttestOptions,
+) -> Result<AttestOutcome, Error> {
+    // compile: the inputs-manifest and registry hashes plus the compile verdict.
+    let compiled = compile(cfg, repo_root)?;
+    let inputs_manifest_hash = compiled.registry.build.content_hash.clone();
+    let registry_hash = sha256_hex(compiled.json.as_bytes());
+    let compile_ok = compiled.validation_passed;
+
+    // lint: the verdict and a hash over the canonical findings. `ok` mirrors the
+    // repo's own `lint --fail-on-warn` gate (no error and no warning; info-tier
+    // is advisory), which is the meaningful "corpus is consistent" claim for an
+    // audit attestation. `findings_hash` captures every finding (including info),
+    // so any change in the findings set is detectable on recompute.
+    let lint_report = lint(cfg, repo_root)?;
+    let lint_ok =
+        lint_report.count(Severity::Error) == 0 && lint_report.count(Severity::Warning) == 0;
+    let findings_hash = sha256_hex(canonical_json::to_string(&lint_report.violations)?.as_bytes());
+
+    // couple (optional, FR-002): specs and code are in sync iff the index built
+    // with no blocking resolver diagnostic (every claimed unit resolves). Pure:
+    // no git diff is needed, so the core stays git-free.
+    let couple = if opts.with_coupling {
+        let outcome = index(cfg, repo_root)?;
+        let index_hash = outcome.index.build.content_hash.clone();
+        let blocking = outcome
+            .index
+            .diagnostics
+            .errors
+            .iter()
+            .any(|d| BLOCKING_RESOLVER_CODES.contains(&d.code.as_str()));
+        let join_hash = sha256_hex(format!("{registry_hash}:{index_hash}").as_bytes());
+        Some(CoupleVerdict {
+            ok: !blocking,
+            index_hash,
+            join_hash,
+        })
+    } else {
+        None
+    };
+
+    let attestation = CorpusAttestation {
+        schema_version: ATTESTATION_SCHEMA_VERSION.to_string(),
+        tool: ToolStamp {
+            name: cfg.branding.compiler_id.clone(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        inputs_manifest_hash,
+        registry_hash,
+        verdicts: Verdicts {
+            compile: CompileVerdict { ok: compile_ok },
+            lint: LintVerdict {
+                ok: lint_ok,
+                findings_hash,
+            },
+            couple,
+        },
+    };
+
+    let json = canonical_json::to_string(&attestation)?;
+    let hash = sha256_hex(json.as_bytes());
+    Ok(AttestOutcome {
+        attestation,
+        json,
+        attestation_hash: hash,
+    })
+}
+
+/// The hash a seal signs and a consumer references: SHA-256 (lowercase hex) over
+/// the canonical JSON of `attestation`. Recomputing it from a *loaded* payload
+/// is what keeps a signature check tamper-evident: a single changed byte changes
+/// the canonical bytes and therefore the hash, so the seal no longer verifies.
+pub fn attestation_hash(attestation: &CorpusAttestation) -> Result<String, Error> {
+    Ok(sha256_hex(
+        canonical_json::to_string(attestation)?.as_bytes(),
+    ))
+}
+
+/// Re-read the corpus and verify it still recomputes to `attestation`
+/// (FR-004 `--recompute`). Version-aware (FR-005): if the attestation's
+/// `tool.version` differs from this build's, the result is
+/// [`VerifyOutcome::VersionMismatch`], not a content mismatch. The recompute
+/// scope mirrors the attestation (coupling is recomputed iff the attestation
+/// carries a coupling block).
+pub fn verify_recompute(
+    cfg: &spec_spine_types::Config,
+    repo_root: &Path,
+    attestation: &CorpusAttestation,
+) -> Result<VerifyOutcome, Error> {
+    let actual_version = env!("CARGO_PKG_VERSION");
+    if attestation.tool.version != actual_version {
+        return Ok(VerifyOutcome::VersionMismatch {
+            expected: attestation.tool.version.clone(),
+            actual: actual_version.to_string(),
+        });
+    }
+
+    let recomputed = attest(
+        cfg,
+        repo_root,
+        AttestOptions {
+            with_coupling: attestation.verdicts.couple.is_some(),
+        },
+    )?
+    .attestation;
+
+    let mut differences = Vec::new();
+    let a = attestation;
+    let b = &recomputed;
+    if a.tool.name != b.tool.name {
+        differences.push(format!("tool.name ({} -> {})", a.tool.name, b.tool.name));
+    }
+    if a.inputs_manifest_hash != b.inputs_manifest_hash {
+        differences.push("inputsManifestHash (corpus inputs changed)".to_string());
+    }
+    if a.registry_hash != b.registry_hash {
+        differences.push("registryHash (compiled registry changed)".to_string());
+    }
+    if a.verdicts.compile.ok != b.verdicts.compile.ok {
+        differences.push(format!(
+            "verdicts.compile.ok ({} -> {})",
+            a.verdicts.compile.ok, b.verdicts.compile.ok
+        ));
+    }
+    if a.verdicts.lint.ok != b.verdicts.lint.ok {
+        differences.push(format!(
+            "verdicts.lint.ok ({} -> {})",
+            a.verdicts.lint.ok, b.verdicts.lint.ok
+        ));
+    }
+    if a.verdicts.lint.findings_hash != b.verdicts.lint.findings_hash {
+        differences.push("verdicts.lint.findingsHash (lint findings changed)".to_string());
+    }
+    match (&a.verdicts.couple, &b.verdicts.couple) {
+        (Some(av), Some(bv)) => {
+            if av.ok != bv.ok {
+                differences.push(format!("verdicts.couple.ok ({} -> {})", av.ok, bv.ok));
+            }
+            if av.index_hash != bv.index_hash {
+                differences.push("verdicts.couple.indexHash (code index changed)".to_string());
+            }
+            if av.join_hash != bv.join_hash {
+                differences.push("verdicts.couple.joinHash".to_string());
+            }
+        }
+        (None, None) => {}
+        // Scope is recomputed from the attestation, so this is unreachable in
+        // practice; recorded as a difference rather than panicking.
+        _ => differences.push("verdicts.couple (scope presence changed)".to_string()),
+    }
+
+    if differences.is_empty() {
+        Ok(VerifyOutcome::Match)
+    } else {
+        Ok(VerifyOutcome::ContentMismatch { differences })
+    }
+}
+
+/// SHA-256 (lowercase hex) over raw bytes. (Distinct from
+/// `hash::content_hash`, which hashes path-keyed, normalized input pieces; here
+/// the inputs are already-canonical bytes.)
+fn sha256_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_hex_is_lowercase_64_hex() {
+        let h = sha256_hex(b"abc");
+        assert_eq!(
+            h,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(h.len(), 64);
+    }
+}

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -12,6 +12,7 @@
 //! [`lint_json`], [`couple_json`], [`scaffold_init_json`], …) is the seam future
 //! FFI bindings wrap.
 
+pub mod attest;
 mod canonical_json;
 pub mod compile;
 pub mod couple;
@@ -28,8 +29,8 @@ pub mod scaffold;
 pub mod sections;
 pub mod symbols;
 
-use serde::Deserialize;
-use spec_spine_types::{Config, Error, Status, load_config};
+use serde::{Deserialize, Serialize};
+use spec_spine_types::{Config, CorpusAttestation, Error, Status, load_config};
 
 // Re-export the type substrate so callers depend on one crate.
 pub use spec_spine_types as types;
@@ -37,6 +38,9 @@ pub use spec_spine_types::{
     CodebaseIndex, Frontmatter, REGISTRY_SCHEMA_VERSION, Registry, SpecRecord, Unit, Violation,
 };
 
+pub use attest::{
+    AttestOptions, AttestOutcome, VerifyOutcome, attest, attestation_hash, verify_recompute,
+};
 pub use compile::{CompileOutcome, MAX_UNDECLARED_EXTRA_FRONTMATTER, compile};
 pub use couple::{
     CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, couple, couple_with,
@@ -219,6 +223,66 @@ pub fn couple_json(request_json: &str) -> Result<String, Error> {
 pub fn scaffold_init_json(config_json: &str) -> Result<String, Error> {
     let config = config_from_json(config_json)?;
     to_json(&scaffold_init(&config)?)
+}
+
+/// Build a corpus attestation (spec 023). Returns
+/// `{ "attestation": <CorpusAttestation>, "attestationHash": "<hex>" }`. Pure:
+/// no key (signing is a CLI post-pass), no clock. `with_coupling` records the
+/// in-sync coupling verdict as well (FR-002).
+pub fn attest_json(
+    config_json: &str,
+    repo_root: &str,
+    with_coupling: bool,
+) -> Result<String, Error> {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Response {
+        attestation: CorpusAttestation,
+        attestation_hash: String,
+    }
+    let config = config_from_json(config_json)?;
+    let outcome = attest(
+        &config,
+        std::path::Path::new(repo_root),
+        AttestOptions { with_coupling },
+    )?;
+    to_json(&Response {
+        attestation: outcome.attestation,
+        attestation_hash: outcome.attestation_hash,
+    })
+}
+
+/// Verify an attestation by recompute (spec 023 FR-004 `--recompute`). Request:
+/// `{ "config"?: Config, "repoRoot": string, "attestation": <CorpusAttestation> }`.
+/// Returns `{ "outcome": "match" }`, `{ "outcome": "versionMismatch", "expected",
+/// "actual" }`, or `{ "outcome": "contentMismatch", "differences": [...] }`. This
+/// mode needs no key and no signature: any third party can run it.
+pub fn verify_attestation_json(request_json: &str) -> Result<String, Error> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct Request {
+        #[serde(default)]
+        config: Config,
+        repo_root: String,
+        attestation: CorpusAttestation,
+    }
+    let request: Request = serde_json::from_str(request_json)
+        .map_err(|e| Error::Parse(format!("invalid verify-attestation request: {e}")))?;
+    let outcome = verify_recompute(
+        &request.config,
+        std::path::Path::new(&request.repo_root),
+        &request.attestation,
+    )?;
+    let value = match outcome {
+        VerifyOutcome::Match => serde_json::json!({ "outcome": "match" }),
+        VerifyOutcome::VersionMismatch { expected, actual } => {
+            serde_json::json!({ "outcome": "versionMismatch", "expected": expected, "actual": actual })
+        }
+        VerifyOutcome::ContentMismatch { differences } => {
+            serde_json::json!({ "outcome": "contentMismatch", "differences": differences })
+        }
+    };
+    Ok(value.to_string())
 }
 
 // --- facade helpers ---

--- a/crates/spec-spine-core/tests/attest.rs
+++ b/crates/spec-spine-core/tests/attest.rs
@@ -1,0 +1,144 @@
+//! Attest (spec 023): determinism (AC-1), recompute match/mismatch (AC-2), the
+//! coupling scope and its independently-checkable verdict (AC-3), and
+//! version-aware verification (AC-5). The signature round-trip (AC-4) lives in
+//! the CLI crate's `seal.rs` unit tests: the core is key-free.
+
+use std::fs;
+use std::path::Path;
+
+use spec_spine_core::{AttestOptions, VerifyOutcome, attest, verify_recompute};
+use spec_spine_types::Config;
+
+/// Write `specs/<id>/spec.md` under `root` with the given extra frontmatter.
+fn write_spec(root: &Path, dir: &str, id: &str, extra: &str) {
+    let spec_dir = root.join("specs").join(dir);
+    fs::create_dir_all(&spec_dir).unwrap();
+    let body = format!(
+        "---\nid: \"{id}\"\ntitle: \"Title {id}\"\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: \"s\"\n{extra}---\n# {id}\n"
+    );
+    fs::write(spec_dir.join("spec.md"), body).unwrap();
+}
+
+/// An ownership edge keeps the spec warning-clean (no L-001), so the lint
+/// verdict is `ok` under the `--fail-on-warn`-equivalent rule. The claimed file
+/// need not exist for the non-coupling cases (compile/lint do not check units).
+const OWNED: &str = "establishes:\n  - \"code.txt\"\n";
+
+#[test]
+fn ac1_attest_is_byte_identical_on_an_unchanged_corpus() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", OWNED);
+    let cfg = Config::default();
+
+    let a = attest(&cfg, tmp.path(), AttestOptions::default()).unwrap();
+    let b = attest(&cfg, tmp.path(), AttestOptions::default()).unwrap();
+
+    assert_eq!(a.json, b.json, "attestation must be byte-identical");
+    assert_eq!(a.attestation_hash, b.attestation_hash);
+    assert!(
+        a.attestation.verdicts.couple.is_none(),
+        "no coupling block without --with-coupling"
+    );
+    assert!(a.attestation.verdicts.compile.ok);
+    assert!(a.attestation.verdicts.lint.ok);
+    assert!(a.json.ends_with("}\n"), "canonical trailing newline");
+}
+
+#[test]
+fn ac2_recompute_matches_unchanged_then_flags_an_edited_spec() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", OWNED);
+    let cfg = Config::default();
+    let outcome = attest(&cfg, tmp.path(), AttestOptions::default()).unwrap();
+
+    assert_eq!(
+        verify_recompute(&cfg, tmp.path(), &outcome.attestation).unwrap(),
+        VerifyOutcome::Match,
+        "an unchanged corpus reproduces the attestation"
+    );
+
+    // A single spec edit flips it to a named mismatch citing the changed input.
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        &format!("{OWNED}owner: \"someone\"\n"),
+    );
+    match verify_recompute(&cfg, tmp.path(), &outcome.attestation).unwrap() {
+        VerifyOutcome::ContentMismatch { differences } => assert!(
+            differences
+                .iter()
+                .any(|d| d.contains("inputsManifestHash") || d.contains("registryHash")),
+            "mismatch must cite the changed input/registry: {differences:?}"
+        ),
+        other => panic!("expected ContentMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn ac5_a_different_tool_version_is_a_named_version_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", OWNED);
+    let cfg = Config::default();
+    let mut attestation = attest(&cfg, tmp.path(), AttestOptions::default())
+        .unwrap()
+        .attestation;
+
+    attestation.tool.version = "0.0.1-other".to_string();
+    match verify_recompute(&cfg, tmp.path(), &attestation).unwrap() {
+        VerifyOutcome::VersionMismatch { expected, actual } => {
+            assert_eq!(expected, "0.0.1-other");
+            assert_ne!(actual, "0.0.1-other", "actual is this build's version");
+        }
+        other => panic!("expected VersionMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn ac3_with_coupling_verdict_is_independently_checkable() {
+    let tmp = tempfile::tempdir().unwrap();
+    // A spec that claims a code unit via a file establishes edge.
+    write_spec(
+        tmp.path(),
+        "001-a",
+        "001-a",
+        "establishes:\n  - \"code.txt\"\n",
+    );
+    fs::write(tmp.path().join("code.txt"), "fn main() {}\n").unwrap();
+    let cfg = Config::default();
+
+    // In sync: the claimed unit resolves, so the coupling verdict is ok.
+    let synced = attest(
+        &cfg,
+        tmp.path(),
+        AttestOptions {
+            with_coupling: true,
+        },
+    )
+    .unwrap();
+    let couple = synced
+        .attestation
+        .verdicts
+        .couple
+        .as_ref()
+        .expect("coupling block present under --with-coupling");
+    assert!(couple.ok, "a resolving claim is in sync");
+    assert!(!couple.index_hash.is_empty());
+    assert!(!couple.join_hash.is_empty());
+
+    // Remove the claimed code: the coupling block fails while the
+    // registry/lint scope still verifies (the two scopes are independent).
+    fs::remove_file(tmp.path().join("code.txt")).unwrap();
+    let drifted = attest(
+        &cfg,
+        tmp.path(),
+        AttestOptions {
+            with_coupling: true,
+        },
+    )
+    .unwrap();
+    let couple = drifted.attestation.verdicts.couple.as_ref().unwrap();
+    assert!(!couple.ok, "a missing claimed unit is not in sync");
+    assert!(drifted.attestation.verdicts.compile.ok);
+    assert!(drifted.attestation.verdicts.lint.ok);
+}

--- a/crates/spec-spine-types/src/attest.rs
+++ b/crates/spec-spine-types/src/attest.rs
@@ -1,0 +1,104 @@
+//! Ledger-seal DTOs (spec 023): the `CorpusAttestation` payload and the detached
+//! `LedgerSeal` envelope.
+//!
+//! Plain data only: no crypto and no clock. The `CorpusAttestation` is a pure
+//! function of `(config, file contents)` (built in `spec-spine-core::attest`),
+//! and the `LedgerSeal` carries the non-reproducible signing identity and time,
+//! populated by the CLI. Keeping the timestamp and key id in the detached seal,
+//! never in the payload, is what lets the attested fact stay reproducible while
+//! the act of attesting carries its own identity. Field names serialize
+//! `camelCase`, matching the registry and index wire.
+
+use serde::{Deserialize, Serialize};
+
+/// The `schemaVersion` emitted in a [`CorpusAttestation`]. Library-owned,
+/// started fresh at `0.1.0`, on its own axis (independent of the registry and
+/// index schema lines). MINOR = additive; MAJOR = breaking, and loaders reject
+/// an unknown MAJOR (see `docs/schema-versioning.md`).
+pub const ATTESTATION_SCHEMA_VERSION: &str = "0.1.0";
+
+/// The tool identity recorded in an attestation: the reproducibility anchor
+/// (spec 023 FR-005). A `--recompute` verify is meaningful only under the same
+/// `version`; a different version is a distinct, named outcome, never a false
+/// content mismatch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolStamp {
+    pub name: String,
+    pub version: String,
+}
+
+/// The compile verdict: did structural validation pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompileVerdict {
+    pub ok: bool,
+}
+
+/// The lint verdict: pass/fail plus a hash over the canonical findings, so a
+/// change in the findings set is detectable on recompute even when `ok` is
+/// unchanged.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LintVerdict {
+    pub ok: bool,
+    pub findings_hash: String,
+}
+
+/// The coupling verdict, present only under `attest --with-coupling` (spec 023
+/// FR-002): specs and code are in sync (every claimed unit resolves, no blocking
+/// resolver diagnostic). `index_hash` is the code-as-source content hash;
+/// `join_hash` binds the registry and index hashes into one handle over the
+/// joined claim.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoupleVerdict {
+    pub ok: bool,
+    pub index_hash: String,
+    pub join_hash: String,
+}
+
+/// The verdicts an attestation freezes. `couple` is present iff the attestation
+/// was built with coupling scope; its absence (not a silent default) marks the
+/// narrower spec-corpus-only claim (FR-002).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Verdicts {
+    pub compile: CompileVerdict,
+    pub lint: LintVerdict,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub couple: Option<CoupleVerdict>,
+}
+
+/// A reproducible, pure-function attestation over the spec corpus state (spec
+/// 023). No clock, no env, no key: re-running `attest` on an unchanged corpus at
+/// the same `tool.version` yields a byte-identical payload. It is the signed,
+/// archival form of a verdict spec-spine already computes (`compile`, `lint`,
+/// optionally `couple`) and otherwise discards into a CI log.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CorpusAttestation {
+    pub schema_version: String,
+    pub tool: ToolStamp,
+    /// SHA-256 over what spec-spine read: the path-sorted, normalized corpus
+    /// inputs (the registry's own input content hash). Content-derived rather
+    /// than a git SHA, so the payload stays git-agnostic.
+    pub inputs_manifest_hash: String,
+    /// SHA-256 over the canonical `registry.json` bytes.
+    pub registry_hash: String,
+    pub verdicts: Verdicts,
+}
+
+/// The detached Ed25519 seal over an attestation (spec 023 FR-003). Produced
+/// only by `attest --sign`. It carries its own non-reproducible identity and
+/// time, kept OUT of the pure payload so the attested fact stays reproducible
+/// while the act of attesting is dated and attributed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LedgerSeal {
+    /// The signature algorithm; `"ed25519"` in v1.
+    pub alg: String,
+    /// An opaque signer identifier (e.g. a public-key fingerprint).
+    pub key_id: String,
+    /// RFC3339 wall-clock instant the seal was produced (CLI-populated).
+    pub signed_at: String,
+    /// Lowercase-hex Ed25519 signature over the 32-byte attestation hash.
+    pub sig: String,
+}

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -19,6 +19,7 @@
 //! - [`version`]: schema-version constants.
 //! - [`error`]: the [`Error`] enum and its exit-code contract.
 
+pub mod attest;
 pub mod codebase;
 pub mod config;
 pub mod edges;
@@ -31,6 +32,10 @@ pub mod version;
 
 // --- curated public prelude (the names callers reach for most) ---
 
+pub use attest::{
+    ATTESTATION_SCHEMA_VERSION, CompileVerdict, CorpusAttestation, CoupleVerdict, LedgerSeal,
+    LintVerdict, ToolStamp, Verdicts,
+};
 pub use codebase::{
     CodebaseIndex, Diagnostic, Diagnostics, ImplementingPath, IndexBuild, LineSpan, PackageKind,
     PackageRecord, ResolvedLocation, ResolvedUnit, SourceField, TraceMapping, TraceSource,

--- a/specs/023-ledger-seal/spec.md
+++ b/specs/023-ledger-seal/spec.md
@@ -1,0 +1,239 @@
+---
+id: "023-ledger-seal"
+title: "Ledger Seal (signed, reproducible attestation over the spec corpus)"
+status: draft
+created: "2026-06-16"
+authors: ["The spec-spine Authors"]
+kind: tooling
+implementation: complete
+risk: medium
+summary: >
+  spec-spine self-describes as a typed, hash-verifiable authority ledger over a
+  markdown spec corpus. A hash-verifiable ledger is an attestation missing only
+  two things: a signature and a verify. This spec completes that sentence. It
+  adds a CorpusAttestation, a deterministic, pure-function payload over the
+  inputs manifest, the registry hash, and the compile/lint (and optionally
+  coupling) verdicts, plus a detached Ed25519 seal over its hash, and a two-mode
+  verify-attestation (recompute, which any third party can run with no key, and
+  signature, which is opt-in). The reproducible recompute mode is the property a
+  run certificate can never have, because runs are side-effecting; this object is
+  the signed, archival, independently-verifiable form of a verdict spec-spine
+  already computes and then throws away into a CI log. It is deliberately NOT
+  called a certificate: that word stays with run-provenance (signed testimony of
+  a non-reproducible event). This is an attestation (recomputable truth).
+depends_on:
+  - "001-compile-registry"      # emits registry.json (the hashed ledger)
+  - "003-conformance-lint"      # the lint verdict
+  - "004-codebase-index"        # the index_hash recorded under --with-coupling
+  - "005-coupling-gate"         # the in-sync verdict (FR-002, optional scope)
+establishes:
+  - "crates/spec-spine-types/src/attest.rs"
+  - "crates/spec-spine-core/src/attest.rs"
+  - "crates/spec-spine-core/tests/attest.rs"
+  - "crates/spec-spine-cli/src/seal.rs"
+  - "crates/spec-spine-cli/src/cmd_attest.rs"
+  - "crates/spec-spine-cli/src/verify_attestation.rs"
+extends:
+  # Additive surface in files other specs established: the public re-exports, the
+  # CLI dispatch frame, and the CLI manifest (the Ed25519 dependency).
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/Cargo.toml", nature: additive }
+references:
+  # The (config, file contents) pure-function claim this capability rests on.
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+---
+
+# 023: Ledger Seal
+
+Filed off the OAP ADR 0002 boundary analysis. ADR 0002 confirmed the run
+certificate is run-provenance (OAP's factory-engine domain), not spec-spine's
+authority-ledger domain. The same analysis surfaced a distinct object it had
+conflated: an attestation over the spec corpus state itself, which is native to
+spec-spine and not addressed by the run cert. This spec owns that object.
+
+## 1. Purpose
+
+spec-spine is a hash-verifiable authority ledger. Today the verdict it computes
+(compiles clean, lint-clean, coupling-green, at registry hash Y) is ephemeral: it
+passes in CI and evaporates into a log. A live gate proves the present and forces
+re-execution every PR, which is correct for CI. It cannot let a future party
+trust a prior clean state without re-running the gate, which is what handoff and
+audit need.
+
+The corpus attestation is the frozen, signed snapshot of that verdict. The
+producer of a verdict is the natural signer of it, so no one downstream has to
+re-run or re-trust the computation, and, uniquely, anyone can, because spec-spine
+is a pure function of `(config, file contents)` and the attestation is therefore
+reproducible bit-for-bit. That makes the corpus link the most verifiable link in
+any audit chain that contains it: a live gate proves the present; a sealed
+attestation lets a future steward trust the past without re-trusting the prover.
+
+A ledger without a seal decays the same way a covenant without a gate decays: the
+moment it is handed off, "this corpus is governed and consistent" becomes a claim
+no one can check after the fact. This spec is the seal.
+
+This capability adds no new ledger semantics: every verdict it freezes is one
+spec-spine already computes (`compile`, `lint`, `couple`). It is the signing and
+the verify, nothing more.
+
+## 2. Territory
+
+This spec establishes the attestation surface across the three-crate layout, and
+additively extends three existing files it must touch, honouring FR-003's "the
+pure core gains no key handling":
+
+- `crates/spec-spine-types/src/attest.rs`: the plain-data DTOs
+  (`CorpusAttestation`, the verdict structs, `LedgerSeal`) and
+  `ATTESTATION_SCHEMA_VERSION`. No crypto, no clock: the type substrate stays
+  key-free.
+- `crates/spec-spine-core/src/attest.rs`: the pure `CorpusAttestation` builder
+  and the `--recompute` verifier, alongside the existing compile/lint/couple
+  engine. No key, no clock, no env.
+- `crates/spec-spine-cli/src/seal.rs`: the detached Ed25519 seal (`--sign`) and
+  its signature check, a post-pass over an already-emitted hash. The only place
+  spec-spine handles a key, kept out of the core.
+- `crates/spec-spine-cli/src/cmd_attest.rs` and
+  `crates/spec-spine-cli/src/verify_attestation.rs`: the `attest` and
+  `verify-attestation` verb wiring (recompute delegates to core; the signature
+  check uses the seal module).
+- `crates/spec-spine-core/tests/attest.rs`: determinism, recompute, and
+  coupling-scope acceptance tests.
+
+It additively extends (no behavior change to the owner) the public re-export
+surfaces (`spec-spine-types` and `spec-spine-core` `lib.rs`), the CLI dispatch
+frame (`main.rs`), and the CLI manifest (`Cargo.toml`, for the Ed25519
+dependency). The schema-version axis for the attestation is its own
+(`ATTESTATION_SCHEMA_VERSION`), independent of the registry and index lines.
+
+## 3. Object shape
+
+```
+CorpusAttestation            # pure function of (config, file contents).
+                             # No clock, no env, no key. Reproducible.
+  schemaVersion
+  tool:        { name: "spec-spine", version: "<x.y.z>" }   # reproducibility anchor (FR-005)
+  inputsManifestHash:  sha256 over what spec-spine read (the registry's input hash)
+  registryHash:        sha256(canonical registry.json)
+  verdicts:
+    compile:  { ok: true }
+    lint:     { ok: true, findingsHash: ... }
+    couple:   { ok: true, indexHash: ..., joinHash: ... }   # present iff --with-coupling (FR-002)
+
+# Emitted alongside, never inside, the attestation:
+attestationHash:  sha256(canonical(CorpusAttestation))      # the chain handle a consumer references
+LedgerSeal                   # detached. Produced only by --sign (FR-003).
+  alg:        ed25519
+  keyId
+  signedAt                   # the timestamp lives HERE, out of the pure payload
+  sig:        ed25519(attestationHash)   # over the 32-byte hash, lowercase hex
+```
+
+`inputsManifestHash` is content-derived rather than a git SHA so the payload
+stays git-agnostic (the manifest is exactly what the pure function already
+reads). `signedAt` and `keyId` live in the detached seal, so the attested fact
+stays reproducible while the act of attesting carries its own non-reproducible
+identity and time.
+
+## 4. Functional requirements
+
+- **FR-001 (corpus attestation, pure).** `spec-spine attest` emits a
+  `CorpusAttestation` over the inputs manifest, the registry hash, and the
+  compile and lint verdicts. It is a pure function of the same
+  `(config, file contents)` the compiler consumes: no clock, no env, no key.
+  Re-running `attest` on an unchanged corpus at the same tool version yields a
+  byte-identical payload.
+- **FR-002 (optional coupling scope).** `attest --with-coupling` additionally
+  records the in-sync verdict against named `indexHash` and `joinHash`. Without
+  the flag the attestation covers spec-corpus state only (the cleanest,
+  code-independent claim). With it, the attestation covers
+  specs-and-code-in-sync (the stronger handoff claim, dependent on the code
+  tree); `ok` is true iff every claimed unit resolves with no blocking resolver
+  diagnostic. Both are first-class and distinguishable by the presence of the
+  coupling block; the scope is never silently widened.
+- **FR-003 (detached seal: signing is a separable wrapper).** `attest --sign`
+  produces, alongside the attestation, a detached Ed25519 signature over
+  `attestationHash`. The compiler core gains no key handling: signing is a
+  post-pass over an already-emitted hash, in the CLI. `keyId` and `signedAt` live
+  in the seal envelope, never in the payload.
+- **FR-004 (two-mode verify).** `spec-spine verify-attestation` supports two
+  independent modes. `--recompute` re-reads the corpus, recompiles, and checks
+  the emitted hashes against the attestation: no key, no signature, offline,
+  runnable by any third party. `--signature` checks the detached seal against a
+  supplied public key: offline, opt-in. The recompute mode is the property the
+  run certificate structurally cannot have; it is the load-bearing reason this
+  object exists.
+- **FR-005 (version-aware verification).** Recompute is reproducible only under
+  the tool version that produced the attestation. `verify-attestation
+  --recompute` reads `tool.version` and either recomputes under that pinned
+  version or reports a version mismatch as a distinct, named outcome: never a
+  false content mismatch, never a skip-as-pass.
+- **FR-006 (degraded-mode visibility).** A mode that cannot run (no key for
+  `--signature`, unreadable corpus for `--recompute`, no mode selected) fails
+  visibly with reason. Skip-as-pass is forbidden, consistent with the ledger's
+  fail-closed posture.
+
+## 5. Acceptance criteria
+
+- **AC-1.** `attest` run twice on an unchanged corpus at one tool version
+  produces byte-identical attestation payloads.
+- **AC-2.** `verify-attestation --recompute` accepts an attestation whose corpus
+  is unchanged; a single spec-file edit flips it to a named mismatch that cites
+  the changed input.
+- **AC-3.** `attest --with-coupling` records the in-sync verdict; removing a
+  claimed code unit fails the coupling block while the registry/lint block still
+  verifies: the two scopes are independently checkable.
+- **AC-4.** `attest --sign` then `verify-attestation --signature` round-trips
+  against the public key; a single tampered payload byte fails the signature; an
+  unsigned attestation still passes `--recompute` (signing is pure-upside, never
+  a gate on truth).
+- **AC-5.** Verifying an attestation produced by a different tool version yields
+  the named version-mismatch outcome, not a false content mismatch.
+
+## 6. Out of scope
+
+- **The run certificate and its chain edge.** OAP's factory-engine run cert may
+  reference this attestation by hash via an additive
+  `corpus_binding.corpus_attestation_hash` field. That field, and the
+  read-not-recompute invariant that protects the boundary, are an OAP-side change
+  owned by **OAP spec 218-run-cert-corpus-binding**, not this spec. Stated here
+  only to mark the seam: spec-spine computes the attestation and publishes its
+  hash; the consumer reads that hash and never recomputes it. If a consumer
+  recomputes corpus state to obtain the hash, it has absorbed the compiler and
+  the boundary is gone. That invariant is enforced as a gate on the consumer side
+  (OAP spec 218), where it lives.
+- **Signer identity / key provisioning.** The seal needs a key; where an
+  operator's or tenant's key comes from is unspecified here and is non-blocking,
+  because an unsigned attestation is already reproducibly true. (Contrast the run
+  cert, whose value collapses without a signer; here the signer is pure upside.)
+- **Transparency log, countersignature, external timestamping.** A detached
+  Ed25519 seal is the floor; richer trust roots are later and additive.
+- **An embedded JSON Schema + conformance test for the attestation.** The
+  payload is canonical-JSON and version-stamped (`ATTESTATION_SCHEMA_VERSION`)
+  and proven deterministic by test; a formal schema artifact mirroring the
+  registry/index conformance gate is a later, additive step.
+
+## 7. Naming (deliberate)
+
+This object is an attestation (recomputable truth) and is deliberately not called
+a certificate. "Certificate" stays with run-provenance: signed testimony of a
+non-reproducible event. Keeping the words apart is what prevents the two objects
+from reconflating, which is precisely the conflation ADR 0002's analysis had to
+untangle.
+
+## 8. Sequencing
+
+Independent of the run-cert distribution work (OAP ADR 0002 / OAP spec 219). This
+capability rides the npm pin every tenant already has, adds no release matrix,
+and touches none of OAP's overlay, so it neither blocks nor is blocked by OAP's
+spec-spine minimization. It is a generic ledger capability (sign your own
+verdict) carrying none of the OWASP / stage-id / pipeline-state baggage that is
+OAP overlay territory (see `docs/design/00-architecture.md`, "Deliberately
+dropped from the generic core").
+
+Order within the spec: `attest` (pure, FR-001/002) first, with standalone value
+and no key story; then `--sign` and `verify-attestation` (FR-003/004) as the
+separable wrapper; then the optional coupling scope. The run-cert chain edge
+(out of scope above) lands as a small additive change in OAP's corpus (spec 218)
+whenever this lands.


### PR DESCRIPTION
## Summary

Implements spec 023 (ledger seal): a signed, reproducible attestation over the
spec corpus state. It is the archival form of a verdict spec-spine already
computes (compile, lint, optionally couple) and otherwise discards into a CI log.

- `attest` emits a pure `CorpusAttestation` (inputs-manifest hash, registry
  hash, compile/lint verdicts). Pure function of (config, file contents): no
  clock, no env, no key; byte-identical on re-run at the same tool version.
- `attest --with-coupling` adds the in-sync verdict (named indexHash + joinHash);
  ok iff every claimed unit resolves with no blocking resolver diagnostic.
- `attest --sign` produces a detached Ed25519 seal over the attestation hash.
  The pure core stays key-free; signing and signature verification live in the
  CLI (seal.rs). keyId and signedAt live in the seal envelope, never the payload.
- `verify-attestation` has two independent modes: `--recompute` (no key, offline,
  runnable by any third party) and `--signature` (against a supplied public key).
  Version-aware (a different tool version is a named outcome, not a false content
  mismatch) and fail-closed (a mode that cannot run fails visibly; never skip-as-pass).

DTOs live in spec-spine-types on their own schema-version axis
(ATTESTATION_SCHEMA_VERSION); no registry or index wire change. The new code is
governed by spec 023, which establishes its six files and additively extends the
four shared files it touches (the two lib.rs, main.rs, the CLI Cargo.toml for the
Ed25519 dependency).

## Testing

- `cargo test --workspace --locked`: all pass (AC-1 determinism, AC-2 recompute
  mismatch, AC-3 coupling scope, AC-5 version mismatch in core/tests/attest.rs;
  Ed25519 sign/verify/tamper round-trip in seal.rs).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- Gate chain green: compile (24 specs, 0 warn), lint --fail-on-warn (clean),
  index check (fresh), couple --base origin/main --head HEAD (12 paths, no drift).
- CLI end-to-end (throwaway corpus): sign then verify round-trips (MATCH + VALID);
  tampered payload yields signature INVALID; a spec edit and a removed claimed
  unit yield recompute CONTENT MISMATCH; no-mode and --sign-without-key exit 3.