### PR TITLE
chore(release): bump package version to 0.9.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e4696491a74bf8da22a523627bb78d453b519343f5b83e829effa8ea19e08d86"
+  "shardHash": "b183cc1632d63a567404b1ada84e1383229f67fa3ff1fbdbf34709a166c128bd"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.8.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.8.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.9.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.9.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.8.0",
-    "@spec-spine/cli-darwin-x64": "0.8.0",
-    "@spec-spine/cli-linux-x64": "0.8.0",
-    "@spec-spine/cli-linux-arm64": "0.8.0",
-    "@spec-spine/cli-win32-x64": "0.8.0"
+    "@spec-spine/cli-darwin-arm64": "0.9.0",
+    "@spec-spine/cli-darwin-x64": "0.9.0",
+    "@spec-spine/cli-linux-x64": "0.9.0",
+    "@spec-spine/cli-linux-arm64": "0.9.0",
+    "@spec-spine/cli-win32-x64": "0.9.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.8.0"
+version = "0.9.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.9.0**. Bumps the package version in lockstep across `Cargo.toml`
(+ internal dep pins), `npm/package.json` (+ `optionalDependencies` pins), and
`py/pyproject.toml` via `scripts/bump_version.py`; `Cargo.lock` and the npm
package index shard are regenerated.

## What ships since v0.8.0

- **Dependency currency (#52)**: cargo-group upgrade to toml 1.1, toml_edit 0.25,
  sha2 0.11, time 0.3.53, jsonschema 0.46, with the code changes their breaking
  APIs required. SHA-256 output unchanged, so the committed shards stay
  byte-identical.
- **Security-audit remediation (#48)**: the High-through-hygiene sweep across
  CI/release, the coupling gate, the installer, and docs.
- **Canonical org-name reconciliation (#47/#51)**: installer download and
  attestation `--repo`, CI badge, install snippets, package metadata, and crate
  READMEs now target `stagecraft-ing/spec-spine` directly.
- **Claude Code skill kit (spec 029, #44/#45)**: vendored, Apache-licensed,
  copy-ready kit folded into the docs site.
- **Documentation website (#1)**: Docusaurus v3 docs site.

No schema change: the registry / index / build-meta / config schema-version
constants are unchanged (this is a package-version-only release).

## Release mechanics

Once merged, tag `v0.9.0` drives `release.yml` to publish all four channels
(crates.io, prebuilt binaries + SBOM/provenance, npm, PyPI). This is the first
release after the org rename; crates.io and npm ride repo secrets (rename-safe),
PyPI rides OIDC Trusted Publishing (verify the trusted publisher points at
`stagecraft-ing/spec-spine`).

## Gate

Green locally: build, workspace tests, compile, `index check` (fresh), lint.

Spec-Drift-Waiver: mechanical release version bump. npm/package.json (spec 007) and py/pyproject.toml (spec 008) change only their version and dependency-pin fields via scripts/bump_version.py; no distribution behavior changes, so the owning specs are intentionally untouched (the established version-bump-PR waiver).
