### PR TITLE
chore: ratify specs 025 + 026 (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -98,8 +98,8 @@
       }
     ],
     "specId": "025-unresolved-unit-severity",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b614214ba4905c3de68893227744744e3edf5e9d09c7900d1012a920f9a2f2ba"
+  "shardHash": "e3994b7e7d65367986dc2257c27f8d672bfa0e429f568ccd58132b47cdd64c45"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -81,8 +81,8 @@
       }
     ],
     "specId": "026-resolution-discovery-fixes",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c86ff36e4f2fdc76a481749215202ffb94688ca022fb2175681fb1acf4a41a97"
+  "shardHash": "49c5fa1e8c9093637e0e31c18e2c70820cfe87fb7f03409481fa04ede68ab200"
 }

--- a/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
@@ -74,10 +74,10 @@
       "7. Security rationale"
     ],
     "specPath": "specs/025-unresolved-unit-severity/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Today the indexer hard-errors (I-003..I-009) on every declared unit that does not resolve, regardless of whether the edge is authoritative or whether the owning spec is even built yet. Two of those errors are not governance failures: an unresolved unit on a non-owning `references` edge is a stale provenance pointer, and an unresolved owning unit on a `draft` / `implementation: pending` spec is legitimate work-in-progress. This spec adds two orthogonal severity tiers over the same resolver, keyed on (a) edge authority and (b) owning-spec lifecycle, so those two cases become counted warnings (a fresh `W-001` / `W-002` band) instead of blocking errors, while an unresolved owning unit on an approved + implemented spec stays a hard error. The downgrade never skips: every such unit is still surfaced and counted, never silently dropped, so the authority-laundering / invisible-drift vector stays closed. The index never fabricates a code location for an unresolved path; authority remains a property of the registry relationship graph, which the coupling gate consults independently of index resolution. Additive: the `warnings` tier and the free-form diagnostic `code` already exist, so this is an `INDEX_SCHEMA_VERSION` MINOR (1.0.0 -> 1.1.0) with no schema-file edit and no registry change.\n",
     "title": "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
   },
-  "shardHash": "622adcfe8e750b30b3584965f4c88d10cbb54106d20015537b9d9b753d596211",
+  "shardHash": "e3c677106b3d69bbcaa170009f097714944db9bb8243b3d147506d5ef9aef567",
   "specVersion": "1.0.0"
 }

--- a/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
@@ -62,10 +62,10 @@
       "6. Out of scope"
     ],
     "specPath": "specs/026-resolution-discovery-fixes/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Three mechanical correctness fixes surfaced by the OAP spec-217 Phase-0 dry run of 0.5.0, all in the indexer's resolution and discovery paths, none changing any schema or DTO shape. (1) Non-workflow YAML (Helm values, infra manifests) is dispatched to the CI-jobs parser, so its `# region:` markers never resolve and a declared section unit on one raises a spurious I-006; route foreign YAML to the region parser, which is exactly the whole-file / region ownership spec 022 §3.2 already promised foreign structured configs (retiring §4's deliberately-deferred D4). (2) A Makefile `## tag:` is silently overwritten when a second `## tag:` precedes any consuming target, so a tagged region is never emitted; make the pending tag deterministic so it is never silently lost. (3) Workspace-member globs declared in a NON-root workspace file (a nested `pnpm-workspace.yaml`) are resolved against the repo root instead of the declaration file's directory, so they match nothing; pre-join such globs with the declaration file's parent. A related lower-priority guard covers a `standalone_rust_workspaces` entry that ends in `Cargo.toml`. Pairs with spec 025 (the severity policy); these are the mechanical half of the 0.6.0 indexer work.\n",
     "title": "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
   },
-  "shardHash": "3b1d8f54c7197a989f7ad72db652b497adca3c3a41600685995ed9122bf296f3",
+  "shardHash": "9e58738f6bd1670e3d89ab0e7bc11abefa48c2a7495383f58bdec19ab7a2327f",
   "specVersion": "1.0.0"
 }

--- a/specs/025-unresolved-unit-severity/spec.md
+++ b/specs/025-unresolved-unit-severity/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "025-unresolved-unit-severity"
 title: "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-06-17"
 owner: "The spec-spine Authors"

--- a/specs/026-resolution-discovery-fixes/spec.md
+++ b/specs/026-resolution-discovery-fixes/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "026-resolution-discovery-fixes"
 title: "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-06-18"
 owner: "The spec-spine Authors"


### PR DESCRIPTION
Flips specs **025** (severity tiers) and **026** (resolution/discovery fixes) from `draft` to `approved`, the last two drafts on `main`.

Both implementations landed (#32, #33) and shipped in v0.6.0 with `implementation: complete`; this is the governance ratification, not new behaviour. Sharding keeps the flips disjoint: each restamps only its own registry + index shards. **Corpus is now 27/27 approved.**

Gate green: `compile` (0 warn), `index check` (fresh), `lint --fail-on-warn` (0/0/0), `couple` (2 paths, no drift, no waiver).