### PR TITLE
chore(release): bump package version to 0.10.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b183cc1632d63a567404b1ada84e1383229f67fa3ff1fbdbf34709a166c128bd"
+  "shardHash": "3c75f869c8960b8474e03f5e0cc0395d7c4382ea0cc14f14d44d14d20693414a"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.9.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.9.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.10.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.10.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.9.0",
-    "@spec-spine/cli-darwin-x64": "0.9.0",
-    "@spec-spine/cli-linux-x64": "0.9.0",
-    "@spec-spine/cli-linux-arm64": "0.9.0",
-    "@spec-spine/cli-win32-x64": "0.9.0"
+    "@spec-spine/cli-darwin-arm64": "0.10.0",
+    "@spec-spine/cli-darwin-x64": "0.10.0",
+    "@spec-spine/cli-linux-x64": "0.10.0",
+    "@spec-spine/cli-linux-arm64": "0.10.0",
+    "@spec-spine/cli-win32-x64": "0.10.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.9.0"
+version = "0.10.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What this ships

The **0.10.0** release. Since v0.9.0 (tagged 2026-07-02) the only user-facing
change is **spec 030 (`030-cargo-workflow-dependency-waiver`)**: the coupling
auto-waiver's dependency-only self-clear, previously npm-only, now also covers
routine Dependabot **cargo** (`Cargo.toml` dependency-version bumps) and
**GitHub Actions workflow** (`uses:` action `@ref` bumps) updates. It amends
specs 004 and 005, is opt-in and per-repo (no default change), and introduces
no schema change.

The `ci:` GitHub Actions major-version bumps (#55) ride along in the tree; they
are CI-only with no binary impact.

## Why a MINOR bump

Additive, opt-in behavior; no breaking change; registry and index schema
versions stay at 1.1.0. Package axis only: `0.9.0 -> 0.10.0`, bumped in lockstep
across `Cargo.toml`, `npm/package.json`, and `py/pyproject.toml` via
`scripts/bump_version.py 0.10.0` (`--check` green). `Cargo.lock` re-locked to the
three workspace crates at 0.10.0; the `spec-spine` npm package index shard
regenerated to 0.10.0.

## Verification (local, green)

- `cargo build --workspace --locked`, `cargo test --workspace --locked`,
  `cargo package --workspace --locked` (all three crates verified in dependency
  order).
- Governed loop: `compile` (31 specs, 0 warn), `index check` (fresh),
  `lint --fail-on-warn` (0/0/0), `couple --base origin/main --head HEAD`
  (only the two mechanical shim drifts below, cleared by the waiver).

## Drift waiver

The version bump touches two claimed distribution-shim manifests without a
behavioral change, so a spec edit would be inappropriate (per the coherence
guard, we waive rather than amend an owning spec to satisfy a mechanical
refresh).

Spec-Drift-Waiver: Mechanical package-version bump to 0.10.0; npm/package.json (007-distribution) and py/pyproject.toml (008-python-distribution) change only their version and version pins in lockstep with Cargo.toml, with no behavioral change to either shim, so no owning-spec edit is warranted.

## After merge (human checkpoint)

Publishing is tag-gated and irreversible; it is not part of this PR. Once merged,
a maintainer tags the release to fan out to crates.io, prebuilt binaries, npm,
and PyPI:

```sh
git tag v0.10.0 && git push origin v0.10.0
```
