### PR TITLE
feat(025): lifecycle- and edge-aware unresolved-unit severity (W-001/W-002)

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -5,6 +5,6 @@
     "path": "crates/spec-spine-cli",
     "specRef": "001-compile-registry"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "6c2f67c15a6884a8220602ce5c7cd1ca6f46a89b1cda1e9fc28ab2c53d73f1a8"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -5,6 +5,6 @@
     "path": "crates/spec-spine-core",
     "specRef": "001-compile-registry"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "f119742359fc2ea1ec534166eae3d021c4f8eb5017fd436990542dd184cfaa5c"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -5,6 +5,6 @@
     "path": "crates/spec-spine-types",
     "specRef": "000-spec-spine-bootstrap"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "1a56c13bbe0430dfd9efa2e8a9e1fc6144d73b806e88dd634a36b40233bb4d7d"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -6,6 +6,6 @@
     "specRef": "007-distribution",
     "version": "0.5.0"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "3d705eed12afaee46a6f497a4932d0d9d5387a6af5046d61c36710af19ce317b"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -9,6 +9,6 @@
     "specId": "000-spec-spine-bootstrap",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "1a95c8e30ba019b3688ca5a232ca32a5cb1b9bb2e44c1a997b04de05f3b48711"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -137,6 +137,6 @@
     "specId": "001-compile-registry",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "0f21fdf254c66bb2ed452902814d4ea3d2c090c7322774a11d92e01227e764cc"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -61,6 +61,6 @@
     "specId": "002-registry-query",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "8899629a770c39a038119bafdd96fe5381a56c2e0b0f42221fe7418cd9027c61"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -44,6 +44,6 @@
     "specId": "003-conformance-lint",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "59d5518573e23ea8b68925255c10fa945f3f61957eca451212889d40b9e9f3de"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -130,6 +130,6 @@
     "specId": "004-codebase-index",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "27dd1b4a533ec0fabe2aef087bc8e807c36dae81fbad4cd9ceb6394e79b81d0f"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -131,6 +131,6 @@
     "specId": "005-coupling-gate",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "8be1ca3694918fdbdd2f3132056faeca8806182fa0dcf5c16d90ed7e2f78b3d6"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -112,6 +112,6 @@
     "specId": "006-init-scaffold",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "637ee2b3b0a22746e6bba35e0bc10748c17614a37f9d7672e41fe066ca9acc8c"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -102,6 +102,6 @@
     "specId": "007-distribution",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "2afb2bc68c8cac6fa5e227fd8d7edb33788dffa05b6cdc49ced50053430ec28b"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -61,6 +61,6 @@
     "specId": "008-python-distribution",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "bebe21758d44ef3f48553042e4057b8dcf202b9e0b5816158dfcacdae6bcc107"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -81,6 +81,6 @@
     "specId": "009-coupling-floor-claim-precedence",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "38a7671efca99cd333111d643d3bdcb2a9e3f72b4c9abdb8d48f003a6de35f21"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -78,6 +78,6 @@
     "specId": "010-registry-query-projection-flags",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "e65afccd4a1781b0f90ab6b890618773a24e58be6bd578995ccbcd23143f1e8e"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -95,6 +95,6 @@
     "specId": "011-index-render-orphans",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "df4e9d755f8f2723e542aa4df2c202a815ce99e59e8d489d86e03b05e7df0f47"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -163,6 +163,6 @@
     "specId": "012-index-hash-slices",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "35e573325eb8a9f0cfb7f94c63453f8ab81fc139cb2cf1bf7f1bd02ae48156c7"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -180,6 +180,6 @@
     "specId": "013-declared-extra-frontmatter-passthrough",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "0f70503ae7d4970b2302ced2bb3572d882469b4011d1a78bb8b1a9e9ed3f27de"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -95,6 +95,6 @@
     "specId": "014-edge-paths-grammar-sugar",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "ee435f4e9e3ffd65b3d62d35312075e0d7acbafcd2ea65de30f1f43770d890a7"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -78,6 +78,6 @@
     "specId": "015-establishes-wrapper-na-alias",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "a78bd57d984fc5cf0dd79bb103bbb37a01855bf5763f4a7ef5e213055d1c02b3"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -44,6 +44,6 @@
     "specId": "016-short-id-resolution",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "a1731b6bb178d3ea1f5289172ee6e776c9f724e3093734f1361d167764ee57ba"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -113,6 +113,6 @@
     "specId": "018-constrains-discriminator-optional-unit",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "1fc6d75a9d712a5c5215f5c18d37dd183cf0972f8d2ba4d63a93f0aba6fde030"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -249,6 +249,6 @@
     "specId": "019-structured-partial-supersedes",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "5e54c6259d4e3081eabfaebfc2e3be7d4ffdb07678f0875a4b611516b3dda38b"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -29,6 +29,6 @@
     "specId": "020-derived-artifact-merge-driver",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "137375132c3d736bce6cc553bcc6ee22472dd3a8ae1a7826bb20d90157f0bd3b"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -44,6 +44,6 @@
     "specId": "021-release-supply-chain-artifacts",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "f70e24138a7d50731ead546ce8d292c3a50a536dcfbb11518fd18995946737d0"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -28,6 +28,6 @@
     "specId": "022-keypath-section-anchors",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "9f691bd8024d7405d041150c675d2048338096b444c1c1d6acfcf0bf642235ce"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -200,6 +200,6 @@
     "specId": "023-ledger-seal",
     "specStatus": "draft"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "daacb7dfa772a1c4246c363966fc8bd58a6386746fb6d6269e2549dbd38019e4"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -491,6 +491,6 @@
     "specId": "024-index-sharding",
     "specStatus": "approved"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "shardHash": "7b0aa2436a7cd394be1ee900f78a8cb39712e5e82c8463d820992b84cd905016"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -1,7 +1,12 @@
 {
   "mapping": {
-    "dependsOn": [
+    "amends": [
       "004-codebase-index"
+    ],
+    "dependsOn": [
+      "001-compile-registry",
+      "004-codebase-index",
+      "005-coupling-gate"
     ],
     "implementingPaths": [
       {
@@ -9,15 +14,7 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-core/src/symbols.rs",
-        "source": "spec-edge"
-      },
-      {
         "path": "crates/spec-spine-core/tests/index.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-types/src/unit.rs",
         "source": "spec-edge"
       },
       {
@@ -29,7 +26,7 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/tests/grammar.rs",
+        "path": "docs/design/00-architecture.md",
         "source": "spec-edge"
       }
     ],
@@ -50,19 +47,6 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/symbols.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-core/src/symbols.rs"
-        }
-      },
-      {
-        "locations": [
-          {
             "file": "crates/spec-spine-core/tests/index.rs"
           }
         ],
@@ -71,19 +55,6 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/tests/index.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-types/src/unit.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-types/src/unit.rs"
         }
       },
       {
@@ -115,20 +86,20 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/tests/grammar.rs"
+            "file": "docs/design/00-architecture.md"
           }
         ],
-        "ownership": true,
-        "sourceField": "extends",
+        "ownership": false,
+        "sourceField": "references",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/tests/grammar.rs"
+          "path": "docs/design/00-architecture.md"
         }
       }
     ],
-    "specId": "017-directory-crate-module-units",
-    "specStatus": "approved"
+    "specId": "025-unresolved-unit-severity",
+    "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "511fb5b28164d20424c2889a2a06448b0c613d6b7ad8f61b5de07673732ca82b"
+  "shardHash": "b614214ba4905c3de68893227744744e3edf5e9d09c7900d1012a920f9a2f2ba"
 }

--- a/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
@@ -1,0 +1,83 @@
+{
+  "record": {
+    "amends": [
+      "004-codebase-index"
+    ],
+    "created": "2026-06-17",
+    "dependsOn": [
+      "001-compile-registry",
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      }
+    ],
+    "id": "025-unresolved-unit-severity",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "025: Severity tiers for unresolved units",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The severity decision",
+      "3.2 The two warning codes",
+      "3.3 Surface, never skip",
+      "3.4 No fabricated mapping (the index's boundary)",
+      "3.5 Authority is a registry property (the consumer boundary)",
+      "3.6 Schema",
+      "4. Functional requirements",
+      "5. Acceptance criteria",
+      "6. Out of scope",
+      "7. Security rationale"
+    ],
+    "specPath": "specs/025-unresolved-unit-severity/spec.md",
+    "status": "draft",
+    "summary": "Today the indexer hard-errors (I-003..I-009) on every declared unit that does not resolve, regardless of whether the edge is authoritative or whether the owning spec is even built yet. Two of those errors are not governance failures: an unresolved unit on a non-owning `references` edge is a stale provenance pointer, and an unresolved owning unit on a `draft` / `implementation: pending` spec is legitimate work-in-progress. This spec adds two orthogonal severity tiers over the same resolver, keyed on (a) edge authority and (b) owning-spec lifecycle, so those two cases become counted warnings (a fresh `W-001` / `W-002` band) instead of blocking errors, while an unresolved owning unit on an approved + implemented spec stays a hard error. The downgrade never skips: every such unit is still surfaced and counted, never silently dropped, so the authority-laundering / invisible-drift vector stays closed. The index never fabricates a code location for an unresolved path; authority remains a property of the registry relationship graph, which the coupling gate consults independently of index resolution. Additive: the `warnings` tier and the free-form diagnostic `code` already exist, so this is an `INDEX_SCHEMA_VERSION` MINOR (1.0.0 -> 1.1.0) with no schema-file edit and no registry change.\n",
+    "title": "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
+  },
+  "shardHash": "622adcfe8e750b30b3584965f4c88d10cbb54106d20015537b9d9b753d596211",
+  "specVersion": "1.0.0"
+}

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -11,9 +11,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use spec_spine_types::{
-    CodebaseIndex, Diagnostic, Diagnostics, Error, INDEX_SCHEMA_VERSION, ImplementingPath,
-    IndexBuild, IndexPackageShard, IndexSpecShard, PackageKind, PackageRecord, ResolvedLocation,
-    ResolvedUnit, SourceField, TraceMapping, TraceSource, Traceability, Unit,
+    CodebaseIndex, Diagnostic, Diagnostics, Error, INDEX_SCHEMA_VERSION, Implementation,
+    ImplementingPath, IndexBuild, IndexPackageShard, IndexSpecShard, PackageKind, PackageRecord,
+    ResolvedLocation, ResolvedUnit, SourceField, TraceMapping, TraceSource, Traceability, Unit,
     parse_frontmatter_with,
 };
 
@@ -59,10 +59,23 @@ pub enum Freshness {
 struct SpecInfo {
     id: String,
     status: String,
+    /// The owning spec's implementation lifecycle. Spec 025's lifecycle severity
+    /// tier keys on `draft` status or `pending` implementation; carried here so
+    /// the resolve loop has both signals without re-reading frontmatter.
+    implementation: Option<Implementation>,
     depends_on: Vec<String>,
     amends: Vec<String>,
     /// (source_field, unit, ownership) for every declared unit.
     units: Vec<(SourceField, Unit, bool)>,
+}
+
+impl SpecInfo {
+    /// True when the spec is still in flight, so an unresolved *owning* unit is a
+    /// counted warning rather than a blocking error (spec 025 §3.1 arm 2):
+    /// `status: draft` or `implementation: pending`.
+    fn in_flight(&self) -> bool {
+        self.status == "draft" || matches!(self.implementation, Some(Implementation::Pending))
+    }
 }
 
 /// Build the codebase index under `repo_root`.
@@ -131,7 +144,13 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
         let mut spec_diags = Diagnostics::default();
 
         // Source 3: spec edges (units).
+        let in_flight = spec.in_flight();
         for (field, unit, ownership) in &spec.units {
+            // `resolve_unit` always emits the natural `I-0xx` hard error into a
+            // local buffer; spec 025 then reclassifies an unresolved unit by
+            // severity tier (edge authority, then owning-spec lifecycle) before
+            // merging it into the spec's diagnostics.
+            let mut unit_diags = Diagnostics::default();
             let locations = resolve_unit(
                 repo_root,
                 unit,
@@ -139,8 +158,9 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
                 &symbol_index,
                 &module_index,
                 &spec.id,
-                &mut spec_diags,
+                &mut unit_diags,
             );
+            classify_unresolved(&mut spec_diags, unit_diags, *ownership, in_flight);
             for loc in &locations {
                 paths
                     .entry(loc.file.clone())
@@ -701,12 +721,52 @@ fn discover_specs(
         out.push(SpecInfo {
             id: fm.id,
             status: status_str(fm.status),
+            implementation: fm.implementation,
             depends_on: fm.depends_on,
             amends: fm.amends,
             units,
         });
     }
     Ok(out)
+}
+
+/// Route an unresolved unit's diagnostic by severity tier (spec 025 §3.1).
+/// `resolve_unit` always produces the natural `I-0xx` hard error; this
+/// reclassifies it, by first-match precedence, before it reaches the spec's
+/// diagnostics:
+///   1. non-owning edge (`references`)        -> `W-002` warning (any lifecycle)
+///   2. owning edge on a draft / pending spec -> `W-001` warning
+///   3. owning edge on a settled spec         -> the `I-0xx` error, unchanged
+///
+/// The downgrade never drops the unit: it always lands in exactly one tier and
+/// is counted (FR-004). `W-001` / `W-002` are deliberately absent from
+/// [`BLOCKING_CODES`], so a warned shard is not flagged stale by `index check`.
+/// The original message (unit kind, path/id, reason) is preserved verbatim; only
+/// the code changes, so the distinct, countable class carries the same evidence
+/// as the error it replaces.
+fn classify_unresolved(
+    dst: &mut Diagnostics,
+    produced: Diagnostics,
+    owning: bool,
+    in_flight: bool,
+) {
+    for d in produced.errors {
+        if !owning {
+            dst.warnings.push(Diagnostic {
+                code: "W-002".to_string(),
+                ..d
+            });
+        } else if in_flight {
+            dst.warnings.push(Diagnostic {
+                code: "W-001".to_string(),
+                ..d
+            });
+        } else {
+            dst.errors.push(d);
+        }
+    }
+    // `resolve_unit` emits no warnings today; forward any for forward-compat.
+    dst.warnings.extend(produced.warnings);
 }
 
 fn resolve_unit(

--- a/crates/spec-spine-core/tests/attest.rs
+++ b/crates/spec-spine-core/tests/attest.rs
@@ -97,13 +97,17 @@ fn ac5_a_different_tool_version_is_a_named_version_mismatch() {
 #[test]
 fn ac3_with_coupling_verdict_is_independently_checkable() {
     let tmp = tempfile::tempdir().unwrap();
-    // A spec that claims a code unit via a file establishes edge.
-    write_spec(
-        tmp.path(),
-        "001-a",
-        "001-a",
-        "establishes:\n  - \"code.txt\"\n",
-    );
+    // A spec that claims a code unit via a file establishes edge. It must be
+    // settled (approved + complete): under spec 025 a missing owning unit only
+    // blocks the coupling verdict for a settled spec; a draft/pending spec's
+    // unbuilt unit is a non-blocking W-001 (legitimate in-flight work).
+    let spec_dir = tmp.path().join("specs").join("001-a");
+    fs::create_dir_all(&spec_dir).unwrap();
+    fs::write(
+        spec_dir.join("spec.md"),
+        "---\nid: \"001-a\"\ntitle: \"Title 001-a\"\nstatus: approved\nimplementation: complete\ncreated: \"2026-06-08\"\nsummary: \"s\"\nestablishes:\n  - \"code.txt\"\n---\n# 001-a\n",
+    )
+    .unwrap();
     fs::write(tmp.path().join("code.txt"), "fn main() {}\n").unwrap();
     let cfg = Config::default();
 

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -33,6 +33,14 @@ fn spec(id: &str, body: &str) -> String {
     )
 }
 
+/// Like [`spec`] but with an explicit lifecycle `status` (spec 025 fixtures need
+/// `draft` corpora; the default helper hardcodes `approved`).
+fn spec_with_status(id: &str, status: &str, body: &str) -> String {
+    format!(
+        "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: {status}\ncreated: \"2026-06-09\"\nsummary: \"s\"\n{body}---\n# {id}\n"
+    )
+}
+
 /// A mixed Rust + npm fixture exercising manifest discovery, the encore fix, and
 /// symbol resolution in both languages.
 fn mixed_fixture() -> tempfile::TempDir {
@@ -173,6 +181,153 @@ fn missing_file_unit_is_blocking_diagnostic_i004() {
     );
     let idx = index(&Config::default(), tmp.path()).unwrap().index;
     assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-004"));
+}
+
+// ===== spec 025: lifecycle- and edge-aware unresolved-unit severity =====
+
+/// AC-1: an unresolved unit on a non-owning `references` edge is a counted
+/// `W-002` warning, never a blocking error, regardless of lifecycle.
+#[test]
+fn ac1_unresolved_reference_is_w002_warning_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "implementation: complete\nreferences:\n  - { unit: { kind: file, path: \"docs/gone.md\" }, role: context }\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        idx.diagnostics.errors.is_empty(),
+        "a dangling reference must not block: {:?}",
+        idx.diagnostics.errors
+    );
+    assert_eq!(
+        idx.diagnostics
+            .warnings
+            .iter()
+            .filter(|d| d.code == "W-002")
+            .count(),
+        1,
+        "exactly one W-002 for the unresolved reference"
+    );
+}
+
+/// AC-2: an unresolved owning unit on a `draft` spec is a counted `W-001`
+/// warning, never a blocking error (legitimate in-flight work).
+#[test]
+fn ac2_draft_owning_unit_is_w001_warning_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec_with_status(
+            "001-x",
+            "draft",
+            "establishes:\n  - \"src/not_built_yet.rs\"\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        idx.diagnostics.errors.is_empty(),
+        "a draft spec's unbuilt owning unit must not block: {:?}",
+        idx.diagnostics.errors
+    );
+    assert_eq!(
+        idx.diagnostics
+            .warnings
+            .iter()
+            .filter(|d| d.code == "W-001")
+            .count(),
+        1
+    );
+}
+
+/// AC-3: `status: approved` but `implementation: pending` is in-flight, so an
+/// unresolved owning unit is `W-001` (spec 025 §3.1 arm 2 keys on either signal).
+#[test]
+fn ac3_pending_owning_unit_is_w001_warning_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "implementation: pending\nestablishes:\n  - \"src/not_built_yet.rs\"\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        idx.diagnostics.errors.is_empty(),
+        "a pending spec's unbuilt owning unit must not block: {:?}",
+        idx.diagnostics.errors
+    );
+    assert_eq!(
+        idx.diagnostics
+            .warnings
+            .iter()
+            .filter(|d| d.code == "W-001")
+            .count(),
+        1
+    );
+}
+
+/// AC-4: a settled (`approved` + `complete`) spec's missing owning unit stays a
+/// hard `I-004` error, unchanged by spec 025 (the complement of AC-2 / AC-3).
+#[test]
+fn ac4_settled_owning_unit_still_errors_i004() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "implementation: complete\nestablishes:\n  - \"src/gone.rs\"\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-004"));
+    assert!(
+        idx.diagnostics.warnings.iter().all(|d| d.code != "W-001"),
+        "a settled spec is not downgraded"
+    );
+}
+
+/// AC-5: edge-type precedence. A `references` edge on a `draft` spec is `W-002`
+/// (arm 1), not `W-001`: edge authority is evaluated before lifecycle.
+#[test]
+fn ac5_reference_on_draft_spec_is_w002_edge_type_precedence() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec_with_status(
+            "001-x",
+            "draft",
+            "references:\n  - { unit: { kind: file, path: \"docs/gone.md\" }, role: context }\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(idx.diagnostics.errors.is_empty());
+    assert_eq!(
+        idx.diagnostics
+            .warnings
+            .iter()
+            .filter(|d| d.code == "W-002")
+            .count(),
+        1
+    );
+    assert!(
+        idx.diagnostics.warnings.iter().all(|d| d.code != "W-001"),
+        "edge-type wins: an unresolved reference is W-002 even on a draft spec"
+    );
 }
 
 #[test]

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -27,7 +27,11 @@ pub const REGISTRY_SCHEMA_VERSION: &str = "1.0.0";
 /// `by-spec/<id>.json` and per-package under `by-package/<slug>.json`; the single
 /// `index.json` is no longer emitted. The aggregate view (orphans, untraced code,
 /// content hash) is recomputed on read; staleness is per-shard.
-pub const INDEX_SCHEMA_VERSION: &str = "1.0.0";
+/// `1.1.0`: additive (spec 025). The resolver downgrades an unresolved unit to a
+/// non-blocking `W-001` (draft/pending owning) or `W-002` (non-owning reference)
+/// warning instead of a hard error; the `warnings` tier and free-form diagnostic
+/// `code` already exist, so no schema-file edit is needed.
+pub const INDEX_SCHEMA_VERSION: &str = "1.1.0";
 
 /// `schemaVersion` emitted in `build-meta.json` (the non-deterministic artifact).
 pub const BUILD_META_SCHEMA_VERSION: &str = "0.1.0";

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -71,8 +71,9 @@ fn validation_passed_follows_error_tier() {
 fn schema_versions_are_pinned() {
     // 1.0.0: MAJOR; the committed registry is sharded per-spec (spec 024).
     assert_eq!(REGISTRY_SCHEMA_VERSION, "1.0.0");
-    // 1.0.0: MAJOR; the committed index is sharded per-spec/per-package (spec 024).
-    assert_eq!(INDEX_SCHEMA_VERSION, "1.0.0");
+    // 1.1.0: additive MINOR (spec 025): unresolved-unit severity tiers (W-001 /
+    // W-002 warnings) on top of the spec-024 sharded MAJOR.
+    assert_eq!(INDEX_SCHEMA_VERSION, "1.1.0");
     assert_eq!(BUILD_META_SCHEMA_VERSION, "0.1.0");
     assert_eq!(CONFIG_VERSION, "0.1.0");
 }

--- a/specs/025-unresolved-unit-severity/spec.md
+++ b/specs/025-unresolved-unit-severity/spec.md
@@ -1,0 +1,277 @@
+---
+id: "025-unresolved-unit-severity"
+title: "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
+status: draft
+kind: "tooling"
+created: "2026-06-17"
+owner: "The spec-spine Authors"
+implementation: pending
+risk: medium
+depends_on:
+  - "001-compile-registry"   # the registry relationship graph: the authority source
+  - "004-codebase-index"     # the resolver whose diagnostic severity this amends
+  - "005-coupling-gate"      # consumes registry authority, never the index mapping (the boundary)
+amends:
+  - "004-codebase-index"     # patches 004's "unresolved unit -> hard I-error" contract in place
+extends:
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/index.rs"      # the resolver: severity decision + W-band
+      - "crates/spec-spine-core/tests/index.rs"    # severity-tier acceptance fixtures
+      - "crates/spec-spine-types/src/version.rs"   # INDEX_SCHEMA_VERSION minor bump
+      - "crates/spec-spine-types/tests/dtos.rs"    # the schema-version pin test for the bump
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  Today the indexer hard-errors (I-003..I-009) on every declared unit that does
+  not resolve, regardless of whether the edge is authoritative or whether the
+  owning spec is even built yet. Two of those errors are not governance failures:
+  an unresolved unit on a non-owning `references` edge is a stale provenance
+  pointer, and an unresolved owning unit on a `draft` / `implementation: pending`
+  spec is legitimate work-in-progress. This spec adds two orthogonal severity
+  tiers over the same resolver, keyed on (a) edge authority and (b) owning-spec
+  lifecycle, so those two cases become counted warnings (a fresh `W-001` /
+  `W-002` band) instead of blocking errors, while an unresolved owning unit on an
+  approved + implemented spec stays a hard error. The downgrade never skips:
+  every such unit is still surfaced and counted, never silently dropped, so the
+  authority-laundering / invisible-drift vector stays closed. The index never
+  fabricates a code location for an unresolved path; authority remains a property
+  of the registry relationship graph, which the coupling gate consults
+  independently of index resolution. Additive: the `warnings` tier and the
+  free-form diagnostic `code` already exist, so this is an `INDEX_SCHEMA_VERSION`
+  MINOR (1.0.0 -> 1.1.0) with no schema-file edit and no registry change.
+---
+
+# 025: Severity tiers for unresolved units
+
+Filed off the OAP spec-217 Phase-0 dry run of the published 0.5.0 library
+against its 220-spec corpus. `index` emitted 116 error diagnostics; after the
+adopter's own config and corpus cleanup, a residual class was the library's, not
+the adopter's: the resolver treats every unresolved unit as a hard error with no
+regard for the edge's authority or the owning spec's lifecycle. This spec settles
+that severity model. It pairs with a separate defects spec for the mechanical
+resolution bugs (region-marker dispatch, Makefile tag handling, nested-workspace
+glob base); those are out of scope here (§6).
+
+## 1. Purpose
+
+The indexer's resolver (`index.rs::resolve_unit`) emits one of `I-003`..`I-009`
+whenever a declared unit fails to resolve against the working tree, and routes it
+to the blocking `errors` tier (`BLOCKING_CODES`). That single severity is too
+blunt along two independent axes:
+
+- **Authority.** spec-spine's model designates `references` as the one
+  **non-owning** edge: the coupling gate already ignores it for ownership
+  (`CLAUDE.md`; `contract.md` §"Typed edges"). Yet an unresolved `references`
+  unit fails `index` exactly as hard as an unresolved `establishes` unit. A
+  dangling provenance pointer is not a governance failure, because no authority
+  ever flows through a non-owning edge. Hard-erroring on it taxes every adopter's
+  provenance hygiene with no governance payoff and causes ongoing link rot as
+  referenced docs move.
+
+- **Lifecycle.** A spec that is `status: draft` or `implementation: pending` may
+  legitimately declare owning units that do not resolve yet: the code is in
+  flight. The previous in-tree OAP indexer silently *tolerated* (effectively
+  skipped) such units; the current library hard-errors them. Both are wrong.
+  Skipping is an invisible-drift vector (a perpetual-draft spec could
+  `establishes:` a path whose units are never validated and whose claim a gate
+  never sees, or point at attacker-staged files with nothing flagging it).
+  Hard-erroring blocks legitimate in-progress work.
+
+The correct rule on both axes is the same: **surface and count the unit, never
+skip it, and let severity follow authority and lifecycle.** This spec encodes
+that as two warning tiers over the existing resolver, leaving the
+approved-and-implemented owning case a hard error.
+
+These two axes are orthogonal and compose: the edge-authority tier (A) covers
+provenance pointers regardless of lifecycle; the lifecycle tier (P2) covers
+in-flight owning claims. Neither subsumes the other (most OAP errors are
+`references` edges on approved + complete specs, which only the edge-authority
+tier reaches).
+
+## 2. Territory
+
+This spec amends 004's resolver-diagnostic contract in place and additively
+claims, alongside 004, the files it must touch:
+
+- `crates/spec-spine-core/src/index.rs`: the severity decision at the
+  `resolve_unit` call sites, and a fresh `W-001` / `W-002` warning band. The
+  resolver already threads an `owning: bool` per unit (the third element of the
+  gathered `(SourceField, Unit, bool)` tuple) and a per-spec `status`; this spec
+  adds the owning spec's `implementation` to that same `SpecInfo` so the decision
+  has both lifecycle signals at hand.
+- `crates/spec-spine-core/tests/index.rs`: the acceptance fixtures (§5).
+- `crates/spec-spine-types/src/version.rs`: the `INDEX_SCHEMA_VERSION` MINOR bump
+  (§3.6).
+
+It touches **nothing** in the registry (`compile`) or the coupling gate
+(`couple`). The `warnings` tier (`Diagnostics::warnings`) and the free-form
+`Diagnostic::code` string already exist, so the new W-band needs no DTO or
+schema-file change. The change is recorded as the `INDEX_SCHEMA_VERSION` minor
+bump alone, mirroring spec 017.
+
+## 3. Behavior
+
+### 3.1 The severity decision
+
+For each declared unit that fails to resolve, the resolver MUST classify the
+diagnostic by this precedence (the first matching arm wins):
+
+1. **Non-owning edge** (the unit's source edge is `references`): emit `W-002`
+   (warning). Lifecycle is irrelevant here, because a non-owning edge carries no
+   authority in any lifecycle state.
+2. **Owning edge on an in-flight spec** (owning spec `status: draft` OR
+   `implementation: pending`): emit `W-001` (warning).
+3. **Owning edge on a settled spec** (owning spec `approved` AND not
+   `implementation: pending`): emit the existing `I-003`..`I-009` error
+   (unchanged).
+
+| edge | owning spec lifecycle | unresolved -> |
+|---|---|---|
+| `references` (non-owning) | any | **W-002** (warning) |
+| owning | `draft` or `implementation: pending` | **W-001** (warning) |
+| owning | `approved` + implemented | `I-003`..`I-009` (error, unchanged) |
+
+A resolved unit is unaffected on every axis: severity tiers govern only the
+failure path.
+
+### 3.2 The two warning codes
+
+- **`W-001` (unresolved unit on an in-flight spec).** An owning unit declared by
+  a `draft` / `implementation: pending` spec did not resolve. The message MUST
+  carry the unit kind, the path/id, and the underlying reason so the warning is
+  as actionable as the error it replaces (e.g. "draft spec '023' file unit
+  'src/x.rs' does not exist").
+- **`W-002` (unresolved non-owning reference).** A `references` unit did not
+  resolve. The message MUST identify the dangling target.
+
+Both codes are new and live in the index `W-` band. They MUST NOT be added to
+`BLOCKING_CODES`, so they never fail `index check` or any blocking-code gate.
+
+### 3.3 Surface, never skip
+
+Every downgraded diagnostic MUST be emitted into the owning spec's shard
+`diagnostics.warnings` and counted. The unit MUST NOT be silently dropped from
+the run. This is the guarantee that keeps a draft spec's unbuilt claim and a
+stale reference both auditable: a consumer can enumerate and accept them
+explicitly, but can never miss them.
+
+### 3.4 No fabricated mapping (the index's boundary)
+
+An unresolved unit MUST NOT contribute a `ResolvedLocation` / `TraceMapping`
+entry. There is no code at an unresolved path, so a mapping entry would assert a
+code-to-spec binding that does not exist: misleading, not protective. The
+index's obligation under this spec is the warning (surface + count), nothing
+more.
+
+### 3.5 Authority is a registry property (the consumer boundary)
+
+This spec changes only the index (code-as-source) view. It makes no change to the
+registry or the coupling gate, and it is **not** the mechanism by which an
+in-flight or referenced claim retains authority. Authority over a path `P`
+derives from the declared `establishes:` / `extends:` (owning) edges in the
+**compiled registry** relationship graph, which exist whether or not `P` is on
+disk and whether or not the index ever mapped it. The coupling gate consults that
+graph directly. So a draft spec's owning claim on `P` is already live to the gate
+the moment code lands at `P`, independent of this spec.
+
+> **Binding consumer note.** The safety of the edge-authority downgrade (§3.1
+> arm 1) holds **only** while consumers derive "who owns `P`" from the registry
+> relationship graph, not from the index mapping. A consumer that derived
+> ownership from the index mapping would inherit a blind spot for unresolved
+> units (which carry no mapping entry, §3.4). Authority queries MUST route
+> through the registry.
+
+### 3.6 Schema
+
+The change is additive (new warning codes in an existing tier; no new field, no
+shape change). `INDEX_SCHEMA_VERSION` MUST bump MINOR: `1.0.0` -> `1.1.0`. The
+on-disk MAJOR is unchanged (`1`), so existing readers accept the index. No
+`index.schema.json` edit is required (the schema is permissive on the diagnostic
+`code` and already admits the `warnings` array). The conformance test
+(`core/tests/conformance.rs`) MUST pass against the embedded `1.1.0` schema.
+
+## 4. Functional requirements
+
+- **FR-001 (edge-authority tier).** An unresolved unit from a non-owning edge
+  (`references`) MUST be emitted as `W-002` in the `warnings` tier, never as a
+  blocking error, on any owning-spec lifecycle.
+- **FR-002 (lifecycle tier).** An unresolved unit from an owning edge whose
+  owning spec is `status: draft` OR `implementation: pending` MUST be emitted as
+  `W-001` in the `warnings` tier, never as a blocking error.
+- **FR-003 (strictness preserved).** An unresolved unit from an owning edge whose
+  owning spec is `approved` AND not `implementation: pending` MUST remain a hard
+  `I-003`..`I-009` error, routed to the `errors` tier, exactly as before this
+  spec.
+- **FR-004 (surface, never skip).** Every unit downgraded under FR-001 / FR-002
+  MUST appear and be counted in the owning spec's `diagnostics.warnings`; it MUST
+  NOT be silently dropped. `W-001` / `W-002` MUST NOT be members of
+  `BLOCKING_CODES`.
+- **FR-005 (no fabricated mapping).** A unit that does not resolve MUST NOT
+  produce a `ResolvedLocation` or `TraceMapping` entry, regardless of severity
+  tier.
+- **FR-006 (registry/gate untouched).** This spec MUST NOT change the registry
+  (`compile`) output or the coupling gate (`couple`) behavior. Authority remains
+  a registry-relationship-graph property (§3.5).
+- **FR-007 (schema).** `INDEX_SCHEMA_VERSION` MUST bump `1.0.0` -> `1.1.0`
+  (additive MINOR), with no schema-file edit; the conformance test MUST pass.
+
+## 5. Acceptance criteria
+
+- **AC-1 (references warn).** A `references` unit pointing at a missing
+  file/section on an `approved` + `implementation: complete` spec yields exactly
+  one `W-002`, zero errors; `index check` exits `0`.
+- **AC-2 (draft owning warn).** An `establishes` unit pointing at a missing path
+  on a `status: draft` spec yields one `W-001`, zero errors.
+- **AC-3 (pending owning warn).** The same on an `approved` spec with
+  `implementation: pending` yields one `W-001`, zero errors.
+- **AC-4 (settled owning still errors).** The same owning unit on an `approved` +
+  `implementation: complete` spec yields the existing `I-004` (or kind-matched
+  `I-0xx`) error, in the `errors` tier, unchanged.
+- **AC-5 (edge-type precedence).** A `references` unit on a `draft` spec yields
+  `W-002` (arm 1), not `W-001`.
+- **AC-6 (self-corpus determinism).** spec-spine's own corpus (all specs
+  `approved` + `complete`, all `references` resolving) produces zero `W-001` /
+  `W-002`; no committed shard gains a `warnings` block; the only committed-shard
+  delta from this spec is the `schemaVersion` field restamp to `1.1.0`.
+- **AC-7 (conformance).** `core/tests/conformance.rs` is green against the
+  embedded `1.1.0` index schema.
+
+## 6. Out of scope
+
+- **The three indexer resolution defects** (non-workflow YAML `# region:`
+  dispatch; Makefile `## tag:` silent overwrite; nested-workspace glob base
+  resolution). They are mechanical correctness fixes, not a severity policy, and
+  are filed as a separate spec amending their real owners (sections work amends
+  spec 022; discovery work amends spec 004).
+- **An opt-in fail-on-warning strictness knob.** This spec sets `W-001` /
+  `W-002` as non-blocking by default (§3.3). A strict adopter, or spec-spine on
+  its own corpus, MAY later wire a policy that fails on the `W-` band; that
+  policy is not defined here. (Making `references` a hard error by default is the
+  *rejected* alternative, decided against in §1 because it taxes provenance
+  hygiene with no governance payoff, not a deferred option.)
+- **Any registry or coupling-gate change** (§3.5, FR-006).
+- **A downstream consumer's gate policy** (e.g. "zero errors plus zero
+  un-accepted warnings"). How a consumer accepts the enumerated warnings is its
+  own concern; this spec only guarantees the warnings are surfaced and counted.
+
+## 7. Security rationale
+
+Two properties make the downgrade safe rather than a drift-hiding hole:
+
+- **Warn, never skip, keeps the unit auditable (FR-004).** A silently skipped
+  unit is the actual laundering vector: a perpetual-draft spec could claim a path
+  whose units are never validated, or point at not-yet-existing / attacker-staged
+  files, and nothing would flag it. A counted `W-001` / `W-002` keeps every such
+  declaration visible and enumerable, so a consumer accepts it deliberately or
+  not at all.
+- **Downgrading `references` cannot launder authority (FR-001).** Authority never
+  flows through a non-owning edge: you cannot smuggle an `establishes`-grade
+  claim into a `references` edge to dodge the error, because `references` confers
+  no ownership in the registry graph the gate consults. The owning-edge severity
+  is untouched except by lifecycle (FR-002 / FR-003), which itself never skips.
+- **The boundary holds only with registry-sourced authority (§3.5).** The above
+  is sound precisely because authority is a registry property, not an index
+  property. The binding consumer note records the one way to break it (deriving
+  ownership from the index mapping) so no future consumer does.


### PR DESCRIPTION
Implements spec **025: severity tiers for unresolved units** (the 0.6.0 headline; option A + P2 unified as one mechanism). Pairs with a follow-up defects spec (026) for the three mechanical resolver fixes, which is out of scope here.

## What changed

The indexer's resolver hard-errored (`I-003`..`I-009`) on every unresolved unit regardless of edge authority or owning-spec lifecycle. Spec 025 adds two orthogonal severity tiers over the same resolver, by first-match precedence:

| edge | owning spec lifecycle | unresolved → |
|---|---|---|
| `references` (non-owning) | any | **W-002** (warning) |
| owning | `draft` or `implementation: pending` | **W-001** (warning) |
| owning | `approved` + implemented | `I-003`..`I-009` (error, unchanged) |

- **Surface, never skip:** every downgrade lands in `diagnostics.warnings` and is counted; `W-001`/`W-002` are absent from `BLOCKING_CODES`, so a warned shard is not flagged stale by `index check`. The authority-laundering vector stays closed.
- **No fabricated mapping:** an unresolved unit never gets a `ResolvedLocation`. Authority stays a property of the registry relationship graph (the gate consults it independently of index resolution); the spec records the binding consumer note (authority must route through the registry, not the index mapping).
- **Additive schema:** the `warnings` tier and free-form `Diagnostic.code` already exist, so `INDEX_SCHEMA_VERSION` bumps MINOR `1.0.0` → `1.1.0` with no schema-file edit. The committed-shard delta is the `schemaVersion` restamp only (no shard gains a warnings block; spec-spine's own corpus is all approved + complete with resolving references).

## Tests

New AC fixtures in `core/tests/index.rs` (`ac1`..`ac5`): references → W-002, draft owning → W-001, pending owning → W-001, settled owning → I-004 unchanged, and edge-type precedence (reference on a draft spec → W-002). Full workspace test/clippy/fmt green; conformance passes at index schema 1.1.0.

## Coupling

Spec-Drift-Waiver: tests/attest.rs only: 023's `ac3_with_coupling_verdict_is_independently_checkable` was updated to use a settled (approved + complete) spec because spec 025 reclassifies a draft spec's missing owning unit as a non-blocking W-001; this adapts 023's test to 025's new severity, with no change to 023's attestation contract.

https://claude.ai/code/session_01HbxpaFZVqmQmmp9CKS2vKF
