### PR TITLE
chore(023): ratify ledger seal (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -198,8 +198,8 @@
       }
     ],
     "specId": "023-ledger-seal",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.0.0",
-  "shardHash": "daacb7dfa772a1c4246c363966fc8bd58a6386746fb6d6269e2549dbd38019e4"
+  "shardHash": "0857bc446ae484a9905a2e3f826be12f502955cfc161a86e206005b162bad44b"
 }

--- a/.derived/spec-registry/by-spec/023-ledger-seal.json
+++ b/.derived/spec-registry/by-spec/023-ledger-seal.json
@@ -95,10 +95,10 @@
       "8. Sequencing"
     ],
     "specPath": "specs/023-ledger-seal/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "spec-spine self-describes as a typed, hash-verifiable authority ledger over a markdown spec corpus. A hash-verifiable ledger is an attestation missing only two things: a signature and a verify. This spec completes that sentence. It adds a CorpusAttestation, a deterministic, pure-function payload over the inputs manifest, the registry hash, and the compile/lint (and optionally coupling) verdicts, plus a detached Ed25519 seal over its hash, and a two-mode verify-attestation (recompute, which any third party can run with no key, and signature, which is opt-in). The reproducible recompute mode is the property a run certificate can never have, because runs are side-effecting; this object is the signed, archival, independently-verifiable form of a verdict spec-spine already computes and then throws away into a CI log. It is deliberately NOT called a certificate: that word stays with run-provenance (signed testimony of a non-reproducible event). This is an attestation (recomputable truth).\n",
     "title": "Ledger Seal (signed, reproducible attestation over the spec corpus)"
   },
-  "shardHash": "567c17f79b66fd1162da80bb6aab5b34a6e240ec109ac81a6e078c2af4bdb874",
+  "shardHash": "0f9f4f3b6aa952f24e5f2ef71adbb4c6cde1a29d2eac307eb1f8c544c9a21f40",
   "specVersion": "1.0.0"
 }

--- a/specs/023-ledger-seal/spec.md
+++ b/specs/023-ledger-seal/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "023-ledger-seal"
 title: "Ledger Seal (signed, reproducible attestation over the spec corpus)"
-status: draft
+status: approved
 created: "2026-06-16"
 authors: ["The spec-spine Authors"]
 kind: tooling


### PR DESCRIPTION
Flips `023-ledger-seal` from `draft` to `approved`, the last draft on `main`.

The implementation landed in #26 (`attest` / `--sign` / `verify-attestation`)
and shipped in v0.5.0; `implementation: complete` was already set. This is the
governance ratification, not new behaviour.

The status change restamps only 023's own registry + index shards (the
conflict-free disjointness spec 024 delivers). Corpus is now 25/25 approved.

Gate locally green: `compile` (0 warn) · `index check` (fresh) ·
`lint --fail-on-warn` (0/0/0) · `couple --base origin/main` (no drift).

https://claude.ai/code/session_01HbxpaFZVqmQmmp9CKS2vKF