### PR TITLE
ci: adopt Dependabot's GitHub Actions major bumps (supersedes #49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     name: build · test · clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # rust-toolchain.toml pins the exact channel (+ rustfmt, clippy).
       - name: Show toolchain
         run: rustc --version && cargo --version
@@ -63,7 +63,7 @@ jobs:
     name: self-governance (compile · index · lint · couple)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history so the coupling gate can diff against the merge base.
           fetch-depth: 0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,16 +18,16 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: website/package-lock.json
       - run: npm ci
       - run: npm run build
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
   deploy:
@@ -38,4 +38,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/determinism.yml
+++ b/.github/workflows/determinism.yml
@@ -44,7 +44,7 @@ jobs:
           - { os: windows-latest,   triple: x86_64-pc-windows-msvc }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Show toolchain
         run: rustc --version && cargo --version
       - name: Build CLI (locked)
@@ -92,7 +92,7 @@ jobs:
             echo "${{ matrix.triple }} registry $(digest_tree .derived/spec-registry)"
             echo "${{ matrix.triple }} index    $(digest_tree .derived/codebase-index)"
           } | tee "digests/${{ matrix.triple }}.txt"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.triple }}
           path: digests/${{ matrix.triple }}.txt
@@ -103,7 +103,7 @@ jobs:
     needs: emit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: digests
           pattern: digest-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Add target (no-op if native)
         run: rustup target add ${{ matrix.triple }}
       - name: Build release binary
@@ -110,11 +110,11 @@ jobs:
           set -euo pipefail
           node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const n=(d.components||[]).length;console.log('SBOM components:',n);if(n===0){console.error('refusing to ship an SBOM with zero components (syft cataloger regression?)');process.exit(1);}" "${ARCHIVE_BASE}.cdx.json"
       - name: Attest build provenance for the archive
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: ${{ env.ARCHIVE_FILE }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: archive-${{ matrix.triple }}
           path: |
@@ -132,7 +132,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: archive-*
@@ -140,7 +140,7 @@ jobs:
       - name: List release assets
         run: ls -la dist
       - name: Create / update the GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: dist/*
           fail_on_unmatched_files: true
@@ -151,7 +151,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Publish types, core, cli (tolerate versions already on crates.io)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Gate on NPM_TOKEN: absent the secret, the whole job is a clean no-op (a
       # skip, never a red X), the same posture as the crates.io token. The first
@@ -200,7 +200,7 @@ jobs:
             echo "::notice title=npm publish skipped::NPM_TOKEN secret not set; skipping npm publish"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: steps.gate.outputs.present == 'true'
         with:
           node-version: 20
@@ -208,7 +208,7 @@ jobs:
 
       # The npm platform packages bundle the prebuilt binaries directly, so they
       # are assembled from the build job's archives (no second Rust build).
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.gate.outputs.present == 'true'
         with:
           path: dist/archives
@@ -273,7 +273,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/spec-spine
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Gate on a repository variable, not a secret: Trusted Publishing has no
       # token to detect. Absent/false => clean skip (a notice, never a red X),
@@ -291,7 +291,7 @@ jobs:
             echo "::notice title=PyPI publish skipped::vars.PYPI_TRUSTED_PUBLISHING is not 'true'; skipping PyPI publish"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: steps.gate.outputs.present == 'true'
         with:
           python-version: "3.12"
@@ -303,7 +303,7 @@ jobs:
       # The wheels bundle the prebuilt binaries directly, so they are assembled
       # from the build job's archives (no second Rust build) -- exactly the
       # publish-npm pattern.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.gate.outputs.present == 'true'
         with:
           path: dist/archives


### PR DESCRIPTION
**Supersedes #49.** Applies Dependabot's 10 GitHub Actions major bumps onto
current main (the #49 branch was cut from a pre-#51 base and could not clear the
gate: Dependabot PRs can't reach `CLAUDE_CODE_OAUTH_TOKEN`, fixed separately in
#53, and can't add a `Spec-Drift-Waiver` line).

## Bumps

| action | from | to |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v6 |
| actions/setup-python | v5 | v6 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/attest-build-provenance | v2 | v4 |
| softprops/action-gh-release | v2 | v3.0.1 (SHA-pinned) |

## Validation

The CI-path bumps (`checkout`, `setup-node`, `upload/download-artifact` in
`ci.yml` and `determinism.yml`) are exercised by this PR's own gate, including
the cross-triple determinism proof. The release-only actions
(`attest-build-provenance`, `action-gh-release`, and `release.yml`'s artifact
steps) are not reachable from PR CI; this PR is intentionally landed **after**
v0.9.0 shipped, so a release never runs on unvalidated majors and these are first
exercised by the next tag.

## Governance

Only `release.yml` is spec-claimed (007/008/021); the other three workflow files
are coupling-floor (`.github/`).

Spec-Drift-Waiver: mechanical CI dependency bump. release.yml changes only pinned `uses:` action versions (no job logic, no publish-behavior change), so the owning specs (007/008/021) are intentionally untouched.
