### PR TITLE
feat(031): add `compile --check`, the registry freshness gate

### DIFF
--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -1,0 +1,152 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "001-compile-registry",
+      "024-index-sharding"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/design/00-architecture.md",
+        "source": "spec-edge"
+      },
+      {
+        "path": "specs/004-codebase-index/spec.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/00-architecture.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "specs/004-codebase-index/spec.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "specs/004-codebase-index/spec.md"
+        }
+      }
+    ],
+    "specId": "031-registry-freshness-check",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "97e86d1dc93e07e15eb562a62afef5fa5c30cd1e5f790eccfa971c0ee1a6ed93"
+}

--- a/.derived/spec-registry/by-spec/031-registry-freshness-check.json
+++ b/.derived/spec-registry/by-spec/031-registry-freshness-check.json
@@ -1,0 +1,98 @@
+{
+  "record": {
+    "created": "2026-08-14",
+    "dependsOn": [
+      "001-compile-registry",
+      "024-index-sharding"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      }
+    ],
+    "id": "031-registry-freshness-check",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "specs/004-codebase-index/spec.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "sectionHeadings": [
+      "031: Registry freshness check",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `spec-spine compile --check`",
+      "3.2 Exit codes",
+      "3.3 Output",
+      "3.4 Determinism",
+      "3.5 Relationship to the existing gates",
+      "3.6 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/031-registry-freshness-check/spec.md",
+    "status": "draft",
+    "summary": "The committed spec-registry shard tree had no freshness gate. `index check` (spec 004) covers only the codebase-index tree, and `compile` is a validation gate that rewrites the shards without ever asserting the committed copies matched, so editing a spec.md and forgetting to recompile lands stale shardHash values with CI green (this is what PR #61 did to specs 017 and 021). This spec adds `spec-spine compile --check`: a non-writing gate that compiles in memory and compares the result byte-for-byte against the committed shards, exiting 2 on staleness exactly as `index check` does. It closes the registry/index asymmetry with a first-class command rather than a repo-local git tree check, so every adopter that commits its registry gets the same guarantee spec-spine gets.\n",
+    "title": "Registry freshness: `spec-spine compile --check`"
+  },
+  "shardHash": "559875a381e5c5cfcbc461813d17e2cb4d780979df285fd094e9dd3c3839aa0b",
+  "specVersion": "1.1.0"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,31 +69,17 @@ jobs:
           fetch-depth: 0
       - name: Build CLI
         run: cargo build --bin spec-spine --locked
-      - name: Compile registry (validation gate)
-        run: ./target/debug/spec-spine compile
-      # Registry-shard freshness. `compile` above is only a *validation* gate: it
-      # rewrites .derived/spec-registry/by-spec/ and reports frontmatter errors,
-      # but says nothing about whether the *committed* shards matched. The index
-      # side has a first-class staleness command (`index check`, spec 004); the
-      # registry side has none, so freshness is asserted against the git tree
-      # instead. Because `compile` is a pure function of (config, spec sources),
-      # a clean tree here proves the committed shards are exactly what the
-      # current specs/*/spec.md compile to. Without this, editing a spec.md and
-      # forgetting to recompile lands stale shardHash values on main with CI
-      # green (this is what PR #61 did to specs 017 and 021).
-      # --untracked-files=all so an added spec's brand-new shard, which no diff
-      # would show, also fails; build-meta.json is gitignored and stays invisible.
-      - name: Registry-shard freshness (committed shards must match the specs)
-        run: |
-          set -euo pipefail
-          dirty="$(git status --porcelain --untracked-files=all -- .derived/spec-registry)"
-          if [ -n "$dirty" ]; then
-            echo "::error::Committed spec-registry shards are stale. Run 'spec-spine compile' and commit the result."
-            echo "$dirty"
-            git diff -- .derived/spec-registry
-            exit 2
-          fi
-          echo "spec-registry shards are fresh"
+      # Validation AND registry-shard freshness in one self-contained gate
+      # (spec 031). `compile --check` compiles in memory and compares against
+      # the committed shards without writing, so it exits 1 on a frontmatter
+      # violation and 2 when a spec.md was edited without recompiling (which is
+      # what PR #61 did to specs 017 and 021, undetected).
+      #
+      # It must NOT be sequenced after a writing `compile`: that would compare
+      # the committed shards against files the same job just overwrote, and the
+      # gate would silently pass forever. Nothing here writes to .derived.
+      - name: Compile registry (validation + shard freshness)
+        run: ./target/debug/spec-spine compile --check
       - name: Codebase index freshness (committed artifacts must be current)
         run: ./target/debug/spec-spine index check
       - name: Conformance lint (fail on warn)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ install → init → annotate → wire-CI walkthrough.
 
 | Command | Capability |
 |---|---|
-| `spec-spine compile` | validate frontmatter, emit the deterministic registry |
+| `spec-spine compile` / `compile --check` | validate frontmatter, emit the deterministic registry / verify the committed shards match without writing |
 | `spec-spine index` / `index check` / `index render` / `index orphans` | emit the codebase index / check staleness / render it as markdown / list orphaned specs |
 | `spec-spine registry list\|show\|status-report\|relationships` | typed read-only queries |
 | `spec-spine lint [--fail-on-warn] [--fail-on-info]` | corpus well-formedness |

--- a/crates/spec-spine-cli/src/cmd_compile.rs
+++ b/crates/spec-spine-cli/src/cmd_compile.rs
@@ -3,22 +3,55 @@
 //! `build-meta.json` sidecar. The single monolithic `registry.json` is no
 //! longer emitted, so two PRs that add or edit different specs write disjoint
 //! files and never conflict on a global content-hash line.
+//!
+//! `--check` (spec 031) is the non-writing form: it compiles in memory and
+//! compares against the committed shards, the registry counterpart of
+//! `index check`.
 
 use std::fs;
 use std::path::Path;
 
 use spec_spine_core::shard::{self, BY_SPEC_DIR};
-use spec_spine_core::{registry_dir, registry_shard_files};
+use spec_spine_core::{
+    CompileOutcome, Freshness, compare_committed_registry, registry_dir, registry_shard_files,
+};
 use spec_spine_types::{BUILD_META_SCHEMA_VERSION, BuildMeta, Error, Severity};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
 use crate::load_repo_config;
 
-/// Returns the process exit code: `0` if validation passed, `1` if it failed.
-pub fn run(repo: &Path) -> Result<u8, Error> {
+/// Returns the process exit code.
+///
+/// Writing form: `0` if validation passed, `1` if it failed. `--check` form:
+/// `0` fresh, `1` validation failed, `2` stale (spec 031 §3.2). Validation
+/// outranks staleness, because a corpus that does not validate cannot vouch
+/// for its shards.
+pub fn run(repo: &Path, check: bool) -> Result<u8, Error> {
     let cfg = load_repo_config(repo)?;
     let outcome = spec_spine_core::compile(&cfg, repo)?;
+
+    if check {
+        if !outcome.validation_passed {
+            report_validation_failure(&outcome);
+            return Ok(1);
+        }
+        return match compare_committed_registry(&cfg, repo, &outcome.shards)? {
+            Freshness::Fresh => {
+                println!(
+                    "spec-registry is fresh: {} shard(s) match the corpus",
+                    outcome.registry.specs.len()
+                );
+                Ok(0)
+            }
+            // Stale detail goes to stderr so it surfaces in a CI log.
+            Freshness::Stale { actual, .. } => {
+                eprintln!("{actual}");
+                eprintln!("spec-registry is STALE: run `spec-spine compile` and commit the result");
+                Ok(2)
+            }
+        };
+    }
 
     let out_dir = registry_dir(&cfg, repo);
     fs::create_dir_all(&out_dir)
@@ -52,13 +85,6 @@ pub fn run(repo: &Path) -> Result<u8, Error> {
     fs::write(&meta_path, meta_json)
         .map_err(|e| Error::Io(format!("write {}: {e}", meta_path.display())))?;
 
-    let errors = outcome
-        .registry
-        .validation
-        .violations
-        .iter()
-        .filter(|v| v.severity == Severity::Error)
-        .count();
     let warnings = outcome
         .registry
         .validation
@@ -76,19 +102,34 @@ pub fn run(repo: &Path) -> Result<u8, Error> {
         );
         Ok(0)
     } else {
-        // Validation failures go to stderr so they surface in CI logs.
-        for v in &outcome.registry.validation.violations {
-            if v.severity == Severity::Error {
-                let at = v.path.as_deref().unwrap_or("-");
-                eprintln!("  {} [{}] {}", v.code, at, v.message);
-            }
-        }
-        eprintln!(
-            "validation FAILED: {errors} error(s), {warnings} warning(s) across {} spec(s)",
-            outcome.registry.specs.len()
-        );
+        report_validation_failure(&outcome);
         Ok(1)
     }
+}
+
+/// Print every error-tier violation, then the summary. Always stderr, so the
+/// failures surface in a CI log. Shared by the writing and `--check` forms so
+/// both fail with the same diagnostic.
+fn report_validation_failure(outcome: &CompileOutcome) {
+    let violations = &outcome.registry.validation.violations;
+    for v in violations {
+        if v.severity == Severity::Error {
+            let at = v.path.as_deref().unwrap_or("-");
+            eprintln!("  {} [{}] {}", v.code, at, v.message);
+        }
+    }
+    let errors = violations
+        .iter()
+        .filter(|v| v.severity == Severity::Error)
+        .count();
+    let warnings = violations
+        .iter()
+        .filter(|v| v.severity == Severity::Warning)
+        .count();
+    eprintln!(
+        "validation FAILED: {errors} error(s), {warnings} warning(s) across {} spec(s)",
+        outcome.registry.specs.len()
+    );
 }
 
 fn now_rfc3339() -> String {

--- a/crates/spec-spine-cli/src/cmd_compile.rs
+++ b/crates/spec-spine-cli/src/cmd_compile.rs
@@ -44,7 +44,12 @@ pub fn run(repo: &Path, check: bool) -> Result<u8, Error> {
                 );
                 Ok(0)
             }
-            // Stale detail goes to stderr so it surfaces in a CI log.
+            // Stale detail goes to stderr so it surfaces in a CI log. `actual`
+            // is already the count line plus one line per stale shard; the
+            // paired `expected` ("N shard(s) matching the corpus") is
+            // deliberately not printed, because the operator's next action does
+            // not depend on it. It stays on the typed verdict for library and
+            // JSON-facade consumers.
             Freshness::Stale { actual, .. } => {
                 eprintln!("{actual}");
                 eprintln!("spec-registry is STALE: run `spec-spine compile` and commit the result");

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -36,7 +36,13 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Compile specs/*/spec.md into a deterministic registry.
-    Compile,
+    Compile {
+        /// Verify the committed shards match the corpus without writing
+        /// anything (exit 2 if stale). The registry counterpart of
+        /// `index check`.
+        #[arg(long)]
+        check: bool,
+    },
     /// Read-only queries over the compiled registry.
     Registry {
         #[command(subcommand)]
@@ -121,7 +127,7 @@ fn main() -> ExitCode {
     };
 
     let result = match &cli.command {
-        Command::Compile => cmd_compile::run(&repo),
+        Command::Compile { check } => cmd_compile::run(&repo, *check),
         Command::Registry { query } => cmd_registry::run(&repo, query),
         Command::Index { action } => cmd_index::run(&repo, action.as_ref()),
         Command::Lint {

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -529,3 +529,68 @@ fn lint_fail_on_warn_gating() {
         .unwrap();
     assert_eq!(code(&strict), 1, "--fail-on-warn fails on a warning");
 }
+
+#[test]
+fn compile_check_exit_contract() {
+    // Spec 031 3.2: 0 fresh, 1 validation failed, 2 stale. Validation outranks
+    // staleness.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "approved");
+    let run = |args: &[&str]| {
+        bin()
+            .arg("--repo")
+            .arg(tmp.path())
+            .args(args)
+            .output()
+            .unwrap()
+    };
+
+    // Never compiled: the committed registry is not vouching for anything.
+    assert_eq!(
+        code(&run(&["compile", "--check"])),
+        2,
+        "unbuilt -> stale (2)"
+    );
+
+    assert_eq!(code(&run(&["compile"])), 0);
+    assert_eq!(
+        code(&run(&["compile", "--check"])),
+        0,
+        "just compiled -> fresh (0)"
+    );
+
+    // --check must not have written anything, so a second check still agrees
+    // and no build-meta sidecar was produced by it.
+    let meta = tmp.path().join(".derived/spec-registry/build-meta.json");
+    let meta_before = fs::read(&meta).unwrap();
+    assert_eq!(code(&run(&["compile", "--check"])), 0);
+    assert_eq!(
+        fs::read(&meta).unwrap(),
+        meta_before,
+        "--check must not restamp build-meta.json"
+    );
+
+    // Edit a spec.md without recompiling: the PR #61 regression.
+    let spec_md = tmp.path().join("specs/001-a/spec.md");
+    let edited = fs::read_to_string(&spec_md).unwrap() + "\nmore body\n";
+    fs::write(&spec_md, edited).unwrap();
+    let stale = run(&["compile", "--check"]);
+    assert_eq!(code(&stale), 2, "edited spec, stale shard -> 2");
+    assert!(
+        String::from_utf8_lossy(&stale.stderr).contains("modified 001-a.json"),
+        "stale detail belongs on stderr: {}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+
+    // Break validation while the shard is ALSO stale: validation wins (1).
+    fs::write(
+        &spec_md,
+        "---\nid: \"mismatched\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-08\"\nsummary: \"s\"\n---\n",
+    )
+    .unwrap();
+    assert_eq!(
+        code(&run(&["compile", "--check"])),
+        1,
+        "validation outranks staleness"
+    );
+}

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -501,16 +501,19 @@ pub fn compare_committed_registry(
     }
     stale.sort();
     let total = stale.len();
-    let listed = if total > STALE_REPORT_CAP {
-        let mut head = stale[..STALE_REPORT_CAP].join(", ");
-        head.push_str(&format!(", and {} more", total - STALE_REPORT_CAP));
-        head
-    } else {
-        stale.join(", ")
-    };
+    // One line per stale shard (spec 031 §3.3), so a CI log stays greppable and
+    // each finding is its own line rather than one wrapped blob.
+    let mut lines: Vec<String> = stale
+        .iter()
+        .take(STALE_REPORT_CAP)
+        .map(|s| format!("  {s}"))
+        .collect();
+    if total > STALE_REPORT_CAP {
+        lines.push(format!("  and {} more", total - STALE_REPORT_CAP));
+    }
     Ok(Freshness::Stale {
         expected: format!("{} shard(s) matching the corpus", expected.len()),
-        actual: format!("{total} stale shard(s): {listed}"),
+        actual: format!("{total} stale shard(s):\n{}", lines.join("\n")),
     })
 }
 

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -15,6 +15,7 @@ use spec_spine_types::{
     parse_frontmatter_with, split_frontmatter,
 };
 
+use crate::index::Freshness;
 use crate::{canonical_json, hash, markdown, shard};
 
 /// Validation codes whose verdict depends on the whole corpus, not one spec:
@@ -429,6 +430,88 @@ pub fn registry_shard_files(shards: &RegistryShardSet) -> Result<Vec<(String, St
             ))
         })
         .collect()
+}
+
+/// The cap on how many stale shards a freshness report names (spec 031 §3.3),
+/// so a corpus-wide restamp reports `and N more` instead of flooding a CI log.
+const STALE_REPORT_CAP: usize = 20;
+
+/// Registry-shard freshness (spec 031): does the committed shard tree equal what
+/// the current corpus compiles to? Compiles in memory and delegates to
+/// [`compare_committed_registry`]; **never writes**.
+///
+/// Reports staleness only. Validation is a separate verdict carried on
+/// [`CompileOutcome`]; a caller that needs both (the CLI, which must rank
+/// validation above staleness) should call [`compile`] and
+/// [`compare_committed_registry`] directly rather than compiling twice.
+pub fn check_registry_freshness(cfg: &Config, repo_root: &Path) -> Result<Freshness, Error> {
+    let outcome = compile(cfg, repo_root)?;
+    compare_committed_registry(cfg, repo_root, &outcome.shards)
+}
+
+/// Compare a freshly compiled shard set against the committed one, byte for
+/// byte (spec 031 §3.1).
+///
+/// The comparison is over the serialized shard *bytes*, not the `shardHash`
+/// field: canonical emission makes a fresh compile reproducible, so an exact
+/// comparison is both the simplest and the strictest check, catching a stale
+/// hash, a hand-edited body, and a schema restamp alike. (The index side
+/// compares recomputed hashes instead only because re-resolving code spans is
+/// expensive; a registry shard is cheap to re-emit.)
+///
+/// Three drift classes are reported together: `modified` (bytes differ),
+/// `missing` (a spec with no committed shard), and `orphaned` (a committed
+/// shard with no spec). The latter two are set-membership failures, invisible
+/// to a content comparison alone, which is why this compares sets.
+///
+/// An unbuilt registry reads as `Stale`, not [`Error::Io`]: a registry that was
+/// never built is by definition not vouching for the corpus (same reasoning as
+/// spec 012 §3.3 for an index predating its slice config).
+pub fn compare_committed_registry(
+    cfg: &Config,
+    repo_root: &Path,
+    shards: &RegistryShardSet,
+) -> Result<Freshness, Error> {
+    let expected: BTreeMap<String, String> = registry_shard_files(shards)?.into_iter().collect();
+    let by_spec = registry_dir(cfg, repo_root).join(shard::BY_SPEC_DIR);
+    // `read_shard_files` yields an empty list for a missing dir, which is what
+    // turns an unbuilt registry into "every shard missing" (stale) rather than
+    // an I/O error.
+    let committed: BTreeMap<String, Vec<u8>> =
+        shard::read_shard_files(&by_spec)?.into_iter().collect();
+
+    let mut stale: Vec<String> = Vec::new();
+    for (name, content) in &expected {
+        match committed.get(name) {
+            None => stale.push(format!("missing {name}")),
+            Some(bytes) if bytes.as_slice() != content.as_bytes() => {
+                stale.push(format!("modified {name}"));
+            }
+            Some(_) => {}
+        }
+    }
+    for name in committed.keys() {
+        if !expected.contains_key(name) {
+            stale.push(format!("orphaned {name}"));
+        }
+    }
+
+    if stale.is_empty() {
+        return Ok(Freshness::Fresh);
+    }
+    stale.sort();
+    let total = stale.len();
+    let listed = if total > STALE_REPORT_CAP {
+        let mut head = stale[..STALE_REPORT_CAP].join(", ");
+        head.push_str(&format!(", and {} more", total - STALE_REPORT_CAP));
+        head
+    } else {
+        stale.join(", ")
+    };
+    Ok(Freshness::Stale {
+        expected: format!("{} shard(s) matching the corpus", expected.len()),
+        actual: format!("{total} stale shard(s): {listed}"),
+    })
 }
 
 /// Read and parse the committed registry shards (gating each shard's MAJOR at

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -43,8 +43,9 @@ pub use attest::{
     AttestOptions, AttestOutcome, VerifyOutcome, attest, attestation_hash, verify_recompute,
 };
 pub use compile::{
-    CompileOutcome, MAX_UNDECLARED_EXTRA_FRONTMATTER, RegistryShardSet, compile,
-    load_committed_registry, registry_dir, registry_shard_files,
+    CompileOutcome, MAX_UNDECLARED_EXTRA_FRONTMATTER, RegistryShardSet, check_registry_freshness,
+    compare_committed_registry, compile, load_committed_registry, registry_dir,
+    registry_shard_files,
 };
 pub use couple::{
     CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, couple, couple_with,
@@ -165,13 +166,34 @@ pub fn lint_json(config_json: &str, repo_root: &str) -> Result<String, Error> {
 /// Check index freshness, returning `{ "fresh": bool, "expected"?, "actual"? }`.
 pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error> {
     let config = config_from_json(config_json)?;
-    let value = match check_index_freshness(&config, std::path::Path::new(repo_root))? {
+    let value = freshness_to_json(check_index_freshness(
+        &config,
+        std::path::Path::new(repo_root),
+    )?);
+    Ok(value.to_string())
+}
+
+/// Check registry-shard freshness (spec 031), returning the same
+/// `{ "fresh": bool, "expected"?, "actual"? }` shape as
+/// [`check_freshness_json`] so a binding handles one verdict type for both
+/// committed trees. Staleness only: the validation verdict rides on
+/// [`compile_json`].
+pub fn check_registry_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error> {
+    let config = config_from_json(config_json)?;
+    let value = freshness_to_json(check_registry_freshness(
+        &config,
+        std::path::Path::new(repo_root),
+    )?);
+    Ok(value.to_string())
+}
+
+fn freshness_to_json(freshness: Freshness) -> serde_json::Value {
+    match freshness {
         Freshness::Fresh => serde_json::json!({ "fresh": true }),
         Freshness::Stale { expected, actual } => {
             serde_json::json!({ "fresh": false, "expected": expected, "actual": actual })
         }
-    };
-    Ok(value.to_string())
+    }
 }
 
 /// Render the committed index as markdown (spec 011). `index_json` is the

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -178,6 +178,12 @@ pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String
 /// [`check_freshness_json`] so a binding handles one verdict type for both
 /// committed trees. Staleness only: the validation verdict rides on
 /// [`compile_json`].
+///
+/// Each call compiles the corpus, so a consumer that wants *both* verdicts
+/// pays two compile passes across this and [`compile_json`]. That is the cost
+/// of keeping the facade one-verdict-per-call; a caller that minds it should
+/// use the typed API ([`compile`] once, then [`compare_committed_registry`]),
+/// which is what the CLI does.
 pub fn check_registry_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error> {
     let config = config_from_json(config_json)?;
     let value = freshness_to_json(check_registry_freshness(

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -568,3 +568,162 @@ fn dangling_short_id_is_left_unchanged_and_still_warns() {
         .unwrap();
     assert_eq!(rec.depends_on, vec!["999".to_string()]);
 }
+
+// ===== registry freshness, `compile --check` (spec 031) =====
+
+/// Emit the shard tree the way the CLI does, so a freshness check has a
+/// committed artifact to compare against.
+fn write_shards(root: &Path, cfg: &Config) {
+    let outcome = compile(cfg, root).unwrap();
+    let dir = spec_spine_core::registry_dir(cfg, root).join(spec_spine_core::shard::BY_SPEC_DIR);
+    let files = spec_spine_core::registry_shard_files(&outcome.shards).unwrap();
+    spec_spine_core::shard::sync_dir(&dir, &files).unwrap();
+}
+
+fn stale_detail(f: &spec_spine_core::Freshness) -> String {
+    match f {
+        spec_spine_core::Freshness::Fresh => panic!("expected stale, got fresh"),
+        spec_spine_core::Freshness::Stale { actual, .. } => actual.clone(),
+    }
+}
+
+#[test]
+fn freshness_check_passes_on_a_just_compiled_tree_and_writes_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "001-alpha", "");
+    write_spec(tmp.path(), "002-beta", "002-beta", "");
+    let cfg = Config::default();
+    write_shards(tmp.path(), &cfg);
+
+    let by_spec =
+        spec_spine_core::registry_dir(&cfg, tmp.path()).join(spec_spine_core::shard::BY_SPEC_DIR);
+    let before = spec_spine_core::shard::read_shard_files(&by_spec).unwrap();
+
+    let verdict = spec_spine_core::check_registry_freshness(&cfg, tmp.path()).unwrap();
+    assert_eq!(verdict, spec_spine_core::Freshness::Fresh);
+
+    // Spec 031 3.1: --check never writes. The shard bytes are untouched and no
+    // build-meta.json appears.
+    let after = spec_spine_core::shard::read_shard_files(&by_spec).unwrap();
+    assert_eq!(before, after, "--check must not rewrite the shard tree");
+    assert!(
+        !spec_spine_core::registry_dir(&cfg, tmp.path())
+            .join("build-meta.json")
+            .exists(),
+        "--check must not write the wall-clock sidecar"
+    );
+}
+
+#[test]
+fn edited_spec_without_recompiling_reads_as_modified() {
+    // The PR #61 regression, pinned: a spec.md body edit that never made it
+    // into the committed shard.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "001-alpha", "");
+    let cfg = Config::default();
+    write_shards(tmp.path(), &cfg);
+
+    let spec_md = tmp.path().join("specs/001-alpha/spec.md");
+    let edited = fs::read_to_string(&spec_md).unwrap() + "\nA new body paragraph.\n";
+    fs::write(&spec_md, edited).unwrap();
+
+    let detail =
+        stale_detail(&spec_spine_core::check_registry_freshness(&cfg, tmp.path()).unwrap());
+    assert!(
+        detail.contains("modified 001-alpha.json"),
+        "expected a modified shard, got: {detail}"
+    );
+}
+
+#[test]
+fn added_spec_without_recompiling_reads_as_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "001-alpha", "");
+    let cfg = Config::default();
+    write_shards(tmp.path(), &cfg);
+
+    // A brand-new spec whose shard was never emitted: invisible to a
+    // content-only comparison, which is why the check compares sets.
+    write_spec(tmp.path(), "002-beta", "002-beta", "");
+
+    let detail =
+        stale_detail(&spec_spine_core::check_registry_freshness(&cfg, tmp.path()).unwrap());
+    assert!(
+        detail.contains("missing 002-beta.json"),
+        "expected a missing shard, got: {detail}"
+    );
+}
+
+#[test]
+fn removed_spec_leaves_an_orphaned_shard() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "001-alpha", "");
+    write_spec(tmp.path(), "002-beta", "002-beta", "");
+    let cfg = Config::default();
+    write_shards(tmp.path(), &cfg);
+
+    fs::remove_dir_all(tmp.path().join("specs/002-beta")).unwrap();
+
+    let detail =
+        stale_detail(&spec_spine_core::check_registry_freshness(&cfg, tmp.path()).unwrap());
+    assert!(
+        detail.contains("orphaned 002-beta.json"),
+        "expected an orphaned shard, got: {detail}"
+    );
+}
+
+#[test]
+fn unbuilt_registry_is_stale_not_an_error() {
+    // Spec 031 3.2: a registry that was never built is not vouching for the
+    // corpus. Stale (2), never Err (3).
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "001-alpha", "");
+    let cfg = Config::default();
+
+    let detail =
+        stale_detail(&spec_spine_core::check_registry_freshness(&cfg, tmp.path()).unwrap());
+    assert!(
+        detail.contains("missing 001-alpha.json"),
+        "expected every shard missing, got: {detail}"
+    );
+}
+
+#[test]
+fn freshness_report_caps_the_named_shards() {
+    // A corpus-wide restamp must not flood a CI log (spec 031 3.3).
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = Config::default();
+    for n in 1..=25 {
+        write_spec(tmp.path(), &format!("{n:03}-s"), &format!("{n:03}-s"), "");
+    }
+
+    let detail =
+        stale_detail(&spec_spine_core::check_registry_freshness(&cfg, tmp.path()).unwrap());
+    assert!(detail.starts_with("25 stale shard(s):"), "got: {detail}");
+    assert!(
+        detail.contains("and 5 more"),
+        "expected a capped tail: {detail}"
+    );
+}
+
+#[test]
+fn registry_freshness_facade_reports_both_verdicts() {
+    // The FFI seam: one verdict shape for both committed trees (spec 031 3.1).
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "001-alpha", "");
+    let cfg = Config::default();
+    let cfg_json = serde_json::to_string(&cfg).unwrap();
+    let root = tmp.path().to_str().unwrap();
+
+    let stale = spec_spine_core::check_registry_freshness_json(&cfg_json, root).unwrap();
+    let stale: serde_json::Value = serde_json::from_str(&stale).unwrap();
+    assert_eq!(stale["fresh"], serde_json::json!(false));
+    assert!(stale["actual"].as_str().unwrap().contains("missing"));
+
+    write_shards(tmp.path(), &cfg);
+    let fresh = spec_spine_core::check_registry_freshness_json(&cfg_json, root).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&fresh).unwrap(),
+        serde_json::json!({ "fresh": true })
+    );
+}

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -704,6 +704,14 @@ fn freshness_report_caps_the_named_shards() {
         detail.contains("and 5 more"),
         "expected a capped tail: {detail}"
     );
+    // Spec 031 3.3: one line per stale shard, so a CI log stays greppable.
+    // A count line + 20 capped entries + the "and N more" tail = 22 lines.
+    let lines: Vec<&str> = detail.lines().collect();
+    assert_eq!(lines.len(), 22, "one line per shard, capped: {detail}");
+    assert!(
+        lines[1..].iter().all(|l| l.starts_with("  ")),
+        "shard lines are indented under the count line: {detail}"
+    );
 }
 
 #[test]

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -152,7 +152,13 @@ jobs:
         with:
           fetch-depth: 0          # full history so the gate can diff the merge base
       - run: cargo install spec-spine-cli   # or download the prebuilt binary
-      - run: spec-spine compile             # validation gate (exit 1 on failure)
+      # If you commit .derived/, use `compile --check`: it validates AND proves
+      # the committed registry shards match the corpus, without writing (exit 1
+      # invalid, 2 stale). If you gitignore .derived/, use plain `spec-spine
+      # compile` instead, since there is no committed artifact to compare.
+      # Never run --check after a writing compile: it would compare the shards
+      # against files the same job just overwrote and pass unconditionally.
+      - run: spec-spine compile --check     # validation + registry freshness
       - run: spec-spine index check         # staleness gate (exit 2 if stale)
       - run: spec-spine lint --fail-on-warn
       - name: Coupling gate

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -152,12 +152,11 @@ jobs:
         with:
           fetch-depth: 0          # full history so the gate can diff the merge base
       - run: cargo install spec-spine-cli   # or download the prebuilt binary
-      # If you commit .derived/, use `compile --check`: it validates AND proves
-      # the committed registry shards match the corpus, without writing (exit 1
-      # invalid, 2 stale). If you gitignore .derived/, use plain `spec-spine
-      # compile` instead, since there is no committed artifact to compare.
-      # Never run --check after a writing compile: it would compare the shards
-      # against files the same job just overwrote and pass unconditionally.
+      # `compile --check` validates the frontmatter AND proves the committed
+      # registry shards match the corpus, without writing (exit 1 invalid,
+      # 2 stale). Never run it after a plain `spec-spine compile` in the same
+      # job: it would compare the shards against files that run just overwrote
+      # and pass unconditionally.
       - run: spec-spine compile --check     # validation + registry freshness
       - run: spec-spine index check         # staleness gate (exit 2 if stale)
       - run: spec-spine lint --fail-on-warn
@@ -172,6 +171,13 @@ jobs:
             --head HEAD \
             --pr-body /tmp/pr-body.txt
 ```
+
+Both freshness steps (`compile --check` and `index check`) compare against
+**committed** artifacts, so this job assumes you commit `.derived/` as described
+in §3. If you gitignore the derived tree instead, drop both `--check`/`check`
+forms and run plain `spec-spine compile` and `spec-spine index` to build the
+artifacts in-job: with nothing committed to compare against, the freshness gates
+would report every shard missing and fail permanently.
 
 This repo dogfoods exactly this pattern; see
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).

--- a/docs/design/00-architecture.md
+++ b/docs/design/00-architecture.md
@@ -441,7 +441,7 @@ pub fn scaffold_init_json  (config_json: &str)                  -> Result<String
 ### 5.2 CLI: one multi-call `spec-spine` binary (recommended; no blocker found)
 
 ```
-spec-spine compile                                  # → .derived/spec-registry/by-spec/ shards (+ build-meta.json)
+spec-spine compile [--check]                        # → .derived/spec-registry/by-spec/ shards (+ build-meta.json); --check verifies the committed shards without writing (spec 031)
 spec-spine index   [check | render | orphans]       # check = per-shard staleness gate; default subcmd writes the index shard trees
 spec-spine registry list|show|status-report|relationships
 spec-spine lint    [--fail-on-warn] [--fail-on-info]

--- a/specs/031-registry-freshness-check/spec.md
+++ b/specs/031-registry-freshness-check/spec.md
@@ -1,0 +1,167 @@
+---
+id: "031-registry-freshness-check"
+title: "Registry freshness: `spec-spine compile --check`"
+status: draft
+kind: "tooling"
+created: "2026-08-14"
+implementation: complete
+owner: "The spec-spine Authors"
+depends_on:
+  - "001-compile-registry"
+  - "024-index-sharding"
+extends:
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+references:
+  # The index-side staleness gate this mirrors for the registry tree, and the
+  # exit-code contract it has to agree with (both bypass-floor / non-owning).
+  - { unit: { kind: file, path: "specs/004-codebase-index/spec.md" }, role: context }
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  The committed spec-registry shard tree had no freshness gate. `index check`
+  (spec 004) covers only the codebase-index tree, and `compile` is a validation
+  gate that rewrites the shards without ever asserting the committed copies
+  matched, so editing a spec.md and forgetting to recompile lands stale
+  shardHash values with CI green (this is what PR #61 did to specs 017 and 021).
+  This spec adds `spec-spine compile --check`: a non-writing gate that compiles
+  in memory and compares the result byte-for-byte against the committed shards,
+  exiting 2 on staleness exactly as `index check` does. It closes the
+  registry/index asymmetry with a first-class command rather than a repo-local
+  git tree check, so every adopter that commits its registry gets the same
+  guarantee spec-spine gets.
+---
+
+# 031: Registry freshness check
+
+## 1. Purpose
+
+spec-spine commits both derived views (spec 024), but only one of them has ever
+had a freshness gate:
+
+- `.derived/codebase-index/**` is gated by `spec-spine index check` (spec 004
+  §3.5, resharded by 024 FR-003), which exits 2 on a stale shard or a changed
+  shard set.
+- `.derived/spec-registry/by-spec/**` has **nothing**. `spec-spine compile`
+  rewrites the shard tree and reports frontmatter violations; it is a
+  *validation* gate and says nothing about what the committed shards held
+  beforehand.
+
+The asymmetry is historical: only the index side ever got a staleness
+subcommand. The cost is real. Commit `9ede89f` (PR #61) edited two `spec.md`
+bodies and refreshed their codebase-index shards but skipped `compile`, so both
+spec-registry shards landed on `main` carrying pre-edit `shardHash` values with
+every CI check green. The ledger's whole claim is that the committed artifact is
+what the sources compile to; an ungated half of it is a claim nobody checks.
+
+A repo-local CI step over `git status` closes this for spec-spine alone (and did,
+as an interim fix). It does not generalize: it lives in one workflow file, it is
+silently vacuous unless a writing `compile` ran first in the same job, and it is
+unavailable to any adopter that commits its registry. **Freshness is a property
+of the ledger, so the tool that owns the ledger should answer it.**
+
+## 2. Territory
+
+The freshness comparison (`compile.rs`), its re-export and JSON facade
+(`lib.rs`), the CLI flag and its exit mapping (`cmd_compile.rs`, `main.rs`), and
+the two test files. All additive: no existing signature changes, no schema
+change, no new DTO. `Freshness` (spec 004's enum, already public) is reused
+rather than duplicated, so both gates report through one type.
+
+## 3. Behavior
+
+### 3.1 `spec-spine compile --check`
+
+Compiles the corpus in memory and compares the result against the committed
+shard tree. **It never writes**: no shard, no `build-meta.json`, no pruning of a
+removed spec's shard. A `--check` run leaves the working tree byte-identical.
+
+The comparison is over the **serialized shard bytes**, not the `shardHash`
+field. Canonical emission (sorted keys, 2-space, LF, trailing newline) makes a
+fresh compile's bytes reproducible, so an exact comparison is both the simplest
+and the strictest check: it catches a stale hash, a hand-edited shard body, and
+a schema-version restamp alike. This is stronger than the index side, which
+compares recomputed hashes because its inputs (code spans) are too expensive to
+re-resolve.
+
+Three staleness classes, all reported together:
+
+- **modified**: a committed shard whose bytes differ from the compiled one.
+- **missing**: a spec with no committed shard (a spec added without recompiling).
+- **orphaned**: a committed shard with no corresponding spec (a spec removed
+  without recompiling).
+
+Missing and orphaned are set-membership failures and are why the check compares
+sets rather than diffing file-by-file: neither is visible to a content
+comparison alone.
+
+### 3.2 Exit codes
+
+Per the stable contract (`docs/design/00-architecture.md`; `Error::exit_code()`):
+
+| exit | condition |
+|---|---|
+| `0` | validation passed and every shard matches |
+| `1` | validation failed |
+| `2` | validation passed but one or more shards are stale |
+| `3` | I/O, parse, or schema failure (unreadable specs dir, corrupt shard) |
+
+**Validation outranks staleness.** A corpus that does not validate cannot vouch
+for its shards, so `1` wins when both hold; the operator fixes the frontmatter
+first, and the staleness verdict is re-derived on the next run. This keeps
+`--check` a single self-contained gate rather than something that must be
+sequenced behind a plain `compile`.
+
+An **unbuilt** registry (no `by-spec/` directory, or an empty one against a
+non-empty corpus) is **stale (2), not an I/O error**: a registry that was never
+built is by definition not vouching for the corpus. This mirrors spec 012 §3.3,
+where an index predating a slice config reads as stale rather than as an error.
+It is the one place `--check` deliberately diverges from plain `compile`, whose
+reader treats a missing registry dir as `Error::Io`.
+
+### 3.3 Output
+
+Fresh prints one line naming the shard count. Stale prints one line per stale
+shard, classified, to **stderr** (so CI logs surface it), then a summary line,
+and is capped at 20 shards with an `and N more` tail so a corpus-wide restamp
+does not flood the log. Message text is not part of the contract; exit codes
+are.
+
+### 3.4 Determinism
+
+`--check` is a pure function of `(config, spec sources, committed shards)`. It
+reads no clock and no environment: notably it does **not** compare
+`build-meta.json`, which carries the wall clock and is gitignored. Two runs over
+one tree agree, and the verdict is identical across the release matrix.
+
+### 3.5 Relationship to the existing gates
+
+`--check` does not replace anything. Plain `compile` remains the writing form
+and keeps its exit semantics. `index check` is untouched: the two gates cover
+disjoint trees and are wired as separate CI steps so a failure names which half
+drifted. The coupling gate (spec 005) is unaffected; `.derived/` stays in the
+bypass floor, because a derived artifact is not code that can drift from a spec.
+
+### 3.6 Tests (minimum)
+
+- Fresh tree after a compile exits 0 and writes nothing (tree byte-identical,
+  verified including mtime-independent content comparison).
+- A `spec.md` body edit without recompiling is detected as `modified` (the PR
+  #61 regression, pinned).
+- A newly added spec dir is detected as `missing`.
+- A removed spec's leftover shard is detected as `orphaned`.
+- An unbuilt registry is stale (2), not an error.
+- Validation failure exits 1 even when shards are also stale (precedence).
+- The JSON facade returns `{ "fresh": bool, ... }` for both verdicts.
+
+## 4. Out of scope
+
+A `--fix` / `--write` mode (that is plain `compile`). Extending the check to
+`build-meta.json` (wall-clock, gitignored, excluded from every determinism gate
+by 001). A combined "check both trees" command: one gate per invocation keeps CI
+failure messages single-subject, per spec 012 §3.3. Teaching the coupling gate
+to consult registry freshness (005 is a code-vs-spec gate; freshness is a
+ledger-vs-source question and stays separate).

--- a/website/docs/cli/compile.md
+++ b/website/docs/cli/compile.md
@@ -51,6 +51,7 @@ $ spec-spine compile --check
 spec-registry is fresh: 42 shard(s) match the corpus
 
 $ spec-spine compile --check      # after editing a spec.md
-1 stale shard(s): modified 017-directory-crate-module-units.json
+1 stale shard(s):
+  modified 017-directory-crate-module-units.json
 spec-registry is STALE: run `spec-spine compile` and commit the result
 ```

--- a/website/docs/cli/compile.md
+++ b/website/docs/cli/compile.md
@@ -11,7 +11,7 @@ Validates spec frontmatter and emits the deterministic registry.
 ## Usage
 
 ```bash
-spec-spine compile
+spec-spine compile [--check]
 ```
 
 ## Description
@@ -20,10 +20,25 @@ The compiler reads the markdown spec corpus (`specs/*/spec.md`), validates the Y
 
 The output is written as per-unit registry shards to `.derived/spec-registry/by-spec/<id>.json`. The output is deterministic: the same inputs produce byte-identical output on every platform.
 
+## `--check`
+
+`--check` is the non-writing form, the registry counterpart of [`index check`](./index.md). It compiles in memory and compares the result byte-for-byte against the committed shards, reporting three kinds of drift:
+
+- **modified**: a committed shard whose bytes differ from the compiled one (a `spec.md` was edited without recompiling).
+- **missing**: a spec with no committed shard (a spec was added without recompiling).
+- **orphaned**: a committed shard with no matching spec (a spec was removed without recompiling).
+
+Use it in CI if you commit `.derived/`. It never writes: no shard, no `build-meta.json`, no pruning.
+
+:::warning
+Do not run `compile --check` after a plain `spec-spine compile` in the same job. The check would compare the committed shards against files that run just overwrote, and would pass unconditionally. `--check` compiles on its own, so it replaces the plain `compile` step rather than following it.
+:::
+
 ## Exit Codes
 
-- `0`: Validation passed and registry written.
-- `1`: Validation failed (e.g., malformed frontmatter, invalid edge).
+- `0`: Validation passed and registry written (or, with `--check`, every shard matches).
+- `1`: Validation failed (e.g., malformed frontmatter, invalid edge). With `--check`, validation outranks staleness: a corpus that does not validate cannot vouch for its shards.
+- `2`: `--check` only. Validation passed but one or more committed shards are stale. A registry that was never built is stale, not an error.
 - `3`: I/O, parse, schema, or config error.
 
 ## Example
@@ -31,4 +46,11 @@ The output is written as per-unit registry shards to `.derived/spec-registry/by-
 ```bash
 $ spec-spine compile
 Compiled 42 specs to .derived/spec-registry/
+
+$ spec-spine compile --check
+spec-registry is fresh: 42 shard(s) match the corpus
+
+$ spec-spine compile --check      # after editing a spec.md
+1 stale shard(s): modified 017-directory-crate-module-units.json
+spec-registry is STALE: run `spec-spine compile` and commit the result
 ```


### PR DESCRIPTION
Files spec **031** and implements it. Supersedes the interim `git status` step from #64 with a first-class command, and resolves the AI review comments from that PR.

## Why

The committed spec-registry shard tree had no freshness gate. `index check` (spec 004) covers only the codebase-index tree, and `compile` is a *validation* gate that rewrites the shards without ever asserting the committed copies matched. #61 edited two `spec.md` bodies, skipped the recompile, and landed stale `shardHash` values on `main` with every check green.

#64 closed this for spec-spine alone. That fix does not generalize: it lives in one workflow file, it is silently vacuous unless a writing `compile` ran first in the same job, and no adopter that commits its registry can use it. Freshness is a property of the ledger, so the tool that owns the ledger should answer it.

## What

`spec-spine compile --check` compiles in memory and compares byte-for-byte against the committed shards. It **never writes**: no shard, no `build-meta.json`, no pruning.

Comparing serialized bytes rather than the `shardHash` field is both simpler and stricter, catching a stale hash, a hand-edited body, and a schema restamp alike. (The index side compares recomputed hashes only because re-resolving code spans is expensive; a registry shard is cheap to re-emit.) Three drift classes report together:

| class | meaning |
|---|---|
| `modified` | committed shard bytes differ from the compiled one |
| `missing` | a spec with no committed shard (spec added without recompiling) |
| `orphaned` | a committed shard with no spec (spec removed without recompiling) |

The latter two are set-membership failures, invisible to a content comparison alone, which is why the check compares sets.

Exit codes follow the existing contract: `0` fresh, `1` validation failed, `2` stale, `3` I/O. **Validation outranks staleness**, since a corpus that does not validate cannot vouch for its shards. An unbuilt registry is stale rather than an I/O error, mirroring spec 012 §3.3.

- core: `check_registry_freshness` + `compare_committed_registry`, reusing spec 004's `Freshness` so both committed trees report through one verdict type.
- facade: `check_registry_freshness_json`, same `{fresh, expected?, actual?}` shape as `check_freshness_json`.
- CI: the two `self_governance` steps collapse into one `compile --check`.

## Responses to the #64 AI review

| comment | disposition |
|---|---|
| Incomplete diagnostic for untracked shards | **Valid, now moot.** The proposed fix does not work, though: `git diff HEAD` does not show untracked files either (verified). `git add -N` would have been the correct mechanism. The git approach is gone entirely; `missing` is now a named drift class. |
| Non-standard exit code, use `exit 1` | **Declined, would break the contract.** Exit codes are stable and repo-wide: `1` validation, `2` stale, `3` I/O, mapped in one place via `Error::exit_code()` (`Error::Stale => 2`). `2` is what `index check` returns for the same condition. Generic bash convention does not apply. |
| Implicit ordering dependency on the preceding compile | **Valid, now structurally impossible.** `--check` compiles on its own, so it replaces the plain compile step rather than following it. The failure mode is called out in the workflow comment, the adoption guide, and the CLI docs, because running `--check` *after* a writing compile would compare shards against files that run just overwrote. |
| Missing `spec.md` co-change evidence | **Not a coupling violation.** `.derived/` is in the bypass floor: a derived artifact is not code that can drift from a spec. #61's mistake was staleness, not coupling, which is exactly the gap with no gate. #64 repaired the state; this PR removes the class. |
| `--untracked-files=all` traversal cost | Moot, no git traversal remains. |

## Verification

| check | result |
|---|---|
| `cargo test --workspace --locked` | all suites pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `compile --check` | fresh, 32 shards |
| `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `couple --base main --head HEAD` | OK, 8 paths checked, no drift |
| `actionlint` | clean |

8 new tests: fresh (asserting the tree is byte-identical afterward), modified, missing, orphaned, unbuilt-is-stale, report cap, the CLI exit contract including validation-over-staleness, and the JSON facade. The #61 regression is pinned as a test.

The full `self_governance` sequence was also run locally against the debug binary, confirming the chain is green and that nothing is written to `.derived/`.

## Notes

Spec 031 is filed as `draft`, per the usual implement-then-ratify split.

Not included, flagged for a separate decision: `AGENTS.md`'s `/init` protocol still runs a **writing** `compile` first and infers staleness from the resulting tree change. It could now use `compile --check` and stay non-mutating. That is a change to the cross-agent protocol, so it seemed worth deciding on its own rather than riding along here. The `kit/` hooks that auto-recompile after a `spec.md` edit are deliberate and unaffected.