### PR TITLE
chore(024): ratify per-unit shard storage (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -489,8 +489,8 @@
       }
     ],
     "specId": "024-index-sharding",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.0.0",
-  "shardHash": "132fa54c40a798b668e171ffac14fe547ce0f6539a8b1e7b4148632a056f175b"
+  "shardHash": "7b0aa2436a7cd394be1ee900f78a8cb39712e5e82c8463d820992b84cd905016"
 }

--- a/.derived/spec-registry/by-spec/024-index-sharding.json
+++ b/.derived/spec-registry/by-spec/024-index-sharding.json
@@ -222,10 +222,10 @@
       "9. Acceptance criteria"
     ],
     "specPath": "specs/024-index-sharding/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The two committed artifacts (the spec registry and the codebase index) were each emitted as one file behind one global content-hash line with id-sorted arrays. Because every spec or package PR rewrites that one hash line, two PRs touching different units collide textually, and GitHub's server-side merge (the web button and the merge queue's speculative build) does not run the spec-020 merge driver, so the conflict surfaces there and the merge queue ejects sibling PRs. This spec shards both artifacts by authority unit: per-spec registry shards under spec-registry/by-spec/<id>.json, per-spec traceability shards under codebase-index/by-spec/<id>.json, and per-package inventory shards under codebase-index/by-package/<slug>.json, each carrying its own input hash. The global view (validation, orphans, untraced code, the aggregate content hash) is computed ON READ from the shard set rather than committed, so there is no shared file to conflict on. Two PRs touching different specs then write disjoint files and never conflict, so the merge queue forms clean speculative stacks and auto-merge stops ejecting in-flight PRs. Staleness becomes per-shard (sharper than the broad hash), the committed shards stay present-on-clone, and a MAJOR schema bump (registry + index -> 1.0.0) marks the new on-disk shape. This generalizes spec 012 (index hash slices) from scoped staleness CHECKING to per-unit STORAGE, and it removes the textual-conflict cause spec 020's merge driver only papers over locally.\n",
     "title": "Per-unit shard storage (conflict-free committed registry + index)"
   },
-  "shardHash": "f944e904e4ed272e52061a40eacf6e1628a8e65ebf9fafef7a95b31db06fcf2c",
+  "shardHash": "3ea1d022d7f3cff37f0cb602a8ca5b76157020e27b45388d964fad06ede11c28",
   "specVersion": "1.0.0"
 }

--- a/specs/024-index-sharding/spec.md
+++ b/specs/024-index-sharding/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "024-index-sharding"
 title: "Per-unit shard storage (conflict-free committed registry + index)"
-status: draft
+status: approved
 created: "2026-06-16"
 authors: ["The spec-spine Authors"]
 kind: tooling


### PR DESCRIPTION
## Summary

Follow-up to #28 (which landed the implementation). Flips spec **024** from `draft` to `approved` now that the sharding implementation is on `main` and the governed loop is green.

The status edit restamps **only 024's own registry + index shards** (`spec-registry/by-spec/024-index-sharding.json`, `codebase-index/by-spec/024-index-sharding.json`) and nothing else — a live demonstration of the conflict-free, per-unit disjointness the spec delivers. Corpus is now 24 approved / 1 draft (023).

## Testing

- `compile` (25 specs, 0 warnings) → `index check` (fresh) → `lint --fail-on-warn` (0/0/0) → `couple --base origin/main --head HEAD` (1 path, no drift).
- Only the two 024 shards differ from `main`; no source changes.