### PR TITLE
chore(029): ratify claude-code-skill-kit (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -25,8 +25,8 @@
       }
     ],
     "specId": "029-claude-code-skill-kit",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0bc017464afa2258cdd7c9b832e7e74bf476a36bd91ab30468cbeca70c2b242e"
+  "shardHash": "8ec2928b80091296ff871f61d208c8d64369f1390058dbf6c97e52b0d947eca2"
 }

--- a/.derived/spec-registry/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/spec-registry/by-spec/029-claude-code-skill-kit.json
@@ -27,10 +27,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/029-claude-code-skill-kit/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "spec-spine ships a copy-ready Claude Code skill kit under kit/: a substrate- agnostic bundle of skills, agents, rules, and config templates that layers a full governed-development loop (init, plan, implement, validate, review, commit, ship) on top of the spec-spine substrate. The bundle is the artifact the \"Use with Claude Code\" documentation points at: an adopter copies kit/.claude into their repository, customizes the bracketed placeholders, and runs the loop. The skills, agents, and rules were extracted from the Open Agentic Platform and generalized for any spec-spine adopter, then distributed here under Apache-2.0. This spec claims authority over the kit/ subtree so the bundle evolves under the same coupling discipline as the rest of the corpus; it does not change any engine behavior.\n",
     "title": "Claude Code skill kit: a vendored, governed adoption bundle"
   },
-  "shardHash": "bc0fa620a2f94bc119abcfb0593e5c5f6083e6a3a74b5648bdac09f1278d34ae",
+  "shardHash": "2ddd4789254cdb2be6184f6cb728bdc2babb3163977eff61171ddc5c255719ad",
   "specVersion": "1.1.0"
 }

--- a/specs/029-claude-code-skill-kit/spec.md
+++ b/specs/029-claude-code-skill-kit/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "029-claude-code-skill-kit"
 title: "Claude Code skill kit: a vendored, governed adoption bundle"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-06-24"
 implementation: complete


### PR DESCRIPTION
## Summary

Flip spec 029 (the vendored Claude Code skill kit) from `draft` to `approved`,
now that the kit and its docs have landed (#44). Restamps the 029 registry and
index shards. Corpus is 30/30 approved.

## Testing

- `spec-spine compile`: 30 specs, 0 warnings
- `spec-spine index check`: fresh
- `spec-spine lint --fail-on-warn`: clean
- `spec-spine couple --base origin/main --head HEAD`: no drift
