### PR TITLE
chore(031): ratify spec 031 and make `/init` non-mutating

### DIFF
--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -148,5 +148,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cf575989f14993841e8fde4919e5e2751a84a5ebcd3a2babe6c2f3f76bede84d"
+  "shardHash": "355a17108dfe70e33ded992f3ee1bb7f3f2dc81413aaeca061da9a27ab5e9feb"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -145,8 +145,8 @@
       }
     ],
     "specId": "031-registry-freshness-check",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "97e86d1dc93e07e15eb562a62afef5fa5c30cd1e5f790eccfa971c0ee1a6ed93"
+  "shardHash": "cf575989f14993841e8fde4919e5e2751a84a5ebcd3a2babe6c2f3f76bede84d"
 }

--- a/.derived/spec-registry/by-spec/031-registry-freshness-check.json
+++ b/.derived/spec-registry/by-spec/031-registry-freshness-check.json
@@ -89,10 +89,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/031-registry-freshness-check/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The committed spec-registry shard tree had no freshness gate. `index check` (spec 004) covers only the codebase-index tree, and `compile` is a validation gate that rewrites the shards without ever asserting the committed copies matched, so editing a spec.md and forgetting to recompile lands stale shardHash values with CI green (this is what PR #61 did to specs 017 and 021). This spec adds `spec-spine compile --check`: a non-writing gate that compiles in memory and compares the result byte-for-byte against the committed shards, exiting 2 on staleness exactly as `index check` does. It closes the registry/index asymmetry with a first-class command rather than a repo-local git tree check, so every adopter that commits its registry gets the same guarantee spec-spine gets.\n",
     "title": "Registry freshness: `spec-spine compile --check`"
   },
-  "shardHash": "559875a381e5c5cfcbc461813d17e2cb4d780979df285fd094e9dd3c3839aa0b",
+  "shardHash": "9784eef8c7adec1409fd733efb0611b2c4a75cbab41b8266a1e9cd40dee159a2",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/031-registry-freshness-check.json
+++ b/.derived/spec-registry/by-spec/031-registry-freshness-check.json
@@ -93,6 +93,6 @@
     "summary": "The committed spec-registry shard tree had no freshness gate. `index check` (spec 004) covers only the codebase-index tree, and `compile` is a validation gate that rewrites the shards without ever asserting the committed copies matched, so editing a spec.md and forgetting to recompile lands stale shardHash values with CI green (this is what PR #61 did to specs 017 and 021). This spec adds `spec-spine compile --check`: a non-writing gate that compiles in memory and compares the result byte-for-byte against the committed shards, exiting 2 on staleness exactly as `index check` does. It closes the registry/index asymmetry with a first-class command rather than a repo-local git tree check, so every adopter that commits its registry gets the same guarantee spec-spine gets.\n",
     "title": "Registry freshness: `spec-spine compile --check`"
   },
-  "shardHash": "9784eef8c7adec1409fd733efb0611b2c4a75cbab41b8266a1e9cd40dee159a2",
+  "shardHash": "39995f7666e6d0633aee9b4c039ce8c46023f80c02f031d98b6d58d3c481740f",
   "specVersion": "1.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ The protocol drives the library through its own built binary, `target/release/sp
 
 - **`0` (fresh):** the committed shards are exactly what the corpus compiles to, so the lifecycle counts below reflect the current `specs/*/spec.md` frontmatter. Report nothing.
 - **`2` (stale):** report "Spec registry: stale, run `spec-spine compile` and commit" **and name the drifted shards from its stderr**, then continue. The lifecycle counts come from the committed ledger and are therefore the stale ones; say so rather than presenting them as current.
-- **`1` (validation failed):** the corpus itself is broken. Surface the violations; freshness is unknowable until they are fixed.
+- **`1` (validation failed):** the corpus itself is broken. Surface the violations, and report the lifecycle counts as **unverified**: they still come from the committed ledger, but with the corpus failing validation there is no way to say whether that ledger corresponds to it. Fixing the violations is the first task of the session, not an aside.
 
 Do **not** substitute a plain `spec-spine compile` here. Writing would repair the tree as a side effect of reading it, which hides the fact that the *committed* copy was stale: the drift then looks like an uncommitted local edit instead of a defect on the branch (this is exactly how the spec 017/021 drift reached `main` unnoticed). `/init` reports; it does not silently mutate.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,17 @@ The protocol drives the library through its own built binary, `target/release/sp
 `/init` asks with `spec-spine compile --check` (spec 031), which compiles in memory and compares against the committed shards **without writing**. Read the exit code:
 
 - **`0` (fresh):** the committed shards are exactly what the corpus compiles to, so the lifecycle counts below reflect the current `specs/*/spec.md` frontmatter. Report nothing.
-- **`2` (stale):** report "Spec registry: stale, run `spec-spine compile` and commit" **and name the drifted shards from its stderr**, then continue. The lifecycle counts come from the committed ledger and are therefore the stale ones; say so rather than presenting them as current.
+- **`2` (stale):** *read stderr before believing it* (see **Stale binary** below). For a genuine staleness report, report "Spec registry: stale, run `spec-spine compile` and commit" **and name the drifted shards from its stderr**, then continue. The lifecycle counts come from the committed ledger and are therefore the stale ones; say so rather than presenting them as current.
 - **`1` (validation failed):** the corpus itself is broken. Surface the violations, and report the lifecycle counts as **unverified**: they still come from the committed ledger, but with the corpus failing validation there is no way to say whether that ledger corresponds to it. Fixing the violations is the first task of the session, not an aside.
+- **any other non-zero** (`3` is I/O / parse / schema / config): treat freshness as unknown, report stderr verbatim, and continue. Never report "fresh" for an exit code you did not recognize.
+
+The counts are formatted in step 2, after every parallel read has returned, so the verdict is always in hand before the numbers are written down.
+
+**Stale binary:** `target/release/spec-spine` is whatever was last built, which is not necessarily this checkout. A binary predating `compile --check` rejects the unknown flag with **exit 2**, the same code as "stale", so the two separate only by stderr: a rejection says `error: unexpected argument '--check'`, while a real report names shards. Rebuild (`cargo build --release -p spec-spine-cli`) and re-run rather than reporting phantom drift. Rebuilding is cheap and is the right reflex whenever the binary predates recent commits.
 
 Do **not** substitute a plain `spec-spine compile` here. Writing would repair the tree as a side effect of reading it, which hides the fact that the *committed* copy was stale: the drift then looks like an uncommitted local edit instead of a defect on the branch (this is exactly how the spec 017/021 drift reached `main` unnoticed). `/init` reports; it does not silently mutate.
 
-**Binary missing:** if the `spec-spine` binary is not built, run `cargo build --release -p spec-spine-cli` and continue. Do NOT fall back to ad-hoc parsing of `.derived/**`.
+**Binary missing or stale:** if the `spec-spine` binary is not built, or predates the commits in this checkout, run `cargo build --release -p spec-spine-cli` and continue (see **Stale binary** above for why a stale one misreports freshness). Do NOT fall back to ad-hoc parsing of `.derived/**`.
 
 If any file is missing: log "not found" and continue.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,13 @@ The protocol drives the library through its own built binary, `target/release/sp
    `.claude/rules/adversarial-prompt-refusal.md` (the three the library
    scaffolds for every adopter via `spec-spine init`, and which it
    carries for itself).
-1. **Refresh the registry, then parallel reads.** Run `spec-spine
-   compile` *first* (see **Registry freshness** below), then dispatch the
-   following simultaneously:
+1. **Parallel reads.** Dispatch the following simultaneously (nothing here
+   mutates the working tree, so there is no required ordering):
    - `CLAUDE.md`: project overview and conventions
    - `README.md`: full project description
    - `standards/spec/contract.md`: normative spec-system summary
    - `standards/spec/constitution.md`: durable principles (tier 2)
+   - `spec-spine compile --check`: freshness gate for the spec registry (non-fatal; see **Registry freshness** below)
    - `spec-spine index check`: staleness gate for the codebase index (non-fatal)
    - `spec-spine index render`: markdown projection of the committed index
    - `spec-spine registry status-report --json --nonzero-only`: lifecycle counts per status
@@ -40,9 +40,17 @@ The protocol drives the library through its own built binary, `target/release/sp
 
 **Read discipline:** the init protocol MUST NOT parse `.derived/**/*.json` directly (no `python`, `jq`, `awk`, `sed` against compiled artifacts). All structural and lifecycle data comes from the `spec-spine` subcommands (`registry`, `index`) and the rendered markdown view. See `.claude/rules/governed-artifact-reads.md`.
 
-**Staleness surface:** if `spec-spine index check` exits non-zero, include "Codebase index: stale, run `spec-spine index`" in the summary and continue. If the index is not built and `render` fails, report "Codebase index: not built" and continue without structural counts.
+**Staleness surface:** both committed trees have their own gate, and each is non-fatal to `/init`: report it in the summary and continue. If `spec-spine index check` exits non-zero, include "Codebase index: stale, run `spec-spine index`". If the index is not built and `render` fails, report "Codebase index: not built" and continue without structural counts. The registry half is `spec-spine compile --check`, whose verdicts are spelled out under **Registry freshness** below.
 
-**Registry freshness:** spec-spine **commits** its compiled artifacts. Since spec 024 both views are committed as per-unit shard trees: `.derived/spec-registry/by-spec/<id>.json` and `.derived/codebase-index/{by-spec,by-package}/*.json` are tracked (only `.derived/**/build-meta.json` is gitignored; no monolithic `registry.json`/`index.json` is committed). The committed shard set is the reference for lifecycle queries. `/init` still runs `spec-spine compile` *first* because compile is deterministic: on a fresh tree it is a no-op that leaves the tracked shards byte-identical, so it costs nothing; but if it changes a shard, the committed copy was stale and the refreshed counts are the correct ones (regenerate and commit the shards before relying on them). Either way the lifecycle counts reflect the current `specs/*/spec.md` frontmatter.
+**Registry freshness:** spec-spine **commits** its compiled artifacts. Since spec 024 both views are committed as per-unit shard trees: `.derived/spec-registry/by-spec/<id>.json` and `.derived/codebase-index/{by-spec,by-package}/*.json` are tracked (only `.derived/**/build-meta.json` is gitignored; no monolithic `registry.json`/`index.json` is committed). The committed shard set is the reference for lifecycle queries, so `/init` has to know whether it is current.
+
+`/init` asks with `spec-spine compile --check` (spec 031), which compiles in memory and compares against the committed shards **without writing**. Read the exit code:
+
+- **`0` (fresh):** the committed shards are exactly what the corpus compiles to, so the lifecycle counts below reflect the current `specs/*/spec.md` frontmatter. Report nothing.
+- **`2` (stale):** report "Spec registry: stale, run `spec-spine compile` and commit" **and name the drifted shards from its stderr**, then continue. The lifecycle counts come from the committed ledger and are therefore the stale ones; say so rather than presenting them as current.
+- **`1` (validation failed):** the corpus itself is broken. Surface the violations; freshness is unknowable until they are fixed.
+
+Do **not** substitute a plain `spec-spine compile` here. Writing would repair the tree as a side effect of reading it, which hides the fact that the *committed* copy was stale: the drift then looks like an uncommitted local edit instead of a defect on the branch (this is exactly how the spec 017/021 drift reached `main` unnoticed). `/init` reports; it does not silently mutate.
 
 **Binary missing:** if the `spec-spine` binary is not built, run `cargo build --release -p spec-spine-cli` and continue. Do NOT fall back to ad-hoc parsing of `.derived/**`.
 

--- a/specs/031-registry-freshness-check/spec.md
+++ b/specs/031-registry-freshness-check/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "031-registry-freshness-check"
 title: "Registry freshness: `spec-spine compile --check`"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-08-14"
 implementation: complete

--- a/specs/031-registry-freshness-check/spec.md
+++ b/specs/031-registry-freshness-check/spec.md
@@ -127,8 +127,14 @@ reader treats a missing registry dir as `Error::Io`.
 Fresh prints one line naming the shard count. Stale prints one line per stale
 shard, classified, to **stderr** (so CI logs surface it), then a summary line,
 and is capped at 20 shards with an `and N more` tail so a corpus-wide restamp
-does not flood the log. Message text is not part of the contract; exit codes
-are.
+does not flood the log.
+
+The stale report's **structure is contractual**, because a consumer reads it:
+the `/init` protocol (`AGENTS.md` § New Sessions) reports the drifted shard
+names back to the operator, and exit 2 alone cannot say *which* shard moved.
+Specifically, each stale shard occupies its own stderr line and carries its
+drift class. The exact wording around those lines (the count line, the summary
+line) is not contractual, and neither is anything on the fresh path.
 
 ### 3.4 Determinism
 


### PR DESCRIPTION
Follow-ups to #65, which landed spec 031's `compile --check`.

## 1. Ratify spec 031 (draft to approved)

031 shipped complete in #65: implementation, 8 tests, docs, and the CI wiring that now runs `compile --check` as the `self_governance` validation step. Corpus is **32/32 approved**.

## 2. `/init` switches to the non-mutating check

`AGENTS.md`'s init protocol ran a **writing** `spec-spine compile` first and inferred staleness from whether the tree changed. That worked, but it repaired the tree as a side effect of reading it, which disguised a stale *committed* shard as an uncommitted local edit. That is precisely how the 017/021 drift reached `main` unnoticed, so the protocol now says not to substitute the plain form.

Three changes:

- **`compile --check` replaces `compile`.** `/init` reports; it does not silently mutate.
- **The gate joins the parallel batch.** It was sequenced *first* only because it wrote, and the reads after it needed refreshed shards. A non-mutating check has no ordering requirement, so step 1 is now a single simultaneous dispatch.
- **The verdict is spelled out per exit code**, including the case that previously had no answer: on stale (2), the lifecycle counts come from the committed ledger, so they must be reported *as stale* rather than presented as current. On fresh (0), the counts are provably current, which is a stronger guarantee than the old "recompile and hope you notice the diff".

The `Staleness surface` note now covers both committed trees rather than only the index.

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 32 shards |
| `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `couple --base main --head HEAD` | OK, 2 paths checked, no drift |
| `registry status-report` | 32 total, 32 approved |

Both branches of the new protocol were exercised, not just the happy path. With a `spec.md` edited and uncommitted, `compile --check` exits 2, names the drifted shard on stderr (which is what the protocol tells agents to report), and leaves `.derived/` **untouched**. Under the old writing form that same scenario silently left a modified shard in the working tree, which is the failure mode this removes.

## Not included

`kit/AGENTS.md` still carries the writing form. Left alone deliberately, not overlooked: `kit/` is claimed territory (spec 029, subtree claim), so changing it needs a 029 amendment or a waiver, and the correct guidance there is conditional on whether the adopter commits `.derived/` at all. An adopter who gitignores the derived tree genuinely wants the plain `compile`, since there is nothing committed to check against. That is an adopter-facing product decision rather than a mechanical propagation of this repo's choice, so it seemed worth deciding separately. Happy to do it either way on a word.