### PR TITLE
chore(ci): rename the dogfood job to self_governance

### DIFF
--- a/.derived/codebase-index/index.json
+++ b/.derived/codebase-index/index.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "contentHash": "5875c27106572d9703b092482847c9a13e08c4d744ab81aa43d9c7b084a38863",
+    "contentHash": "310147c0ea7e78829a715f9b87bdac4294947d1b708b4f0d65b115185842c20b",
     "indexerId": "spec-spine",
     "indexerVersion": "0.4.0",
     "repoRoot": "."

--- a/.derived/spec-registry/registry.json
+++ b/.derived/spec-registry/registry.json
@@ -2,7 +2,7 @@
   "build": {
     "compilerId": "spec-spine",
     "compilerVersion": "0.4.0",
-    "contentHash": "151b3ffd22070b1ccada01fb35929ceede25c87a42e0f2cc594bf9c861b959ee",
+    "contentHash": "773dfd68d2f4f6909f16fe600ce024e5379e308e6a57bf914f10e50f022c63f3",
     "inputRoot": "."
   },
   "specVersion": "0.3.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
-# Build + test + lint, then dogfood: run spec-spine's OWN governance gates against
-# its OWN corpus. A spec-spine that is not itself spec-governed is hypocritical.
+# Build + test + lint, then self-governance: run spec-spine's OWN governance gates
+# against its OWN corpus. A spec-spine that is not itself spec-governed is hypocritical.
 #
 # Cross-triple tree-sitter symbol-span determinism is a Phase-5 release-matrix
 # concern (the resolver is pinned exact; see docs/design/00-architecture.md §10.1),
@@ -43,7 +43,7 @@ jobs:
       - name: Format
         run: cargo fmt --all --check
 
-  dogfood:
+  self_governance:
     name: self-governance (compile · index · lint · couple)
     runs-on: ubuntu-latest
     steps:
@@ -91,15 +91,15 @@ jobs:
   ci-gate:
     name: ci-gate
     if: ${{ always() }}
-    needs: [test, dogfood, determinism]
+    needs: [test, self_governance, determinism]
     runs-on: ubuntu-latest
     steps:
       - name: Require all CI jobs to have passed
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
           echo "A required CI job failed or was cancelled:"
-          echo "  test=${{ needs.test.result }}  dogfood=${{ needs.dogfood.result }}  determinism=${{ needs.determinism.result }}"
+          echo "  test=${{ needs.test.result }}  self_governance=${{ needs.self_governance.result }}  determinism=${{ needs.determinism.result }}"
           exit 1
       - name: All required CI jobs passed
         run: |
-          echo "ci-gate passed: test, dogfood, and determinism are all green"
+          echo "ci-gate passed: test, self_governance, and determinism are all green"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ emission, expect that gate to be the real test.
 ## Self-governance (dogfood): why `.derived/` is committed
 
 This repo runs its own gates against its own corpus in CI (`.github/workflows/ci.yml`
-`dogfood` job). Consequences:
+`self_governance` job). Consequences:
 
 - `.derived/spec-registry/registry.json` and `.derived/codebase-index/index.json`
   are **committed** (only `build-meta.json` is gitignored). After any change that

--- a/specs/020-derived-artifact-merge-driver/spec.md
+++ b/specs/020-derived-artifact-merge-driver/spec.md
@@ -116,7 +116,7 @@ it too. The build/test/clippy/fmt job, the self-governance
 `merge_group`.
 
 `ci.yml` ends in a single **`ci-gate`** aggregator job that `needs` every other
-CI job (test, dogfood, determinism) and fails if any of them failed or was
+CI job (test, self_governance, determinism) and fails if any of them failed or was
 cancelled (a skipped job counts as a pass). Branch protection and the merge
 queue require just this one check name, rather than an enumerated, drift-prone
 list of individual job names.


### PR DESCRIPTION
## Summary

The CI job that runs spec-spine's own governance gates (compile, index check,
lint, couple) was keyed `dogfood`. Its check display name was already the
clearer "self-governance (compile · index · lint · couple)". This renames the
job id to match.

- `dogfood:` -> `self_governance:` in `.github/workflows/ci.yml`, with the
  `ci-gate` aggregation (`needs` and its echo), spec 020's job-list prose, and
  the CLAUDE.md job reference updated in lockstep.
- An underscore (not a hyphen) keeps `needs.self_governance.result` valid in the
  `ci-gate` expression; the human-facing check name is unchanged, so branch
  protection / merge-queue required-check names are unaffected.
- Regenerates the committed `.derived` artifacts: `.github/workflows/**` is a
  hashed index input, and the spec 020 body edit changes the registry content
  hash.

No behavior change to any gate; this is a naming/clarity chore.

## Testing

- Gate chain green: compile (24 specs, 0 warn), lint --fail-on-warn (clean),
  index check (fresh), couple --base origin/main --head HEAD (no drift).
- `ci.yml` verified internally consistent: no residual `dogfood`; the job id,
  `needs`, and `ci-gate` aggregation all reference `self_governance`.