### PR TITLE
feat(032): ownership coverage: `index coverage` and the `C-002` ratchet

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2c40fb0eb15c8345837785bf16436f136400f7efa83288686ca647b7df291b13"
+  "shardHash": "68beb3c91e6b39469e6808d60b896613eeb078654c9835935972cd57f0ad3a9b"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05ab08fdf1df93fb311d2bdf9afe1e268d3b0c9b0fbe42005fdd67551b378698"
+  "shardHash": "0e351be024629a309510ae09e06e80f0dca3bd034e4997587c09b1d688b25074"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c08e44330e526fd49c92d47f91d166f5bd0a668117c364baf575e19045bb6e0e"
+  "shardHash": "9dd1d6781a92ba8138cc5447a8929e075dea5c9ebc1750f33f2cfc5566db4a8c"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.10.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3c75f869c8960b8474e03f5e0cc0395d7c4382ea0cc14f14d44d14d20693414a"
+  "shardHash": "cb6de8279125f814c9972a0890e099c86663a990eee4d87e49391bea040f988b"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -10,5 +10,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1a95c8e30ba019b3688ca5a232ca32a5cb1b9bb2e44c1a997b04de05f3b48711"
+  "shardHash": "06b53a9b09e9d16e7a41bff4557a4639fdcbad274cd118ef81730992be354b6d"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0f21fdf254c66bb2ed452902814d4ea3d2c090c7322774a11d92e01227e764cc"
+  "shardHash": "6d4071580a9b41b5b2133d7905ae02d6a8e207e2957414c57fdc4d004dd80774"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8899629a770c39a038119bafdd96fe5381a56c2e0b0f42221fe7418cd9027c61"
+  "shardHash": "33e425cace7ec6c983f92564d70a93c53fec8fe1c3e6234e4087ff1d42ecccaf"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "59d5518573e23ea8b68925255c10fa945f3f61957eca451212889d40b9e9f3de"
+  "shardHash": "6159dfbf28390649bf62642b0838bff89d4d6eb751efccd5b89143aecd2cd3e1"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09f22d551db233e4560ab907f0fe2298cbfc720a19fe99528fb33eb1daf53576"
+  "shardHash": "8d77aea612adc4744db68450d5fbbebfd4a0e71ea41305bab331c3c1e6e91e21"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9be95b4903a14f346e64ee6d28b0f5fd72b1a94a8ae38dd5c4da19635d9bdbb6"
+  "shardHash": "ddcd1af54f771be50008808ad8f821f7f8a8827bd13e851502610cc962145963"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "637ee2b3b0a22746e6bba35e0bc10748c17614a37f9d7672e41fe066ca9acc8c"
+  "shardHash": "a944da0ab00badf20a2d693ba66b221f316429d7888d2195f0d2afeb6e005a37"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2afb2bc68c8cac6fa5e227fd8d7edb33788dffa05b6cdc49ced50053430ec28b"
+  "shardHash": "b4fe3227f2db4c6e22109ea3daa578d250a22e6e3d55d8e4bdd10928f41cc9ae"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bebe21758d44ef3f48553042e4057b8dcf202b9e0b5816158dfcacdae6bcc107"
+  "shardHash": "250b0af071226f763166ddb53dd6b0a82736a2517eecf84d16da6daf449f27cd"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "38a7671efca99cd333111d643d3bdcb2a9e3f72b4c9abdb8d48f003a6de35f21"
+  "shardHash": "710acc8378d83ad16122eb3f1f1db67f4bb224b9a810d8d317f1be5906b5c572"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e65afccd4a1781b0f90ab6b890618773a24e58be6bd578995ccbcd23143f1e8e"
+  "shardHash": "80dd1f30b8163b7da2456a1c7be804b4ac18fb66307ee327a0fb15c047c1047b"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "df4e9d755f8f2723e542aa4df2c202a815ce99e59e8d489d86e03b05e7df0f47"
+  "shardHash": "728a3d5d2746e1b271a61372307a6edf6677c42e24dc841722695b25fac500fc"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "35e573325eb8a9f0cfb7f94c63453f8ab81fc139cb2cf1bf7f1bd02ae48156c7"
+  "shardHash": "03de72c101237522ea593ed2aba39604f8e8b5c1a1cac02bf29bf7539dc504e6"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0f70503ae7d4970b2302ced2bb3572d882469b4011d1a78bb8b1a9e9ed3f27de"
+  "shardHash": "e56d39752a5f5d564ead9e2444ccc932c4cc592cfaa6b8b5fff9ffc1f4c4087c"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ee435f4e9e3ffd65b3d62d35312075e0d7acbafcd2ea65de30f1f43770d890a7"
+  "shardHash": "6768b886ebd617119536721c0fdc007df374fed493d4c850e06ba86a936b0ca3"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a78bd57d984fc5cf0dd79bb103bbb37a01855bf5763f4a7ef5e213055d1c02b3"
+  "shardHash": "4923086b9e3f7eed78315cb60659a5f6377844887915730eabb8a331454e7d79"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a1731b6bb178d3ea1f5289172ee6e776c9f724e3093734f1361d167764ee57ba"
+  "shardHash": "248fbb3960646084f14afdc80136e239b144e460409365360ef2232c726aee35"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a1cf9965c9339e857f56690608d17d5c7b22629859f9e9fb840e57c05b117799"
+  "shardHash": "8563c691252fa17d1f0d5dd737d7ba928759732a49e8c152e3136bb3ecc251a8"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1fc6d75a9d712a5c5215f5c18d37dd183cf0972f8d2ba4d63a93f0aba6fde030"
+  "shardHash": "392b66912accb3ff2a2cb22e026579f52379e14ec62edff7828f2027d1afebe3"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "137375132c3d736bce6cc553bcc6ee22472dd3a8ae1a7826bb20d90157f0bd3b"
+  "shardHash": "620a7cc0d0800e5043458f74b414a1114c260ad15326ff30c30ee33481248e82"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f3bf1b7b1d1b9f7198cc4fcbe18f0e7c262173be2f5870c9be27320ef59e04f8"
+  "shardHash": "f2864b4b04267358fe8419fc9510d72a3fb8ee19b1d205186f9c8447446deab8"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9f691bd8024d7405d041150c675d2048338096b444c1c1d6acfcf0bf642235ce"
+  "shardHash": "565073d3a55a32c26020a126abeb2a40c16767b84827716c9bca5421365404e8"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -201,5 +201,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0857bc446ae484a9905a2e3f826be12f502955cfc161a86e206005b162bad44b"
+  "shardHash": "77f11ab8ffa173ae85c1cdc74e1450529c2653e7c13d5b61080d3bd7386ac35b"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -492,5 +492,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b0aa2436a7cd394be1ee900f78a8cb39712e5e82c8463d820992b84cd905016"
+  "shardHash": "718a64c503e965c2884bc1ac82b626aeb77fc2ee9f8b30fca8bed3a55d2fa410"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e3994b7e7d65367986dc2257c27f8d672bfa0e429f568ccd58132b47cdd64c45"
+  "shardHash": "30d0773f486bf48ffec22b0fd38a5283905a75039644bae6551a1c9f58b1cd7c"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -84,5 +84,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "49c5fa1e8c9093637e0e31c18e2c70820cfe87fb7f03409481fa04ede68ab200"
+  "shardHash": "1b8eeafa462b73fc8f223ec3427767d6fbdc9c36ee5008f5f7cfd6e3ef2be483"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -84,5 +84,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3e00bdf14177549c89bcedf37bd34f775c97f91f438b2423d9c180f210526264"
+  "shardHash": "b5f52280dcb9b41ac036c791c7288b06480ca51da93f0ce098a2f7f828dd8b7c"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ac827d266daec624a5389c8d94d7bb1e14fcb5c56d41554104c8c96b8781837f"
+  "shardHash": "1941d40c521ccd7d9fabcab1eeac00290c863fdc5f7175f4ea40df8daa20cec7"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8ec2928b80091296ff871f61d208c8d64369f1390058dbf6c97e52b0d947eca2"
+  "shardHash": "876200ffbc8bced69488d13cb479da4c30b39ed6ba38a5d25d570cc970c21e98"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f94adb5c814498643ca5c13e7f2117fce4236f750c91aa46325f9dfb6ff3d5e0"
+  "shardHash": "e9f3da5e1b79b16844deb5657547f17709da59414fc7746e1d23da95545fdab9"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -148,5 +148,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "355a17108dfe70e33ded992f3ee1bb7f3f2dc81413aaeca061da9a27ab5e9feb"
+  "shardHash": "1375aa489f0373fdb3b40535cd201cf4d22436265ebb619776119acc048386fc"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -1,12 +1,25 @@
 {
   "mapping": {
     "dependsOn": [
-      "001-compile-registry",
-      "005-coupling-gate"
+      "004-codebase-index",
+      "005-coupling-gate",
+      "009-coupling-floor-claim-precedence"
     ],
     "implementingPaths": [
       {
-        "path": "crates/spec-spine-core/src/compile.rs",
+        "path": "crates/spec-spine-cli/src/cmd_couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/couple.rs",
         "source": "spec-edge"
       },
       {
@@ -14,19 +27,15 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/index.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-core/src/lint.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-core/src/query.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-core/tests/compile.rs",
+        "path": "crates/spec-spine-core/src/lib.rs",
         "source": "spec-edge"
       },
       {
@@ -34,11 +43,15 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/src/edges.rs",
+        "path": "crates/spec-spine-core/tests/coverage.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/src/frontmatter.rs",
+        "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/coverage.rs",
         "source": "spec-edge"
       },
       {
@@ -46,19 +59,7 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/src/registry.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-types/src/version.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-types/tests/dtos.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-types/tests/grammar.rs",
+        "path": "docs/design/00-architecture.md",
         "source": "spec-edge"
       }
     ],
@@ -66,14 +67,92 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/compile.rs"
+            "file": "crates/spec-spine-core/src/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_couple.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-core/src/compile.rs"
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/couple.rs"
         }
       },
       {
@@ -105,40 +184,14 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/lint.rs"
+            "file": "crates/spec-spine-core/src/lib.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-core/src/lint.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-core/src/query.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-core/src/query.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-core/tests/compile.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-core/tests/compile.rs"
+          "path": "crates/spec-spine-core/src/lib.rs"
         }
       },
       {
@@ -157,27 +210,14 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/src/edges.rs"
+            "file": "crates/spec-spine-types/src/config.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/src/edges.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-types/src/frontmatter.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-types/src/frontmatter.rs"
+          "path": "crates/spec-spine-types/src/config.rs"
         }
       },
       {
@@ -196,59 +236,20 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/src/registry.rs"
+            "file": "docs/design/00-architecture.md"
           }
         ],
-        "ownership": true,
-        "sourceField": "extends",
+        "ownership": false,
+        "sourceField": "references",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/src/registry.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-types/src/version.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-types/src/version.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-types/tests/dtos.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-types/tests/dtos.rs"
-        }
-      },
-      {
-        "locations": [
-          {
-            "file": "crates/spec-spine-types/tests/grammar.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-types/tests/grammar.rs"
+          "path": "docs/design/00-architecture.md"
         }
       }
     ],
-    "specId": "019-structured-partial-supersedes",
-    "specStatus": "approved"
+    "specId": "032-ownership-coverage",
+    "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d2b76d73490724d06edbad5ef8cc037adf4744cdef31a6e9a71530f28b9dfc4e"
+  "shardHash": "790f1465d780230e724e57bcdd47867ec69aae71856dcd9f34bd5cfc2c33e645"
 }

--- a/.derived/spec-registry/by-spec/032-ownership-coverage.json
+++ b/.derived/spec-registry/by-spec/032-ownership-coverage.json
@@ -1,0 +1,142 @@
+{
+  "record": {
+    "created": "2026-08-28",
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate",
+      "009-coupling-floor-claim-precedence"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/src/coverage.rs"
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/tests/coverage.rs"
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-types/src/coverage.rs"
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      }
+    ],
+    "id": "032-ownership-coverage",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "032: Ownership coverage",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 Ownership tiers",
+      "3.2 The universe",
+      "3.3 `spec-spine index coverage`",
+      "3.4 `C-002`: the ownership ratchet",
+      "3.5 Why `require_ownership` defaults off",
+      "3.6 Deletions",
+      "3.7 Determinism",
+      "3.8 Measured on this repo",
+      "3.9 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/032-ownership-coverage/spec.md",
+    "status": "draft",
+    "summary": "spec-spine refuses drift but has never required coverage. The coupling gate skips a changed path that no spec claims (\"not a coupling concern\"), and the only coverage-shaped signal, `traceability.untracedCode`, is package-granular and read by nothing, so a crate with one governed file and two hundred ungoverned ones reports as traced. \"This application is fully specified\" is therefore not a state the tool can assert. This spec adds two additive pieces that share one definition of ownership. `spec-spine index coverage` reports, per source file, whether a spec *specifically* claims it (a resolved unit or a comment header), whether only a package's manifest floor covers it, or whether nothing does; `--fail-on-untraced` turns that into the whole-tree assertion. `[coupling] require_ownership` (default false) makes the gate ask the same question of every changed source file and refuse a floor-only or unowned one as `C-002`, the PR-time ratchet. Coverage is a read verb over the tree and the committed ledger, like `index check`: nothing new is committed, no schema version moves, and the report predicts the gate exactly because both call one classifier over one universe.\n",
+    "title": "Ownership coverage: `spec-spine index coverage` and the `C-002` ratchet"
+  },
+  "shardHash": "562354b6106b4cab27995e4f3a47d77a41321dbe37429ff030613ee12ae7c8e2",
+  "specVersion": "1.1.0"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
         run: ./target/debug/spec-spine compile --check
       - name: Codebase index freshness (committed artifacts must be current)
         run: ./target/debug/spec-spine index check
+      # Informational (spec 032): which source files no spec specifically
+      # claims. Exit 0 on a report (2 only when stale, which the step above
+      # already refuses). The gate form is `[coupling] require_ownership`
+      # (off here by decision, see spec-spine.toml) and, once the lists are
+      # empty, `index coverage --fail-on-untraced`.
+      - name: Ownership coverage (report)
+        run: ./target/debug/spec-spine index coverage
       - name: Conformance lint (fail on warn)
         run: ./target/debug/spec-spine lint --fail-on-warn
       # The coupling gate is a PR-time gate (spec 005 §1): it joins the spec and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ The protocol drives the library through its own built binary, `target/release/sp
    - `spec-spine compile --check`: freshness gate for the spec registry (non-fatal; see **Registry freshness** below)
    - `spec-spine index check`: staleness gate for the codebase index (non-fatal)
    - `spec-spine index render`: markdown projection of the committed index
+   - `spec-spine index coverage`: which source files no spec specifically claims (spec 032; non-fatal, exit 2 if the index is stale)
    - `spec-spine registry status-report --json --nonzero-only`: lifecycle counts per status
    - `spec-spine registry list --ids-only`: spec id list (for latest-spec detection)
    - `ls crates/`: library crate layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ cargo run -p spec-spine-cli -- compile                 # writes .derived/spec-re
 cargo run -p spec-spine-cli -- index check             # staleness gate (exit 2 if stale)
 cargo run -p spec-spine-cli -- lint --fail-on-warn
 cargo run -p spec-spine-cli -- couple --base origin/main --head HEAD
+cargo run -p spec-spine-cli -- index coverage            # which source files no spec specifically claims (spec 032)
 ```
 
 Exit codes are a stable contract: `0` ok · `1` validation failure / not found /
@@ -91,7 +92,11 @@ Since spec 024 both are stored **sharded** (one committed file per authority uni
 `spec-registry/by-spec/<id>.json`, `codebase-index/by-spec/<id>.json`,
 `codebase-index/by-package/<slug>.json`); the aggregate view is recomputed from
 the shard set on read, never committed. The **gate chain is `compile → index →
-lint → couple`**. The
+lint → couple`**. `index coverage` (spec 032) is the read verb beside it: it
+reports, per source file, whether a spec specifically claims it, only a
+manifest floor covers it, or nothing does; `[coupling] require_ownership`
+turns that into a `C-002` refusal on the gate (off in this repo, by decision,
+with the five floor-only files named in `spec-spine.toml`). The
 coupling clearance algorithm (amends-awareness, the strict-expansion guard,
 waiver parsing, bypass matching) is ported behaviorally intact from OAP. Modules
 cite their source; preserve the cited semantics when editing `couple.rs`.

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ install → init → annotate → wire-CI walkthrough.
 | Command | Capability |
 |---|---|
 | `spec-spine compile` / `compile --check` | validate frontmatter, emit the deterministic registry / verify the committed shards match without writing |
-| `spec-spine index` / `index check` / `index render` / `index orphans` | emit the codebase index / check staleness / render it as markdown / list orphaned specs |
+| `spec-spine index` / `index check` / `index render` / `index orphans` / `index coverage` | emit the codebase index / check staleness / render it as markdown / list orphaned specs / report which source files no spec specifically claims (`--fail-on-untraced` asserts full coverage) |
 | `spec-spine registry list\|show\|status-report\|relationships` | typed read-only queries |
 | `spec-spine lint [--fail-on-warn] [--fail-on-info]` | corpus well-formedness |
-| `spec-spine couple` | the PR-time coupling gate (refuses drift) |
+| `spec-spine couple` | the PR-time coupling gate (refuses drift; with `[coupling] require_ownership` also refuses a changed source file no spec claims) |
 | `spec-spine init [--force]` | scaffold a new adopter |
 
 Exit codes: `0` ok · `1` validation failure / not found / drift · `2` stale ·

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -48,17 +48,36 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
     let report = couple(&cfg, repo, &diff, waiver.as_ref())?;
 
     if report.has_blocking_drift() {
-        eprintln!(
-            "spec-spine couple: {} drift violation(s): a changed path lacks an authoring edit to an owning spec.\n",
-            report.violations.len()
-        );
-        for v in &report.violations {
-            eprintln!("  {}", v.message);
+        let unclaimed = report
+            .violations
+            .iter()
+            .filter(|v| v.code == "C-002")
+            .count();
+        let drift = report.violations.len() - unclaimed;
+        if unclaimed == 0 {
+            eprintln!(
+                "spec-spine couple: {drift} drift violation(s): a changed path lacks an authoring edit to an owning spec.\n"
+            );
+        } else {
+            eprintln!(
+                "spec-spine couple: {} violation(s): {drift} drift (C-001), {unclaimed} unclaimed (C-002, require_ownership is on).\n",
+                report.violations.len()
+            );
         }
-        eprintln!(
-            "\nResolve by editing an owning spec's spec.md, or add a '{}' line to the PR body.",
-            cfg.coupling.waiver_keyword
-        );
+        for v in &report.violations {
+            eprintln!("  {} {}", v.code, v.message);
+        }
+        if unclaimed == 0 {
+            eprintln!(
+                "\nResolve by editing an owning spec's spec.md, or add a '{}' line to the PR body.",
+                cfg.coupling.waiver_keyword
+            );
+        } else {
+            eprintln!(
+                "\nResolve by editing an owning spec's spec.md (C-001), claiming the path in a spec's owning edge (C-002), or add a '{}' line to the PR body.",
+                cfg.coupling.waiver_keyword
+            );
+        }
     } else if let Some(reason) = &report.waiver {
         println!(
             "spec-spine couple: {} violation(s) {}, reason: {reason}",
@@ -91,6 +110,9 @@ fn build_diff_input(repo: &Path, args: &CoupleArgs) -> Result<DiffInput, Error> 
             .map(|p| DiffFile {
                 path: p.to_string(),
                 hunks: Vec::new(),
+                // `--paths-from` carries no history, so a listed path is never
+                // known to be a deletion: the ratchet judges it as an edit.
+                deleted: false,
             })
             .collect();
         return Ok(DiffInput { files });
@@ -220,10 +242,17 @@ fn run_git_diff(repo: &Path, base: &str, head: &str) -> Result<String, Error> {
 
 /// Parse `git diff --no-color -U0` output into a [`DiffInput`]. New-side hunk
 /// ranges become inclusive [`LineSpan`]s; a deleted file (`+++ /dev/null`) is
-/// registered with no hunks (a whole-file change).
+/// registered with no hunks (a whole-file change) and flagged `deleted` so the
+/// spec 032 ownership ratchet can leave it alone.
 fn parse_unified_diff(diff_text: &str) -> DiffInput {
     use std::collections::BTreeMap;
-    let mut files: BTreeMap<String, Vec<LineSpan>> = BTreeMap::new();
+    /// Per-path accumulator: new-side hunks and whether the path was deleted.
+    #[derive(Default)]
+    struct Entry {
+        hunks: Vec<LineSpan>,
+        deleted: bool,
+    }
+    let mut files: BTreeMap<String, Entry> = BTreeMap::new();
     let mut current_path: Option<String> = None;
     let mut minus_path: Option<String> = None;
 
@@ -232,19 +261,21 @@ fn parse_unified_diff(diff_text: &str) -> DiffInput {
             minus_path = strip_diff_prefix(rest.trim());
         } else if let Some(rest) = line.strip_prefix("+++ ") {
             let p = rest.trim();
-            if p == "/dev/null" {
+            let deleted = p == "/dev/null";
+            if deleted {
                 // Deletion: the changed path is the old (minus) side, whole-file.
                 current_path = minus_path.clone();
             } else {
                 current_path = strip_diff_prefix(p);
             }
             if let Some(path) = &current_path {
-                files.entry(path.clone()).or_default();
+                let entry = files.entry(path.clone()).or_default();
+                entry.deleted = deleted;
             }
         } else if line.starts_with("@@") {
             if let Some(path) = &current_path {
                 if let Some(span) = parse_hunk_header(line) {
-                    files.entry(path.clone()).or_default().push(span);
+                    files.entry(path.clone()).or_default().hunks.push(span);
                 }
             }
         }
@@ -253,7 +284,11 @@ fn parse_unified_diff(diff_text: &str) -> DiffInput {
     DiffInput {
         files: files
             .into_iter()
-            .map(|(path, hunks)| DiffFile { path, hunks })
+            .map(|(path, entry)| DiffFile {
+                path,
+                hunks: entry.hunks,
+                deleted: entry.deleted,
+            })
             .collect(),
     }
 }
@@ -331,6 +366,22 @@ mod tests {
         let d = parse_unified_diff(diff);
         let f = d.files.iter().find(|f| f.path == "gone.rs").unwrap();
         assert!(f.hunks.is_empty(), "deletion ⇒ whole-file (no hunks)");
+        assert!(f.deleted, "deletion is flagged for the ownership ratchet");
+    }
+
+    #[test]
+    fn modified_and_added_files_are_not_deleted() {
+        let diff = "diff --git a/Makefile b/Makefile\n\
+                    --- a/Makefile\n\
+                    +++ b/Makefile\n\
+                    @@ -10,2 +10,3 @@ ctx\n\
+                    diff --git a/new.rs b/new.rs\n\
+                    new file mode 100644\n\
+                    --- /dev/null\n\
+                    +++ b/new.rs\n\
+                    @@ -0,0 +1,3 @@\n";
+        let d = parse_unified_diff(diff);
+        assert!(d.files.iter().all(|f| !f.deleted), "{:?}", d.files);
     }
 
     #[test]

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -2,8 +2,10 @@
 //! under `<derived>/codebase-index/{by-spec,by-package}/`; `spec-spine index
 //! check`: per-shard staleness; `spec-spine index render` / `index orphans`:
 //! read-side projections of the committed shard set (spec 011; never recompute,
-//! never check freshness). The single monolithic `index.json` is no longer
-//! emitted, so PRs touching different specs/packages write disjoint files.
+//! never check freshness); `spec-spine index coverage`: file-granular
+//! ownership coverage of the tree against the committed shards (spec 032;
+//! freshness-guarded like `couple`). The single monolithic `index.json` is no
+//! longer emitted, so PRs touching different specs/packages write disjoint files.
 
 use std::fs;
 use std::path::Path;
@@ -11,10 +13,10 @@ use std::path::Path;
 use clap::Subcommand;
 use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
 use spec_spine_core::{
-    Freshness, check_index_freshness, check_slice_freshness, index, index_dir, index_shard_files,
-    load_committed_index, orphans, render_markdown, slices_path,
+    Freshness, check_index_freshness, check_slice_freshness, coverage, index, index_dir,
+    index_shard_files, load_committed_index, orphans, render_markdown, slices_path,
 };
-use spec_spine_types::{Config, Error};
+use spec_spine_types::{Config, CoverageReport, Error};
 
 use crate::load_repo_config;
 
@@ -32,6 +34,14 @@ pub enum IndexAction {
     Orphans {
         #[arg(long)]
         json: bool,
+    },
+    /// Report which source files no spec specifically claims (spec 032).
+    Coverage {
+        #[arg(long)]
+        json: bool,
+        /// Fail (exit 1) unless every source file has a specific owning spec.
+        #[arg(long)]
+        fail_on_untraced: bool,
     },
 }
 
@@ -58,6 +68,26 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 }
             }
             Ok(0)
+        }
+        Some(IndexAction::Coverage {
+            json,
+            fail_on_untraced,
+        }) => {
+            // Freshness-guarded inside `coverage`: a stale index is `Error::Stale`
+            // (exit 2), so the report never describes the wrong ledger.
+            let report = coverage(&cfg, repo)?;
+            if *json {
+                let s = serde_json::to_string_pretty(&report)
+                    .map_err(|e| Error::Schema(e.to_string()))?;
+                println!("{s}");
+            } else {
+                print!("{}", render_coverage(&report));
+            }
+            Ok(if *fail_on_untraced && !report.is_fully_claimed() {
+                1
+            } else {
+                0
+            })
         }
         Some(IndexAction::Check { slice }) => {
             let (freshness, subject) = match slice {
@@ -115,6 +145,56 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
             Ok(0)
         }
     }
+}
+
+/// The human form of the coverage report: one headline, one line per package,
+/// then the two debt lists (omitted when empty).
+fn render_coverage(report: &CoverageReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let total = report.source_files;
+    if total == 0 {
+        out.push_str("coverage: no source files under any discovered package\n");
+        return out;
+    }
+    let pct = (report.claimed_files as f64) * 100.0 / (total as f64);
+    let _ = writeln!(
+        out,
+        "coverage: {}/{total} source files specifically claimed ({pct:.1}%); {} floor-only, {} unclaimed",
+        report.claimed_files,
+        report.floor_only_files.len(),
+        report.unclaimed_files.len()
+    );
+    for p in &report.packages {
+        let path = if p.path.is_empty() {
+            "."
+        } else {
+            p.path.as_str()
+        };
+        let floor = p
+            .floor_spec
+            .as_deref()
+            .map(|s| format!("floor {s}"))
+            .unwrap_or_else(|| "no floor".to_string());
+        let _ = writeln!(
+            out,
+            "  {path} ({floor}): {}/{} claimed, {} floor-only, {} unclaimed",
+            p.claimed_files, p.source_files, p.floor_only, p.unclaimed
+        );
+    }
+    if !report.floor_only_files.is_empty() {
+        out.push_str("\nfloor-only (owned only by a package floor; claim in a spec):\n");
+        for f in &report.floor_only_files {
+            let _ = writeln!(out, "  {f}");
+        }
+    }
+    if !report.unclaimed_files.is_empty() {
+        out.push_str("\nunclaimed (no owning spec):\n");
+        for f in &report.unclaimed_files {
+            let _ = writeln!(out, "  {f}");
+        }
+    }
+    out
 }
 
 /// Write (or remove) the per-slice sidecar `slices.json` (spec 012/024). The

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -594,3 +594,83 @@ fn compile_check_exit_contract() {
         "validation outranks staleness"
     );
 }
+
+#[test]
+fn index_coverage_reports_and_gates() {
+    // Spec 032: `index coverage` is a freshness-guarded read verb over the
+    // tree and the committed index; `--fail-on-untraced` is the whole-tree
+    // "fully specified" assertion.
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    let write = |rel: &str, content: &str| {
+        let p = r.join(rel);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, content).unwrap();
+    };
+    write(
+        "Cargo.toml",
+        "[package]\nname = \"root\"\nversion = \"0.1.0\"\n",
+    );
+    write("src/lib.rs", "pub fn a() {}\n");
+    write("src/other.rs", "pub fn b() {}\n");
+    write(
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-08\"\nsummary: \"s\"\nestablishes:\n  - \"src/lib.rs\"\n---\n# 001-a\n",
+    );
+    let run = |args: &[&str]| bin().arg("--repo").arg(r).args(args).output().unwrap();
+
+    assert_eq!(
+        code(&run(&["index", "coverage"])),
+        3,
+        "no committed index -> artifact missing (3)"
+    );
+    assert_eq!(code(&run(&["index"])), 0);
+
+    let text = run(&["index", "coverage"]);
+    assert_eq!(code(&text), 0, "a report, not a gate");
+    let out = String::from_utf8_lossy(&text.stdout);
+    assert!(
+        out.contains(
+            "coverage: 1/2 source files specifically claimed (50.0%); 0 floor-only, 1 unclaimed"
+        ),
+        "{out}"
+    );
+    assert!(
+        out.contains("unclaimed (no owning spec):\n  src/other.rs"),
+        "{out}"
+    );
+
+    let json = run(&["index", "coverage", "--json"]);
+    assert_eq!(code(&json), 0);
+    let report: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(report["sourceFiles"], 2);
+    assert_eq!(report["claimedFiles"], 1);
+    assert_eq!(
+        report["unclaimedFiles"],
+        serde_json::json!(["src/other.rs"])
+    );
+
+    assert_eq!(
+        code(&run(&["index", "coverage", "--fail-on-untraced"])),
+        1,
+        "an untraced file fails the assertion"
+    );
+
+    // Claim the file, re-index: fully specified.
+    write(
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-08\"\nsummary: \"s\"\nestablishes:\n  - \"src/\"\n---\n# 001-a\n",
+    );
+    assert_eq!(
+        code(&run(&["index", "coverage"])),
+        2,
+        "stale index -> 2, never a report over the wrong ledger"
+    );
+    assert_eq!(code(&run(&["index"])), 0);
+    let full = run(&["index", "coverage", "--fail-on-untraced"]);
+    assert_eq!(code(&full), 0, "{}", String::from_utf8_lossy(&full.stderr));
+    assert!(
+        String::from_utf8_lossy(&full.stdout)
+            .contains("coverage: 2/2 source files specifically claimed (100.0%)")
+    );
+}

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -554,3 +554,91 @@ fn workflow_uses_bump_auto_waives() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+// ===== spec 032: the ownership ratchet, end to end =====
+
+/// A crate with no manifest floor: `src/lib.rs` is claimed by a file unit,
+/// anything else under it is unowned. `require_ownership` is on.
+fn setup_ratchet(root: &Path) {
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        root,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n",
+    );
+    write(root, "crate-a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        root,
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \"crate-a/src/lib.rs\"\n---\n# 001-a\n## body\n",
+    );
+    write(
+        root,
+        "spec-spine.toml",
+        "[coupling]\nrequire_ownership = true\n",
+    );
+}
+
+#[test]
+fn ratchet_refuses_new_unowned_source_and_allows_its_deletion() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_ratchet(root);
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // Add an unowned source file: C-002, exit 1, named as such.
+    write(root, "crate-a/src/extra.rs", "pub fn extra() {}\n");
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "add unowned"]);
+    let refused = couple_git(root);
+    let stderr = String::from_utf8_lossy(&refused.stderr);
+    assert_eq!(code(&refused), 1, "{stderr}");
+    assert!(stderr.contains("1 unclaimed (C-002"), "{stderr}");
+    assert!(
+        stderr.contains("'crate-a/src/extra.rs' is not claimed by any spec"),
+        "{stderr}"
+    );
+
+    // A PR-body waiver clears it like any violation.
+    write(
+        root,
+        "pr-body.txt",
+        "Spec-Drift-Waiver: vendored drop, spec to follow\n",
+    );
+    let waived = bin()
+        .arg("--repo")
+        .arg(root)
+        .args(["couple", "--base", "HEAD~1", "--head", "HEAD", "--pr-body"])
+        .arg(root.join("pr-body.txt"))
+        .output()
+        .unwrap();
+    assert_eq!(code(&waived), 0);
+    assert!(String::from_utf8_lossy(&waived.stdout).contains("waived"));
+
+    // Deleting the unowned file is how coverage goes up: no C-002, exit 0.
+    fs::remove_file(root.join("crate-a/src/extra.rs")).unwrap();
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "remove unowned"]);
+    let allowed = couple_git(root);
+    assert_eq!(
+        code(&allowed),
+        0,
+        "{}",
+        String::from_utf8_lossy(&allowed.stderr)
+    );
+
+    // And the whole-tree assertion agrees: fully specified again.
+    let full = bin()
+        .arg("--repo")
+        .arg(root)
+        .args(["index", "coverage", "--fail-on-untraced"])
+        .output()
+        .unwrap();
+    assert_eq!(code(&full), 0, "{}", String::from_utf8_lossy(&full.stderr));
+}

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -6,6 +6,11 @@
 //! **`git` never runs here**: the CLI parses `git diff --no-color -U0
 //! base...head` into a typed [`DiffInput`] and passes it in.
 //!
+//! Spec 032 adds a second, opt-in verdict: with `[coupling] require_ownership`
+//! on, a changed source file that no spec *specifically* owns is `C-002`. The
+//! ownership question is answered by [`crate::coverage`], the same classifier
+//! `spec-spine index coverage` reports with, so the report predicts the gate.
+//!
 //! The behavioral semantics are ported intact from OAP
 //! `tools/spec-spine/spec-code-coupling-check/src/lib.rs`
 //! (`legitimate_owners` + the FR-005 strict-expansion guard, `is_bypass_against`,
@@ -19,6 +24,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use spec_spine_types::{CodebaseIndex, Config, Error, LineSpan, Registry, Severity, Violation};
 
+use crate::coverage::{Ownership, classify, in_coverage_universe};
 use crate::index::{Freshness, check_index_freshness};
 
 /// The hardcoded generic bypass floor (spec 005 §3.5): the **single built-in
@@ -59,6 +65,13 @@ pub struct DiffFile {
     pub path: String,
     #[serde(default)]
     pub hunks: Vec<LineSpan>,
+    /// The path no longer exists at head (the CLI sets this from a
+    /// `+++ /dev/null` header). Drift (`C-001`) treats a deletion like any
+    /// whole-file change; the ownership ratchet (`C-002`, spec 032) never
+    /// refuses one, since removing unowned code is how coverage goes up.
+    /// Additive: absent in older `couple_json` requests, so it defaults off.
+    #[serde(default)]
+    pub deleted: bool,
 }
 
 /// A PR-body waiver: the trimmed reason after the configured keyword.
@@ -140,9 +153,37 @@ pub fn couple_with(
         }
         checked_paths += 1;
 
+        // Spec 032: the ownership ratchet. Asked before the drift question,
+        // over exactly the universe `index coverage` reports on, so the report
+        // predicts this arm. A deleted path is never refused for lacking an
+        // owner. `C-002` takes precedence over `C-001` for one path (claiming
+        // the file in a spec resolves both), so a path raises at most one code.
+        if cfg.coupling.require_ownership && !file.deleted && in_coverage_universe(cfg, index, path)
+        {
+            let message = match classify(index, path) {
+                Ownership::Specific => None,
+                Ownership::FloorOnly(floors) => Some(format!(
+                    "'{path}' has no specific owning spec; only the package floor of {} covers it (require_ownership is on)",
+                    floors.join(", ")
+                )),
+                Ownership::Unowned => Some(format!(
+                    "'{path}' is not claimed by any spec (require_ownership is on)"
+                )),
+            };
+            if let Some(message) = message {
+                violations.push(Violation {
+                    code: "C-002".to_string(),
+                    severity: Severity::Error,
+                    message,
+                    path: Some(path.clone()),
+                });
+                continue;
+            }
+        }
+
         let owners = owners_for_path(path, &file.hunks, index, &superseders);
         if owners.is_empty() {
-            continue; // unclaimed path, not a coupling concern
+            continue; // unclaimed path: not a drift concern (see the ratchet above)
         }
         if any_owner_in_diff(&owners, &diff_paths) {
             continue; // primary-owner heuristic: any one owner's spec.md cleared it
@@ -349,7 +390,7 @@ fn span_overlaps_hunk(span: Option<LineSpan>, hunk: LineSpan) -> bool {
 /// Slash-anchored prefix match: a directory `claim` (trailing `/`, or any path
 /// treated as a directory) owns every file under it; an exact path matches
 /// itself (ported from OAP `claim_matches`).
-fn claim_matches(claim: &str, path: &str) -> bool {
+pub(crate) fn claim_matches(claim: &str, path: &str) -> bool {
     if claim == path {
         return true;
     }

--- a/crates/spec-spine-core/src/coverage.rs
+++ b/crates/spec-spine-core/src/coverage.rs
@@ -1,0 +1,299 @@
+//! Ownership coverage (spec 032): the inverse of the coupling gate's question.
+//!
+//! `couple` asks "did an owned path change without its spec?" (`C-001`). This
+//! module asks "which source files does no spec *specifically* own?", and, when
+//! `[coupling] require_ownership` is on, the gate asks the same of every changed
+//! path (`C-002`). Both read ownership through one classifier ([`classify`])
+//! over one universe ([`in_coverage_universe`]), so the report predicts the
+//! gate exactly: a file the report calls claimed is one the gate will never
+//! refuse for lack of an owner, and vice versa.
+//!
+//! "Specific" is the load-bearing word. A manifest floor
+//! (`[package.metadata.<ns>].spec`, spec 005 §3.6) makes its spec an owner of
+//! every file in the package, which is the right safety net for `C-001` and a
+//! useless coverage signal: a crate with one governed file and two hundred
+//! ungoverned ones would read as fully traced. The floor therefore counts as
+//! ownership for drift and as **debt** for coverage.
+//!
+//! Pure function of `(config, index, file listing)`. The freshness-guarded
+//! form [`coverage`] refuses a stale committed index (exit 2) exactly as
+//! `couple` does, so the report is always read against the ledger the corpus
+//! compiled to. Nothing here is committed: coverage is a read verb over the
+//! tree and the ledger, like `index check`, not a field of the index.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use spec_spine_types::{
+    CodebaseIndex, Config, CoverageReport, Error, PackageCoverage, PackageRecord, TraceSource,
+};
+
+use crate::couple::{claim_matches, is_bypassed_path};
+use crate::index::{Freshness, check_index_freshness, load_committed_index, walk_source};
+use crate::pathutil::rel_posix;
+
+/// The source extensions the indexer treats as code: the set the comment-header
+/// scan reads and the coverage universe enumerates. One list, so the coverage
+/// denominator and the spec-binding scan can never disagree about what counts
+/// as a source file.
+pub const SOURCE_EXTS: &[&str] = &["rs", "ts", "tsx", "js", "jsx", "go", "py", "sh"];
+
+/// How one source file is owned, at whole-file granularity (spec 032 §3.1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Ownership {
+    /// A resolved ownership-bearing unit (any kind, exact or subtree) or a
+    /// `// Spec:` comment header covers the file: an author decided which spec
+    /// governs it.
+    Specific,
+    /// Only a package's manifest floor (spec 005 §3.6) covers the file. Carries
+    /// the floor spec ids, sorted, for the `C-002` message.
+    FloorOnly(Vec<String>),
+    /// No spec owns the file.
+    Unowned,
+}
+
+/// Classify one path's ownership against the index. Spans are ignored: this
+/// is a whole-file question, which is what keeps it answerable from a file
+/// listing alone and identical between the report and the gate.
+pub fn classify(index: &CodebaseIndex, path: &str) -> Ownership {
+    for m in &index.traceability.mappings {
+        // 1. Unit claims: ownership-bearing resolved units, exact or subtree.
+        //    `references` units are non-owning and never count.
+        for ru in m.resolved_units.iter().filter(|ru| ru.ownership) {
+            if ru
+                .locations
+                .iter()
+                .any(|loc| claim_matches(&loc.file, path))
+            {
+                return Ownership::Specific;
+            }
+        }
+        // 2. Comment headers: a file naming its own spec. Exact match only (a
+        //    header claims the file it sits in, never a subtree). `Multiple`
+        //    on a file path means a header agreed with another source.
+        //    `SpecEdge` paths are deliberately not read here: an owning unit
+        //    was caught above, and a `references` unit's location must not
+        //    become ownership through the path-level back door.
+        for ip in &m.implementing_paths {
+            if ip.path == path
+                && matches!(
+                    ip.source,
+                    TraceSource::CommentHeader | TraceSource::Multiple
+                )
+            {
+                return Ownership::Specific;
+            }
+        }
+    }
+    // 3. The manifest floor: every discovered package whose directory contains
+    //    the file and whose manifest names a spec.
+    let floors: BTreeSet<String> = index
+        .packages
+        .iter()
+        .filter(|p| package_contains(&p.path, path))
+        .filter_map(|p| p.spec_ref.clone())
+        .collect();
+    if floors.is_empty() {
+        Ownership::Unowned
+    } else {
+        Ownership::FloorOnly(floors.into_iter().collect())
+    }
+}
+
+/// Is `path` in the coverage universe: a source file (by extension) inside a
+/// discovered package, outside `index.resolver_exclusions`, and not bypassed
+/// by the gate (claim-aware, spec 009)? The report and `C-002` share this
+/// predicate, so a path one of them ignores the other ignores too.
+pub fn in_coverage_universe(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool {
+    has_source_ext(path)
+        && !has_excluded_component(path, &cfg.index.resolver_exclusions)
+        && index
+            .packages
+            .iter()
+            .any(|p| package_contains(&p.path, path))
+        && !is_bypassed_path(cfg, index, path)
+}
+
+/// Enumerate the coverage universe under `repo_root`: the source files of
+/// every discovered package, walked in sorted order with `resolver_exclusions`
+/// pruned, filtered by [`in_coverage_universe`], and deduplicated (a nested
+/// package is walked by its parent too). Repo-relative POSIX, sorted.
+pub fn enumerate_source_files(
+    cfg: &Config,
+    repo_root: &Path,
+    index: &CodebaseIndex,
+) -> Vec<String> {
+    let mut files: BTreeSet<String> = BTreeSet::new();
+    for pkg in &index.packages {
+        let dir = repo_root.join(&pkg.path);
+        for file in walk_source(&dir, SOURCE_EXTS, repo_root, &cfg.index.resolver_exclusions) {
+            let rel = rel_posix(repo_root, &file);
+            if in_coverage_universe(cfg, index, &rel) {
+                files.insert(rel);
+            }
+        }
+    }
+    files.into_iter().collect()
+}
+
+/// The pure report over an already-loaded index and file listing (overlays,
+/// tests). Paths outside the universe are ignored; the listing is sorted and
+/// deduplicated before classification, so the output is a pure function of the
+/// *set* of paths. Each file is attributed to the deepest package containing
+/// it.
+pub fn coverage_with(cfg: &Config, index: &CodebaseIndex, files: &[String]) -> CoverageReport {
+    let mut per_package: BTreeMap<String, PackageCoverage> = index
+        .packages
+        .iter()
+        .map(|p| {
+            (
+                p.path.clone(),
+                PackageCoverage {
+                    path: p.path.clone(),
+                    floor_spec: p.spec_ref.clone(),
+                    source_files: 0,
+                    claimed_files: 0,
+                    floor_only: 0,
+                    unclaimed: 0,
+                },
+            )
+        })
+        .collect();
+    let universe: BTreeSet<&String> = files
+        .iter()
+        .filter(|f| in_coverage_universe(cfg, index, f))
+        .collect();
+
+    let mut report = CoverageReport {
+        source_files: 0,
+        claimed_files: 0,
+        floor_only_files: Vec::new(),
+        unclaimed_files: Vec::new(),
+        packages: Vec::new(),
+    };
+    for file in universe {
+        let Some(entry) =
+            owning_package(&index.packages, file).and_then(|p| per_package.get_mut(&p.path))
+        else {
+            continue; // unreachable: the universe requires a containing package
+        };
+        entry.source_files += 1;
+        report.source_files += 1;
+        match classify(index, file) {
+            Ownership::Specific => {
+                entry.claimed_files += 1;
+                report.claimed_files += 1;
+            }
+            Ownership::FloorOnly(_) => {
+                entry.floor_only += 1;
+                report.floor_only_files.push(file.clone());
+            }
+            Ownership::Unowned => {
+                entry.unclaimed += 1;
+                report.unclaimed_files.push(file.clone());
+            }
+        }
+    }
+    report.packages = per_package.into_values().collect();
+    report
+}
+
+/// The freshness-guarded report: refuses a stale committed index
+/// ([`Error::Stale`], exit 2) exactly as `couple` does, loads the committed
+/// shard set, enumerates the universe under `repo_root`, and classifies it.
+pub fn coverage(cfg: &Config, repo_root: &Path) -> Result<CoverageReport, Error> {
+    match check_index_freshness(cfg, repo_root)? {
+        Freshness::Stale { expected, actual } => return Err(Error::Stale { expected, actual }),
+        Freshness::Fresh => {}
+    }
+    let index = load_committed_index(cfg, repo_root)?;
+    let files = enumerate_source_files(cfg, repo_root, &index);
+    Ok(coverage_with(cfg, &index, &files))
+}
+
+/// Source-extension test on a repo-relative POSIX path, with the same
+/// `Path::extension` semantics the walk uses (a dotfile has no extension).
+fn has_source_ext(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| SOURCE_EXTS.contains(&e))
+        .unwrap_or(false)
+}
+
+/// True if any `/`-separated component of `path` is an excluded directory
+/// name (the string-path twin of `pathutil::is_excluded`).
+fn has_excluded_component(path: &str, exclusions: &[String]) -> bool {
+    path.split('/')
+        .any(|seg| exclusions.iter().any(|ex| ex == seg))
+}
+
+/// Does the package rooted at `pkg_path` contain `path`? A root package
+/// (`""` or `.`) contains everything; otherwise slash-anchored prefix.
+fn package_contains(pkg_path: &str, path: &str) -> bool {
+    let pkg = pkg_path.trim_end_matches('/');
+    pkg.is_empty() || pkg == "." || path.starts_with(&format!("{pkg}/"))
+}
+
+/// The deepest discovered package containing `path` (a nested package wins
+/// over the workspace root that also contains it).
+fn owning_package<'a>(packages: &'a [PackageRecord], path: &str) -> Option<&'a PackageRecord> {
+    packages
+        .iter()
+        .filter(|p| package_contains(&p.path, path))
+        .max_by_key(|p| p.path.trim_end_matches('/').len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_ext_follows_path_extension_semantics() {
+        assert!(has_source_ext("crates/x/src/lib.rs"));
+        assert!(has_source_ext("scripts/run.sh"));
+        assert!(!has_source_ext("README.md"));
+        assert!(!has_source_ext("Cargo.toml"));
+        assert!(!has_source_ext(".rs"), "a dotfile has no extension");
+        assert!(!has_source_ext("noext"));
+    }
+
+    #[test]
+    fn package_containment_is_slash_anchored() {
+        assert!(package_contains("", "src/lib.rs"));
+        assert!(package_contains(".", "src/lib.rs"));
+        assert!(package_contains("crates/x", "crates/x/src/lib.rs"));
+        assert!(package_contains("crates/x/", "crates/x/src/lib.rs"));
+        assert!(!package_contains("crates/x", "crates/xy/src/lib.rs"));
+    }
+
+    #[test]
+    fn deepest_package_wins() {
+        let pkgs = vec![
+            PackageRecord {
+                name: "root".into(),
+                path: "".into(),
+                kind: spec_spine_types::PackageKind::RustLib,
+                version: None,
+                edition: None,
+                spec_ref: None,
+            },
+            PackageRecord {
+                name: "inner".into(),
+                path: "crates/inner".into(),
+                kind: spec_spine_types::PackageKind::RustLib,
+                version: None,
+                edition: None,
+                spec_ref: None,
+            },
+        ];
+        assert_eq!(
+            owning_package(&pkgs, "crates/inner/src/lib.rs").map(|p| p.name.as_str()),
+            Some("inner")
+        );
+        assert_eq!(
+            owning_package(&pkgs, "src/main.rs").map(|p| p.name.as_str()),
+            Some("root")
+        );
+    }
+}

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -17,6 +17,7 @@ use spec_spine_types::{
     parse_frontmatter_with,
 };
 
+use crate::coverage::SOURCE_EXTS;
 use crate::manifest;
 use crate::pathutil::{is_excluded, rel_posix};
 use crate::sections;
@@ -909,10 +910,17 @@ fn scan_comment_headers(
     all_ids: &BTreeSet<String>,
 ) -> Vec<(String, String)> {
     let mut links: Vec<(String, String)> = Vec::new();
-    let exts = ["rs", "ts", "tsx", "js", "jsx", "go", "py", "sh"];
+    // The extension list is shared with the coverage universe (spec 032) so
+    // the spec-binding scan and the coverage denominator agree on what a
+    // source file is.
     for pkg in packages {
         let pkg_dir = repo_root.join(&pkg.path);
-        for file in walk_source(&pkg_dir, &exts, repo_root, &cfg.index.resolver_exclusions) {
+        for file in walk_source(
+            &pkg_dir,
+            SOURCE_EXTS,
+            repo_root,
+            &cfg.index.resolver_exclusions,
+        ) {
             let Ok(content) = fs::read_to_string(&file) else {
                 continue;
             };
@@ -1055,7 +1063,14 @@ fn glob_files(repo_root: &Path, pattern: &str) -> Vec<PathBuf> {
     out
 }
 
-fn walk_source(dir: &Path, exts: &[&str], repo_root: &Path, exclusions: &[String]) -> Vec<PathBuf> {
+/// Sorted source files under `dir` (by extension), pruning
+/// `index.resolver_exclusions`. Shared with the coverage universe (spec 032).
+pub(crate) fn walk_source(
+    dir: &Path,
+    exts: &[&str],
+    repo_root: &Path,
+    exclusions: &[String],
+) -> Vec<PathBuf> {
     let mut out = Vec::new();
     walk(dir, exts, repo_root, exclusions, &mut out);
     out.sort();

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -9,13 +9,14 @@
 //! parses the diff and passes a typed [`DiffInput`] in). The public API returns
 //! owned, `serde`-serializable DTOs (from [`spec_spine_types`]); the
 //! JSON-in/JSON-out facade ([`compile_json`], [`query_json`], [`index_json`],
-//! [`lint_json`], [`couple_json`], [`scaffold_init_json`], …) is the seam future
+//! [`lint_json`], [`couple_json`], [`coverage_json`], [`scaffold_init_json`], …) is the seam future
 //! FFI bindings wrap.
 
 pub mod attest;
 mod canonical_json;
 pub mod compile;
 pub mod couple;
+pub mod coverage;
 pub mod dep_only;
 mod hash;
 pub mod index;
@@ -36,7 +37,8 @@ use spec_spine_types::{Config, CorpusAttestation, Error, Status, load_config};
 // Re-export the type substrate so callers depend on one crate.
 pub use spec_spine_types as types;
 pub use spec_spine_types::{
-    CodebaseIndex, Frontmatter, REGISTRY_SCHEMA_VERSION, Registry, SpecRecord, Unit, Violation,
+    CodebaseIndex, CoverageReport, Frontmatter, PackageCoverage, REGISTRY_SCHEMA_VERSION, Registry,
+    SpecRecord, Unit, Violation,
 };
 
 pub use attest::{
@@ -50,6 +52,10 @@ pub use compile::{
 pub use couple::{
     CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, couple, couple_with,
     is_bypassed_path, parse_waiver,
+};
+pub use coverage::{
+    Ownership, SOURCE_EXTS, classify, coverage, coverage_with, enumerate_source_files,
+    in_coverage_universe,
 };
 pub use dep_only::{
     CARGO_DEPENDENCY_TABLES, DEPENDENCY_TABLES, FileContents, cargo_dependency_only_change,
@@ -200,6 +206,15 @@ fn freshness_to_json(freshness: Freshness) -> serde_json::Value {
             serde_json::json!({ "fresh": false, "expected": expected, "actual": actual })
         }
     }
+}
+
+/// Report file-granular ownership coverage against the committed index (spec
+/// 032), returning the [`CoverageReport`] as JSON. Freshness-guarded like
+/// `couple`: a stale committed index is [`Error::Stale`] (exit 2), never a
+/// report over the wrong ledger.
+pub fn coverage_json(config_json: &str, repo_root: &str) -> Result<String, Error> {
+    let config = config_from_json(config_json)?;
+    to_json(&coverage(&config, std::path::Path::new(repo_root))?)
 }
 
 /// Render the committed index as markdown (spec 011). `index_json` is the

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -9,13 +9,19 @@ use spec_spine_core::{DiffFile, DiffInput, Waiver, couple_with};
 use spec_spine_types::{CodebaseIndex, Config, LineSpan, Registry};
 
 fn index_from(mappings: Value) -> CodebaseIndex {
+    index_with_packages(json!([]), mappings)
+}
+
+/// Like [`index_from`] but with a package inventory, which the spec 032
+/// ownership ratchet needs (its universe is "source files inside a package").
+fn index_with_packages(packages: Value, mappings: Value) -> CodebaseIndex {
     serde_json::from_value(json!({
         "schemaVersion": "0.1.0",
         "build": {
             "indexerId": "t", "indexerVersion": "0.1.0",
             "repoRoot": ".", "contentHash": "t"
         },
-        "packages": [],
+        "packages": packages,
         "traceability": {
             "mappings": mappings,
             "orphanedSpecs": [],
@@ -48,6 +54,15 @@ fn file(path: &str, hunks: &[LineSpan]) -> DiffFile {
     DiffFile {
         path: path.to_string(),
         hunks: hunks.to_vec(),
+        deleted: false,
+    }
+}
+
+fn deleted(path: &str) -> DiffFile {
+    DiffFile {
+        path: path.to_string(),
+        hunks: Vec::new(),
+        deleted: true,
     }
 }
 
@@ -705,4 +720,343 @@ fn is_bypassed_path_is_claim_aware() {
         &index,
         "src/lib.rs"
     ));
+}
+
+// ── spec 032: the ownership ratchet (C-002) ───────────────────────────────
+
+/// `require_ownership = true`, everything else default.
+fn ratchet_config() -> Config {
+    let mut cfg = Config::default();
+    cfg.coupling.require_ownership = true;
+    cfg
+}
+
+fn run_with(
+    cfg: &Config,
+    index: &CodebaseIndex,
+    diff: &DiffInput,
+    waiver: Option<&Waiver>,
+) -> spec_spine_core::CoupleReport {
+    couple_with(cfg, &empty_registry(), index, diff, waiver).unwrap()
+}
+
+fn codes(report: &spec_spine_core::CoupleReport) -> Vec<(&str, &str)> {
+    report
+        .violations
+        .iter()
+        .map(|v| (v.path.as_deref().unwrap_or(""), v.code.as_str()))
+        .collect()
+}
+
+/// One crate at `crates/x` whose manifest names `000-floor`. Spec `001-a`
+/// claims `src/lib.rs` by file unit and `src/hdr.rs` by comment header; spec
+/// `002-r` only *references* `src/ref.rs` (its location still lands in
+/// `implementingPaths` as a spec-edge path, which must not count).
+fn floored_index() -> CodebaseIndex {
+    index_with_packages(
+        json!([{ "name": "x", "path": "crates/x", "kind": "rust-lib", "specRef": "000-floor" }]),
+        json!([
+            {
+                "specId": "000-floor",
+                "implementingPaths": [{ "path": "crates/x", "source": "manifest-metadata" }],
+                "resolvedUnits": []
+            },
+            {
+                "specId": "001-a",
+                "implementingPaths": [
+                    { "path": "crates/x/src/hdr.rs", "source": "comment-header" },
+                    { "path": "crates/x/src/lib.rs", "source": "spec-edge" }
+                ],
+                "resolvedUnits": [{
+                    "unit": { "kind": "file", "path": "crates/x/src/lib.rs" },
+                    "sourceField": "establishes",
+                    "ownership": true,
+                    "locations": [{ "file": "crates/x/src/lib.rs" }]
+                }]
+            },
+            {
+                "specId": "002-r",
+                "implementingPaths": [{ "path": "crates/x/src/ref.rs", "source": "spec-edge" }],
+                "resolvedUnits": [{
+                    "unit": { "kind": "file", "path": "crates/x/src/ref.rs" },
+                    "sourceField": "references",
+                    "ownership": false,
+                    "locations": [{ "file": "crates/x/src/ref.rs" }]
+                }]
+            }
+        ]),
+    )
+}
+
+/// The same crate with no manifest floor: an unclaimed file has no owner at all.
+fn unfloored_index() -> CodebaseIndex {
+    index_with_packages(
+        json!([{ "name": "x", "path": "crates/x", "kind": "rust-lib" }]),
+        json!([{
+            "specId": "001-a",
+            "implementingPaths": [{ "path": "crates/x/src/lib.rs", "source": "spec-edge" }],
+            "resolvedUnits": [{
+                "unit": { "kind": "file", "path": "crates/x/src/lib.rs" },
+                "sourceField": "establishes",
+                "ownership": true,
+                "locations": [{ "file": "crates/x/src/lib.rs" }]
+            }]
+        }]),
+    )
+}
+
+#[test]
+fn ratchet_off_skips_an_unowned_path() {
+    // The pre-032 contract, pinned: an unowned path is not a coupling concern.
+    let report = run_with(
+        &Config::default(),
+        &unfloored_index(),
+        &diff(vec![file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)])]),
+        None,
+    );
+    assert!(report.violations.is_empty(), "{:?}", report.violations);
+    assert_eq!(report.checked_paths, 1, "walked, just not judged");
+}
+
+#[test]
+fn ratchet_on_refuses_an_unowned_path() {
+    let report = run_with(
+        &ratchet_config(),
+        &unfloored_index(),
+        &diff(vec![file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)])]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/stray.rs", "C-002")]);
+    assert!(
+        report.violations[0]
+            .message
+            .contains("is not claimed by any spec"),
+        "{}",
+        report.violations[0].message
+    );
+    assert!(report.has_blocking_drift());
+}
+
+#[test]
+fn floor_only_path_is_c002_naming_the_floor() {
+    // Owned by the manifest floor and nothing else. Without the ratchet this
+    // is C-001 (the floor is an owner); with it, the floor is debt.
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)])]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/stray.rs", "C-002")]);
+    let msg = &report.violations[0].message;
+    assert!(msg.contains("only the package floor of 000-floor"), "{msg}");
+
+    // Editing the floor spec clears drift, never coverage: the ratchet is not a
+    // clearance rule, it is a claim requirement.
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![
+            file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)]),
+            file("specs/000-floor/spec.md", &[]),
+        ]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/stray.rs", "C-002")]);
+}
+
+#[test]
+fn floor_only_path_without_the_ratchet_is_plain_c001() {
+    let report = run_with(
+        &Config::default(),
+        &floored_index(),
+        &diff(vec![file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)])]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/stray.rs", "C-001")]);
+}
+
+#[test]
+fn unit_claimed_path_is_c001_not_c002() {
+    // A specific claim satisfies the ratchet; drift is judged as before.
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![file("crates/x/src/lib.rs", &[LineSpan::new(1, 2)])]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/lib.rs", "C-001")]);
+    let cleared = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![
+            file("crates/x/src/lib.rs", &[LineSpan::new(1, 2)]),
+            file("specs/001-a/spec.md", &[]),
+        ]),
+        None,
+    );
+    assert!(cleared.violations.is_empty(), "{:?}", cleared.violations);
+}
+
+#[test]
+fn header_claimed_path_is_specific() {
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![
+            file("crates/x/src/hdr.rs", &[LineSpan::new(1, 2)]),
+            file("specs/001-a/spec.md", &[]),
+        ]),
+        None,
+    );
+    assert!(report.violations.is_empty(), "{:?}", report.violations);
+}
+
+#[test]
+fn references_never_satisfy_the_ratchet() {
+    // 002-r references ref.rs; that is context, not ownership. The file is
+    // floor-only, and the message names the floor, not the referencing spec.
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![
+            file("crates/x/src/ref.rs", &[LineSpan::new(1, 2)]),
+            file("specs/002-r/spec.md", &[]),
+        ]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/ref.rs", "C-002")]);
+    let msg = &report.violations[0].message;
+    assert!(msg.contains("000-floor") && !msg.contains("002-r"), "{msg}");
+}
+
+#[test]
+fn deleted_paths_are_never_c002() {
+    // Removing unowned code is how coverage goes up.
+    let report = run_with(
+        &ratchet_config(),
+        &unfloored_index(),
+        &diff(vec![deleted("crates/x/src/stray.rs")]),
+        None,
+    );
+    assert!(report.violations.is_empty(), "{:?}", report.violations);
+
+    // A deleted floor-only file: no C-002 either. Drift (C-001) still applies
+    // to it exactly as to any whole-file change of an owned path.
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![deleted("crates/x/src/stray.rs")]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/stray.rs", "C-001")]);
+}
+
+#[test]
+fn paths_outside_the_universe_never_raise_c002() {
+    // Not source, not in a package, or pruned by resolver_exclusions: the
+    // ratchet asks its question only where `index coverage` counts.
+    let report = run_with(
+        &ratchet_config(),
+        &unfloored_index(),
+        &diff(vec![
+            file("spec-spine.toml", &[]),            // not a source file
+            file("crates/x/notes.md", &[]),          // not a source file
+            file("scripts/tool.py", &[]),            // outside every package
+            file("crates/x/target/gen.rs", &[]),     // excluded directory
+            file("crates/x/node_modules/a.js", &[]), // excluded directory
+        ]),
+        None,
+    );
+    assert!(report.violations.is_empty(), "{:?}", report.violations);
+}
+
+#[test]
+fn bypassed_paths_never_raise_c002() {
+    // The floor and adopter additions are filtered before the question is
+    // asked, so coverage is asked only of paths the gate would judge.
+    let mut cfg = ratchet_config();
+    cfg.coupling
+        .bypass_prefixes
+        .push("crates/x/vendor/".to_string());
+    let report = run_with(
+        &cfg,
+        &unfloored_index(),
+        &diff(vec![
+            file("crates/x/vendor/v.rs", &[LineSpan::new(1, 1)]),
+            file(".derived/x.json", &[]),
+        ]),
+        None,
+    );
+    assert!(report.violations.is_empty(), "{:?}", report.violations);
+    assert_eq!(report.checked_paths, 0);
+}
+
+#[test]
+fn explicit_claim_under_bypass_is_c001_not_c002() {
+    // Spec 009: an explicit unit claim beats the bypass set. Such a path has a
+    // specific owner by construction, so it can only ever be C-001.
+    let mut cfg = ratchet_config();
+    cfg.coupling
+        .bypass_prefixes
+        .push("crates/x/vendor/".to_string());
+    let index = index_with_packages(
+        json!([{ "name": "x", "path": "crates/x", "kind": "rust-lib" }]),
+        json!([{
+            "specId": "001-a",
+            "implementingPaths": [],
+            "resolvedUnits": [{
+                "unit": { "kind": "file", "path": "crates/x/vendor/v.rs" },
+                "sourceField": "establishes",
+                "ownership": true,
+                "locations": [{ "file": "crates/x/vendor/v.rs" }]
+            }]
+        }]),
+    );
+    let report = run_with(
+        &cfg,
+        &index,
+        &diff(vec![file("crates/x/vendor/v.rs", &[LineSpan::new(1, 1)])]),
+        None,
+    );
+    assert_eq!(codes(&report), vec![("crates/x/vendor/v.rs", "C-001")]);
+}
+
+#[test]
+fn waiver_clears_c002_exactly_as_c001() {
+    let waiver = Waiver {
+        reason: "vendored drop; spec to follow".to_string(),
+    };
+    let report = run_with(
+        &ratchet_config(),
+        &unfloored_index(),
+        &diff(vec![file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)])]),
+        Some(&waiver),
+    );
+    assert_eq!(codes(&report), vec![("crates/x/src/stray.rs", "C-002")]);
+    assert!(
+        !report.has_blocking_drift(),
+        "retained for review, not blocking"
+    );
+}
+
+#[test]
+fn one_diff_can_carry_both_codes_but_one_path_carries_one() {
+    let report = run_with(
+        &ratchet_config(),
+        &floored_index(),
+        &diff(vec![
+            file("crates/x/src/stray.rs", &[LineSpan::new(1, 2)]),
+            file("crates/x/src/lib.rs", &[LineSpan::new(1, 2)]),
+        ]),
+        None,
+    );
+    assert_eq!(
+        codes(&report),
+        vec![
+            ("crates/x/src/lib.rs", "C-001"),
+            ("crates/x/src/stray.rs", "C-002")
+        ],
+        "sorted by path; each path raises exactly one code"
+    );
 }

--- a/crates/spec-spine-core/tests/coverage.rs
+++ b/crates/spec-spine-core/tests/coverage.rs
@@ -1,0 +1,341 @@
+//! Ownership-coverage tests (spec 032): the classifier's tiers, the universe
+//! the report and the gate share, determinism, the freshness guard, and the
+//! JSON facade. Fixtures are real trees fed through `index`, so the
+//! implementing-path and resolved-unit shapes are the indexer's own.
+
+use std::fs;
+use std::path::Path;
+
+use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
+use spec_spine_core::{
+    Ownership, classify, coverage, coverage_json, coverage_with, enumerate_source_files,
+    in_coverage_universe, index, index_dir, index_shard_files,
+};
+use spec_spine_types::{Config, CoverageReport, Error, load_config};
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let p = root.join(rel);
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(p, content).unwrap();
+}
+
+fn spec(id: &str, body: &str) -> String {
+    format!(
+        "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-09\"\nsummary: \"s\"\n{body}---\n# {id}\n"
+    )
+}
+
+/// Write the index shards as the CLI's `spec-spine index` does.
+fn emit_index(cfg: &Config, repo: &Path) {
+    let outcome = index(cfg, repo).unwrap();
+    let dir = index_dir(cfg, repo);
+    let (by_spec, by_package) = index_shard_files(&outcome.shards).unwrap();
+    shard::sync_dir(&dir.join(BY_SPEC_DIR), &by_spec).unwrap();
+    shard::sync_dir(&dir.join(BY_PACKAGE_DIR), &by_package).unwrap();
+}
+
+/// Two crates. `crates/a` names `000-floor` in its manifest; `001-a` claims
+/// `src/lib.rs` (file unit) and `src/sub/` (subtree unit) and is named by a
+/// comment header in `src/hdr.rs`; `002-r` only references `src/ref.rs`;
+/// `src/stray.rs` is floor-only. `crates/b` has no floor; `003-d` claims
+/// `src/deep` by directory unit; `src/lib.rs` is unclaimed. Plus the noise the
+/// universe must ignore: an excluded dir, a bypassed dir, a non-source file,
+/// and a script outside every package.
+fn fixture() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(
+        r,
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"crates/a\", \"crates/b\"]\n",
+    );
+    write(
+        r,
+        "crates/a/Cargo.toml",
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"000-floor\"\n",
+    );
+    write(r, "crates/a/src/lib.rs", "pub fn a() {}\n");
+    write(r, "crates/a/src/sub/one.rs", "pub fn one() {}\n");
+    write(
+        r,
+        "crates/a/src/hdr.rs",
+        "// Spec: specs/001-a/spec.md\npub fn h() {}\n",
+    );
+    write(r, "crates/a/src/ref.rs", "pub fn r() {}\n");
+    write(r, "crates/a/src/stray.rs", "pub fn s() {}\n");
+    write(r, "crates/a/target/gen.rs", "pub fn g() {}\n");
+    write(r, "crates/a/vendor/v.rs", "pub fn v() {}\n");
+    write(r, "crates/a/notes.md", "# notes\n");
+    write(
+        r,
+        "crates/b/Cargo.toml",
+        "[package]\nname = \"b\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "crates/b/src/lib.rs", "pub fn b() {}\n");
+    write(r, "crates/b/src/deep/x.rs", "pub fn x() {}\n");
+    write(r, "scripts/tool.py", "print('outside every package')\n");
+
+    write(r, "specs/000-floor/spec.md", &spec("000-floor", ""));
+    write(
+        r,
+        "specs/001-a/spec.md",
+        &spec(
+            "001-a",
+            "establishes:\n  - \"crates/a/src/lib.rs\"\n  - \"crates/a/src/sub/\"\n",
+        ),
+    );
+    write(
+        r,
+        "specs/002-r/spec.md",
+        &spec(
+            "002-r",
+            "references:\n  - { unit: { kind: file, path: \"crates/a/src/ref.rs\" }, role: context }\n",
+        ),
+    );
+    write(
+        r,
+        "specs/003-d/spec.md",
+        &spec(
+            "003-d",
+            "establishes:\n  - { kind: directory, path: \"crates/b/src/deep\" }\n",
+        ),
+    );
+    tmp
+}
+
+fn fixture_config() -> Config {
+    let mut cfg = Config::default();
+    cfg.coupling
+        .bypass_prefixes
+        .push("crates/a/vendor/".to_string());
+    cfg
+}
+
+#[test]
+fn report_classifies_every_tier() {
+    let fx = fixture();
+    let cfg = fixture_config();
+    emit_index(&cfg, fx.path());
+    let report = coverage(&cfg, fx.path()).unwrap();
+
+    assert_eq!(report.source_files, 7, "{report:#?}");
+    assert_eq!(report.claimed_files, 4, "{report:#?}");
+    assert_eq!(
+        report.floor_only_files,
+        vec!["crates/a/src/ref.rs", "crates/a/src/stray.rs"],
+        "a referenced file is floor-only: references are not ownership"
+    );
+    assert_eq!(report.unclaimed_files, vec!["crates/b/src/lib.rs"]);
+    assert_eq!(report.untraced_files(), 3);
+    assert!(!report.is_fully_claimed());
+
+    assert_eq!(report.packages.len(), 2);
+    let a = &report.packages[0];
+    assert_eq!(a.path, "crates/a");
+    assert_eq!(a.floor_spec.as_deref(), Some("000-floor"));
+    assert_eq!(
+        (a.source_files, a.claimed_files, a.floor_only, a.unclaimed),
+        (5, 3, 2, 0)
+    );
+    let b = &report.packages[1];
+    assert_eq!(b.path, "crates/b");
+    assert_eq!(b.floor_spec, None);
+    assert_eq!(
+        (b.source_files, b.claimed_files, b.floor_only, b.unclaimed),
+        (2, 1, 0, 1)
+    );
+}
+
+#[test]
+fn classifier_tiers_directly() {
+    let fx = fixture();
+    let cfg = fixture_config();
+    let idx = index(&cfg, fx.path()).unwrap().index;
+    assert_eq!(classify(&idx, "crates/a/src/lib.rs"), Ownership::Specific);
+    assert_eq!(
+        classify(&idx, "crates/a/src/sub/one.rs"),
+        Ownership::Specific,
+        "a subtree unit covers its files"
+    );
+    assert_eq!(
+        classify(&idx, "crates/a/src/hdr.rs"),
+        Ownership::Specific,
+        "a comment header is a specific claim"
+    );
+    assert_eq!(
+        classify(&idx, "crates/a/src/ref.rs"),
+        Ownership::FloorOnly(vec!["000-floor".to_string()])
+    );
+    assert_eq!(
+        classify(&idx, "crates/a/src/stray.rs"),
+        Ownership::FloorOnly(vec!["000-floor".to_string()])
+    );
+    assert_eq!(
+        classify(&idx, "crates/b/src/deep/x.rs"),
+        Ownership::Specific,
+        "a directory-kind unit covers its subtree"
+    );
+    assert_eq!(classify(&idx, "crates/b/src/lib.rs"), Ownership::Unowned);
+}
+
+#[test]
+fn universe_excludes_noise_and_is_the_gates_predicate() {
+    let fx = fixture();
+    let cfg = fixture_config();
+    let idx = index(&cfg, fx.path()).unwrap().index;
+    let files = enumerate_source_files(&cfg, fx.path(), &idx);
+    assert_eq!(
+        files,
+        vec![
+            "crates/a/src/hdr.rs",
+            "crates/a/src/lib.rs",
+            "crates/a/src/ref.rs",
+            "crates/a/src/stray.rs",
+            "crates/a/src/sub/one.rs",
+            "crates/b/src/deep/x.rs",
+            "crates/b/src/lib.rs",
+        ]
+    );
+    for f in &files {
+        assert!(in_coverage_universe(&cfg, &idx, f), "{f}");
+    }
+    for out in [
+        "crates/a/target/gen.rs", // resolver exclusion
+        "crates/a/vendor/v.rs",   // adopter bypass
+        "crates/a/notes.md",      // not a source file
+        "scripts/tool.py",        // outside every package
+        "crates/a/Cargo.toml",    // a manifest, not source
+        "specs/001-a/spec.md",    // the corpus
+    ] {
+        assert!(!in_coverage_universe(&cfg, &idx, out), "{out}");
+    }
+}
+
+#[test]
+fn report_is_deterministic_and_a_function_of_the_path_set() {
+    let fx = fixture();
+    let cfg = fixture_config();
+    let idx = index(&cfg, fx.path()).unwrap().index;
+    let files = enumerate_source_files(&cfg, fx.path(), &idx);
+    let a = coverage_with(&cfg, &idx, &files);
+    let b = coverage_with(&cfg, &idx, &files);
+    assert_eq!(a, b);
+
+    // Unsorted, duplicated, and noisy input yields the same report.
+    let mut noisy: Vec<String> = files.iter().rev().cloned().collect();
+    noisy.extend(files.iter().cloned());
+    noisy.push("scripts/tool.py".to_string());
+    noisy.push("crates/a/target/gen.rs".to_string());
+    assert_eq!(coverage_with(&cfg, &idx, &noisy), a);
+}
+
+#[test]
+fn coverage_is_freshness_guarded() {
+    let fx = fixture();
+    let cfg = fixture_config();
+    // No index at all: an artifact-missing I/O error (3), as for `couple`.
+    assert!(matches!(coverage(&cfg, fx.path()), Err(Error::Io(_))));
+
+    emit_index(&cfg, fx.path());
+    assert!(coverage(&cfg, fx.path()).is_ok());
+
+    // A spec edit without re-indexing: stale (2), never a report over the
+    // wrong ledger.
+    write(
+        fx.path(),
+        "specs/001-a/spec.md",
+        &spec("001-a", "establishes:\n  - \"crates/a/src/\"\n"),
+    );
+    assert!(matches!(
+        coverage(&cfg, fx.path()),
+        Err(Error::Stale { .. })
+    ));
+}
+
+#[test]
+fn crate_unit_claims_the_whole_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"pkg\"]\n");
+    write(
+        r,
+        "pkg/Cargo.toml",
+        "[package]\nname = \"pkg\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "pkg/src/lib.rs", "pub fn a() {}\n");
+    write(r, "pkg/src/other.rs", "pub fn b() {}\n");
+    write(
+        r,
+        "specs/001-x/spec.md",
+        &spec("001-x", "establishes:\n  - { kind: crate, id: \"pkg\" }\n"),
+    );
+    let cfg = Config::default();
+    emit_index(&cfg, r);
+    let report = coverage(&cfg, r).unwrap();
+    assert_eq!((report.source_files, report.claimed_files), (2, 2));
+    assert!(report.is_fully_claimed(), "{report:#?}");
+}
+
+#[test]
+fn root_package_attributes_nested_files_to_the_nested_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(
+        r,
+        "Cargo.toml",
+        "[package]\nname = \"root\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"000-root\"\n\
+         [workspace]\nmembers = [\"crates/inner\"]\n",
+    );
+    write(r, "src/main.rs", "fn main() {}\n");
+    write(
+        r,
+        "crates/inner/Cargo.toml",
+        "[package]\nname = \"inner\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "crates/inner/src/lib.rs", "pub fn i() {}\n");
+    write(r, "specs/000-root/spec.md", &spec("000-root", ""));
+    let cfg = Config::default();
+    emit_index(&cfg, r);
+    let report = coverage(&cfg, r).unwrap();
+
+    assert_eq!(
+        report.source_files, 2,
+        "nested file counted once: {report:#?}"
+    );
+    let root = report.packages.iter().find(|p| p.path.is_empty()).unwrap();
+    let inner = report
+        .packages
+        .iter()
+        .find(|p| p.path == "crates/inner")
+        .unwrap();
+    assert_eq!((root.source_files, root.floor_only), (1, 1));
+    assert_eq!((inner.source_files, inner.floor_only), (1, 1));
+    // The root floor still covers the nested file (it is inside the root
+    // package too), so it is floor-only rather than unclaimed.
+    assert_eq!(
+        report.floor_only_files,
+        vec!["crates/inner/src/lib.rs", "src/main.rs"]
+    );
+    assert!(report.unclaimed_files.is_empty());
+}
+
+#[test]
+fn require_ownership_defaults_off_and_parses() {
+    assert!(!Config::default().coupling.require_ownership);
+    let cfg = load_config("[coupling]\nrequire_ownership = true\n").unwrap();
+    assert!(cfg.coupling.require_ownership);
+}
+
+#[test]
+fn facade_round_trips_the_report() {
+    let fx = fixture();
+    let cfg = fixture_config();
+    emit_index(&cfg, fx.path());
+    let config_json = serde_json::to_string(&cfg).unwrap();
+    let json = coverage_json(&config_json, fx.path().to_str().unwrap()).unwrap();
+    let report: CoverageReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(report, coverage(&cfg, fx.path()).unwrap());
+    assert!(json.contains("\"floorOnlyFiles\""), "camelCase wire form");
+}

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -189,6 +189,17 @@ pub struct CouplingConfig {
     /// version string (a new package, a `scripts` edit, spec-binding
     /// metadata) refuses the auto-waiver, fail-closed. Default `false`.
     pub auto_waive_dependency_only: bool,
+    /// Opt-in ownership ratchet (spec 032). When `true`, a changed source file
+    /// inside a discovered package that no spec **specifically** claims is a
+    /// `C-002` violation instead of being skipped as "not a coupling concern".
+    /// Specific means a resolved ownership-bearing unit (file / section /
+    /// symbol / directory / crate / module) or a `// Spec:` comment header;
+    /// a manifest floor alone (`[package.metadata.<ns>].spec`, spec 005 §3.6)
+    /// does not count, because it covers a whole package regardless of what
+    /// anyone has thought about. Default `false`: `C-001` holds for any
+    /// corpus the day it is written, but full coverage is a state a repo has
+    /// to reach first. `spec-spine index coverage` reports the distance.
+    pub require_ownership: bool,
 }
 
 impl Default for CouplingConfig {
@@ -200,6 +211,7 @@ impl Default for CouplingConfig {
             bypass_prefixes: Vec::new(),
             waiver_keyword: "Spec-Drift-Waiver:".to_string(),
             auto_waive_dependency_only: false,
+            require_ownership: false,
         }
     }
 }

--- a/crates/spec-spine-types/src/coverage.rs
+++ b/crates/spec-spine-types/src/coverage.rs
@@ -1,0 +1,60 @@
+//! Ownership-coverage DTOs (spec 032): the file-granular answer to "how much
+//! of the code does the corpus specifically claim?", emitted by `spec-spine
+//! index coverage` and by the `coverage_json` facade.
+//!
+//! These are read-side report shapes, not committed artifacts: nothing here is
+//! written under the derived directory, so no schema version carries them.
+
+use serde::{Deserialize, Serialize};
+
+/// The whole-tree coverage report. Every path is repo-relative POSIX; every
+/// list is sorted and deduplicated, so the report is byte-identical across
+/// platforms for one tree.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoverageReport {
+    /// Source files enumerated across every discovered package: the
+    /// denominator. Same universe the coupling gate's `C-002` examines.
+    pub source_files: usize,
+    /// Files with a **specific** owner: a resolved ownership-bearing unit or a
+    /// `// Spec:` comment header covers them.
+    pub claimed_files: usize,
+    /// Files whose only owner is a package's manifest floor
+    /// (`[package.metadata.<ns>].spec`, spec 005 §3.6).
+    pub floor_only_files: Vec<String>,
+    /// Files no spec owns at all.
+    pub unclaimed_files: Vec<String>,
+    /// Per-package breakdown, sorted by package path.
+    pub packages: Vec<PackageCoverage>,
+}
+
+impl CoverageReport {
+    /// Files `[coupling] require_ownership` would refuse: floor-only plus
+    /// unclaimed.
+    pub fn untraced_files(&self) -> usize {
+        self.floor_only_files.len() + self.unclaimed_files.len()
+    }
+
+    /// True when every source file has a specific owner (the state
+    /// `require_ownership` defends, and what `--fail-on-untraced` asserts).
+    pub fn is_fully_claimed(&self) -> bool {
+        self.untraced_files() == 0
+    }
+}
+
+/// One discovered package's share of the report. Counts only; the file lists
+/// live on the aggregate report (their repo-relative paths attribute them).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageCoverage {
+    /// Repo-relative POSIX path of the package directory (`""` for a root
+    /// package).
+    pub path: String,
+    /// The floor spec named in the package manifest, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub floor_spec: Option<String>,
+    pub source_files: usize,
+    pub claimed_files: usize,
+    pub floor_only: usize,
+    pub unclaimed: usize,
+}

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! ## Layout
 //! - [`config`]: the `spec-spine.toml` model ([`Config`]).
+//! - [`coverage`]: the ownership-coverage report DTOs (spec 032).
 //! - [`frontmatter`]: the authored grammar ([`Frontmatter`], [`parse_frontmatter`]).
 //! - [`unit`] / [`edges`]: the authority-unit and relationship vocabulary.
 //! - [`registry`]: the compiled spec-as-source DTOs ([`Registry`]).
@@ -22,6 +23,7 @@
 pub mod attest;
 pub mod codebase;
 pub mod config;
+pub mod coverage;
 pub mod edges;
 pub mod error;
 pub mod frontmatter;
@@ -45,6 +47,7 @@ pub use config::{
     AllowlistConfig, BrandingConfig, Config, CouplingConfig, FrontmatterConfig, IndexConfig,
     LayoutConfig, ManifestConfig, ProvenanceConfig, load_config,
 };
+pub use coverage::{CoverageReport, PackageCoverage};
 pub use edges::{
     CoAuthorityItem, ConstrainItem, ExtendItem, Origin, Provenance, ReferenceItem, RefineItem,
     SupersedeItem, SupersedeScope, SupersedeScoped,

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -193,6 +193,34 @@ Spec-Drift-Waiver: refactor moves helper out of the owned section; behavior unch
 
 The waiver is global to the run and downgrades violations to warnings.
 
+### Coverage: "is everything specified?"
+
+The gate above refuses drift in code a spec claims; it says nothing about code
+no spec claims. `spec-spine index coverage` (spec 032) answers that, per
+source file, against the committed index:
+
+```sh
+spec-spine index coverage                      # the report (exit 2 if the index is stale)
+spec-spine index coverage --json               # the same as a CoverageReport
+spec-spine index coverage --fail-on-untraced   # exit 1 unless every source file is claimed
+```
+
+A file is **specifically claimed** when a resolved unit (file, section,
+symbol, directory, crate, module) or a `// Spec:` comment header covers it.
+A file only a manifest floor (`[package.metadata.<ns>].spec`) covers is
+**floor-only**: the floor is the right safety net for drift and a useless
+coverage signal, so it counts as debt here. Anything else is **unclaimed**.
+The universe is source files inside discovered packages, minus
+`resolver_exclusions` and bypassed paths; prose, manifests, workflows and
+config are never counted.
+
+To turn coverage into a PR-time ratchet, set `[coupling] require_ownership =
+true`: a changed floor-only or unclaimed source file is then a `C-002`
+violation (waivable like `C-001`; deletions are exempt). The report predicts
+the gate exactly, both read one classifier over one universe. The intended
+sequence: read the report, flip the flag to stop new debt, drive the lists to
+empty, then add `--fail-on-untraced` to CI to defend the state.
+
 ---
 
 ## Config: `spec-spine.toml`
@@ -217,6 +245,7 @@ divergence observed across the reference repos. Every sub-table is
 | `branding.compiler_id` / `indexer_id` | ids stamped in emitted `build` metadata | `"spec-spine"` |
 | `coupling.bypass_prefixes` | **additions** to the built-in bypass floor (additive; cannot remove a floor entry) | `[]` |
 | `coupling.waiver_keyword` | the PR-body waiver keyword | `"Spec-Drift-Waiver:"` |
+| `coupling.require_ownership` | the ownership ratchet (spec 032): a changed source file inside a package that no spec **specifically** claims (a resolved unit or a `// Spec:` header; a manifest floor alone does not count) is a `C-002` violation. Read `spec-spine index coverage` first; turn on to stop new debt | `false` |
 | `coupling.auto_waive_dependency_only` | when `true` and no PR-body waiver is present, mechanically self-waives PRs where every non-bypassed changed path is a recognized dependency manifest with only version-pin changes: a `package.json` dependency table, a `Cargo.toml` dependency version, or a claimed `.github/workflows/*.yml` `uses:` action ref (the dependabot-class path); fail-closed on anything more (spec 005 §3.5, extended by spec 030) | `false` |
 | `provenance.uri_schemes` | open kind→scheme map for provenance URIs | `{ knowledge = "knowledge://", code-fingerprint = "fingerprint://" }` |
 | `frontmatter.extra_known_keys` | recognized frontmatter keys added without forking the types crate | `[]` |

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,15 @@ pub fn check_index_freshness(cfg: &Config, repo_root: &Path) -> Result<Freshness
 
 // Per-slice staleness (spec 012): `name` is a configured `[index.slices]` key.
 pub fn check_slice_freshness(cfg: &Config, repo_root: &Path, name: &str) -> Result<Freshness, Error>;
+
+// Ownership coverage (spec 032): which source files no spec specifically
+// claims. Freshness-guarded like `couple` (a stale index is Error::Stale);
+// the pure form takes an already-loaded index and a path listing.
+pub fn coverage     (cfg: &Config, repo_root: &Path) -> Result<CoverageReport, Error>;
+pub fn coverage_with(cfg: &Config, index: &CodebaseIndex, files: &[String]) -> CoverageReport;
+pub fn classify(index: &CodebaseIndex, path: &str) -> Ownership;   // Specific | FloorOnly(ids) | Unowned
+pub fn in_coverage_universe(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool;
+pub fn enumerate_source_files(cfg: &Config, repo_root: &Path, index: &CodebaseIndex) -> Vec<String>;
 ```
 
 Returned outcomes carry both the typed struct and the canonical bytes the CLI
@@ -89,7 +98,8 @@ The gate never shells out; the caller passes a parsed diff:
 
 ```rust
 pub struct DiffInput { pub files: Vec<DiffFile> }
-pub struct DiffFile  { pub path: String, pub hunks: Vec<LineSpan> }  // empty hunks ⇒ whole-file change
+pub struct DiffFile  { pub path: String, pub hunks: Vec<LineSpan>,    // empty hunks ⇒ whole-file change
+                       pub deleted: bool }                            // `+++ /dev/null`; C-002 skips it (spec 032)
 pub struct Waiver    { pub reason: String }
 
 // Build a Waiver from a PR body using the configured keyword:
@@ -225,6 +235,7 @@ pub fn compile_json        (config_json: &str, repo_root: &str) -> Result<String
 pub fn index_json          (config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn lint_json           (config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error>;
+pub fn coverage_json       (config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn couple_json         (request_json: &str)                 -> Result<String, Error>;
 pub fn query_json          (request_json: &str)                 -> Result<String, Error>;
 pub fn render_json         (config_json: &str, index_json: &str) -> Result<String, Error>;
@@ -241,6 +252,9 @@ pub fn scaffold_init_json  (config_json: &str)                  -> Result<String
 - `couple_json` request: `{ "config"?: Config, "repoRoot": string, "diff":
   DiffInput, "waiver"?: { "reason": string } }`.
 - `check_freshness_json` returns `{ "fresh": bool, "expected"?, "actual"? }`.
+- `coverage_json` (spec 032) returns the `CoverageReport`: `sourceFiles`,
+  `claimedFiles`, the sorted `floorOnlyFiles` / `unclaimedFiles` lists, and
+  per-package counts. A stale committed index is `Error::Stale`, not a report.
 - `render_json` (spec 011) takes `config_json` and the aggregate index JSON
   text and returns the markdown projection (a JSON-encoded string).
   `orphans_json` (spec 011) takes only the index JSON text and returns the

--- a/docs/design/00-architecture.md
+++ b/docs/design/00-architecture.md
@@ -269,6 +269,10 @@ indexer_id  = "spec-spine"
 bypass_prefixes = []
 # The PR-body waiver keyword (free-text reason follows the colon).
 waiver_keyword = "Spec-Drift-Waiver:"
+# Spec 032: refuse a changed source file that no spec specifically claims
+# (C-002). Off by default: full coverage is a state a repo reaches, not one it
+# inherits. `spec-spine index coverage` reports the distance.
+require_ownership = false
 
 [provenance]
 # OPEN scheme registry: the closed enum forced edits to shared types
@@ -661,7 +665,10 @@ checks; full enumeration lands in the Phase 1/3/4 specs):
   errors) fails `index check`.
 - **`C###`**: *coupling* gate violations (spec 005). `C-001` = a changed,
   non-bypassed path lacks an authoring edit to any spec that owns it (and no
-  waiver excuses it) → exit 1.
+  waiver excuses it) → exit 1. `C-002` (spec 032, only with `[coupling]
+  require_ownership`) = a changed source file inside a package that no spec
+  specifically claims (floor-only or unowned) → exit 1; one path raises at
+  most one of the two.
 
 ### 10.4 Deliberately dropped from the generic core (overlay territory)
 

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -45,6 +45,13 @@ indexer_id  = "spec-spine"
 # a README tweak would read as code drift. `**/README.md` = tail-suffix match.
 bypass_prefixes = ["**/README.md"]
 waiver_keyword = "Spec-Drift-Waiver:"
+# Spec 032: refuse a changed source file that no spec specifically claims
+# (C-002). Off here on purpose: `spec-spine index coverage` reports this repo at
+# 59/64 (five files owned only by their crate's manifest floor, see 032 §3.8),
+# and claiming them means editing the tier-1 bootstrap spec, a human's call.
+# The path to adopt is: read the report, flip this on to stop new debt, drive
+# the lists to empty, then add `index coverage --fail-on-untraced` to CI.
+require_ownership = false
 
 [provenance.uri_schemes]
 knowledge        = "knowledge://"

--- a/specs/032-ownership-coverage/spec.md
+++ b/specs/032-ownership-coverage/spec.md
@@ -1,0 +1,325 @@
+---
+id: "032-ownership-coverage"
+title: "Ownership coverage: `spec-spine index coverage` and the `C-002` ratchet"
+status: draft
+kind: "tooling"
+created: "2026-08-28"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "004-codebase-index"
+  - "005-coupling-gate"
+  - "009-coupling-floor-claim-precedence"
+establishes:
+  - "crates/spec-spine-core/src/coverage.rs"
+  - "crates/spec-spine-core/tests/coverage.rs"
+  - "crates/spec-spine-types/src/coverage.rs"
+extends:
+  # The gate's second verdict (`C-002`), the `deleted` diff flag, and the
+  # code-aware CLI summary.
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/src/cmd_couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/tests/couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/tests/couple.rs", nature: additive }
+  # The shared source-extension list and the `index coverage` verb.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  # The config knob and the report DTO re-export (000 floors the types crate;
+  # the same additive shape specs 012 and 013 used).
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  # The core re-exports, the `coverage_json` facade, and the e2e exit-code
+  # contract file (001's surface, as for specs 011/012/031).
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  spec-spine refuses drift but has never required coverage. The coupling gate
+  skips a changed path that no spec claims ("not a coupling concern"), and the
+  only coverage-shaped signal, `traceability.untracedCode`, is package-granular
+  and read by nothing, so a crate with one governed file and two hundred
+  ungoverned ones reports as traced. "This application is fully specified" is
+  therefore not a state the tool can assert. This spec adds two additive
+  pieces that share one definition of ownership. `spec-spine index coverage`
+  reports, per source file, whether a spec *specifically* claims it (a resolved
+  unit or a comment header), whether only a package's manifest floor covers it,
+  or whether nothing does; `--fail-on-untraced` turns that into the whole-tree
+  assertion. `[coupling] require_ownership` (default false) makes the gate ask
+  the same question of every changed source file and refuse a floor-only or
+  unowned one as `C-002`, the PR-time ratchet. Coverage is a read verb over the
+  tree and the committed ledger, like `index check`: nothing new is committed,
+  no schema version moves, and the report predicts the gate exactly because
+  both call one classifier over one universe.
+---
+
+# 032: Ownership coverage
+
+## 1. Purpose
+
+spec-spine's claim is that an authority and its derivation move together. The
+engine enforces one direction of that claim: code that a spec claims cannot
+change without the spec (`C-001`, spec 005). It says nothing about whether the
+corpus claims anything in particular. Two things keep unowned code invisible:
+
+- **The gate skips it.** `couple.rs` resolves the owners of every changed path
+  and, on an empty owner set, moves on. That is the right default (a gate that
+  failed on unowned code would be unadoptable), but it is unconditional, so a
+  repo that has reached full coverage has no way to defend it. Coverage, once
+  earned, decays silently.
+- **The metric cannot see it.** `traceability.untracedCode` lists packages with
+  neither a `spec_ref` nor any implementing path inside them. One claimed path
+  anywhere in a package marks the whole package traced, so for a monorepo the
+  number is almost always zero and never actionable. Nothing in `lint`,
+  `couple`, or the CLI reads it.
+
+A finer metric has a trap of its own. The manifest floor
+(`[package.metadata.<ns>].spec`, spec 005 §3.6) makes its spec an owner of
+every file in the package, which is exactly right for drift and exactly wrong
+for coverage: counted as coverage, it makes any repo that follows the adoption
+guide read 100% by construction. This repo would read 61/61 that way. The
+metric is only honest if the floor counts as **debt**, not as coverage.
+
+The adopter this serves is the one specifying an application before writing
+it (the workflow spec 025's `W-001` tier exists for). Its burn-down lists the
+declared units that resolve nowhere; nothing lists the code that was never
+declared. This spec supplies that second list and the gate that keeps it empty.
+
+## 2. Territory
+
+`spec-spine-core`'s new `coverage.rs` (the classifier, the universe predicate,
+the enumeration, and the report; established here) and its tests; the report
+DTOs in `spec-spine-types` (`coverage.rs`, established here); the `C-002` arm
+and the `deleted` diff flag in `couple.rs`; the `require_ownership` knob in
+`config.rs`; the `index coverage` subcommand in `cmd_index.rs`; the code-aware
+summary in `cmd_couple.rs`; the shared source-extension list in `index.rs`; the
+re-exports and `coverage_json` facade in `lib.rs`; the e2e contract tests.
+
+All additive. No existing signature changes, no emitted-artifact change, no
+schema version moves: coverage is a read verb, not a field of the index (§3.3).
+
+## 3. Behavior
+
+### 3.1 Ownership tiers
+
+For one repo-relative source file, the classifier answers with the most
+specific of three tiers, spans ignored (this is a whole-file question):
+
+1. **Specific.** Some spec's *resolved, ownership-bearing* unit covers the
+   file: a `file` unit (exact, or a trailing-slash subtree), a `section` or
+   `symbol` unit located in it, or a `directory` / `crate` / `module` unit
+   (spec 017) whose subtree contains it; **or** the file names its spec in a
+   `// Spec:` comment header (spec 004 §3.2). An author decided which spec
+   governs this file.
+2. **Floor-only.** No specific claim, but a discovered package whose manifest
+   names a spec contains the file. The floor is a safety net that covers a
+   whole package regardless of what anyone has thought about, so it counts as
+   ownership for drift (`C-001`, unchanged) and as debt here.
+3. **Unowned.** Nothing covers it.
+
+`references` units never count, in any tier: they are non-owning (spec 000,
+constitution) and their locations are read from `resolvedUnits` with the
+ownership flag, never from the path-level `implementingPaths` they also land in.
+A file that a spec merely references is floor-only or unowned like any other.
+
+**Untraced** means floor-only or unowned: the set `require_ownership` refuses.
+
+### 3.2 The universe
+
+Both the report and the gate ask the tier question of exactly one set of
+paths, the **coverage universe**: a path is in it iff
+
+- its extension is one the indexer treats as source (`rs`, `ts`, `tsx`, `js`,
+  `jsx`, `go`, `py`, `sh`; the list the comment-header scan already uses, now
+  shared so the two can never disagree about what a source file is);
+- it lies inside a discovered package's directory (a root package contains
+  everything; a file inside a nested package is attributed to the nested one);
+- no path component is in `index.resolver_exclusions`;
+- the gate would not bypass it (the floor plus `coupling.bypass_prefixes`,
+  claim-aware per spec 009).
+
+Prose, manifests, workflows, config (`spec-spine.toml` included), the corpus,
+and scripts outside every package are not code the corpus can be expected to
+claim, so they are outside the universe and can never raise `C-002`. This is
+what makes the flag adoptable without a new bypass vocabulary, and it is what
+makes the report an exact predictor: a file the report calls claimed is one the
+gate will never refuse for lack of an owner, and a file it lists is one the
+gate will refuse the next time it changes.
+
+### 3.3 `spec-spine index coverage`
+
+A read verb over the working tree and the committed index:
+
+```
+coverage: 56/64 source files specifically claimed (87.5%); 8 floor-only, 0 unclaimed
+  crates/spec-spine-cli (floor 001-compile-registry): 13/13 claimed, 0 floor-only, 0 unclaimed
+  crates/spec-spine-core (floor 001-compile-registry): 25/28 claimed, 3 floor-only, 0 unclaimed
+  ...
+
+floor-only (owned only by a package floor; claim in a spec):
+  crates/spec-spine-core/tests/query.rs
+  ...
+```
+
+- It is **freshness-guarded** exactly like `couple`: a stale committed index is
+  exit 2, never a report over the wrong ledger. An unbuilt index is the same
+  I/O error (3) `render` gives.
+- `--json` emits the `CoverageReport` DTO: totals, the two sorted debt lists,
+  and per-package counts (with the package's floor spec, if any). The same
+  shape comes back from the `coverage_json` facade.
+- `--fail-on-untraced` exits 1 unless every source file is specifically
+  claimed. This is the whole-tree assertion "fully specified", runnable in CI
+  once a repo has reached it, and the natural companion to `lint
+  --fail-on-warn`.
+- It writes nothing and changes no committed artifact.
+
+Coverage is deliberately **not** a field of the index. Storing it would mean
+either walking the tree inside the committed-index loader (so `render` stops
+being a projection of the shards, spec 011, and every `couple` run pays a full
+source walk) or committing it per package and folding it into the shard hash
+(so every file added to any crate stales the index and rewrites that crate's
+shard, eroding spec 024's conflict-free property for the most common kind of
+concurrent PR). A verb over `(tree, committed shards)` has neither cost and is
+the same shape as `index check`.
+
+`traceability.untracedCode` is left exactly as it is: its package-granular
+question ("is this package governed at all?") is a different one, and changing
+an emitted field's meaning in place would silently alter it for every consumer.
+
+### 3.4 `C-002`: the ownership ratchet
+
+When `[coupling] require_ownership = true`, the gate asks the tier question of
+every changed path in the universe, **before** the drift question, and refuses
+a floor-only or unowned one:
+
+```
+C-002  '<path>' has no specific owning spec; only the package floor of <ids> covers it (require_ownership is on)
+C-002  '<path>' is not claimed by any spec (require_ownership is on)
+```
+
+Severity `Error`, in the same `violations` list as `C-001`, sorted with it by
+path. Everything upstream of the ownership question applies unchanged:
+
+1. **The bypass set still exempts** (floor plus adopter additions), and an
+   explicit claim still overrides it (spec 009); such a path has a specific
+   owner by construction and can only ever be `C-001`.
+2. **Waivers still clear it.** `C-002` is an ordinary violation, so the PR-body
+   `Spec-Drift-Waiver:` line suppresses the failure exit with the violation
+   retained for review. The spec 005 §3.5 dependency-only auto-waiver is
+   unaffected: manifests are outside the universe.
+3. **One path, one code.** `C-002` takes precedence: a floor-only file that
+   changed without its floor spec would otherwise also be `C-001`, but claiming
+   the file in a spec resolves both, so the single-subject message is the
+   useful one. A specifically claimed file is judged for drift exactly as
+   before.
+4. **Editing the floor spec does not clear `C-002`.** The ratchet is a claim
+   requirement, not a clearance rule; only a specific claim satisfies it.
+
+The CLI summary names both codes when both are present ("2 violation(s): 1
+drift (C-001), 1 unclaimed (C-002, require_ownership is on)") and its resolve
+hint adds "claiming the path in a spec's owning edge". Every violation line is
+now prefixed with its code (`C-001 '<path>' changed without ...`), so a reader
+can tell the two apart without the summary; with no `C-002` present the
+summary and resolve lines keep their pre-032 wording.
+
+### 3.5 Why `require_ownership` defaults off
+
+`C-001` becomes true of a repo the moment its corpus is written; `C-002`
+becomes true only once every source file has a specific claim. Shipping the
+flag on would fail every existing adopter's next PR, this repo's included, for
+a condition none of them could measure until now. The intended path is the
+ratchet: read the report, turn the flag on to stop new debt, drive the lists to
+empty, then add `--fail-on-untraced` to CI to defend the state.
+
+### 3.6 Deletions
+
+The CLI marks a path whose diff header is `+++ /dev/null` as `deleted`
+(`DiffFile.deleted`, additive: absent in an older `couple_json` request, so it
+defaults off). `C-002` never fires on a deleted path: removing unowned code is
+how coverage goes up, and a ratchet that refused it would be backwards. Drift
+is unchanged: deleting a claimed file is still a whole-file change of an owned
+path, judged as before. `--paths-from` carries no history, so a listed path is
+judged as an edit.
+
+### 3.7 Determinism
+
+`coverage_with` is a pure function of `(config, index, path set)`: the listing
+is sorted and deduplicated before classification, so order and duplicates in
+the input cannot change the output. `enumerate_source_files` reads no clock and
+no environment: the walk sorts every directory listing before descending, and
+every emitted path is repo-relative POSIX. `C-002` is a pure function of
+`(config, registry, index, diff)` like every other verdict `couple_with`
+produces. Two runs over one tree agree, and the verdict is identical across the
+release matrix.
+
+### 3.8 Measured on this repo
+
+At the commit that lands this spec, `index coverage` reports 59/64 source
+files specifically claimed (92.2%). The five floor-only files are
+`crates/spec-spine-core/tests/query.rs`, `crates/spec-spine-types/src/error.rs`,
+`crates/spec-spine-types/tests/config.rs`, `crates/spec-spine-types/tests/dogfood.rs`
+and `crates/spec-spine-types/tests/schema.rs` (all owned only by their crate's
+floor: `001` for core, `000` for types). Under the pre-032 package-granular
+metric the same tree read as fully traced. Claiming those files means editing
+`002` and the tier-1 `000`, which is a governance decision for a human, so the
+dogfood config ships with `require_ownership = false` and the debt named.
+
+### 3.9 Tests (minimum)
+
+- The classifier returns Specific for a file unit, a subtree unit, a
+  directory-kind unit, a crate-kind unit, and a comment header; FloorOnly
+  (naming the floor) for a file only a manifest covers; Unowned otherwise; and
+  FloorOnly for a file a spec merely references.
+- The universe excludes an excluded directory, a bypassed directory, a
+  non-source file, a manifest, the corpus, and a script outside every package;
+  every enumerated file satisfies the predicate (the report and the gate pinned
+  to one set).
+- The report is identical across two runs and across an unsorted, duplicated,
+  noisy listing; a nested package's files are counted once and attributed to
+  the nested package.
+- `coverage` is an I/O error with no index, a report after `index`, and
+  `Error::Stale` after a spec edit without re-indexing.
+- With the flag off, an unowned changed path yields no violation (the pre-032
+  contract, pinned). With it on: an unowned path is `C-002`; a floor-only path
+  is `C-002` naming the floor, with or without the floor spec in the diff; a
+  unit-claimed path is `C-001` and clears with its spec; a header-claimed path
+  is specific; a referenced file is floor-only; a deleted path is never
+  `C-002`; paths outside the universe and bypassed paths never are; an explicit
+  claim under a bypass is `C-001`; a waiver clears `C-002`; one diff sorts
+  `C-001` and `C-002` by path with one code per path.
+- End to end: `index coverage` is 3 before `index`, reports text and JSON, is
+  1 under `--fail-on-untraced` with debt and 0 without, and is 2 when stale;
+  with `require_ownership` on, a real `git diff` adding an unowned source file
+  exits 1 naming `C-002`, a waiver clears it, and deleting the file exits 0.
+- `require_ownership` defaults to `false` and parses from TOML.
+
+## 4. Out of scope
+
+**Making `require_ownership` the default.** A future MAJOR may revisit it; it
+cannot change under a MINOR without breaking every adopter.
+
+**The upstream direction.** Hash-pinning a vendored external authority (an
+RFC, a paper) so that revising it makes the deriving spec stale is the natural
+sibling of this spec and needs a `references`-side unit contract and a
+staleness input, neither of which this spec touches.
+
+**A lint-side coverage gate.** `lint` judges corpus well-formedness, not the
+code tree. The whole-tree assertion lives on the verb that reads the tree
+(`index coverage --fail-on-untraced`); the per-change ratchet lives on the gate
+that names a changed path (`C-002`).
+
+**Non-source assets.** The extension list is the indexer's; a governed `.sql`
+or `.proto` is a resolver question, not a coverage one.
+
+**Span-granular coverage.** Whether a file with one claimed symbol and ten
+unclaimed ones is "covered" is a finer question than a file listing can
+answer, and answering it would make the report and the gate disagree (the gate
+sees hunks, the report sees files). File granularity is the contract.
+
+**Changing what `C-001` counts as an owner.** Today the drift gate reads every
+`implementingPaths` entry as ownership, including the locations of `references`
+units, which contradicts spec 004 §3.2 ("`references` is non-owning and
+contributes no traceability"). This spec's classifier does not inherit that
+reading, so `C-002` is correct; aligning `C-001` and the traceability lists is
+a separate amendment against 004/005.

--- a/website/docs/claude-code/troubleshooting.md
+++ b/website/docs/claude-code/troubleshooting.md
@@ -53,7 +53,9 @@ to a spec. **Fix (waiver):** include a `Spec-Drift-Waiver` block in the PR body
 at creation time (requires explicit user approval; the agent never adds it
 alone). Paths on the bypass floor (`.github/**`, `docs/**`, lockfiles) and any
 `[coupling] bypass_prefixes` in `spec-spine.toml` are exempt; unowned paths clear
-automatically.
+automatically unless `[coupling] require_ownership` is on, in which case a
+changed source file no spec specifically claims is a `C-002` (claim it in a
+spec's owning edge, or waive). `spec-spine index coverage` lists those files.
 
 ## "pr-prep regenerated `.derived/`"
 

--- a/website/docs/cli/couple.md
+++ b/website/docs/cli/couple.md
@@ -16,7 +16,9 @@ spec-spine couple --base <ref> --head <ref> [--pr-body FILE] [--paths-from FILE]
 
 ## Description
 
-The coupling gate cross-references every modified code path against the authority graph. If a path is changed but its owning spec is not part of the diff (and no waiver is present), the gate fails.
+The coupling gate cross-references every modified code path against the authority graph. If a path is changed but its owning spec is not part of the diff (and no waiver is present), the gate fails with `C-001`.
+
+A path no spec owns is skipped by default. With `[coupling] require_ownership = true` (spec 032), a changed source file inside a discovered package that no spec *specifically* claims (a manifest floor alone does not count) fails with `C-002` instead; deletions are exempt, and a waiver clears it like any violation. `spec-spine index coverage` lists exactly the files that flag would refuse.
 
 It uses `git diff --no-color -U0 base...head` to determine the changed paths.
 

--- a/website/docs/cli/index.md
+++ b/website/docs/cli/index.md
@@ -13,8 +13,9 @@ Scans manifests and specs to emit the codebase index, and provides staleness che
 ```bash
 spec-spine index
 spec-spine index check [--slice NAME]
-spec-spine index render [--json]
+spec-spine index render
 spec-spine index orphans [--json]
+spec-spine index coverage [--json] [--fail-on-untraced]
 ```
 
 ## Subcommands
@@ -40,6 +41,15 @@ Lists specs that have no resolved code units (i.e., specs that claim authority o
 
 - **`--json`**: Output the list of orphaned spec IDs as a JSON array.
 
+### `index coverage`
+
+Reports, per source file inside a discovered package, whether a spec *specifically* claims it (a resolved unit or a `// Spec:` comment header), whether only a package's manifest floor covers it (**floor-only**), or whether nothing does (**unclaimed**). Freshness-guarded like `couple`: a stale committed index exits `2` rather than reporting against the wrong ledger. Prose, manifests, workflows, config, and paths under `resolver_exclusions` or the bypass set are never counted.
+
+- **`--json`**: Output the `CoverageReport` (totals, the two sorted file lists, per-package counts).
+- **`--fail-on-untraced`**: Exit `1` unless every source file is specifically claimed. The whole-tree "fully specified" assertion for CI.
+
+The same classifier drives the coupling gate's `C-002` when `[coupling] require_ownership` is on, so this report lists exactly the files that flag would refuse.
+
 ## Exit Codes
 
 - **`index` (write):**
@@ -49,6 +59,11 @@ Lists specs that have no resolved code units (i.e., specs that claim authority o
   - `0`: Fresh.
   - `2`: Stale (committed index is out of date).
   - `3`: I/O or parse error.
+- **`index coverage`:**
+  - `0`: Reported (or, with `--fail-on-untraced`, fully claimed).
+  - `1`: `--fail-on-untraced` and at least one source file is floor-only or unclaimed.
+  - `2`: Stale (run `spec-spine index` first).
+  - `3`: I/O or parse error (no committed index).
 
 ## Example
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -59,6 +59,8 @@ bypass_prefixes = []
 waiver_keyword = "Spec-Drift-Waiver:"
 # Auto-waive PRs that only change dependency versions in package.json.
 auto_waive_dependency_only = false
+# Refuse a changed source file that no spec specifically claims (C-002).
+require_ownership = false
 
 [provenance.uri_schemes]
 # Open map of provenance kind to URI scheme.
@@ -95,6 +97,7 @@ extra_known_keys = []
 - **`bypass_prefixes`**: An additive list of path prefixes that bypass the coupling gate. This adds to the built-in floor (which includes `.github/`, `docs/`, lockfiles, etc.). You cannot remove entries from the built-in floor.
 - **`waiver_keyword`**: The string the gate looks for in a PR body to apply a waiver.
 - **`auto_waive_dependency_only`**: If `true`, the gate mechanically self-waives PRs where every non-bypassed changed path is a `package.json` with only dependency version-string changes (e.g., Dependabot PRs).
+- **`require_ownership`**: If `true`, a changed source file inside a discovered package that no spec *specifically* claims (a resolved unit or a `// Spec:` header; a manifest floor alone does not count) is a `C-002` violation. Deletions are exempt and waivers apply. Read `spec-spine index coverage` first: it lists exactly the files this flag would refuse. Default `false`.
 
 ### `[provenance.uri_schemes]`
 - An open map defining URI schemes for different provenance kinds.


### PR DESCRIPTION
Files spec **032** and implements it. Rewrites the exploratory branch `claude/spec-spine-test-options-vlxi1k` from scratch (evaluation below); that branch is not merged and can be deleted once this lands.

## Why

spec-spine refuses drift but has never required coverage. The gate skips a changed path that no spec claims ("not a coupling concern"), and the only coverage-shaped signal, `traceability.untracedCode`, is package-granular and read by nothing: a crate with one governed file and two hundred ungoverned ones reports as traced. "This application is fully specified" is not a state the tool can assert, which is the one thing the spec-first workflow (spec 025's `W-001` tier, the raft-corpus experiment) actually needs.

A finer metric has a trap: the manifest floor (`[package.metadata.<ns>].spec`, spec 005 §3.6) makes its spec an owner of every file in the package. Counted as coverage, any repo that follows the adoption guide reads 100% by construction; this repo would read 61/61. The number is only honest if the floor counts as **debt**.

## What

One classifier, one universe, two consumers:

- **`spec-spine index coverage [--json] [--fail-on-untraced]`**: per source file inside a discovered package, *specific* (a resolved ownership-bearing unit of any kind, or a `// Spec:` header), *floor-only* (only a manifest floor covers it), or *unclaimed*. Freshness-guarded like `couple` (stale index is exit 2). `--fail-on-untraced` is the whole-tree "fully specified" assertion for CI. Nothing is committed and no schema version moves: coverage is a read verb over `(tree, committed shards)`, the same shape as `index check`.
- **`[coupling] require_ownership`** (default `false`): the gate asks the same question of every changed source file and refuses a floor-only or unclaimed one as **`C-002`**, before the drift question, one code per path. Deletions are exempt (`DiffFile.deleted`, additive, set from `+++ /dev/null`): removing unowned code is how coverage goes up. Waivers apply. `references` never count, in either tier.
- The universe is source files inside packages, minus `resolver_exclusions` and the claim-aware bypass set (spec 009). Prose, manifests, workflows, config and the corpus can never raise `C-002`, and the report predicts the gate exactly because both call the same predicate.
- `couple`'s summary names both codes when both are present; with no `C-002` the wording is byte-identical to before.
- `coverage_json` facade; docs (adoption guide, architecture §3.1/§10.3, api, website config + CLI reference + troubleshooting), README, CLAUDE.md, the `/init` protocol in AGENTS.md, and an informational CI step.

**Measured on this repo:** `59/64 source files specifically claimed (92.2%); 5 floor-only, 0 unclaimed`. The five (`core/tests/query.rs`, `types/src/error.rs`, `types/tests/{config,dogfood,schema}.rs`) are owned only by their crate's floor; claiming them means editing spec 002 and the tier-1 spec 000, so the dogfood flag ships off with the debt named in `spec-spine.toml`.

## Evaluation of `claude/spec-spine-test-options-vlxi1k`

Right diagnosis and the right shape (opt-in `C-002`, file-granular predictor, default off), but not mergeable, and the problems were structural rather than cosmetic:

| issue | this PR |
|---|---|
| The coverage number counted the manifest floor as coverage, so it read 61/61 here and would read 100% on any manifest-annotated repo (the spec's own §3.3 called this a "known limit"; it is the exact case the objective named) | floor is a tier of its own and counts as debt |
| Predictor and gate disagreed on the universe: `untracedFiles` counted package source files, `C-002` fired on any non-bypassed path (`CLAUDE.md`, `spec-spine.toml`, `standards/spec/contract.md`) | one shared predicate |
| `untracedFiles` was computed by walking the working tree inside `load_committed_index`: `render` stopped being a projection of the shards (spec 011), the aggregate stopped being a function of the shard set (spec 024), and every `couple` run paid a full source walk | a read verb, nothing in the index |
| Deleting an unowned file raised `C-002` | `deleted` flag |
| `INDEX_SCHEMA_VERSION` bump plus a schema-file edit for two aggregate-only fields | no schema change |
| Record contradictions: the doc comment said a package `spec_ref` "does not claim files" while the spec, test and code said it does; `version.rs` said "no schema-file edit needed" after editing the schema; the commit said "every shardHash is unchanged" (all changed: `spec-spine.toml` is a global input) | n/a |
| No docs, no CLI wording (`couple` called a coverage violation "drift"), filed straight to `approved`, em dashes throughout, AI attribution trailers | all addressed; filed as draft |

## Findings raised (not fixed here)

1. **`references` leak into `C-001` ownership.** `index.rs` inserts every resolved location into `implementingPaths` without an ownership filter, and `owners_for_path` reads every implementing path as an owner. Reproduce on `main`: `printf 'specs/004-codebase-index/spec.md\n' > p && spec-spine couple --paths-from p` fails with `C-001` naming 025/026/027/030/031 as owners, purely because they `references` 004. This contradicts spec 004 §3.2 ("`references` is non-owning and contributes no traceability") and the constitution, and it also skews `orphanedSpecs` / `untracedCode`. Masked so far because every PR touching 004 included a referencing spec. The new classifier reads `resolvedUnits` with the ownership flag and does not inherit the bug; aligning `C-001` and the traceability lists is a separate amendment against 004/005 (spec 032 §4 names it).
2. **Five floor-only files** (above): a decision for a human, since two owners are tier-1.
3. **`couple.rs` hardcodes `specs/`** in `any_owner_in_diff` and `spec_id_for_spec_md_path`, so an adopter with a non-default `layout.specs_dir` can never clear `C-001` by editing their spec.
4. **raft-corpus**: `Cargo.toml` names `000-raft-bootstrap` as the manifest floor while the README says "000 owns no code"; once code lands, every unclaimed file will be floor-only under 000, which is exactly what `index coverage` will list and `require_ownership` will refuse. Its `spec-spine.toml` already sets `require_ownership = false` against this design.
5. **Kit sync**: `kit/AGENTS.md` should gain the `index coverage` init read once this lands (same follow-up shape as #67 for `compile --check`).

## Verification

| check | result |
|---|---|
| `cargo test --workspace --locked` | all suites pass (28 new tests: 9 coverage, 13 gate arms, 3 classifier unit tests, 2 CLI e2e, 1 diff-parser) |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `compile --check` | fresh, 33 shards |
| `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `couple --paths-from <change set>` | OK, 21 paths checked, no drift (032's edges clear everything; no waiver) |
| `index coverage` | 59/64, 5 floor-only, 0 unclaimed |

## Notes

Spec 032 is filed as `draft`, per the usual implement-then-ratify split.

Review pass (`/code-review`) found one item: the spec first claimed `couple`'s output was byte-identical with no `C-002` present, but every violation line is now prefixed with its code (`C-001 '<path>' changed without ...`) so the two codes read the same way. The prefix is intentional (one format, not two), and the draft's sentence was corrected to say exactly that; the summary and resolve lines keep their pre-032 wording. Flagging it here so the choice is reviewed rather than buried. Its `references` edge deliberately cites only `docs/design/00-architecture.md` (bypassed) and not spec 025's `spec.md`, to avoid widening finding 1's blast radius.
