### PR TITLE
ci: skip AI review on Dependabot PRs instead of hard-failing ci-gate

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -66,16 +66,31 @@ jobs:
       # absent and the review cannot run. Detect that here and skip visibly
       # (below) rather than hard-failing the required ci-gate on every external
       # contribution. Same-repo PRs (fork=false) keep the strict secret check.
-      - name: Detect fork PR
+      #
+      # Dependabot PRs are the same case in disguise: they run against the
+      # Dependabot secret store, NOT the Actions store, so the OAuth token is
+      # structurally unavailable even though the head is same-repo (fork=false).
+      # Without this, every automated dependency PR hard-fails the required
+      # ci-gate on the "secret is unset" guard below. Detect the Dependabot actor
+      # and skip visibly, exactly as for a fork.
+      - name: Detect fork / Dependabot PR
         id: ctx
         env:
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
         run: |
           if [ "${HEAD_REPO}" != "${BASE_REPO}" ]; then
             echo "fork=true" >> "$GITHUB_OUTPUT"
           else
             echo "fork=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Literal string compare (not a case-glob: `dependabot[bot]` would be
+          # read as a bracket expression).
+          if [ "${ACTOR}" = "dependabot[bot]" ]; then
+            echo "dependabot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dependabot=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute diff size
@@ -99,21 +114,21 @@ jobs:
           fi
 
       - name: Generate diff
-        if: steps.diff.outputs.skip != 'true' && steps.ctx.outputs.fork != 'true'
+        if: steps.diff.outputs.skip != 'true' && steps.ctx.outputs.fork != 'true' && steps.ctx.outputs.dependabot != 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: git diff "${BASE_SHA}...${HEAD_SHA}" > /tmp/pr-diff.txt
 
       - name: Install Claude CLI
-        if: steps.diff.outputs.skip != 'true' && steps.ctx.outputs.fork != 'true'
+        if: steps.diff.outputs.skip != 'true' && steps.ctx.outputs.fork != 'true' && steps.ctx.outputs.dependabot != 'true'
         run: npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
 
       # Prompt prelude is fed via -p; the diff is piped to stdin. No shell
       # interpolation of contributor-controlled content occurs.
       - name: Run AI Review
         id: aireview
-        if: steps.diff.outputs.skip != 'true' && steps.ctx.outputs.fork != 'true'
+        if: steps.diff.outputs.skip != 'true' && steps.ctx.outputs.fork != 'true' && steps.ctx.outputs.dependabot != 'true'
         env:
           # Subscription-backed auth via the Claude Code OAuth token, NOT an
           # API key. ANTHROPIC_API_KEY is deliberately NOT set: an empty/unset
@@ -263,3 +278,24 @@ jobs:
             echo "\`ci-gate\` still passes so the external contribution is not blocked, but **a human reviewer must review this PR manually.**"
           } > /tmp/fork-skip-comment.md
           gh pr comment "$PR_NUMBER" --body-file /tmp/fork-skip-comment.md || echo "::warning::could not post fork-skip notice comment (fork GITHUB_TOKEN is read-only)"
+
+      - name: Skip notice (Dependabot PR; make the skip VISIBLE, not silent)
+        # Dependabot PRs run against the Dependabot secret store, so
+        # CLAUDE_CODE_OAUTH_TOKEN is structurally unavailable and the review is
+        # skipped (not hard-failed) just like a fork. The GITHUB_TOKEN on a
+        # Dependabot PR is read-only, so a PR comment may not post; the
+        # ::warning:: annotation keeps the skip visible in the checks UI.
+        if: steps.ctx.outputs.dependabot == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "::warning::AI review SKIPPED; Dependabot PRs cannot access CLAUDE_CODE_OAUTH_TOKEN (Dependabot secret store). ci-gate passes so the dependency PR is not blocked; review manually if the bump is non-trivial."
+          {
+            echo "## AI Code Review: SKIPPED (Dependabot PR)"
+            echo ""
+            echo "Dependabot PRs run against the Dependabot secret store, so this workflow cannot access the \`CLAUDE_CODE_OAUTH_TOKEN\` secret and the automated AI review did **not** run."
+            echo ""
+            echo "\`ci-gate\` still passes so the dependency PR is not blocked, but **review the bump manually if it is non-trivial.**"
+          } > /tmp/dependabot-skip-comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/dependabot-skip-comment.md || echo "::warning::could not post Dependabot-skip notice comment (Dependabot GITHUB_TOKEN is read-only)"


### PR DESCRIPTION
## Problem

Dependabot PRs run against the **Dependabot secret store**, not the Actions store, so `CLAUDE_CODE_OAUTH_TOKEN` is structurally unavailable. The AI-review step's "secret is unset" guard then hard-failed the required `ci-gate` on **every** Dependabot PR (this is why #49 and #50 both showed `ai-review = failure`), turning routine dependency bumps into red, un-mergeable PRs.

## Fix

Fork PRs already hit this exact wall (GitHub withholds secrets from forks) and are detected and skipped visibly. Dependabot is the same case in disguise: same-repo head (`fork=false`) but no secret access. This detects the `dependabot[bot]` actor alongside the fork check and skips the review the same way, with a visible `::warning::` and a PR notice so a green `ci-gate` never silently implies "reviewed".

The strict "secret missing" hard-fail is **preserved** for ordinary same-repo, non-Dependabot PRs (a real operator misconfiguration must still surface).

## Governance

`ai-pr-review.yml` is coupling-floor (`.github/`, unclaimed by any spec), so no spec edit or waiver is required. This PR is authored by a human, so its own ai-review runs normally (dogfood).