### PR TITLE
docs(kit): switch the kit init protocol to the non-mutating `compile --check`

### DIFF
--- a/kit/AGENTS.md
+++ b/kit/AGENTS.md
@@ -28,14 +28,13 @@ picked up on the next init.
    `.claude/rules/governed-artifact-reads.md`, and
    `.claude/rules/adversarial-prompt-refusal.md`.
 
-1. **Refresh the registry, then parallel reads.** Run `spec-spine compile`
-   first (the registry is a deterministic artifact; recompiling guarantees
-   lifecycle counts reflect the current `specs/*/spec.md` frontmatter), then
-   dispatch simultaneously:
+1. **Parallel reads.** Dispatch the following simultaneously (nothing here
+   mutates the working tree, so there is no required ordering):
    - `CLAUDE.md`: project overview, governance model, conventions
    - `README.md`: full project description
    - `standards/spec/contract.md`: the short normative spec-spine contract
    - `standards/spec/constitution.md`: durable constitutional baseline
+   - `spec-spine compile --check`: freshness gate for the spec registry (non-fatal; see **Registry freshness** below)
    - `spec-spine index check`: staleness gate for the codebase index (non-fatal)
    - `spec-spine registry status-report --json --nonzero-only`: lifecycle counts
    - `spec-spine registry list --ids-only`: spec inventory (for latest-spec detection)
@@ -52,8 +51,39 @@ picked up on the next init.
 directly (no `python`, `jq`, `awk`, `sed` against compiled artifacts). All
 structural and lifecycle data comes from `spec-spine` subcommands.
 
-**Staleness surface:** if `spec-spine index check` exits non-zero, include
-"Codebase index: stale, run `spec-spine index`" in the summary and continue.
+**Staleness surface:** both committed artifacts have their own gate, and neither
+is fatal to `/init`: report it in the summary and continue. If `spec-spine index
+check` exits non-zero, include "Codebase index: stale, run `spec-spine index`".
+The registry half is `spec-spine compile --check`, below.
+
+**Registry freshness:** if you commit your derived artifacts (the setup the
+`index check` step above already assumes), `/init` asks whether the committed
+registry still matches the corpus using `spec-spine compile --check`, which
+compiles in memory and compares **without writing**. Read the exit code:
+
+- **`0` (fresh):** the committed shards are exactly what the corpus compiles to,
+  so the lifecycle counts reflect the current `specs/*/spec.md` frontmatter.
+  Report nothing.
+- **`2` (stale):** report "Spec registry: stale, run `spec-spine compile` and
+  commit" and name the drifted shards from its stderr, then continue. The
+  lifecycle counts come from the committed ledger and are therefore the stale
+  ones; say so rather than presenting them as current.
+- **`1` (validation failed):** the corpus itself is broken. Surface the
+  violations and report the counts as unverified.
+
+Do **not** substitute a plain `spec-spine compile` here. Writing repairs the
+tree as a side effect of reading it, which hides that the *committed* copy was
+stale: the drift then reads as an uncommitted local edit rather than as a defect
+already on the branch. `/init` reports; it does not silently mutate.
+
+If you **gitignore** the derived directory instead, there is nothing committed
+to compare against and both freshness gates would report everything missing.
+Drop `compile --check` and `index check` from step 1 and run plain `spec-spine
+compile` and `spec-spine index` there, to build the artifacts for the session.
+
+> `compile --check` needs a `spec-spine` new enough to ship it. On an older CLI
+> the flag is rejected; either upgrade, or use the gitignored-derived variant
+> above until you do.
 
 **CLI missing:** if `spec-spine --version` fails, run `/setup`. Do NOT fall back
 to ad-hoc parsing of `.derived/**/*.json`.

--- a/kit/AGENTS.md
+++ b/kit/AGENTS.md
@@ -64,12 +64,29 @@ compiles in memory and compares **without writing**. Read the exit code:
 - **`0` (fresh):** the committed shards are exactly what the corpus compiles to,
   so the lifecycle counts reflect the current `specs/*/spec.md` frontmatter.
   Report nothing.
-- **`2` (stale):** report "Spec registry: stale, run `spec-spine compile` and
-  commit" and name the drifted shards from its stderr, then continue. The
+- **`2` (stale):** *first check stderr, see the CLI-version note below.* If it
+  is a genuine staleness report, name the drifted shards from stderr, report
+  "Spec registry: stale, run `spec-spine compile` and commit", and continue. The
   lifecycle counts come from the committed ledger and are therefore the stale
   ones; say so rather than presenting them as current.
 - **`1` (validation failed):** the corpus itself is broken. Surface the
   violations and report the counts as unverified.
+- **any other non-zero** (`3` is I/O, parse, schema, or config; a missing binary
+  gives whatever the shell returns): treat freshness as unknown, report the
+  stderr verbatim, and continue. Never report "fresh" for a code you did not
+  recognize.
+
+The counts are formatted in step 2, after every parallel read has returned, so
+the freshness verdict is always in hand before the lifecycle numbers are
+written down. Do not emit counts earlier.
+
+> **CLI version.** `compile --check` needs a `spec-spine` new enough to ship it.
+> An older CLI rejects the unknown flag with **exit 2 as well**, the same code
+> as "stale", so the two are distinguishable only by stderr: a rejection says
+> `error: unexpected argument '--check'`, while a real staleness report names
+> shards. Reporting a version problem as spec drift would send someone chasing a
+> phantom, so check the message before believing the code. To resolve it, either
+> upgrade, or use the gitignored-derived variant below until you do.
 
 Do **not** substitute a plain `spec-spine compile` here. Writing repairs the
 tree as a side effect of reading it, which hides that the *committed* copy was
@@ -78,12 +95,10 @@ already on the branch. `/init` reports; it does not silently mutate.
 
 If you **gitignore** the derived directory instead, there is nothing committed
 to compare against and both freshness gates would report everything missing.
-Drop `compile --check` and `index check` from step 1 and run plain `spec-spine
-compile` and `spec-spine index` there, to build the artifacts for the session.
-
-> `compile --check` needs a `spec-spine` new enough to ship it. On an older CLI
-> the flag is rejected; either upgrade, or use the gitignored-derived variant
-> above until you do.
+Drop `compile --check` and `index check`, and instead run plain `spec-spine
+compile` and `spec-spine index` **before** the rest of step 1: those two write
+the artifacts that the `registry` and `index` reads below them consume, so for
+this variant only, step 1 is no longer order-free.
 
 **CLI missing:** if `spec-spine --version` fails, run `/setup`. Do NOT fall back
 to ad-hoc parsing of `.derived/**/*.json`.


### PR DESCRIPTION
Propagates the `/init` protocol change from #66 into the shipped kit template.

Spec-Drift-Waiver: kit/AGENTS.md content update within spec 029's claimed subtree. 029 governs the kit's inventory (which files ship) and its substrate-agnostic generalization contract, both unchanged here; it deliberately does not specify the init protocol's steps. No 029 claim became untrue, so amending 029 would be a mechanical refresh purely to satisfy the gate, which `.claude/rules/adversarial-prompt-refusal.md` forbids. Waiving is the sanctioned instrument for exactly this case.

## What changed

The kit's New Sessions template ran a **writing** `spec-spine compile` first and inferred freshness from whether the tree changed. Writing repairs the tree as a side effect of reading it, which disguises a stale *committed* artifact as an uncommitted local edit. An adopter's `/init` would therefore paper over drift already sitting on their branch, which is the failure mode that reached this repo's own `main`.

The template now uses `compile --check`. Being non-mutating, it also joins the parallel batch rather than being sequenced first, and the verdict is spelled out per exit code, including that stale counts must be reported *as stale* rather than presented as current.

## Two cases the repo's own protocol does not have to handle

The kit targets adopters on arbitrary setups, so unlike this repo's `AGENTS.md` it cannot assume either premise:

- **Gitignored derived tree.** With nothing committed to compare against, both freshness gates would report everything missing and fail permanently. The template says to drop `compile --check` *and* `index check` from step 1 and run plain `compile` + `index` there instead, building the artifacts for the session. (This case already existed for `index check`; it was simply never written down.)
- **Older CLI.** `compile --check` ships in an unreleased version, so an adopter on the current published `spec-spine` gets a rejected flag. A short note says to upgrade or use the gitignored-derived variant meanwhile.

## Generalization contract (029 §3.2)

Kept substrate-agnostic. No numbered specs (the only `specs/NNN` reference is the pre-existing generic `specs/000-.../spec.md` bootstrap pointer), no `crates/`, no `target/release`, no reference to this repo's own incident. Verified by grep, not by eye.

## Verification

| check | result |
|---|---|
| `compile` / `index` | no derived-artifact change (029's `kit/` unit does not hash subtree contents) |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `couple` **without** waiver | exit 1, correctly refuses: `'kit/AGENTS.md' changed without an authoring edit to any owning spec (029-claude-code-skill-kit)` |
| `couple` **with** waiver | exit 0, 1 violation waived |

The gate was deliberately run both ways rather than only the passing one, to confirm the claim is real and that the waiver is what clears it.

## Note

The waiver mechanism is blanket, not path-scoped: the line clears every drift violation in the PR, not just `kit/AGENTS.md`. That is safe here because this PR touches exactly one file, but it is worth remembering when a waiver rides on a larger change.