### PR TITLE
feat(026): indexer resolution + discovery fixes (foreign-YAML regions, Makefile tags, nested-workspace globs)

### DIFF
--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -1,0 +1,88 @@
+{
+  "mapping": {
+    "amends": [
+      "004-codebase-index",
+      "022-keypath-section-anchors"
+    ],
+    "dependsOn": [
+      "004-codebase-index",
+      "022-keypath-section-anchors"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/manifest.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/sections.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/design/00-architecture.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/manifest.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/manifest.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/sections.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/sections.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/00-architecture.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "specId": "026-resolution-discovery-fixes",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "c86ff36e4f2fdc76a481749215202ffb94688ca022fb2175681fb1acf4a41a97"
+}

--- a/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
@@ -1,0 +1,71 @@
+{
+  "record": {
+    "amends": [
+      "004-codebase-index",
+      "022-keypath-section-anchors"
+    ],
+    "created": "2026-06-18",
+    "dependsOn": [
+      "004-codebase-index",
+      "022-keypath-section-anchors"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/sections.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/manifest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      }
+    ],
+    "id": "026-resolution-discovery-fixes",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "026: Indexer resolution + discovery fixes",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 D1: foreign YAML resolves region markers",
+      "3.2 D2: a pending Makefile tag is never silently lost",
+      "3.3 D3: nested-workspace globs resolve against the declaration file",
+      "4. Functional requirements",
+      "5. Acceptance criteria",
+      "6. Out of scope"
+    ],
+    "specPath": "specs/026-resolution-discovery-fixes/spec.md",
+    "status": "draft",
+    "summary": "Three mechanical correctness fixes surfaced by the OAP spec-217 Phase-0 dry run of 0.5.0, all in the indexer's resolution and discovery paths, none changing any schema or DTO shape. (1) Non-workflow YAML (Helm values, infra manifests) is dispatched to the CI-jobs parser, so its `# region:` markers never resolve and a declared section unit on one raises a spurious I-006; route foreign YAML to the region parser, which is exactly the whole-file / region ownership spec 022 §3.2 already promised foreign structured configs (retiring §4's deliberately-deferred D4). (2) A Makefile `## tag:` is silently overwritten when a second `## tag:` precedes any consuming target, so a tagged region is never emitted; make the pending tag deterministic so it is never silently lost. (3) Workspace-member globs declared in a NON-root workspace file (a nested `pnpm-workspace.yaml`) are resolved against the repo root instead of the declaration file's directory, so they match nothing; pre-join such globs with the declaration file's parent. A related lower-priority guard covers a `standalone_rust_workspaces` entry that ends in `Cargo.toml`. Pairs with spec 025 (the severity policy); these are the mechanical half of the 0.6.0 indexer work.\n",
+    "title": "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
+  },
+  "shardHash": "3b1d8f54c7197a989f7ad72db652b497adca3c3a41600685995ed9122bf296f3",
+  "specVersion": "1.0.0"
+}

--- a/crates/spec-spine-core/src/manifest.rs
+++ b/crates/spec-spine-core/src/manifest.rs
@@ -91,6 +91,13 @@ fn discover_rust(
     members.extend(cfg.layout.standalone_rust_workspaces.iter().cloned());
 
     for member in &members {
+        // A standalone entry may name a directory or a `Cargo.toml` path; strip a
+        // trailing manifest filename so glob_manifests appends it exactly once
+        // (spec 026 FR-005: a `.../Cargo.toml` entry must not double-join).
+        let member = member
+            .strip_suffix("Cargo.toml")
+            .map(|s| s.trim_end_matches('/'))
+            .unwrap_or(member.as_str());
         for manifest in glob_manifests(
             repo_root,
             member,
@@ -187,12 +194,20 @@ fn discover_npm(
                 manifests.push(decl_path.clone());
                 let ws = doc.get("workspaces");
                 if let Some(arr) = ws.and_then(|w| w.as_array()) {
-                    globs.extend(arr.iter().filter_map(|v| v.as_str().map(String::from)));
+                    globs.extend(
+                        arr.iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|g| rebase_glob(decl, g)),
+                    );
                 } else if let Some(arr) = ws
                     .and_then(|w| w.get("packages"))
                     .and_then(|p| p.as_array())
                 {
-                    globs.extend(arr.iter().filter_map(|v| v.as_str().map(String::from)));
+                    globs.extend(
+                        arr.iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|g| rebase_glob(decl, g)),
+                    );
                 }
                 // The root package.json that declares workspaces is itself a record.
                 if doc.get("name").is_some() {
@@ -208,7 +223,11 @@ fn discover_npm(
             if let Ok(doc) = serde_yaml::from_str::<serde_yaml::Value>(&src) {
                 manifests.push(decl_path.clone());
                 if let Some(arr) = doc.get("packages").and_then(|p| p.as_sequence()) {
-                    globs.extend(arr.iter().filter_map(|v| v.as_str().map(String::from)));
+                    globs.extend(
+                        arr.iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|g| rebase_glob(decl, g)),
+                    );
                 }
             }
         }
@@ -291,6 +310,21 @@ pub fn npm_hash_projection(content: &str, namespace: &str) -> Option<String> {
 }
 
 // ===== shared =====
+
+/// Rebase a workspace-member glob declared in `decl` (a repo-relative declaration
+/// file path) onto that file's parent directory, so a NON-root workspace file
+/// (e.g. `product/pnpm-workspace.yaml` declaring `apps/*`) resolves its members
+/// relative to itself, not the repo root (spec 026 D3). A root-level declaration
+/// (no parent) returns the glob unchanged. `standalone_npm_packages` are
+/// repo-root-relative by contract and are deliberately NOT routed through here.
+fn rebase_glob(decl: &str, glob: &str) -> String {
+    match Path::new(decl).parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            format!("{}/{}", parent.to_string_lossy(), glob)
+        }
+        _ => glob.to_string(),
+    }
+}
 
 /// Expand `<member>/<manifest_file>` under `repo_root` (member may contain glob
 /// metacharacters), returning matches not inside an excluded directory, sorted.

--- a/crates/spec-spine-core/src/sections.rs
+++ b/crates/spec-spine-core/src/sections.rs
@@ -40,9 +40,14 @@ pub fn enumerate_sections(content: &str, file_name: &str) -> Vec<(String, LineSp
             // of the legacy bare-`jobs.<name>` behavior).
             workflow_yaml_sections(content)
         } else {
-            // Foreign YAML keeps the legacy bare-job behavior; routing it to
-            // region markers is spec 022 D4, deliberately deferred (§4).
-            ci_job_sections(content)
+            // Foreign YAML (Helm values, infra manifests) keeps whole-file /
+            // `# region:` ownership, exactly as spec 022 §3.2 promised. Spec 026
+            // implements that region half (retiring §4's deferred D4) and unions
+            // it with the legacy bare-`jobs.<name>` anchors so a foreign YAML that
+            // carried a resolvable job anchor does not regress (026 FR-002).
+            let mut out = region_sections(content, comment_token(base));
+            out.extend(ci_job_sections(content));
+            out
         }
     } else {
         region_sections(content, comment_token(base))
@@ -130,16 +135,20 @@ fn slug(text: &str) -> String {
 fn makefile_sections(content: &str) -> Vec<(String, LineSpan)> {
     let lines: Vec<&str> = content.lines().collect();
     let mut out: Vec<(String, LineSpan)> = Vec::new();
-    let mut pending_tag: Option<String> = None;
+    // Tags awaiting their target. A single `Option` silently clobbered an
+    // unconsumed `## tag:` when a second one preceded any target (spec 026 D2);
+    // a vector preserves every tag deterministically, so none is ever lost.
+    let mut pending_tags: Vec<String> = Vec::new();
 
     let mut i = 0;
     while i < lines.len() {
         let line = lines[i];
         let trimmed = line.trim_start();
 
-        // `## tag: name` tags the next target.
+        // `## tag: name` tags the next target. Multiple tags before one target
+        // all apply to it (none is dropped).
         if let Some(rest) = trimmed.strip_prefix("## tag:") {
-            pending_tag = Some(rest.trim().to_string());
+            pending_tags.push(rest.trim().to_string());
             i += 1;
             continue;
         }
@@ -175,7 +184,7 @@ fn makefile_sections(content: &str) -> Vec<(String, LineSpan)> {
                     j += 1;
                 }
                 out.push((target.clone(), LineSpan::new(start, end)));
-                if let Some(tag) = pending_tag.take() {
+                for tag in pending_tags.drain(..) {
                     out.push((tag, LineSpan::new(start, end)));
                 }
             }
@@ -819,6 +828,48 @@ mod tests {
             resolve_section(rs, "lib.rs", "core"),
             Some(LineSpan::new(2, 5))
         );
+    }
+
+    // ===== spec 026: resolution + discovery fixes =====
+
+    #[test]
+    fn foreign_yaml_resolves_region_markers() {
+        // A Helm values.yaml is not a governed workflow, so its `# region:`
+        // markers must resolve (spec 026 D1, fulfilling spec 022 §3.2).
+        let yaml = "image:\n  repo: x\n# region: access-gate\nrbac:\n  create: true\n# endregion\nother: 1\n";
+        assert_eq!(
+            resolve_section(yaml, "deploy/values.yaml", "access-gate"),
+            Some(LineSpan::new(3, 6))
+        );
+    }
+
+    #[test]
+    fn foreign_yaml_still_resolves_bare_jobs() {
+        // Non-regression (spec 026 FR-002): a foreign YAML with a `jobs:` block
+        // keeps its bare-job anchors via the union with ci_job_sections.
+        let yaml = "jobs:\n  build:\n    runs-on: x\n  test:\n    runs-on: y\n";
+        assert!(resolve_section(yaml, "other.yaml", "build").is_some());
+        assert!(resolve_section(yaml, "other.yaml", "test").is_some());
+    }
+
+    #[test]
+    fn makefile_multiple_pending_tags_are_not_lost() {
+        // spec 026 D2: a `## tag:` followed by non-target lines then a second
+        // `## tag:` must not clobber the first; both tag the next target.
+        let mk = "## tag: ci-fast\nVAR := 1\n## tag: ci-slow\ntest:\n\tcargo test\n";
+        let names: Vec<String> = enumerate_sections(mk, "Makefile")
+            .into_iter()
+            .map(|(a, _)| a)
+            .collect();
+        assert!(
+            names.contains(&"ci-fast".to_string()),
+            "first tag kept: {names:?}"
+        );
+        assert!(
+            names.contains(&"ci-slow".to_string()),
+            "second tag present: {names:?}"
+        );
+        assert!(names.contains(&"test".to_string()));
     }
 
     // ===== spec 022: keypath section anchors =====

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -183,6 +183,67 @@ fn missing_file_unit_is_blocking_diagnostic_i004() {
     assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-004"));
 }
 
+// ===== spec 026: resolution + discovery fixes =====
+
+/// AC-1 (spec 026 D1): a section unit on a foreign (non-workflow) YAML resolves
+/// via its `# region:` marker end to end, with no spurious I-006.
+#[test]
+fn foreign_yaml_section_unit_resolves_no_i006() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "deploy/values.yaml",
+        "image:\n  repo: x\n# region: access-gate\nrbac:\n  create: true\n# endregion\n",
+    );
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "establishes:\n  - { kind: section, file: \"deploy/values.yaml\", anchor: \"access-gate\" }\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        idx.diagnostics.errors.iter().all(|d| d.code != "I-006"),
+        "no spurious I-006 for a present region marker: {:?}",
+        idx.diagnostics.errors
+    );
+    let m = mapping(&idx, "001-x");
+    assert!(
+        m.resolved_units.iter().any(|u| !u.locations.is_empty()),
+        "the section unit resolved to a location"
+    );
+}
+
+/// AC-4 (spec 026 D3): a non-root pnpm-workspace.yaml resolves its member globs
+/// relative to its own directory, not the repo root.
+#[test]
+fn nested_pnpm_workspace_discovers_members() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "product/pnpm-workspace.yaml",
+        "packages:\n  - \"apps/*\"\n",
+    );
+    write(
+        tmp.path(),
+        "product/apps/web/package.json",
+        "{\n  \"name\": \"web\"\n}\n",
+    );
+    write(tmp.path(), "specs/001-x/spec.md", &spec("001-x", ""));
+    let mut cfg = Config::default();
+    cfg.layout.npm_workspaces = vec!["product/pnpm-workspace.yaml".to_string()];
+    let idx = index(&cfg, tmp.path()).unwrap().index;
+    let names: Vec<&str> = idx.packages.iter().map(|p| p.name.as_str()).collect();
+    assert!(
+        names.contains(&"web"),
+        "nested-workspace member discovered relative to the decl file: {names:?}"
+    );
+}
+
 // ===== spec 025: lifecycle- and edge-aware unresolved-unit severity =====
 
 /// AC-1: an unresolved unit on a non-owning `references` edge is a counted

--- a/specs/026-resolution-discovery-fixes/spec.md
+++ b/specs/026-resolution-discovery-fixes/spec.md
@@ -1,0 +1,185 @@
+---
+id: "026-resolution-discovery-fixes"
+title: "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
+status: draft
+kind: "tooling"
+created: "2026-06-18"
+owner: "The spec-spine Authors"
+implementation: pending
+risk: low
+depends_on:
+  - "004-codebase-index"          # section resolution + manifest discovery
+  - "022-keypath-section-anchors" # the eligible-file predicate and §3.2 region promise
+amends:
+  - "004-codebase-index"          # Makefile `## tag:` determinism; nested-workspace glob base
+  - "022-keypath-section-anchors" # fulfill §3.2's foreign-YAML region promise; retire §4's D4 deferral
+extends:
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/sections.rs"   # foreign-YAML region dispatch + Makefile tag determinism
+      - "crates/spec-spine-core/src/manifest.rs"   # nested-workspace glob base resolution
+      - "crates/spec-spine-core/tests/index.rs"    # nested-workspace + foreign-YAML-region fixtures
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  Three mechanical correctness fixes surfaced by the OAP spec-217 Phase-0 dry run
+  of 0.5.0, all in the indexer's resolution and discovery paths, none changing any
+  schema or DTO shape. (1) Non-workflow YAML (Helm values, infra manifests) is
+  dispatched to the CI-jobs parser, so its `# region:` markers never resolve and a
+  declared section unit on one raises a spurious I-006; route foreign YAML to the
+  region parser, which is exactly the whole-file / region ownership spec 022 §3.2
+  already promised foreign structured configs (retiring §4's deliberately-deferred
+  D4). (2) A Makefile `## tag:` is silently overwritten when a second `## tag:`
+  precedes any consuming target, so a tagged region is never emitted; make the
+  pending tag deterministic so it is never silently lost. (3) Workspace-member
+  globs declared in a NON-root workspace file (a nested `pnpm-workspace.yaml`) are
+  resolved against the repo root instead of the declaration file's directory, so
+  they match nothing; pre-join such globs with the declaration file's parent. A
+  related lower-priority guard covers a `standalone_rust_workspaces` entry that
+  ends in `Cargo.toml`. Pairs with spec 025 (the severity policy); these are the
+  mechanical half of the 0.6.0 indexer work.
+---
+
+# 026: Indexer resolution + discovery fixes
+
+Filed off the OAP spec-217 Phase-0 dry run of the published 0.5.0 library against
+its 220-spec corpus. After separating the adopter's own config and corpus issues,
+three residual diagnostics were library defects in the resolution (`sections.rs`)
+and discovery (`manifest.rs`) paths. This spec owns the fixes. It is the
+mechanical companion to spec 025 (the unresolved-unit severity policy); the two
+are split so each disposition stands on its own.
+
+## 1. Purpose
+
+Each defect makes the indexer report a false negative (a unit that should resolve,
+or a package that should be discovered, silently does not):
+
+- **D1 (foreign-YAML regions).** `enumerate_sections` routes any non-workflow
+  `.yml` / `.yaml` to `ci_job_sections` (which only finds a `jobs:` block), never
+  to `region_sections`. A `# region: <name>` marker in a Helm `values.yaml` or an
+  infra manifest is therefore invisible, and a spec that declares a section unit
+  on it gets a spurious `I-006` ("section unit not found"). This contradicts spec
+  022 §3.2, which already states foreign structured configs "keep whole-file /
+  `region:` ownership"; the code shipped only the whole-file half, deferring the
+  region half as §4's D4. The marker exists on disk; only the dispatch is wrong.
+
+- **D2 (Makefile tag overwrite).** `makefile_sections` sets
+  `pending_tag = Some(...)` unconditionally on each `## tag:` line. If a `## tag:`
+  is followed by variable-only lines (no target) and then a second `## tag:`, the
+  first tag is clobbered before any target consumes it, so its region is never
+  emitted: a silent, position-dependent loss, which is unpredictable behavior, not
+  a documented limitation.
+
+- **D3 (nested-workspace glob base).** `discover_npm` pushes the raw member globs
+  from a workspace declaration file into the resolve set, and `glob_manifests`
+  joins them against `repo_root`. For a declaration file that is **not** at the
+  repo root (e.g. `product/pnpm-workspace.yaml` declaring `["apps/*"]`), the globs
+  must resolve against the file's parent (`product/`), not the root, or they
+  expand to `apps/*` at the root and match nothing. The library's own config doc
+  comment references the related "template-encore" bug; this is the same class,
+  not fully fixed.
+
+## 2. Territory
+
+This spec amends the two owning specs' contracts in place via edge (it does not
+rewrite their bodies): spec 022's foreign-config ownership (D1 fulfils §3.2 and
+retires the §4 D4 deferral) and spec 004's Makefile-section parsing (D2) and
+manifest discovery (D3). It additively claims, alongside 004, the files it edits:
+
+- `crates/spec-spine-core/src/sections.rs`: the `enumerate_sections` dispatch (D1)
+  and `makefile_sections` tag handling (D2), with their inline `#[cfg(test)]`
+  fixtures.
+- `crates/spec-spine-core/src/manifest.rs`: the glob base join in `discover_npm`
+  (D3) and the `standalone_rust_workspaces` guard.
+- `crates/spec-spine-core/tests/index.rs`: end-to-end fixtures (a foreign YAML
+  with a `# region:` resolving a section unit; a nested `pnpm-workspace.yaml`
+  discovering its members).
+
+No schema, DTO, or `INDEX_SCHEMA_VERSION` change: these are behavioral
+corrections within the existing grammar (the 0.6.0 schema minor is spec 025's).
+
+## 3. Behavior
+
+### 3.1 D1: foreign YAML resolves region markers
+
+`enumerate_sections` MUST route a `.yml` / `.yaml` file that is **not** a governed
+workflow (spec 022's `is_workflow_path` predicate is false) to `region_sections`
+with the `#` comment token, so `# region: <name>` ... `# endregion` markers
+resolve. Governed workflow files keep the spec-022 keypath grammar (a strict
+superset of bare-`jobs.<name>`), unchanged. A foreign YAML that happens to contain
+a top-level `jobs:` block but no region markers MUST NOT regress: the
+implementation SHOULD fall back to (or union with) `ci_job_sections` so any
+previously resolvable bare-job anchor still resolves. (In practice foreign YAML
+with a `jobs:` block and a declared job section unit is rare-to-nonexistent, but
+the fix must not silently drop it.)
+
+### 3.2 D2: a pending Makefile tag is never silently lost
+
+`makefile_sections` MUST NOT discard an unconsumed `## tag:` when a second
+`## tag:` is seen. The pending tag MUST be resolved deterministically: a second
+`## tag:` before any target MUST NOT silently overwrite the first; instead the
+prior pending tag is preserved (emitted against the next consuming target, or
+retained alongside the new one) so behavior does not depend on intervening
+non-target lines. The existing `# BEGIN <name>` / `# END` explicit region keeps
+its verbatim-name semantics (the name is exactly what follows `# BEGIN `); this
+spec does not change it.
+
+### 3.3 D3: nested-workspace globs resolve against the declaration file
+
+When `discover_npm` reads member globs from a workspace declaration file at a
+non-root path, it MUST pre-join each glob with the declaration file's parent
+directory (relative to the repo root) before resolving, so a nested
+`pnpm-workspace.yaml` (or nested `package.json#workspaces`) resolves its members
+relative to itself. `standalone_npm_packages` globs are repo-root-relative by
+contract and MUST remain so (the fix applies only to declaration-file-derived
+globs). Lower priority: a `standalone_rust_workspaces` entry that ends in
+`Cargo.toml` currently yields `.../Cargo.toml/Cargo.toml` and discovers nothing;
+`discover_rust` SHOULD accept either a directory or a `Cargo.toml` path, or emit a
+clear diagnostic rather than silently discovering nothing.
+
+## 4. Functional requirements
+
+- **FR-001 (D1).** A non-workflow YAML file's `# region: <name>` markers MUST
+  resolve as section anchors; a section unit declared on one MUST NOT raise
+  `I-006` when the marker is present.
+- **FR-002 (D1 non-regression).** Governed workflow YAML keeps the spec-022
+  keypath grammar unchanged; a foreign YAML with a bare `jobs:` block MUST NOT
+  lose previously resolvable job anchors.
+- **FR-003 (D2).** No `## tag:` is silently dropped: a tagged Makefile region MUST
+  be emitted regardless of intervening non-target lines or a later `## tag:`.
+- **FR-004 (D3).** Member globs from a non-root workspace declaration file MUST
+  resolve relative to that file's directory; `standalone_npm_packages` globs MUST
+  stay repo-root-relative.
+- **FR-005 (D3 guard, SHOULD).** A `standalone_rust_workspaces` entry ending in
+  `Cargo.toml` SHOULD resolve (directory-or-manifest) or emit a clear diagnostic,
+  never silently discover nothing.
+- **FR-006 (no schema change).** No DTO, schema file, or `INDEX_SCHEMA_VERSION`
+  change; behavior corrections within the existing grammar only.
+
+## 5. Acceptance criteria
+
+- **AC-1 (D1).** A fixture with a plain `values.yaml` containing
+  `# region: foo` ... `# endregion` and a spec section unit `{ file: values.yaml,
+  anchor: foo }` resolves to the marker's span, zero `I-006`.
+- **AC-2 (D1 non-regression).** A `.github/workflows/ci.yml` still resolves its
+  keypath/job anchors unchanged.
+- **AC-3 (D2).** A Makefile with `## tag: a` then variable-only lines, then
+  `## tag: b` then a target, emits regions for **both** `a` and `b` (the first is
+  not lost).
+- **AC-4 (D3).** A fixture with `product/pnpm-workspace.yaml` declaring
+  `["apps/*"]` and a package at `product/apps/web/package.json` discovers `web`;
+  the same globs do not spuriously match a root-level `apps/`.
+- **AC-5 (self-corpus determinism).** spec-spine's own committed shards are
+  unchanged by these fixes (its corpus has no foreign-YAML region units, no
+  multi-`## tag:` Makefile, no nested workspace), so the only committed-artifact
+  delta is 026's own two new shards.
+
+## 6. Out of scope
+
+- **The severity policy** (lifecycle / edge-type warning tiers): spec 025.
+- **Any schema or `INDEX_SCHEMA_VERSION` change** (FR-006).
+- **New unit kinds or new config keys.** D3 reuses the existing `npm_workspaces`
+  declaration mechanism; it does not add configuration.
+- **The package version bump and release** (0.6.0): separate release steps once
+  025 and 026 are on `main`.


### PR DESCRIPTION
Implements spec **026: indexer resolution + discovery fixes** (the mechanical half of 0.6.0). Three correctness fixes from the OAP spec-217 Phase-0 dry run, **no schema/DTO change** (the index schema 1.1.0 minor belongs to #32 / spec 025).

> **Rebased onto `main`** after #32 (spec 025) merged; the diff is 026-only and the coupling gate is clean against `origin/main` with no waiver.

## The three defects

- **D1 (foreign-YAML regions).** Non-workflow YAML was dispatched to the CI-jobs parser, so a `# region:` marker in a Helm `values.yaml` / infra manifest never resolved and a section unit on it raised a spurious `I-006`. Now routed to the region parser, the whole-file / `region:` ownership spec 022 §3.2 already promised foreign configs (this retires §4's deferred D4). Unioned with `ci_job_sections` so a foreign YAML with a bare `jobs:` block keeps its job anchors (FR-002).
- **D2 (Makefile `## tag:` overwrite).** A `## tag:` followed by non-target lines then a second `## tag:` silently clobbered the first. Pending tags now accumulate in a vector and all apply to the next target, so none is lost (deterministic, position-independent).
- **D3 (nested-workspace globs).** Member globs from a non-root workspace declaration file (e.g. `product/pnpm-workspace.yaml`) were resolved against the repo root and matched nothing. Now pre-joined with the declaration file's parent. `standalone_npm_packages` stay repo-root-relative. Plus the `standalone_rust_workspaces` guard: `discover_rust` accepts a directory or a `Cargo.toml` path (no `Cargo.toml/Cargo.toml` double-join).

## Edges

`amends: [004-codebase-index, 022-keypath-section-anchors]`; additively claims `sections.rs`, `manifest.rs`, `tests/index.rs` under 004.

## Tests

Inline (`sections.rs`): foreign-YAML region resolution, bare-job non-regression, multi-`## tag:` Makefile. End-to-end (`tests/index.rs`): a section unit on a foreign YAML resolves with no `I-006` (AC-1); a nested `pnpm-workspace.yaml` discovers its members (AC-4). Full workspace test + clippy + fmt green; coupling clean (no waiver). AC-5: spec-spine's own committed shards are unchanged (it has none of these constructs); only 026's two new shards are added.

https://claude.ai/code/session_01HbxpaFZVqmQmmp9CKS2vKF
