### PR TITLE
chore(release): bump package version to 0.8.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8695e1aa95235e48dfd72f16e597e444aae8809e7d2c667de4c89665e0a21a96"
+  "shardHash": "e4696491a74bf8da22a523627bb78d453b519343f5b83e829effa8ea19e08d86"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.7.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.7.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.8.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.8.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.7.0",
-    "@spec-spine/cli-darwin-x64": "0.7.0",
-    "@spec-spine/cli-linux-x64": "0.7.0",
-    "@spec-spine/cli-linux-arm64": "0.7.0",
-    "@spec-spine/cli-win32-x64": "0.7.0"
+    "@spec-spine/cli-darwin-arm64": "0.8.0",
+    "@spec-spine/cli-darwin-x64": "0.8.0",
+    "@spec-spine/cli-linux-x64": "0.8.0",
+    "@spec-spine/cli-linux-arm64": "0.8.0",
+    "@spec-spine/cli-win32-x64": "0.8.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.7.0"
+version = "0.8.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Ships spec 028 (references-provenance `derived_at`): an optional ISO-8601 `derived_at` timestamp on the `references` provenance edge, so an adopter emitting fingerprint or knowledge provenance can record when the reference was derived. Additive optional field, so 0.7.0 -> 0.8.0.

Carries the additive registry schema minor (`REGISTRY_SCHEMA_VERSION` 1.0.0 -> 1.1.0; precedent 013 / 019 / 025); the index schema is unchanged.

Bumps the three version files in lockstep (`Cargo.toml`, `npm/package.json`, `py/pyproject.toml`) + `Cargo.lock`, and regenerates the `by-package/spec-spine.json` index shard (which records the npm package version).

## Pre-flight (local)
- `scripts/bump_version.py --check 0.8.0`: OK (all locations agree)
- `compile` / `index check` / `lint --fail-on-warn`: ok / fresh / 0-0-0
- `couple --pr-body`: clears with the waiver below

Spec-Drift-Waiver: npm/package.json (spec 007) and py/pyproject.toml (spec 008) carry a mechanical version-string bump (0.7.0 -> 0.8.0) with no change to the distribution contract either spec governs. Standard release-bump waiver, as for v0.7.0 (#38) and v0.6.0 (#34).
