### PR TITLE
feat(027): feature-gate tree-sitter symbol/module resolution

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f119742359fc2ea1ec534166eae3d021c4f8eb5017fd436990542dd184cfaa5c"
+  "shardHash": "64406c5191495ec7dd3bf809026b7acf41767795e5e05ab7505c039157346fbe"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -1,0 +1,88 @@
+{
+  "mapping": {
+    "amends": [
+      "004-codebase-index",
+      "017-directory-crate-module-units"
+    ],
+    "dependsOn": [
+      "004-codebase-index",
+      "017-directory-crate-module-units"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/symbols.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/design/00-architecture.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/symbols.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/symbols.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/00-architecture.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "specId": "027-symbol-resolution-feature-gate",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "f83f253ef5efe4cc65f4901d10442ece036f141b2e47da1274419dc5befe8b3c"
+}

--- a/.derived/spec-registry/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/spec-registry/by-spec/027-symbol-resolution-feature-gate.json
@@ -1,0 +1,71 @@
+{
+  "record": {
+    "amends": [
+      "004-codebase-index",
+      "017-directory-crate-module-units"
+    ],
+    "created": "2026-06-18",
+    "dependsOn": [
+      "004-codebase-index",
+      "017-directory-crate-module-units"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/symbols.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      }
+    ],
+    "id": "027-symbol-resolution-feature-gate",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "027: Feature-gate symbol/module resolution",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The feature",
+      "3.2 Feature on (default)",
+      "3.3 Feature off (`default-features = false`)",
+      "4. Functional requirements",
+      "5. Acceptance criteria",
+      "6. Out of scope"
+    ],
+    "specPath": "specs/027-symbol-resolution-feature-gate/spec.md",
+    "status": "draft",
+    "summary": "Adds a default-enabled `symbol-resolution` cargo feature to `spec-spine-core` that gates the tree-sitter dependency tree (tree-sitter + the Rust/TypeScript grammars) and the symbol/module resolution code. The CLI and `spec-spine index` keep default features, so adopter and self-governance behavior is byte-for-byte unchanged. Library consumers that read only the committed shards (`load_committed_registry` / `load_committed_index`) can build with `default-features = false` to drop tree-sitter entirely, which removes a hard blocker: tree-sitter declares `links = \"tree-sitter\"`, so a host workspace that pins a different tree-sitter (e.g. an analysis crate on `^0.26` while this crate pins `=0.25.10`) cannot otherwise resolve a single lockfile, and adding `spec-spine-core` anywhere in that workspace fails resolution before compilation. The seam is minimal: the `SymbolIndex` / `ModuleIndex` types and their `resolve` lookups are plain `BTreeMap` wrappers (no tree-sitter) and stay compiled, so the index resolver, its readers, and `compile()` build with the feature off; only the `build_*` functions and their parse helpers are gated. No DTO, JSON Schema, or `INDEX_SCHEMA_VERSION` change: the on-disk index shape is identical. Filed off the OAP spec-217 engine-swap work, which is blocked workspace-wide by exactly this `links` clash across its eight planned read-path consumers.\n",
+    "title": "Feature-gate tree-sitter symbol/module resolution for dependency-free embedding"
+  },
+  "shardHash": "9d3c7e8d6b878b12ce0b0e9c85b84abd09eebfb741136c84e4b12963faf73c1a",
+  "specVersion": "1.0.0"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,22 @@ jobs:
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - name: Format
         run: cargo fmt --all --check
+      # Spec 027: prove `spec-spine-core` compiles, tests, and lints with symbol
+      # resolution OFF, so a host workspace pinning a different tree-sitter can embed
+      # the committed-shard readers without a `links = "tree-sitter"` clash. A
+      # regression that re-couples the readers to tree-sitter fails here.
+      - name: Build (no default features)
+        run: cargo build -p spec-spine-core --no-default-features --locked
+      - name: Assert tree-sitter absent without the feature
+        run: |
+          if cargo tree -p spec-spine-core --no-default-features -i tree-sitter --locked 2>/dev/null | grep -q .; then
+            echo "::error::tree-sitter must NOT be in the --no-default-features dependency tree"
+            exit 1
+          fi
+      - name: Test (no default features)
+        run: cargo test -p spec-spine-core --no-default-features --locked
+      - name: Clippy (no default features)
+        run: cargo clippy -p spec-spine-core --no-default-features --all-targets --locked -- -D warnings
 
   self_governance:
     name: self-governance (compile · index · lint · couple)

--- a/crates/spec-spine-core/Cargo.toml
+++ b/crates/spec-spine-core/Cargo.toml
@@ -16,6 +16,16 @@ readme = "README.md"
 [package.metadata.spec-spine]
 spec = "001-compile-registry"
 
+[features]
+default = ["symbol-resolution"]
+# Tree-sitter symbol/module resolution (spec 027). Default-on, so the CLI and
+# `spec-spine index` are behaviorally unchanged. Library consumers that read only
+# the committed shards (`load_committed_registry`/`load_committed_index`) can
+# disable it with `default-features = false` to drop the tree-sitter native
+# dependency tree, avoiding a `links = "tree-sitter"` version clash when the host
+# workspace pins a different tree-sitter.
+symbol-resolution = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript"]
+
 [dependencies]
 spec-spine-types = { workspace = true }
 serde = { workspace = true }
@@ -24,9 +34,10 @@ sha2 = { workspace = true }
 # Symbol resolution. Pinned EXACT (=): the resolver is a determinism input
 # across the 5-triple release matrix (Phase-3 watch-item 2): an unpinned grammar
 # would shift symbol line-spans and surface as flaky goldens. Cargo.lock is committed.
-tree-sitter = "=0.25.10"
-tree-sitter-rust = "=0.24.2"
-tree-sitter-typescript = "=0.23.2"
+# Gated behind the default `symbol-resolution` feature (spec 027).
+tree-sitter = { version = "=0.25.10", optional = true }
+tree-sitter-rust = { version = "=0.24.2", optional = true }
+tree-sitter-typescript = { version = "=0.23.2", optional = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -21,7 +21,7 @@ use crate::manifest;
 use crate::pathutil::{is_excluded, rel_posix};
 use crate::sections;
 use crate::shard;
-use crate::symbols::{self, ModuleIndex, SymbolIndex};
+use crate::symbols::{ModuleIndex, SymbolIndex};
 use crate::{canonical_json, hash};
 
 /// Resolver hard-error codes (`I-003`..`I-009`) that fail `index check`.
@@ -93,37 +93,51 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
     let comment_links = scan_comment_headers(cfg, repo_root, &discovered.packages, &all_ids);
 
     // Symbol index, built only if some spec declares a symbol unit (avoids
-    // parsing all source for corpora that use only file/section units).
-    let needs_symbols = specs.iter().any(|s| {
-        s.units
-            .iter()
-            .any(|(_, u, _)| matches!(u, Unit::Symbol { .. }))
-    });
-    let symbol_index = if needs_symbols {
-        symbols::build_symbol_index(
-            repo_root,
-            &discovered.packages,
-            &cfg.index.resolver_exclusions,
-        )
-    } else {
-        SymbolIndex::default()
+    // parsing all source for corpora that use only file/section units). When the
+    // `symbol-resolution` feature is compiled out (spec 027), tree-sitter is not
+    // linked: no index is built and symbol units resolve to nothing (the same
+    // result a corpus declaring no symbol units already yields).
+    #[cfg(feature = "symbol-resolution")]
+    let symbol_index = {
+        let needs_symbols = specs.iter().any(|s| {
+            s.units
+                .iter()
+                .any(|(_, u, _)| matches!(u, Unit::Symbol { .. }))
+        });
+        if needs_symbols {
+            crate::symbols::build_symbol_index(
+                repo_root,
+                &discovered.packages,
+                &cfg.index.resolver_exclusions,
+            )
+        } else {
+            SymbolIndex::default()
+        }
     };
+    #[cfg(not(feature = "symbol-resolution"))]
+    let symbol_index = SymbolIndex::default();
 
     // Module index, built only if some spec declares a module unit (spec 017).
-    let needs_modules = specs.iter().any(|s| {
-        s.units
-            .iter()
-            .any(|(_, u, _)| matches!(u, Unit::Module { .. }))
-    });
-    let module_index = if needs_modules {
-        symbols::build_module_index(
-            repo_root,
-            &discovered.packages,
-            &cfg.index.resolver_exclusions,
-        )
-    } else {
-        ModuleIndex::default()
+    // Tree-sitter-backed, so likewise gated behind `symbol-resolution` (spec 027).
+    #[cfg(feature = "symbol-resolution")]
+    let module_index = {
+        let needs_modules = specs.iter().any(|s| {
+            s.units
+                .iter()
+                .any(|(_, u, _)| matches!(u, Unit::Module { .. }))
+        });
+        if needs_modules {
+            crate::symbols::build_module_index(
+                repo_root,
+                &discovered.packages,
+                &cfg.index.resolver_exclusions,
+            )
+        } else {
+            ModuleIndex::default()
+        }
     };
+    #[cfg(not(feature = "symbol-resolution"))]
+    let module_index = ModuleIndex::default();
 
     // The scalar folded into every shard hash so a config / extra-input change
     // restamps all shards (spec 024); two PRs touching only disjoint specs never

--- a/crates/spec-spine-core/src/symbols.rs
+++ b/crates/spec-spine-core/src/symbols.rs
@@ -6,15 +6,29 @@
 //! (spec 017) additionally resolves top-level inline `mod X { ... }` blocks to
 //! their block spans. The tree-sitter core and grammar crates are pinned exactly
 //! so spans are identical across platforms.
+//!
+//! The tree-sitter machinery (the `build_*` functions and their parse helpers) is
+//! gated behind the default `symbol-resolution` feature (spec 027). The
+//! [`SymbolIndex`] / [`ModuleIndex`] types and their `resolve` lookups carry no
+//! tree-sitter dependency and are always compiled, so the index resolver and its
+//! committed-shard readers build with the feature off; symbol/module units then
+//! resolve to nothing (the same path a corpus declaring no such units takes).
 
 use std::collections::BTreeMap;
+
+use spec_spine_types::ResolvedLocation;
+
+#[cfg(feature = "symbol-resolution")]
 use std::fs;
+#[cfg(feature = "symbol-resolution")]
 use std::path::{Path, PathBuf};
 
-use spec_spine_types::{LineSpan, PackageKind, PackageRecord, ResolvedLocation};
-use tree_sitter::{Language, Node, Parser};
-
+#[cfg(feature = "symbol-resolution")]
 use crate::pathutil::{is_excluded, rel_posix};
+#[cfg(feature = "symbol-resolution")]
+use spec_spine_types::{LineSpan, PackageKind, PackageRecord};
+#[cfg(feature = "symbol-resolution")]
+use tree_sitter::{Language, Node, Parser};
 
 /// A resolved symbol index: qualified id → sorted physical locations.
 #[derive(Debug, Default)]
@@ -52,6 +66,7 @@ impl ModuleIndex {
 
 /// Build the Rust module index across all Rust packages. Deterministic: packages
 /// and files are processed in sorted order and every id's locations are sorted.
+#[cfg(feature = "symbol-resolution")]
 pub fn build_module_index(
     repo_root: &Path,
     packages: &[PackageRecord],
@@ -103,6 +118,7 @@ pub fn build_module_index(
 }
 
 /// `crate::seg::…::seg` for a module path; the crate root is the bare crate name.
+#[cfg(feature = "symbol-resolution")]
 fn qualify_module(crate_name: &str, module: &[String]) -> String {
     let mut parts = Vec::with_capacity(module.len() + 1);
     parts.push(crate_name.to_string());
@@ -112,6 +128,7 @@ fn qualify_module(crate_name: &str, module: &[String]) -> String {
 
 /// Top-level `mod X { ... }` blocks (those with a body) and their spans. A
 /// bodyless `mod X;` is skipped: the file-module entry for its file covers it.
+#[cfg(feature = "symbol-resolution")]
 fn extract_inline_mods(src: &str) -> Vec<(String, LineSpan)> {
     let mut parser = Parser::new();
     if parser
@@ -138,6 +155,7 @@ fn extract_inline_mods(src: &str) -> Vec<(String, LineSpan)> {
 
 /// Build the symbol index across all packages. Deterministic: packages and
 /// files are processed in sorted order and every id's locations are sorted.
+#[cfg(feature = "symbol-resolution")]
 pub fn build_symbol_index(
     repo_root: &Path,
     packages: &[PackageRecord],
@@ -167,6 +185,7 @@ pub fn build_symbol_index(
 
 // ===== Rust =====
 
+#[cfg(feature = "symbol-resolution")]
 const RUST_KINDS: &[&str] = &[
     "function_item",
     "struct_item",
@@ -179,6 +198,7 @@ const RUST_KINDS: &[&str] = &[
     "mod_item",
 ];
 
+#[cfg(feature = "symbol-resolution")]
 fn index_rust(
     repo_root: &Path,
     pkg: &PackageRecord,
@@ -206,6 +226,7 @@ fn index_rust(
 
 /// Rust module path from a file under `src/`: `src/lib.rs`/`main.rs`/`mod.rs`
 /// → crate root (`[]`); `src/foo.rs` → `["foo"]`; `src/foo/bar.rs` → `["foo","bar"]`.
+#[cfg(feature = "symbol-resolution")]
 fn rust_module_path(src_dir: &Path, file: &Path) -> Vec<String> {
     let rel = file.strip_prefix(src_dir).unwrap_or(file);
     let mut parts: Vec<String> = rel
@@ -223,6 +244,7 @@ fn rust_module_path(src_dir: &Path, file: &Path) -> Vec<String> {
 
 // ===== TypeScript =====
 
+#[cfg(feature = "symbol-resolution")]
 const TS_KINDS: &[&str] = &[
     "function_declaration",
     "class_declaration",
@@ -231,6 +253,7 @@ const TS_KINDS: &[&str] = &[
     "enum_declaration",
 ];
 
+#[cfg(feature = "symbol-resolution")]
 fn index_ts(
     repo_root: &Path,
     pkg: &PackageRecord,
@@ -264,6 +287,7 @@ fn index_ts(
 
 /// TS module path from a file under the package dir: components minus extension,
 /// dropping a trailing `index`.
+#[cfg(feature = "symbol-resolution")]
 fn ts_module_path(pkg_dir: &Path, file: &Path) -> Vec<String> {
     let rel = file.strip_prefix(pkg_dir).unwrap_or(file);
     let mut parts: Vec<String> = rel
@@ -282,6 +306,7 @@ fn ts_module_path(pkg_dir: &Path, file: &Path) -> Vec<String> {
 // ===== shared =====
 
 /// `prefix::module::...::name` (module segments omitted when empty).
+#[cfg(feature = "symbol-resolution")]
 fn qualify(prefix: &str, module: &[String], name: &str) -> String {
     let mut parts = Vec::with_capacity(module.len() + 2);
     parts.push(prefix.to_string());
@@ -292,6 +317,7 @@ fn qualify(prefix: &str, module: &[String], name: &str) -> String {
 
 /// Parse `src` and return `(item_name, span)` for each top-level node whose kind
 /// is in `kinds`, unwrapping a TS `export_statement` to reach its declaration.
+#[cfg(feature = "symbol-resolution")]
 fn extract(src: &str, language: Language, kinds: &[&str]) -> Vec<(String, LineSpan)> {
     let mut parser = Parser::new();
     if parser.set_language(&language).is_err() {
@@ -318,6 +344,7 @@ fn extract(src: &str, language: Language, kinds: &[&str]) -> Vec<(String, LineSp
     out
 }
 
+#[cfg(feature = "symbol-resolution")]
 fn symbol_of(node: Node, src: &str) -> Option<(String, LineSpan)> {
     let name = node
         .child_by_field_name("name")?
@@ -332,6 +359,7 @@ fn symbol_of(node: Node, src: &str) -> Option<(String, LineSpan)> {
 
 /// Recursively collect files with one of `exts` under `root`, sorted, skipping
 /// excluded directories.
+#[cfg(feature = "symbol-resolution")]
 fn walk_files(root: &Path, exts: &[&str], repo_root: &Path, exclusions: &[String]) -> Vec<PathBuf> {
     let mut out = Vec::new();
     walk(root, exts, repo_root, exclusions, &mut out);
@@ -339,6 +367,7 @@ fn walk_files(root: &Path, exts: &[&str], repo_root: &Path, exclusions: &[String
     out
 }
 
+#[cfg(feature = "symbol-resolution")]
 fn walk(
     dir: &Path,
     exts: &[&str],
@@ -368,7 +397,7 @@ fn walk(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "symbol-resolution"))]
 mod tests {
     use super::*;
 

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -5,11 +5,14 @@
 use std::fs;
 use std::path::Path;
 
+use spec_spine_core::{authorities, index, index_shard_files};
+// Freshness / shard-emit helpers are exercised only by the staleness tests, which
+// are gated on `symbol-resolution` (spec 027): their `mixed_fixture` declares
+// symbol units, so feature-off they emit blocking diagnostics.
+#[cfg(feature = "symbol-resolution")]
 use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
-use spec_spine_core::{
-    Freshness, IndexOutcome, authorities, check_index_freshness, index, index_dir,
-    index_shard_files,
-};
+#[cfg(feature = "symbol-resolution")]
+use spec_spine_core::{Freshness, IndexOutcome, check_index_freshness, index_dir};
 use spec_spine_types::{Config, INDEX_SCHEMA, LineSpan, PackageKind, Unit};
 
 fn write(root: &Path, rel: &str, content: &str) {
@@ -20,6 +23,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 /// Write an index outcome to disk as the CLI's `spec-spine index` does: the
 /// per-spec/per-package shard tree (spec 024), not a monolithic `index.json`.
+#[cfg(feature = "symbol-resolution")]
 fn emit_index_shards(cfg: &Config, repo: &Path, outcome: &IndexOutcome) {
     let dir = index_dir(cfg, repo);
     let (by_spec, by_package) = index_shard_files(&outcome.shards).unwrap();
@@ -108,6 +112,7 @@ fn mapping<'a>(
         .expect("mapping present")
 }
 
+#[cfg(feature = "symbol-resolution")]
 fn symbol_span(m: &spec_spine_types::TraceMapping, sym_id: &str) -> Option<LineSpan> {
     m.resolved_units
         .iter()
@@ -148,6 +153,7 @@ fn discovers_rust_and_npm_packages() {
     assert_eq!(web.spec_ref.as_deref(), Some("002-ts"));
 }
 
+#[cfg(feature = "symbol-resolution")]
 #[test]
 fn resolves_rust_symbols_with_exact_spans() {
     // Per-platform span golden (watch-item 2): pinned tree-sitter ⇒ identical
@@ -159,6 +165,7 @@ fn resolves_rust_symbols_with_exact_spans() {
     assert_eq!(symbol_span(m, "rs_thing::Beta"), Some(LineSpan::new(2, 4)));
 }
 
+#[cfg(feature = "symbol-resolution")]
 #[test]
 fn resolves_typescript_symbols_with_exact_spans() {
     let fx = mixed_fixture();
@@ -460,6 +467,11 @@ fn emitted_index_shards_conform_to_embedded_schema() {
     check(INDEX_PACKAGE_SHARD_SCHEMA, &by_package);
 }
 
+// Gated on `symbol-resolution` (spec 027): `mixed_fixture` declares symbol units
+// owned by settled specs, which without resolution emit blocking diagnostics, so
+// `check_index_freshness` reports the just-emitted index stale (correct contract,
+// but it makes this generic-staleness assertion unusable feature-off).
+#[cfg(feature = "symbol-resolution")]
 #[test]
 fn staleness_detects_input_change() {
     let fx = mixed_fixture();
@@ -485,6 +497,7 @@ fn staleness_detects_input_change() {
     ));
 }
 
+#[cfg(feature = "symbol-resolution")]
 #[test]
 fn staleness_detects_symbol_source_line_shift() {
     // The freshness false-negative (spec 004 §3.5): a source-line shift in a file
@@ -637,6 +650,7 @@ fn missing_directory_unit_is_blocking_diagnostic_i007() {
     assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-007"));
 }
 
+#[cfg(feature = "symbol-resolution")]
 #[test]
 fn module_unit_resolves_inline_and_file_modules() {
     let fx = module_fixture();

--- a/specs/027-symbol-resolution-feature-gate/spec.md
+++ b/specs/027-symbol-resolution-feature-gate/spec.md
@@ -1,0 +1,184 @@
+---
+id: "027-symbol-resolution-feature-gate"
+title: "Feature-gate tree-sitter symbol/module resolution for dependency-free embedding"
+status: draft
+kind: "tooling"
+created: "2026-06-18"
+owner: "The spec-spine Authors"
+implementation: complete
+risk: low
+depends_on:
+  - "004-codebase-index"                 # symbol resolution (symbols.rs, index.rs)
+  - "017-directory-crate-module-units"   # module resolution (build_module_index)
+amends:
+  - "004-codebase-index"                 # §3.3 symbol resolution is now build-feature-gated
+  - "017-directory-crate-module-units"   # the Rust module index is likewise gated
+extends:
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/symbols.rs"   # tree-sitter machinery moved behind the feature
+      - "crates/spec-spine-core/src/index.rs"     # gated build call sites; the readers stay ungated
+      - "crates/spec-spine-core/tests/index.rs"   # tree-sitter-dependent tests cfg-gated
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  Adds a default-enabled `symbol-resolution` cargo feature to `spec-spine-core`
+  that gates the tree-sitter dependency tree (tree-sitter + the Rust/TypeScript
+  grammars) and the symbol/module resolution code. The CLI and `spec-spine index`
+  keep default features, so adopter and self-governance behavior is byte-for-byte
+  unchanged. Library consumers that read only the committed shards
+  (`load_committed_registry` / `load_committed_index`) can build with
+  `default-features = false` to drop tree-sitter entirely, which removes a hard
+  blocker: tree-sitter declares `links = "tree-sitter"`, so a host workspace that
+  pins a different tree-sitter (e.g. an analysis crate on `^0.26` while this crate
+  pins `=0.25.10`) cannot otherwise resolve a single lockfile, and adding
+  `spec-spine-core` anywhere in that workspace fails resolution before compilation.
+  The seam is minimal: the `SymbolIndex` / `ModuleIndex` types and their `resolve`
+  lookups are plain `BTreeMap` wrappers (no tree-sitter) and stay compiled, so the
+  index resolver, its readers, and `compile()` build with the feature off; only the
+  `build_*` functions and their parse helpers are gated. No DTO, JSON Schema, or
+  `INDEX_SCHEMA_VERSION` change: the on-disk index shape is identical. Filed off the
+  OAP spec-217 engine-swap work, which is blocked workspace-wide by exactly this
+  `links` clash across its eight planned read-path consumers.
+---
+
+# 027: Feature-gate symbol/module resolution
+
+Filed off the OAP spec-217 engine-swap, which replaces an in-tree spec-spine
+engine with the published library. The read-path repoint is type-correct, but the
+swap is blocked workspace-wide by a native-library version conflict: this crate's
+unconditional `tree-sitter =0.25.10` versus an analysis crate's `^0.26`.
+`tree-sitter` sets `links = "tree-sitter"`, so cargo permits exactly one version
+per dependency graph and the two are disjoint; because cargo resolves a workspace
+as one lockfile, adding `spec-spine-core` anywhere makes resolution fail before
+compilation. The consumers OAP repoints call only the committed-shard readers,
+which do no symbol resolution, so the tree-sitter dependency they drag in is dead
+weight that nonetheless gates the whole graph.
+
+## 1. Purpose
+
+Let a consumer embed `spec-spine-core` purely as a typed reader of the committed
+registry/index shards without pulling tree-sitter into its dependency graph, while
+keeping symbol/module resolution the default everywhere it is actually used (the
+CLI, `spec-spine index`, and this repo's own self-governance).
+
+The tree-sitter dependency is reachable from exactly one module (`symbols.rs`),
+itself reached from exactly two call sites, both inside `index()`
+(`build_symbol_index`, `build_module_index`). `compile()` and the committed-shard
+readers (`load_committed_registry`, `load_committed_index`) never touch it.
+Resolution is therefore separable from reading along a clean seam.
+
+## 2. Territory
+
+This spec additively claims, alongside spec 004 (and the spec-017 additive
+extension already over the same files), the three files it edits, and amends the
+contracts of 004 (§3.3 symbol resolution) and 017 (the Rust module index) in place
+via edge: both capabilities are now conditional on a build feature, default-on.
+
+- `crates/spec-spine-core/Cargo.toml`: the `[features]` table and the now-`optional`
+  tree-sitter dependencies. (Manifest; not separately spec-owned, governed by this
+  spec's prose and the source files below.)
+- `crates/spec-spine-core/src/symbols.rs`: the `use tree_sitter::*` import, the
+  `build_symbol_index` / `build_module_index` functions, and their parse helpers,
+  constants, and inline tests are gated behind `symbol-resolution`. The
+  `SymbolIndex` / `ModuleIndex` structs and their `resolve` methods are **not**
+  gated (they carry no tree-sitter dependency).
+- `crates/spec-spine-core/src/index.rs`: the two `build_*` call sites are gated,
+  falling back to an empty index when the feature is off. The `symbols` type import,
+  `resolve_unit`, and the resolve loop are unchanged.
+- `crates/spec-spine-core/tests/index.rs`: tests that assert symbol or module span
+  resolution are `#[cfg(feature = "symbol-resolution")]`-gated, with their
+  resolution-only helpers/imports.
+
+The package version bump and crates.io publish (a new cargo feature is a
+semver-minor, target `0.7.0`) are out of scope here: they are a separate release
+step (`docs/releasing.md`), as for every prior spec.
+
+## 3. Behavior
+
+### 3.1 The feature
+
+`spec-spine-core` declares a feature `symbol-resolution`, in `default`, that
+enables the (now-`optional`) `tree-sitter`, `tree-sitter-rust`, and
+`tree-sitter-typescript` dependencies. The exact version pins (`=0.25.10`,
+`=0.24.2`, `=0.23.2`) and the determinism rationale (a resolver line-span is a
+release-matrix input) are unchanged; the dependencies become optional, not
+unpinned.
+
+### 3.2 Feature on (default)
+
+Behavior is byte-for-byte identical to 0.6.0. `spec-spine-cli` keeps default
+features, so `spec-spine compile | index | lint | couple` and the committed
+shards are unchanged. Symbol units resolve to `(file, line-span)` and module units
+to file/inline-block spans exactly as specs 004 and 017 define.
+
+### 3.3 Feature off (`default-features = false`)
+
+tree-sitter is absent from the dependency graph. `compile()` and the committed-shard
+readers compile and behave identically (they never used symbols). `index()` still
+runs: package discovery, comment-header and manifest linkage, and file / section /
+directory / crate resolution are unaffected. Only `symbol` and `module` units go
+unresolved, exactly as they would in a corpus that declared none: the symbol and
+module indices are empty, and a declared symbol/module unit resolves to no
+location.
+
+This degradation is **not silent**. An unresolved *owning* symbol/module unit on a
+settled spec is a blocking `I-0xx` diagnostic (spec 004 §3.5, spec 025 severity
+policy), so `index check` fails (exit 2) rather than emitting a fresh-looking but
+incomplete index. A consumer that compiles symbol resolution out is therefore told,
+loudly, if its corpus actually needs it. Because the committed shards are only ever
+produced by the CLI (default features), no `default-features = false` build can
+commit a divergent artifact through the normal flow.
+
+## 4. Functional requirements
+
+- **FR-001 (gate exists, default-on).** `spec-spine-core` exposes a
+  `symbol-resolution` feature in its `default` set that gates the three tree-sitter
+  crates as `optional` dependencies.
+- **FR-002 (no tree-sitter when off).** `cargo build -p spec-spine-core
+  --no-default-features` succeeds with no tree-sitter crate in the dependency tree.
+- **FR-003 (readers feature-independent).** `load_committed_registry`,
+  `load_committed_index`, and `compile()` compile and behave identically with and
+  without the feature.
+- **FR-004 (default unchanged).** With default features, `index()` emits populated
+  `resolved_units` with line-spans, and this repo's committed shards are unchanged.
+- **FR-005 (loud degradation).** With the feature off, a corpus that declares an
+  owning symbol/module unit on a settled spec yields a blocking diagnostic
+  (`index check` exit 2), never a fresh-but-incomplete index.
+- **FR-006 (no schema change).** No DTO, JSON Schema, or `INDEX_SCHEMA_VERSION`
+  change; the on-disk index shape is identical with or without the feature.
+- **FR-007 (tests both ways).** The `spec-spine-core` test suite passes both with
+  and without the feature; tree-sitter-dependent tests are cfg-gated.
+
+## 5. Acceptance criteria
+
+- **AC-1 (no tree-sitter off).** `cargo tree -p spec-spine-core
+  --no-default-features -i tree-sitter` reports no such package; with default
+  features it shows `tree-sitter 0.25.10`.
+- **AC-2 (default behaviorally unchanged).** `cargo test --workspace` is green and
+  `spec-spine index` emits populated `resolved_units` and line-spans.
+- **AC-3 (readers off).** `cargo test -p spec-spine-core --no-default-features` is
+  green (the reader and file/section/directory/crate paths included), and clippy
+  passes with `-D warnings` in both configurations.
+- **AC-4 (CI enforces both).** CI builds, tests, and clippy-checks the crate under
+  `--no-default-features`, and asserts tree-sitter is absent from that tree, so a
+  regression that re-couples the readers to tree-sitter fails the build.
+- **AC-5 (self-corpus delta).** The only committed-artifact change from this spec is
+  its own two new registry/index shards plus a restamp of the
+  `by-package/spec-spine-core` index shard (the `Cargo.toml` `[features]` edit
+  re-hashes the package manifest). No other spec's `by-spec` shard changes: the
+  source edits to `symbols.rs` / `index.rs` shift no resolved symbol/module span in
+  this repo's own corpus, so the gate output is identical with default features.
+
+## 6. Out of scope
+
+- **The package version bump and release** (`0.7.0`): a separate release step.
+- **Any schema or `INDEX_SCHEMA_VERSION` change** (FR-006): the index shape is
+  identical with the feature on or off.
+- **Removing or unpinning tree-sitter**, or changing what symbol/module resolution
+  produces when it *is* enabled (specs 004 and 017 are unchanged in substance).
+- **A Python grammar or any new resolved language**: still deferred.
+- **Splitting the readers into a separate crate.** A feature gate is sufficient and
+  keeps one published crate; a `spec-spine-read` crate is a heavier change not
+  justified by the current consumers.


### PR DESCRIPTION
feat(027): feature-gate tree-sitter symbol/module resolution

Adds a default-enabled `symbol-resolution` cargo feature to spec-spine-core so
consumers that read only committed shards can build with `default-features = false`
and drop tree-sitter, avoiding a `links = "tree-sitter"` version clash. Default
behavior is byte-for-byte unchanged. Files spec 027; adds a CI leg proving the
crate builds/tests/lints with no tree-sitter in the no-default-features tree.

Spec-Drift-Waiver: crates/spec-spine-core/Cargo.toml gains a `[features]` table and
marks the tree-sitter dependencies `optional` to realize spec 027's symbol-resolution
gate. This is a mechanical manifest edit. The feature's behavioral contract is
authored in spec 027 and its claimed source files (symbols.rs, index.rs); spec 001
(compile-registry) governs the compile capability, which is unchanged.
