### PR TITLE
feat(028): accept optional `derived_at` on `references` provenance

### DIFF
--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -1,0 +1,100 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "001-compile-registry"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-types/src/edges.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/version.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/dtos.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/grammar.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/design/00-architecture.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/edges.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/edges.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/version.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/grammar.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/00-architecture.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "specId": "028-references-provenance-derived-at",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "3a65dc76ab946dc0ed22a747fb3b2666200fc6e722d1a30e5c4709a677f23e25"
+}

--- a/.derived/spec-registry/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/spec-registry/by-spec/000-spec-spine-bootstrap.json
@@ -39,5 +39,5 @@
     ]
   },
   "shardHash": "8a81c6d20b380f4f2c8beee60b6520a2044beaffd853f3b149f2059164e6357d",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/001-compile-registry.json
+++ b/.derived/spec-registry/by-spec/001-compile-registry.json
@@ -56,5 +56,5 @@
     "title": "Compile the spec corpus into a deterministic registry"
   },
   "shardHash": "58803b08fdf779e5843f33e636689e1f29f677e49494300adc25d1cb42fef5fb",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/002-registry-query.json
+++ b/.derived/spec-registry/by-spec/002-registry-query.json
@@ -41,5 +41,5 @@
     "title": "Typed read-only query over the registry"
   },
   "shardHash": "e075b2ad750b46d7fa9b2a29b6a1b5583d32c61861e3e874c47a6568aa8ce0de",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/003-conformance-lint.json
+++ b/.derived/spec-registry/by-spec/003-conformance-lint.json
@@ -32,5 +32,5 @@
     "title": "Corpus conformance lint"
   },
   "shardHash": "be02284a66e38f359de7ac79a51d03d21ed5a9f66eb6fbb933dd9d66129f3a26",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/004-codebase-index.json
+++ b/.derived/spec-registry/by-spec/004-codebase-index.json
@@ -59,5 +59,5 @@
     "title": "Codebase index and the file/section/symbol unit grammar"
   },
   "shardHash": "c39532ea6057b9b570aab1c24eb948c1d7402e47b1aac71ae108b7bb889762f7",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/005-coupling-gate.json
+++ b/.derived/spec-registry/by-spec/005-coupling-gate.json
@@ -71,5 +71,5 @@
     "title": "The coupling gate: join the two views and refuse drift"
   },
   "shardHash": "1dacea3dce23b7365013b65489a254ea55751b20017a86ed5a6b3056a6c4d5f9",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/006-init-scaffold.json
+++ b/.derived/spec-registry/by-spec/006-init-scaffold.json
@@ -61,5 +61,5 @@
     "title": "init: scaffold a new adopter"
   },
   "shardHash": "2a90e685c63337303451b94eed70100a33e049f30f9f180e3091bd7d213668ca",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/007-distribution.json
+++ b/.derived/spec-registry/by-spec/007-distribution.json
@@ -46,5 +46,5 @@
     "title": "Distribution: npm binary shim + the release pipeline"
   },
   "shardHash": "94fa8ee4358e9f6c07f7dec2d23976b7a03ee3fa2e3ed5f7a066ba41f26e62eb",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/008-python-distribution.json
+++ b/.derived/spec-registry/by-spec/008-python-distribution.json
@@ -48,5 +48,5 @@
     "title": "Distribution: uvx/PyPI wheel shim"
   },
   "shardHash": "5ed99bc4931788962a6f03cb1ca3063d6e7ac0fc813747a18bc6ed401dccb0e7",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/spec-registry/by-spec/009-coupling-floor-claim-precedence.json
@@ -64,5 +64,5 @@
     "title": "Coupling gate: explicit unit claims take precedence over the bypass floor"
   },
   "shardHash": "fafe4b8775e6cffee0338ce5f7facbefbc9bce0b681a6cfcecdd167bb085b2c8",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/spec-registry/by-spec/010-registry-query-projection-flags.json
@@ -59,5 +59,5 @@
     "title": "Registry query: --ids-only and --nonzero-only projection flags"
   },
   "shardHash": "7c052714a9855c12a3fa56438af2c744611b6c86880ca92d6b9c0ccdbb556c01",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/011-index-render-orphans.json
+++ b/.derived/spec-registry/by-spec/011-index-render-orphans.json
@@ -61,5 +61,5 @@
     "title": "Index: implement the reserved render and orphans subcommands"
   },
   "shardHash": "6d8ae06d93216cdeb1367f2476b2a9754c73a6aebb9ec57f9c6f350d877fd0be",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/012-index-hash-slices.json
+++ b/.derived/spec-registry/by-spec/012-index-hash-slices.json
@@ -100,5 +100,5 @@
     "title": "Index: named hash slices and `index check --slice <name>`"
   },
   "shardHash": "6f32352ebc96b9dc307fa10d466d416eb5885ea87e27e9b0e65944c1b8205f9c",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/spec-registry/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -108,5 +108,5 @@
     "title": "Frontmatter: declared extra keys carry arbitrary YAML, verbatim"
   },
   "shardHash": "28a565c9fc06090cfd714cce3d0e952cda85479819639a38eacfd3acd6859385",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/spec-registry/by-spec/014-edge-paths-grammar-sugar.json
@@ -67,5 +67,5 @@
     "title": "Edge grammar: `paths:` list sugar on extends/refines items"
   },
   "shardHash": "1b4b94a2fa4356c421601553521fdd8ec9ef8f26268169d75c524f1093cdd61c",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/spec-registry/by-spec/015-establishes-wrapper-na-alias.json
@@ -59,5 +59,5 @@
     "title": "Frontmatter sugar: `unit:`-wrapped establishes items and the `n/a` implementation alias"
   },
   "shardHash": "c49bb5976c14cfc6af0568ab731c22ed80339d22e2a9950add91dfcec1063b3d",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/016-short-id-resolution.json
+++ b/.derived/spec-registry/by-spec/016-short-id-resolution.json
@@ -43,5 +43,5 @@
     "title": "Compile: resolve short spec ids on `depends_on` and `superseded_by`"
   },
   "shardHash": "8afee33f14bdd0f970e5d52d642260afb7e15e97cdf1229da98d406d57cdf6ad",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/017-directory-crate-module-units.json
+++ b/.derived/spec-registry/by-spec/017-directory-crate-module-units.json
@@ -84,5 +84,5 @@
     "title": "Authority units: resolve the reserved directory / crate / module kinds"
   },
   "shardHash": "94f909f1a86ecc36103aa32f3ba13a5c7b0d32fd5aae939a30ceebe61603b368",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/spec-registry/by-spec/018-constrains-discriminator-optional-unit.json
@@ -76,5 +76,5 @@
     "title": "Constrains grammar: classification discriminator and optional unit"
   },
   "shardHash": "245f184e4d47adc3dc2d9193cd9049eab928f2d44aea33c5d0cb2b0a4077e35b",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/spec-registry/by-spec/019-structured-partial-supersedes.json
@@ -141,5 +141,5 @@
     "title": "Supersedes grammar: structured items and partial (unit-scoped) transfer"
   },
   "shardHash": "60e1fc1e10a19cb2865cbdabdcd6acec3216048e97251d503f71fb4cc8903206",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/spec-registry/by-spec/020-derived-artifact-merge-driver.json
@@ -32,5 +32,5 @@
     "title": "Derived-artifact merge driver and merge-queue serialization"
   },
   "shardHash": "f451c26d859ab652c9455b462c6667701c863533fa1e47b01f6a7e846c15c9fd",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/spec-registry/by-spec/021-release-supply-chain-artifacts.json
@@ -39,5 +39,5 @@
     "title": "Release supply-chain artifacts: per-target SBOM and build provenance"
   },
   "shardHash": "5cd17fd3dac750a4800bd31da50d966390a17e942c6dddcbc3f30320c1134dec",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/022-keypath-section-anchors.json
+++ b/.derived/spec-registry/by-spec/022-keypath-section-anchors.json
@@ -40,5 +40,5 @@
     "title": "Bounded keypath section anchors for first-party structured config"
   },
   "shardHash": "faa3125907663ce2568439efc5c05a8730bf80e85887b45dce56c4c679b79d21",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/023-ledger-seal.json
+++ b/.derived/spec-registry/by-spec/023-ledger-seal.json
@@ -100,5 +100,5 @@
     "title": "Ledger Seal (signed, reproducible attestation over the spec corpus)"
   },
   "shardHash": "0f9f4f3b6aa952f24e5f2ef71adbb4c6cde1a29d2eac307eb1f8c544c9a21f40",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/024-index-sharding.json
+++ b/.derived/spec-registry/by-spec/024-index-sharding.json
@@ -227,5 +227,5 @@
     "title": "Per-unit shard storage (conflict-free committed registry + index)"
   },
   "shardHash": "3ea1d022d7f3cff37f0cb602a8ca5b76157020e27b45388d964fad06ede11c28",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
@@ -79,5 +79,5 @@
     "title": "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
   },
   "shardHash": "e3c677106b3d69bbcaa170009f097714944db9bb8243b3d147506d5ef9aef567",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
@@ -67,5 +67,5 @@
     "title": "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
   },
   "shardHash": "9e58738f6bd1670e3d89ab0e7bc11abefa48c2a7495383f58bdec19ab7a2327f",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/spec-registry/by-spec/027-symbol-resolution-feature-gate.json
@@ -67,5 +67,5 @@
     "title": "Feature-gate tree-sitter symbol/module resolution for dependency-free embedding"
   },
   "shardHash": "5e2995ada4bfdc3084df4c0e9576e27d52fbc846951d7e619daa5b755e8ff819",
-  "specVersion": "1.0.0"
+  "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/spec-registry/by-spec/028-references-provenance-derived-at.json
@@ -1,0 +1,75 @@
+{
+  "record": {
+    "created": "2026-06-18",
+    "dependsOn": [
+      "001-compile-registry"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/edges.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/grammar.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      }
+    ],
+    "id": "028-references-provenance-derived-at",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "028: References provenance, optional `derived_at`",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The field",
+      "3.2 Absent field is byte-stable",
+      "3.3 Schema-version bump",
+      "3.4 The gate is not weakened",
+      "4. Functional requirements",
+      "5. Acceptance criteria",
+      "6. Out of scope"
+    ],
+    "specPath": "specs/028-references-provenance-derived-at/spec.md",
+    "status": "draft",
+    "summary": "Adds an optional `derived_at` field to the `Provenance` struct carried on a `references` edge: `{ kind, ref, derived_at? }`. `derived_at` is a generic, optional ISO-8601 timestamp recording when the reference was derived, preserved verbatim with no format validation in the type (an adopter that wants format enforcement adds a lint). The field is additive and optional, so a corpus that declares none is unaffected and `deny_unknown_fields` is preserved (the field becomes known, not a hole in the schema). The registry format gains an emittable field, so `REGISTRY_SCHEMA_VERSION` bumps an additive minor 1.0.0 -> 1.1.0 (the permissive shard schema file is unchanged; the bump only restamps the `specVersion` carried by each committed registry shard, leaving every `shardHash` and `record` body byte-identical, because a shard hash is taken over the `spec.md` source bytes). Filed off the OAP spec-217 engine-swap, whose decomposition synthesizer (OAP spec 165) emits this shape because OAP spec 161 FR-007 requires `provenance.derived_at`; the published library rejected it at parse with `V-002: unknown field derived_at`, producing zero shards. This is the second small, broadly-useful additive concession from the 217 swap (the first was the spec-027 symbol-resolution feature gate, shipped as 0.7.0).\n",
+    "title": "References provenance: optional derived_at timestamp"
+  },
+  "shardHash": "2d6a8958dde22c390c36b1015779265269c4df6291b100100a3bea7f5fb31bfe",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-types/src/edges.rs
+++ b/crates/spec-spine-types/src/edges.rs
@@ -271,9 +271,15 @@ pub struct ReferenceItem {
     pub role: Option<String>,
 }
 
-/// A provenance reference carried on a `references` edge: `{ kind, ref }`.
+/// A provenance reference carried on a `references` edge:
+/// `{ kind, ref, derived_at? }`.
 ///
 /// `kind` keys into `config.provenance.uri_schemes` to validate `ref`'s scheme.
+/// `derived_at` is a generic, optional ISO-8601 timestamp recording when the
+/// reference was derived (spec 028): additive and preserved verbatim, with no
+/// timestamp-format validation in the type (an adopter that wants format
+/// enforcement adds a lint). `deny_unknown_fields` is preserved: the field is
+/// now known, not a hole in the schema.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Provenance {
@@ -281,6 +287,11 @@ pub struct Provenance {
     /// The provenance URI. (`ref` is a Rust keyword, hence the rename.)
     #[serde(rename = "ref")]
     pub reference: String,
+    /// Optional ISO-8601 timestamp recording when this reference was derived
+    /// (spec 028). Absent items do not serialize the field, so existing goldens
+    /// stay byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derived_at: Option<String>,
 }
 
 /// The `origin` bootstrap marker, NOT a relationship edge.

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -18,7 +18,11 @@
 /// under `by-spec/<id>.json`; the single `registry.json` is no longer emitted.
 /// The aggregate view (validation, content hash) is recomputed on read. Loaders
 /// reject an unknown MAJOR, so a 0.x reader cannot misread a 1.x shard tree.
-pub const REGISTRY_SCHEMA_VERSION: &str = "1.0.0";
+/// `1.1.0`: additive MINOR (spec 028). A `references` provenance item may carry
+/// an optional `derived_at` ISO-8601 timestamp; the registry format gains an
+/// emittable field, so the minor bumps. The permissive shard schema is unchanged
+/// and a corpus that declares no `derived_at` emits byte-identical record bodies.
+pub const REGISTRY_SCHEMA_VERSION: &str = "1.1.0";
 
 /// `schemaVersion` emitted in the codebase index, carried by each index shard.
 /// `0.2.0`: additive `build.sliceHashes` (spec 012).

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -69,8 +69,9 @@ fn validation_passed_follows_error_tier() {
 
 #[test]
 fn schema_versions_are_pinned() {
-    // 1.0.0: MAJOR; the committed registry is sharded per-spec (spec 024).
-    assert_eq!(REGISTRY_SCHEMA_VERSION, "1.0.0");
+    // 1.0.0: MAJOR, sharded registry (spec 024); 1.1.0: additive MINOR (spec
+    // 028), optional `references` provenance `derived_at` timestamp.
+    assert_eq!(REGISTRY_SCHEMA_VERSION, "1.1.0");
     // 1.1.0: additive MINOR (spec 025): unresolved-unit severity tiers (W-001 /
     // W-002 warnings) on top of the spec-024 sharded MAJOR.
     assert_eq!(INDEX_SCHEMA_VERSION, "1.1.0");

--- a/crates/spec-spine-types/tests/grammar.rs
+++ b/crates/spec-spine-types/tests/grammar.rs
@@ -312,3 +312,64 @@ fn supersedes_full_and_partial_forms_parse() {
     assert!(!fm.supersedes[3].is_full());
     assert_eq!(fm.supersedes[3].partial_unit(), None);
 }
+
+#[test]
+fn references_provenance_derived_at_round_trips() {
+    // Spec 028 AC-1: a `references` provenance `{ kind, ref, derived_at }` parses
+    // and the timestamp is preserved on re-emit. (The shape OAP spec 165 emits.)
+    let fm = fm_with_edges(
+        "references:\n  - { role: decomposition-origin, provenance: { kind: code-fingerprint, ref: \"xray-fingerprint://abc123\", derived_at: \"2026-06-18T00:00:00Z\" } }\n",
+    );
+    assert_eq!(fm.references.len(), 1);
+    assert_eq!(
+        fm.references[0].role.as_deref(),
+        Some("decomposition-origin")
+    );
+    let prov = fm.references[0]
+        .provenance
+        .as_ref()
+        .expect("provenance present");
+    assert_eq!(prov.kind, "code-fingerprint");
+    assert_eq!(prov.reference, "xray-fingerprint://abc123");
+    assert_eq!(prov.derived_at.as_deref(), Some("2026-06-18T00:00:00Z"));
+
+    // Re-emit preserves the timestamp under the wire name `derived_at` (and `ref`).
+    let json = serde_json::to_string(prov).unwrap();
+    assert!(
+        json.contains("\"derived_at\":\"2026-06-18T00:00:00Z\""),
+        "{json}"
+    );
+    assert!(
+        json.contains("\"ref\":\"xray-fingerprint://abc123\""),
+        "{json}"
+    );
+}
+
+#[test]
+fn references_provenance_without_derived_at_omits_the_field() {
+    // Spec 028 AC-2: an item without `derived_at` parses unchanged and does NOT
+    // serialize the field (`skip_serializing_if`), so existing goldens are
+    // byte-identical.
+    let fm = fm_with_edges(
+        "references:\n  - { provenance: { kind: knowledge, ref: \"knowledge://x\" } }\n",
+    );
+    let prov = fm.references[0]
+        .provenance
+        .as_ref()
+        .expect("provenance present");
+    assert_eq!(prov.derived_at, None);
+    let json = serde_json::to_string(prov).unwrap();
+    assert!(
+        !json.contains("derived_at"),
+        "absent field must not serialize: {json}"
+    );
+}
+
+#[test]
+fn references_provenance_unknown_field_is_rejected() {
+    // Spec 028 AC-3: a genuinely-unknown provenance field still trips
+    // `deny_unknown_fields`; the gate is not weakened by the additive field.
+    let src = "---\nid: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
+references:\n  - { provenance: { kind: k, ref: \"r\", bogus: \"x\" } }\n---\n";
+    assert!(parse_frontmatter(src).is_err());
+}

--- a/specs/028-references-provenance-derived-at/spec.md
+++ b/specs/028-references-provenance-derived-at/spec.md
@@ -1,0 +1,182 @@
+---
+id: "028-references-provenance-derived-at"
+title: "References provenance: optional derived_at timestamp"
+status: draft
+kind: "tooling"
+created: "2026-06-18"
+owner: "The spec-spine Authors"
+implementation: complete
+risk: low
+depends_on:
+  - "001-compile-registry"               # the references edge + Provenance type + registry schema
+extends:
+  - spec: "000-spec-spine-bootstrap"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/edges.rs"      # the Provenance struct gains an optional field
+      - "crates/spec-spine-types/tests/grammar.rs"  # provenance round-trip + rejection tests
+      - "crates/spec-spine-types/tests/dtos.rs"      # the pinned REGISTRY_SCHEMA_VERSION assertion
+  - spec: "001-compile-registry"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/version.rs"     # REGISTRY_SCHEMA_VERSION 1.0.0 -> 1.1.0
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  Adds an optional `derived_at` field to the `Provenance` struct carried on a
+  `references` edge: `{ kind, ref, derived_at? }`. `derived_at` is a generic,
+  optional ISO-8601 timestamp recording when the reference was derived, preserved
+  verbatim with no format validation in the type (an adopter that wants format
+  enforcement adds a lint). The field is additive and optional, so a corpus that
+  declares none is unaffected and `deny_unknown_fields` is preserved (the field
+  becomes known, not a hole in the schema). The registry format gains an
+  emittable field, so `REGISTRY_SCHEMA_VERSION` bumps an additive minor 1.0.0 ->
+  1.1.0 (the permissive shard schema file is unchanged; the bump only restamps the
+  `specVersion` carried by each committed registry shard, leaving every
+  `shardHash` and `record` body byte-identical, because a shard hash is taken over
+  the `spec.md` source bytes). Filed off the OAP spec-217 engine-swap, whose
+  decomposition synthesizer (OAP spec 165) emits this shape because OAP spec 161
+  FR-007 requires `provenance.derived_at`; the published library rejected it at
+  parse with `V-002: unknown field derived_at`, producing zero shards. This is the
+  second small, broadly-useful additive concession from the 217 swap (the first
+  was the spec-027 symbol-resolution feature gate, shipped as 0.7.0).
+---
+
+# 028: References provenance, optional `derived_at`
+
+Filed off the OAP spec-217 engine-swap, which repoints OAP's decomposition
+pipeline promotion step at the published `spec-spine-core::compile`. That compile
+rejected pipeline-generated specs at parse time:
+
+```
+V-002: malformed frontmatter: unknown field `derived_at`, expected `kind` or `ref`
+```
+
+OAP's decomposition synthesizer (OAP spec 165) emits a `code-fingerprint`
+provenance reference carrying a `derived_at` timestamp, because OAP spec 161
+FR-007 requires `provenance.derived_at`:
+
+```yaml
+references:
+  - role: decomposition-origin
+    provenance:
+      kind: code-fingerprint
+      ref: "xray-fingerprint://<sha256>"
+      derived_at: "<ISO-8601>"
+```
+
+The library `Provenance` struct was `{ kind, ref }` with `deny_unknown_fields`, so
+`derived_at` was rejected at parse and the spec produced zero shards. OAP's in-tree
+compiler tolerated the field; the strict library does not. The
+`code-fingerprint` / `xray-fingerprint://` scheme is already registrable through
+`[provenance.uri_schemes]` in the adopter's `spec-spine.toml`, so `derived_at` was
+the only blocker.
+
+## 1. Purpose
+
+Let `Provenance` carry an optional, generic derivation timestamp so a fingerprint
+or knowledge provenance reference can record *when* it was derived, without
+weakening the strict grammar for anyone else. `derived_at` is not OAP-specific in
+spirit: any adopter emitting fingerprint or knowledge provenance benefits from a
+derivation timestamp. The change is additive and optional, so specs without it are
+byte-for-byte unaffected.
+
+## 2. Territory
+
+This spec additively claims, alongside spec 000 (the type substrate) and spec 001
+(the registry schema), the four files it edits. It amends no existing contract: the
+`{ kind, ref }` shape stays valid and unchanged; the field is purely additive.
+
+- `crates/spec-spine-types/src/edges.rs`: the `Provenance` struct gains
+  `derived_at: Option<String>` with `#[serde(default, skip_serializing_if =
+  "Option::is_none")]`. `deny_unknown_fields` is retained.
+- `crates/spec-spine-types/src/version.rs`: `REGISTRY_SCHEMA_VERSION` bumps
+  1.0.0 -> 1.1.0 (additive minor), because the registry format can now emit a
+  field it could not before.
+- `crates/spec-spine-types/tests/grammar.rs`: round-trip and rejection tests for
+  the new field (AC-1, AC-2, AC-3).
+- `crates/spec-spine-types/tests/dtos.rs`: the pinned `REGISTRY_SCHEMA_VERSION`
+  assertion follows the bump.
+
+The package version bump and crates.io publish (an additive optional field is a
+semver-minor, target `0.8.0`) are out of scope here: they are a separate release
+step (`docs/releasing.md`), as for every prior spec.
+
+## 3. Behavior
+
+### 3.1 The field
+
+`Provenance` is `{ kind, ref, derived_at? }`. `derived_at` is an opaque string
+preserved verbatim: the type performs no timestamp-format validation, matching how
+`ref`'s scheme is validated against config rather than hard-coded. An adopter that
+wants ISO-8601 enforcement adds a lint over the compiled registry.
+
+### 3.2 Absent field is byte-stable
+
+`skip_serializing_if = "Option::is_none"` means a provenance reference that
+declares no `derived_at` serializes exactly as before. Every existing corpus,
+including this repo's own, emits byte-identical record bodies; the only on-disk
+change is the `specVersion` restamp (3.3).
+
+### 3.3 Schema-version bump
+
+The registry format gains an emittable field, so `REGISTRY_SCHEMA_VERSION` bumps
+an additive minor (1.0.0 -> 1.1.0), consistent with spec 013 (0.2.0), spec 019
+(0.3.0), and the index policy in spec 025. The embedded shard schema file is
+already permissive (`additionalProperties` on the record payload), so no schema
+file changes and the conformance test (which validates emitted JSON against the
+embedded schema) still passes. Because a registry shard hash is taken over the
+`spec.md` source bytes, the bump restamps only the `specVersion` field of each
+committed registry shard; every `shardHash` and `record` body is byte-identical.
+
+### 3.4 The gate is not weakened
+
+`deny_unknown_fields` is preserved on `Provenance`: a genuinely-unknown field
+(neither `kind`, `ref`, nor `derived_at`) still produces the V-002 parse error.
+The additive field closes one hole by name; it does not open the struct.
+
+## 4. Functional requirements
+
+- **FR-001 (additive field).** `Provenance` carries an optional
+  `derived_at: Option<String>` that defaults to absent and is skipped on
+  serialization when absent.
+- **FR-002 (passthrough).** `derived_at` is preserved verbatim on parse and
+  re-emit; the type performs no timestamp-format validation.
+- **FR-003 (strictness retained).** `deny_unknown_fields` stays on `Provenance`:
+  an unknown field still fails parse with V-002.
+- **FR-004 (additive minor).** `REGISTRY_SCHEMA_VERSION` is 1.1.0; the embedded
+  registry/shard schema files are unchanged and the conformance test passes.
+- **FR-005 (byte-stable absence).** A corpus that declares no `derived_at` emits
+  byte-identical registry record bodies; only the per-shard `specVersion` restamps.
+
+## 5. Acceptance criteria
+
+- **AC-1 (round-trips).** A `references` provenance item `{ kind, ref, derived_at }`
+  parses and the timestamp is preserved on re-emit
+  (`references_provenance_derived_at_round_trips` in `tests/grammar.rs`).
+- **AC-2 (absent field omitted).** An item without `derived_at` parses and does
+  NOT serialize the field
+  (`references_provenance_without_derived_at_omits_the_field`).
+- **AC-3 (strict).** An item with a genuinely-unknown provenance field still
+  produces the `deny_unknown_fields` error
+  (`references_provenance_unknown_field_is_rejected`).
+- **AC-4 (suite green).** `cargo test --workspace --locked` passes, including the
+  conformance and golden suites; `tests/dtos.rs` asserts the 1.1.0 pin.
+- **AC-5 (self-corpus delta).** The committed-artifact change is exactly: (a) the
+  `specVersion` field restamps 1.0.0 -> 1.1.0 in every registry `by-spec` shard,
+  with every `shardHash` and `record` body byte-identical; (b) the two new 028
+  shards (`spec-registry/by-spec/028-*.json`,
+  `codebase-index/by-spec/028-*.json`). No existing index shard changes: 028
+  claims its source files as file units (which track path, not content) and
+  per-spec sharding (spec 024) confines 028's new claims to its own shard, so no
+  other spec's `by-spec` record or any `by-package` shard moves.
+
+## 6. Out of scope
+
+- **The package version bump and release** (`0.8.0`): a separate release step.
+- **Timestamp-format validation.** `derived_at` is an opaque passthrough string;
+  format enforcement, if wanted, is an adopter lint, not a type concern.
+- **Provenance scheme validation.** Wiring `kind` against
+  `[provenance.uri_schemes]` is unchanged by this spec.
+- **Any other provenance field.** Only `derived_at` is added; the struct stays
+  closed (`deny_unknown_fields`) to everything else.


### PR DESCRIPTION
## What

Adds an optional `derived_at` field to the `Provenance` struct carried on a `references` edge: `{ kind, ref, derived_at? }`. It is a generic, opaque ISO-8601 timestamp recording when the reference was derived, preserved verbatim with no format validation in the type (an adopter that wants format enforcement adds a lint). The field is additive and optional, so a corpus that declares none is byte-for-byte unaffected, and `deny_unknown_fields` is preserved: the field becomes known, not a hole in the schema.

## Why

Filed off the OAP spec-217 engine-swap, whose decomposition synthesizer (OAP spec 165) emits this shape because OAP spec 161 FR-007 requires `provenance.derived_at`. The strict published library rejected it at parse with `V-002: unknown field derived_at`, producing zero shards. This is the second small, broadly-useful additive concession from the 217 swap (the first was the spec-027 symbol-resolution feature gate, shipped as 0.7.0).

## Changes

| Surface | Change |
|---|---|
| `crates/spec-spine-types/src/edges.rs` | `Provenance` gains `derived_at: Option<String>` (`skip_serializing_if`, `deny_unknown_fields` retained) |
| `crates/spec-spine-types/src/version.rs` | `REGISTRY_SCHEMA_VERSION` 1.0.0 -> 1.1.0 (additive minor; precedent 013 / 019 / 025) |
| `crates/spec-spine-types/tests/grammar.rs` | round-trip (AC-1), absence-omits-field (AC-2), unknown-field-rejected (AC-3) |
| `crates/spec-spine-types/tests/dtos.rs` | pinned `REGISTRY_SCHEMA_VERSION` assertion follows the bump |
| `specs/028-references-provenance-derived-at/spec.md` | new governing spec, `status: draft`, additively `extends` 000 + 001 |
| `.derived/` | 28 registry shards restamp `specVersion`; two new 028 shards |

## Schema versioning

The registry format gains an emittable field, so `REGISTRY_SCHEMA_VERSION` bumps an additive minor. The embedded shard schema file is permissive (`additionalProperties` on the record payload) and is unchanged, so the conformance test still passes. Because a registry shard hash is taken over the `spec.md` source bytes, the bump only restamps the `specVersion` carried by each committed shard, leaving every `shardHash` and `record` body byte-identical. `check_major` / `reject_unknown_major` are MAJOR-only, so 1.1.0 loads against the 1.1.0 binary and old 1.0.0 shards still load.

## Gate (local)

- `compile`: ok (29 specs, 0 warnings)
- `lint --fail-on-warn`: ok (0 / 0 / 0)
- `index check`: fresh
- `couple --base origin/main --head HEAD`: ok (5 paths, no drift; no waiver needed, spec 028 claims all edited files)
- `cargo test --workspace --locked`, `clippy -D warnings`, `fmt --check`: green

## Follow-ups (separate PRs, per convention)

- Ratify spec 028 `draft -> approved`.
- Release `0.8.0` (additive optional field is a semver-minor) to all four channels; the version-bump PR carries the 007 / 008 `Spec-Drift-Waiver`.