### PR TITLE
chore(032): ratify spec 032 (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -248,8 +248,8 @@
       }
     ],
     "specId": "032-ownership-coverage",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "790f1465d780230e724e57bcdd47867ec69aae71856dcd9f34bd5cfc2c33e645"
+  "shardHash": "1d93aa9bc737ab9b4220be0678eae5bea3563e0f72856291725cf9594064b0ce"
 }

--- a/.derived/spec-registry/by-spec/032-ownership-coverage.json
+++ b/.derived/spec-registry/by-spec/032-ownership-coverage.json
@@ -133,10 +133,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/032-ownership-coverage/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "spec-spine refuses drift but has never required coverage. The coupling gate skips a changed path that no spec claims (\"not a coupling concern\"), and the only coverage-shaped signal, `traceability.untracedCode`, is package-granular and read by nothing, so a crate with one governed file and two hundred ungoverned ones reports as traced. \"This application is fully specified\" is therefore not a state the tool can assert. This spec adds two additive pieces that share one definition of ownership. `spec-spine index coverage` reports, per source file, whether a spec *specifically* claims it (a resolved unit or a comment header), whether only a package's manifest floor covers it, or whether nothing does; `--fail-on-untraced` turns that into the whole-tree assertion. `[coupling] require_ownership` (default false) makes the gate ask the same question of every changed source file and refuse a floor-only or unowned one as `C-002`, the PR-time ratchet. Coverage is a read verb over the tree and the committed ledger, like `index check`: nothing new is committed, no schema version moves, and the report predicts the gate exactly because both call one classifier over one universe.\n",
     "title": "Ownership coverage: `spec-spine index coverage` and the `C-002` ratchet"
   },
-  "shardHash": "562354b6106b4cab27995e4f3a47d77a41321dbe37429ff030613ee12ae7c8e2",
+  "shardHash": "71d23a503adb3411b7ba0f428eb6e1309a797a445b476ec4d80314713c00e4c4",
   "specVersion": "1.1.0"
 }

--- a/specs/032-ownership-coverage/spec.md
+++ b/specs/032-ownership-coverage/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "032-ownership-coverage"
 title: "Ownership coverage: `spec-spine index coverage` and the `C-002` ratchet"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-08-28"
 implementation: complete


### PR DESCRIPTION
Flips `032-ownership-coverage` to `approved` now that #68 has landed, and restamps its two shards (`compile` + `index`). Corpus: 33/33 approved.

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 33 shards |
| `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `registry status-report --nonzero-only` | `{ total: 33, approved: 33 }` |

Only `specs/032-ownership-coverage/spec.md` and its shards change; 032's own edit clears the coupling gate.