### PR TITLE
chore(release): bump package version to 0.7.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cb0eaf17753ea51746ab3eb90e1ff80c8cf69ea5a76a4ebb96def0217cd87681"
+  "shardHash": "8695e1aa95235e48dfd72f16e597e444aae8809e7d2c667de4c89665e0a21a96"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.6.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.6.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.7.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.7.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.6.0",
-    "@spec-spine/cli-darwin-x64": "0.6.0",
-    "@spec-spine/cli-linux-x64": "0.6.0",
-    "@spec-spine/cli-linux-arm64": "0.6.0",
-    "@spec-spine/cli-win32-x64": "0.6.0"
+    "@spec-spine/cli-darwin-arm64": "0.7.0",
+    "@spec-spine/cli-darwin-x64": "0.7.0",
+    "@spec-spine/cli-linux-x64": "0.7.0",
+    "@spec-spine/cli-linux-arm64": "0.7.0",
+    "@spec-spine/cli-win32-x64": "0.7.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.6.0"
+version = "0.7.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
chore(release): bump package version to 0.7.0

Ships spec 027 (symbol-resolution feature gate): the default-on cargo feature that
lets consumers embed spec-spine-core as a typed reader of the committed shards without
pulling tree-sitter into their dependency graph. A new cargo feature is a semver-minor,
so 0.6.0 -> 0.7.0. No schema change (REGISTRY/INDEX schema versions unchanged).

Bumps the three version files in lockstep (Cargo.toml, npm/package.json,
py/pyproject.toml) + Cargo.lock, and regenerates the by-package/spec-spine.json index
shard (which records the npm package version).

Spec-Drift-Waiver: npm/package.json (spec 007) and py/pyproject.toml (spec 008) carry a
mechanical version-string bump (0.6.0 -> 0.7.0) with no change to the distribution
contract either spec governs. Standard release-bump waiver, as for v0.6.0 (#34) and
v0.5.0 (#30).
