### PR TITLE
chore(release): bump to v0.5.0 (ships spec 023 ledger seal + spec 024 index sharding)

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "schemaVersion": "1.0.0",
-  "shardHash": "bd7041bc01879bef24a44846ff86fac9fb2628d8475bc1a55366f74df2e420ad"
+  "shardHash": "3d705eed12afaee46a6f497a4932d0d9d5387a6af5046d61c36710af19ce317b"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.4.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.4.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.5.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.5.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.4.0",
-    "@spec-spine/cli-darwin-x64": "0.4.0",
-    "@spec-spine/cli-linux-x64": "0.4.0",
-    "@spec-spine/cli-linux-arm64": "0.4.0",
-    "@spec-spine/cli-win32-x64": "0.4.0"
+    "@spec-spine/cli-darwin-arm64": "0.5.0",
+    "@spec-spine/cli-darwin-x64": "0.5.0",
+    "@spec-spine/cli-linux-x64": "0.5.0",
+    "@spec-spine/cli-linux-arm64": "0.5.0",
+    "@spec-spine/cli-win32-x64": "0.5.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.4.0"
+version = "0.5.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Release v0.5.0

Cuts a release of two approved, implemented capabilities that have sat on `main`
since the last published tag (`v0.4.0`): spec 023 (ledger seal) and spec 024
(per-spec index sharding). Both are `status: approved`, `implementation:
complete`; `0.4.0` predates both, so downstream adopters cannot pin a sharded
spec-spine until this ships.

This PR is the **version bump only**. It touches no engine behavior: it bumps
every distribution surface in lockstep via `scripts/bump_version.py` and
regenerates the one committed index shard that records the npm package version.

### BREAKING (on-disk format): per-spec index sharding (spec 024)

The single `registry.json` / `index.json` are replaced by per-unit shard trees
(`by-spec/<id>.json`, `by-package/<slug>.json`). The on-disk **schema is MAJOR
`1.0.0`**; a 0.x reader rejects 1.x shards (exit `3`). Adopters upgrading from
0.4.0 must:

1. regenerate (`spec-spine compile` + `spec-spine index`),
2. commit the resulting shard tree, and
3. repoint any merge-driver `.gitattributes` globs to the shard paths.

The **crate** version stays a pre-1.0 minor (`0.5.0`); the on-disk schema MAJOR
is decoupled from the package version by design (see
`crates/spec-spine-types/src/version.rs`). Breaking on-disk changes are expected
within `0.x` minors per SemVer.

### NEW: ledger seal (spec 023)

`attest` / `attest --sign` / `verify-attestation`: a two-mode recompute +
signature over a reproducible corpus attestation.

### Changes

- `Cargo.toml` (`[workspace.package]` version + the two internal sibling pins),
  `Cargo.lock`, `npm/package.json` (version + the five `@spec-spine/cli-*`
  platform pins), `py/pyproject.toml`: all bumped `0.4.0` -> `0.5.0` in lockstep.
- `.derived/codebase-index/by-package/spec-spine.json`: regenerated; the tracked
  npm package version moves `0.4.0` -> `0.5.0` (the only derived shard affected).

### Verification (local, all green)

`compile` clean; `index check` fresh; `lint --fail-on-warn` 0/0/0; `cargo test
--workspace --locked` all pass; `cargo clippy --all-targets -- -D warnings`
clean; `cargo fmt --all --check` clean. The cross-platform determinism gate runs
in CI.

Spec-Drift-Waiver: Mechanical package-version bump only. The two flagged paths
(`npm/package.json` owned by spec 007-distribution, `py/pyproject.toml` owned by
spec 008-python-distribution) change only their version string for the v0.5.0
release; no owning spec's authority claims and no runtime behavior change. Per
.claude/rules/adversarial-prompt-refusal.md a mechanical version refresh must be
waived, not resolved by amending the owning specs. This mirrors the v0.4.0 bump
(PR #25).
