### PR TITLE
chore(release): bump package version to 0.11.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cb6de8279125f814c9972a0890e099c86663a990eee4d87e49391bea040f988b"
+  "shardHash": "5600c068b8bc900790f0b165df4eddf24a567b65f9c7564503ac0b8d42a19ec9"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.10.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.10.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.11.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.11.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.10.0",
-    "@spec-spine/cli-darwin-x64": "0.10.0",
-    "@spec-spine/cli-linux-x64": "0.10.0",
-    "@spec-spine/cli-linux-arm64": "0.10.0",
-    "@spec-spine/cli-win32-x64": "0.10.0"
+    "@spec-spine/cli-darwin-arm64": "0.11.0",
+    "@spec-spine/cli-darwin-x64": "0.11.0",
+    "@spec-spine/cli-linux-x64": "0.11.0",
+    "@spec-spine/cli-linux-arm64": "0.11.0",
+    "@spec-spine/cli-win32-x64": "0.11.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.10.0"
+version = "0.11.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What this ships

The **0.11.0** release. Since v0.10.0 (tagged 2026-07-03) two specs landed:

- **spec 031 (`031-registry-freshness-check`)**: `spec-spine compile --check`,
  the non-mutating registry freshness gate. It compiles in memory and compares
  against the committed shards without writing (exit 2 on stale, naming the
  drifted shards), closing the gap that let stale shardHashes reach main. CI
  now gates registry-shard freshness (#64, #65), and the `/init` protocol and
  kit are non-mutating (#66, #67).
- **spec 032 (`032-ownership-coverage`)**: `spec-spine index coverage`
  (`--json`, `--fail-on-untraced`), reporting each source file as specifically
  claimed, floor-only, or unclaimed, with the manifest floor counted as debt;
  and the opt-in `[coupling] require_ownership` ratchet, which refuses a
  changed floor-only or unclaimed source file as `C-002` using the same
  classifier as the report.

The repository rename (#61) rides along in the tree; it has no binary impact.

## Why a MINOR bump

Additive, opt-in behavior only: a new flag, a new read verb, and a new
optional config key; no breaking change; registry and index schema versions
stay at 1.1.0. Package axis only: `0.10.0 -> 0.11.0`, bumped in lockstep
across `Cargo.toml`, `npm/package.json`, and `py/pyproject.toml` via
`scripts/bump_version.py 0.11.0` (`--check` green). `Cargo.lock` re-locked to
the three workspace crates at 0.11.0; the `spec-spine` npm package index shard
regenerated to 0.11.0.

## Verification (local, green)

- `cargo build --release --locked`, `cargo test --workspace --locked`,
  `cargo package --workspace --locked` (all three crates verified in
  dependency order).
- Governed loop: `compile` (33 specs, 0 warn), `index check` (fresh),
  `lint --fail-on-warn` (0/0/0), `couple --base origin/main --head HEAD`
  (only the two mechanical shim drifts below, cleared by the waiver).

## Drift waiver

The version bump touches two claimed distribution-shim manifests without a
behavioral change, so a spec edit would be inappropriate (per the coherence
guard, we waive rather than amend an owning spec to satisfy a mechanical
refresh).

Spec-Drift-Waiver: Mechanical package-version bump to 0.11.0; npm/package.json (007-distribution) and py/pyproject.toml (008-python-distribution) change only their version and version pins in lockstep with Cargo.toml, with no behavioral change to either shim, so no owning-spec edit is warranted.

## After merge (human checkpoint)

Publishing is tag-gated and irreversible; it is not part of this PR. Once
merged, a maintainer tags the release to fan out to crates.io, prebuilt
binaries, npm, and PyPI:

```sh
git tag v0.11.0 && git push origin v0.11.0
```
