### PR TITLE
chore(release): bump package version to 0.6.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3d705eed12afaee46a6f497a4932d0d9d5387a6af5046d61c36710af19ce317b"
+  "shardHash": "cb0eaf17753ea51746ab3eb90e1ff80c8cf69ea5a76a4ebb96def0217cd87681"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.5.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.5.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.6.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.6.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.5.0",
-    "@spec-spine/cli-darwin-x64": "0.5.0",
-    "@spec-spine/cli-linux-x64": "0.5.0",
-    "@spec-spine/cli-linux-arm64": "0.5.0",
-    "@spec-spine/cli-win32-x64": "0.5.0"
+    "@spec-spine/cli-darwin-arm64": "0.6.0",
+    "@spec-spine/cli-darwin-x64": "0.6.0",
+    "@spec-spine/cli-linux-x64": "0.6.0",
+    "@spec-spine/cli-linux-arm64": "0.6.0",
+    "@spec-spine/cli-win32-x64": "0.6.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.5.0"
+version = "0.6.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Lockstep package-version bump to **0.6.0** across Cargo (workspace + internal pins), npm (version + the five `@spec-spine/cli-*` platform pins), and `py/pyproject.toml`; `Cargo.lock` refreshed; the npm by-package index shard restamped (0.5.0 to 0.6.0).

Ships the 0.6.0 indexer work:
- **spec 025**: lifecycle- and edge-aware unresolved-unit severity (`W-001`/`W-002` warning tiers; index schema MINOR `1.0.0` to `1.1.0`).
- **spec 026**: foreign-YAML `# region:` dispatch, Makefile `## tag:` determinism, nested-workspace glob base.

The package-version axis is independent of the schema axis (`docs/schema-versioning.md`). Once this is on `main`, the `v0.6.0` tag triggers the release workflow (crates.io + npm + PyPI).

Gate green: workspace test + clippy + fmt, `index check` fresh, `lint --fail-on-warn` clean.

## Coupling

Spec-Drift-Waiver: Mechanical package-version bump only. The two flagged paths (npm/package.json owned by spec 007-distribution, py/pyproject.toml owned by spec 008-python-distribution) change only their version string 0.5.0 -> 0.6.0 for the v0.6.0 release; no change to either distribution contract.