### PR TITLE
feat(033): V-014, dependency cycle refusal on `depends_on`

### DIFF
--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -1,0 +1,50 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "001-compile-registry",
+      "016-short-id-resolution"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/compile.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      }
+    ],
+    "specId": "033-dependency-cycle-refusal",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "3d3355f2d45a5c16debe8613b4f0e19655eb6212c14cee7f1a599e96dc37ff60"
+}

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -43,8 +43,8 @@
       }
     ],
     "specId": "033-dependency-cycle-refusal",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3d3355f2d45a5c16debe8613b4f0e19655eb6212c14cee7f1a599e96dc37ff60"
+  "shardHash": "41437c528ed2f1d2e921c9579807ce10ca75907d2c595853c353db89e49d8034"
 }

--- a/.derived/spec-registry/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/spec-registry/by-spec/033-dependency-cycle-refusal.json
@@ -1,0 +1,50 @@
+{
+  "record": {
+    "created": "2026-09-03",
+    "dependsOn": [
+      "001-compile-registry",
+      "016-short-id-resolution"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      }
+    ],
+    "id": "033-dependency-cycle-refusal",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "risk": "low",
+    "sectionHeadings": [
+      "033: Dependency cycle refusal",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The check",
+      "3.2 Cross-spec, so never sharded",
+      "3.3 Determinism",
+      "3.4 Placement: compile, not lint",
+      "3.5 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/033-dependency-cycle-refusal/spec.md",
+    "status": "draft",
+    "summary": "`depends_on` is the one edge whose graph shape spec-spine never checked. A dangling target is a `V-010` warning, but a cycle passes: two specs that depend on each other compile with zero warnings and lint clean at every severity, so a corpus can be green and structurally unexecutable. This spec adds `V-014`, an error-tier, corpus-wide check that reports a cycle in the resolved `depends_on` graph and names the path. It is the sibling of `V-010` and lives beside it in `compile.rs`, the first step of the gate chain and the step `compile --check` verifies, so a cycle fails the build at the earliest point and no new verb is introduced. `V-014` joins `CROSS_SPEC_CODES`, so it is never stored in a registry shard and is recomputed from the assembled records on read; both the fresh-compile and committed-shard paths reach one detector, so the two views cannot disagree. Scheduling semantics stay out: readiness, contract pinning and downstream invalidation depend on merge history and a run journal, which are not a pure function of the corpus and therefore not spec-spine's to compute.\n",
+    "title": "Dependency cycle refusal: the `V-014` corpus-wide check on `depends_on`"
+  },
+  "shardHash": "8e56ac589f5da11b18bfc67f16c85973d2ae5f1e31ca8abb9e7f669a12ee90f9",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/spec-registry/by-spec/033-dependency-cycle-refusal.json
@@ -41,10 +41,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/033-dependency-cycle-refusal/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`depends_on` is the one edge whose graph shape spec-spine never checked. A dangling target is a `V-010` warning, but a cycle passes: two specs that depend on each other compile with zero warnings and lint clean at every severity, so a corpus can be green and structurally unexecutable. This spec adds `V-014`, an error-tier, corpus-wide check that reports a cycle in the resolved `depends_on` graph and names the path. It is the sibling of `V-010` and lives beside it in `compile.rs`, the first step of the gate chain and the step `compile --check` verifies, so a cycle fails the build at the earliest point and no new verb is introduced. `V-014` joins `CROSS_SPEC_CODES`, so it is never stored in a registry shard and is recomputed from the assembled records on read; both the fresh-compile and committed-shard paths reach one detector, so the two views cannot disagree. Scheduling semantics stay out: readiness, contract pinning and downstream invalidation depend on merge history and a run journal, which are not a pure function of the corpus and therefore not spec-spine's to compute.\n",
     "title": "Dependency cycle refusal: the `V-014` corpus-wide check on `depends_on`"
   },
-  "shardHash": "8e56ac589f5da11b18bfc67f16c85973d2ae5f1e31ca8abb9e7f669a12ee90f9",
+  "shardHash": "edc8debf7e8ab3ca2314bdba9ee2271f52f069309dbfa8807b969749a3030a4d",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -19,10 +19,11 @@ use crate::index::Freshness;
 use crate::{canonical_json, hash, markdown, shard};
 
 /// Validation codes whose verdict depends on the whole corpus, not one spec:
-/// duplicate id/prefix and dangling/unresolved edge targets. They are NOT
-/// stored per registry shard (storing them would let a sibling spec's PR stale
-/// this shard); they are recomputed from the assembled record set on read.
-const CROSS_SPEC_CODES: &[&str] = &["V-003", "V-004", "V-008", "V-010"];
+/// duplicate id/prefix, dangling/unresolved edge targets, and a `depends_on`
+/// cycle. They are NOT stored per registry shard (storing them would let a
+/// sibling spec's PR stale this shard); they are recomputed from the assembled
+/// record set on read.
+const CROSS_SPEC_CODES: &[&str] = &["V-003", "V-004", "V-008", "V-010", "V-014"];
 
 /// The cap on **undeclared** `extra_frontmatter` keys before `V-007` fires.
 /// Keys listed in `frontmatter.extra_known_keys` are intentional and exempt;
@@ -169,6 +170,9 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
         records.push(build_record(p.fm, p.spec_path, &p.body));
     }
     records.sort_by(|a, b| a.id.cmp(&b.id));
+    // V-014 reads the records, not the parsed frontmatter, so it sees the
+    // short-id-resolved `depends_on` (spec 016) rather than the authored text.
+    detect_dependency_cycle(&records, &mut violations);
 
     // --- shard projection + aggregate content hash (spec 024) ---
     // One shard per spec, each carrying its compiled record, its corpus-
@@ -364,6 +368,86 @@ fn detect_duplicates(specs: &[(String, String)], out: &mut Vec<Violation>) {
                 format!("duplicate spec id '{id}' ({count} specs)"),
                 None,
             ));
+        }
+    }
+}
+
+/// V-014 (error): a cycle in the `depends_on` graph (spec 033).
+///
+/// spec-spine attaches no scheduling semantics to `depends_on`, but a cycle is
+/// a corpus defect under any reading: the edge says one spec's authority rests
+/// on another's, and a cycle asserts that of every spec on it at once. It is
+/// also the one `depends_on` defect its sibling check cannot see, because every
+/// id on a cycle resolves; V-010 fires only on a dangling target.
+///
+/// Iterative DFS over an explicit stack, so a deep corpus cannot overflow the
+/// real one. Edges leaving the corpus are skipped (V-010's finding, not this
+/// one). Start order is `records` order, which both callers sort by id, and
+/// child order is authored order, so which cycle is found is a pure function of
+/// the corpus. One cycle is reported per compile: the path names every spec on
+/// it, and breaking it is what reveals any other.
+fn detect_dependency_cycle(records: &[SpecRecord], out: &mut Vec<Violation>) {
+    const WHITE: u8 = 0;
+    const GREY: u8 = 1;
+    const BLACK: u8 = 2;
+
+    let ids: std::collections::BTreeSet<&str> = records.iter().map(|r| r.id.as_str()).collect();
+    let mut deps: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut spec_paths: BTreeMap<&str, &str> = BTreeMap::new();
+    for r in records {
+        deps.insert(
+            r.id.as_str(),
+            r.depends_on
+                .iter()
+                .map(String::as_str)
+                .filter(|d| ids.contains(d))
+                .collect(),
+        );
+        spec_paths.insert(r.id.as_str(), r.spec_path.as_str());
+    }
+    let mut color: BTreeMap<&str, u8> = ids.iter().map(|id| (*id, WHITE)).collect();
+
+    for r in records {
+        if color.get(r.id.as_str()).copied().unwrap_or(BLACK) != WHITE {
+            continue;
+        }
+        // (spec id, index of the next depends_on entry to walk from it).
+        let mut stack: Vec<(&str, usize)> = vec![(r.id.as_str(), 0)];
+        color.insert(r.id.as_str(), GREY);
+        while let Some(&(node, at)) = stack.last() {
+            let Some(child) = deps.get(node).and_then(|d| d.get(at)).copied() else {
+                color.insert(node, BLACK);
+                stack.pop();
+                continue;
+            };
+            if let Some(top) = stack.last_mut() {
+                top.1 = at + 1;
+            }
+            match color.get(child).copied().unwrap_or(BLACK) {
+                WHITE => {
+                    color.insert(child, GREY);
+                    stack.push((child, 0));
+                }
+                GREY => {
+                    // `child` is still on the current path, so everything from
+                    // its position up to the top of the stack is the cycle;
+                    // naming it once more closes the path into a loop.
+                    let from = stack.iter().position(|&(n, _)| n == child).unwrap_or(0);
+                    let mut cycle: Vec<&str> = stack[from..].iter().map(|&(n, _)| n).collect();
+                    cycle.push(child);
+                    let at_path = cycle
+                        .first()
+                        .and_then(|id| spec_paths.get(*id))
+                        .map(|p| p.to_string());
+                    out.push(error(
+                        "V-014",
+                        format!("depends_on cycle: {}", cycle.join(" -> ")),
+                        at_path,
+                    ));
+                    return;
+                }
+                _ => {}
+            }
         }
     }
 }
@@ -574,10 +658,12 @@ pub fn load_committed_registry(cfg: &Config, repo_root: &Path) -> Result<Registr
     })
 }
 
-/// Re-derive the corpus-wide validation findings (V-003/004/008/010) from the
-/// assembled records. A local mirror of the cross-spec checks in [`compile`]
-/// (kept equal by value, not linkage), so the assembled registry's validation
-/// matches a fresh compile's for a corpus that has any. Records are id-sorted,
+/// Re-derive the corpus-wide validation findings (V-003/004/008/010/014) from
+/// the assembled records. A local mirror of the cross-spec checks in
+/// [`compile`] (kept equal by value for V-003/004/008/010, and by linkage for
+/// V-014, which both paths reach through [`detect_dependency_cycle`]), so the
+/// assembled registry's validation matches a fresh compile's for a corpus that
+/// has any. Records are id-sorted,
 /// which equals compile's discovery order, so V-004's "shared by" pairing agrees.
 fn recompute_cross_spec_violations(records: &[SpecRecord]) -> Vec<Violation> {
     let mut out: Vec<Violation> = Vec::new();
@@ -613,6 +699,7 @@ fn recompute_cross_spec_violations(records: &[SpecRecord]) -> Vec<Violation> {
             }
         }
     }
+    detect_dependency_cycle(records, &mut out);
     out
 }
 

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -569,6 +569,181 @@ fn dangling_short_id_is_left_unchanged_and_still_warns() {
     assert_eq!(rec.depends_on, vec!["999".to_string()]);
 }
 
+// ===== V-014: depends_on cycles (spec 033) =====
+
+fn cycle_violation(outcome: &spec_spine_core::CompileOutcome) -> spec_spine_types::Violation {
+    outcome
+        .registry
+        .validation
+        .violations
+        .iter()
+        .find(|v| v.code == "V-014")
+        .cloned()
+        .expect("V-014 expected")
+}
+
+#[test]
+fn two_spec_dependency_cycle_is_an_error_naming_the_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"011-b\"]\n");
+    write_spec(tmp.path(), "011-b", "011-b", "depends_on: [\"010-a\"]\n");
+    let cfg = Config::default();
+
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+
+    assert!(!outcome.validation_passed, "a cycle must fail validation");
+    let v = cycle_violation(&outcome);
+    assert_eq!(v.severity, Severity::Error);
+    assert_eq!(v.message, "depends_on cycle: 010-a -> 011-b -> 010-a");
+    // Anchored at the spec the path starts from, so the diagnostic points
+    // somewhere a reader can open.
+    assert_eq!(v.path.as_deref(), Some("specs/010-a/spec.md"));
+    // Every id on the cycle resolves, so its sibling check stays quiet: V-014
+    // is the only thing that can see this.
+    assert!(!codes(&outcome).contains(&"V-010".to_string()));
+}
+
+#[test]
+fn self_dependency_is_a_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"010-a\"]\n");
+    let cfg = Config::default();
+
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+
+    assert!(!outcome.validation_passed);
+    assert_eq!(
+        cycle_violation(&outcome).message,
+        "depends_on cycle: 010-a -> 010-a"
+    );
+}
+
+#[test]
+fn cycle_reached_through_a_longer_chain_names_only_the_loop() {
+    // 010 -> 011 -> 012 -> 013 -> 011: the entry spec is on the path to the
+    // cycle but not on the cycle, so it must not appear in the reported loop.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"011-b\"]\n");
+    write_spec(tmp.path(), "011-b", "011-b", "depends_on: [\"012-c\"]\n");
+    write_spec(tmp.path(), "012-c", "012-c", "depends_on: [\"013-d\"]\n");
+    write_spec(tmp.path(), "013-d", "013-d", "depends_on: [\"011-b\"]\n");
+    let cfg = Config::default();
+
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+
+    let v = cycle_violation(&outcome);
+    assert_eq!(
+        v.message,
+        "depends_on cycle: 011-b -> 012-c -> 013-d -> 011-b"
+    );
+    assert_eq!(v.path.as_deref(), Some("specs/011-b/spec.md"));
+}
+
+#[test]
+fn a_cycle_written_with_short_ids_is_still_a_cycle() {
+    // Spec 016 resolves `011` to `011-b` before the records are built, so the
+    // detector must see the resolved graph, not the authored text.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"011\"]\n");
+    write_spec(tmp.path(), "011-b", "011-b", "depends_on: [\"010\"]\n");
+    let cfg = Config::default();
+
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+
+    assert_eq!(
+        cycle_violation(&outcome).message,
+        "depends_on cycle: 010-a -> 011-b -> 010-a"
+    );
+}
+
+#[test]
+fn a_dangling_dependency_is_v010_and_never_a_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"999-gone\"]\n");
+    let cfg = Config::default();
+
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+
+    assert!(codes(&outcome).contains(&"V-010".to_string()));
+    assert!(!codes(&outcome).contains(&"V-014".to_string()));
+}
+
+#[test]
+fn a_diamond_is_not_a_cycle() {
+    // Two paths to one dependency revisit a BLACK node; only a GREY one (still
+    // on the current path) is a cycle.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-base", "010-base", "");
+    write_spec(tmp.path(), "011-l", "011-l", "depends_on: [\"010-base\"]\n");
+    write_spec(tmp.path(), "012-r", "012-r", "depends_on: [\"010-base\"]\n");
+    write_spec(
+        tmp.path(),
+        "013-top",
+        "013-top",
+        "depends_on: [\"011-l\", \"012-r\"]\n",
+    );
+    let cfg = Config::default();
+
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+
+    assert!(outcome.validation_passed);
+    assert!(!codes(&outcome).contains(&"V-014".to_string()));
+}
+
+#[test]
+fn the_reported_cycle_is_deterministic_across_runs() {
+    // Two disjoint cycles: whichever is reported, it must be the same one
+    // every time, since only that makes the registry reproducible.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"011-b\"]\n");
+    write_spec(tmp.path(), "011-b", "011-b", "depends_on: [\"010-a\"]\n");
+    write_spec(tmp.path(), "020-c", "020-c", "depends_on: [\"021-d\"]\n");
+    write_spec(tmp.path(), "021-d", "021-d", "depends_on: [\"020-c\"]\n");
+    let cfg = Config::default();
+
+    let first = compile(&cfg, tmp.path()).unwrap();
+    let second = compile(&cfg, tmp.path()).unwrap();
+
+    assert_eq!(first.json, second.json);
+    assert_eq!(
+        cycle_violation(&first).message,
+        cycle_violation(&second).message
+    );
+}
+
+#[test]
+fn the_cycle_is_not_stored_in_a_shard_but_is_recomputed_on_read() {
+    // Cross-spec codes never land in a shard (a sibling's PR would stale it),
+    // so the committed reader has to re-derive V-014. Both paths run the same
+    // detector, so the two views agree.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "010-a", "010-a", "depends_on: [\"011-b\"]\n");
+    write_spec(tmp.path(), "011-b", "011-b", "depends_on: [\"010-a\"]\n");
+    let cfg = Config::default();
+    let outcome = compile(&cfg, tmp.path()).unwrap();
+    for shard in &outcome.shards.spec_shards {
+        assert!(
+            !shard.local_violations.iter().any(|v| v.code == "V-014"),
+            "V-014 must not be stored per shard"
+        );
+    }
+
+    write_shards(tmp.path(), &cfg);
+    let committed = spec_spine_core::load_committed_registry(&cfg, tmp.path()).unwrap();
+
+    let from_shards: Vec<&spec_spine_types::Violation> = committed
+        .validation
+        .violations
+        .iter()
+        .filter(|v| v.code == "V-014")
+        .collect();
+    assert_eq!(from_shards.len(), 1);
+    assert_eq!(
+        from_shards[0].message,
+        "depends_on cycle: 010-a -> 011-b -> 010-a"
+    );
+}
+
 // ===== registry freshness, `compile --check` (spec 031) =====
 
 /// Emit the shard tree the way the CLI does, so a freshness check has a

--- a/specs/033-dependency-cycle-refusal/spec.md
+++ b/specs/033-dependency-cycle-refusal/spec.md
@@ -1,0 +1,202 @@
+---
+id: "033-dependency-cycle-refusal"
+title: "Dependency cycle refusal: the `V-014` corpus-wide check on `depends_on`"
+status: draft
+kind: "tooling"
+created: "2026-09-03"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "001-compile-registry"
+  - "016-short-id-resolution"
+extends:
+  # The detector, its place in the cross-spec code set, and both call sites
+  # (the fresh compile and the committed-shard reader).
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+summary: >
+  `depends_on` is the one edge whose graph shape spec-spine never checked. A
+  dangling target is a `V-010` warning, but a cycle passes: two specs that
+  depend on each other compile with zero warnings and lint clean at every
+  severity, so a corpus can be green and structurally unexecutable. This spec
+  adds `V-014`, an error-tier, corpus-wide check that reports a cycle in the
+  resolved `depends_on` graph and names the path. It is the sibling of `V-010`
+  and lives beside it in `compile.rs`, the first step of the gate chain and the
+  step `compile --check` verifies, so a cycle fails the build at the earliest
+  point and no new verb is introduced. `V-014` joins
+  `CROSS_SPEC_CODES`, so it is never stored in a registry shard and is
+  recomputed from the assembled records on read; both the fresh-compile and
+  committed-shard paths reach one detector, so the two views cannot disagree.
+  Scheduling semantics stay out: readiness, contract pinning and downstream
+  invalidation depend on merge history and a run journal, which are not a pure
+  function of the corpus and therefore not spec-spine's to compute.
+---
+
+# 033: Dependency cycle refusal
+
+## 1. Purpose
+
+Of the eight typed edges, `depends_on` is the only one that describes an
+ordering. spec-spine validates that its targets exist (`V-010`, a warning since
+spec 001) and nothing else about the shape of the graph they form. A cycle
+therefore compiled clean, before this spec:
+
+```
+spec-spine compile                             -> compiled 3 spec(s), 0 warning(s)
+spec-spine lint --fail-on-warn --fail-on-info  -> 0 error(s), 0 warning(s), 0 info
+```
+
+That corpus is green and cannot be executed in dependency order by anything.
+The defect is real regardless of who consumes the graph: the edge asserts that
+one spec's authority rests on another's, and a cycle asserts that of every spec
+on it simultaneously, which is not a claim an author can have meant.
+
+Today the failure surfaces late and elsewhere. A consumer that orders work by
+`depends_on` discovers it at scheduling time, in its own process, against a
+corpus it does not own; the author who wrote the cycle saw a green gate on the
+PR that introduced it. Moving the check here puts the diagnosis at the point of
+authorship, in the repository that caused it, on the same run that already
+answers every other question about the corpus.
+
+The constitution decides how much of the graph belongs here. Principle 2:
+every artifact is a pure function of `(config, file contents)`. Cycle detection
+is exactly that. Readiness ("is every dependency shipped?"), contract pinning
+and downstream invalidation are not: they need merge history and a run journal,
+inputs that no compile can see. That line is the whole scope of this spec.
+
+## 2. Territory
+
+`compile.rs`: the `detect_dependency_cycle` detector, the `V-014` entry in
+`CROSS_SPEC_CODES`, and the two call sites that reach it. `tests/compile.rs`:
+the coverage in section 3.5. Both are spec 001's units, extended additively.
+
+No new subcommand, no new config key, no signature change, no emitted-artifact
+change, and no schema version moves: `V-014` is an ordinary `Violation` in the
+`validation` report that already carries `V-003` through `V-013`.
+
+## 3. Behavior
+
+### 3.1 The check
+
+Over the assembled `SpecRecord` set, `V-014` reports a cycle in the directed
+graph whose edges are each spec's `depends_on` entries:
+
+```
+V-014  [specs/010-a/spec.md] depends_on cycle: 010-a -> 011-b -> 010-a
+```
+
+Severity **error**, so it fails validation and the CLI's exit code 1, the same
+tier as `V-003`, `V-004` and `V-008`. A cycle has no legitimate reading, so
+there is nothing for a warning tier to defer to.
+
+- **Edges leaving the corpus are skipped.** A `depends_on` naming a spec that
+  does not exist is `V-010`'s finding; a dangling target is never reported as
+  a cycle, and never suppresses one elsewhere.
+- **A self-dependency is a cycle** of length one, reported as `010-a ->
+  010-a`.
+- **Short ids resolve first.** The detector reads the records, not the parsed
+  frontmatter, so a cycle written with spec 016's short form (`depends_on:
+  ["011"]`) is seen in its resolved form and reported with full ids.
+- **The path is the loop, not the walk.** When a cycle is reached through
+  specs that are not on it, only the loop is named: for `010 -> 011 -> 012 ->
+  013 -> 011`, the message is `011-b -> 012-c -> 013-d -> 011-b`. The
+  violation's `path` is the `spec.md` of the first spec on that loop.
+- **One cycle per compile.** The first cycle found is reported and the walk
+  stops. A corpus can hold several, and enumerating all elementary cycles is
+  worth neither the cost nor the wall of output; breaking the reported one is
+  what reveals the next.
+
+### 3.2 Cross-spec, so never sharded
+
+`V-014` joins `CROSS_SPEC_CODES`. A cycle is a property of the record set, not
+of any one spec, so storing it in a shard would let a sibling spec's PR stale
+that shard, which is precisely what spec 024's sharding exists to prevent. It
+is therefore recomputed from the assembled records by
+`load_committed_registry`, as `V-003`, `V-004`, `V-008` and `V-010` already
+are.
+
+The fresh-compile path and the committed-shard path call **one** detector.
+The four older cross-spec codes are duplicated between the two and kept equal
+by value; `V-014` is kept equal by linkage instead, which is the stronger
+guarantee and the shape a future consolidation should take.
+
+### 3.3 Determinism
+
+The detector is a pure function of the record set. Start order is the record
+order, which both callers sort by id; child order is the authored `depends_on`
+order with out-of-corpus targets filtered out. So for a corpus with more than
+one cycle, *which* cycle is reported is fixed by the corpus alone, and two
+compiles of one tree emit byte-identical JSON. The walk is an iterative DFS
+over an explicit stack rather than recursion, so corpus depth cannot overflow
+the real stack: core stays panic-free on user input.
+
+### 3.4 Placement: compile, not lint
+
+The two code families are disjoint by design and neither reprints the other's
+findings: `compile` emits the structural `V-` codes, `lint` emits the
+convention `L-` codes and discards the violations of the compile it runs
+internally. That is long-standing behavior and is not specific to this code: a
+`V-008` corpus is `exit 1` naming the violation under `compile` and `exit 0`,
+silent, under `lint --fail-on-warn`. `V-014` behaves exactly like its siblings,
+and putting it in `lint` would have meant a second reporting path for a
+structural finding rather than a shared one.
+
+Compile is the right home on all three counts:
+
+- **The question is structural.** `V-010` answers "does this edge's target
+  exist?"; "do these edges form a cycle?" is the same question about the same
+  edge, one level up. Corpus well-formedness, not corpus convention.
+- **The cross-spec machinery only exists here.** Being a property of the
+  record set, `V-014` must be excluded from the shards and re-derived on read
+  (section 3.2), and `load_committed_registry` is the only place that happens.
+- **It fails at the earliest point.** `compile` is step one of the
+  `compile -> index -> lint -> couple` chain and the first thing CI calls, and
+  `compile --check` reports it too (exit 1, validation failed), so a corpus
+  cannot reach the later gates with a cycle in it.
+
+What this does **not** do is make `index`, `lint`, `couple` or the `registry`
+queries print the cycle; they exit on their own findings as before. The
+validation report is carried on the `Registry` those consumers hold, so a
+programmatic reader sees `V-014` without a new API; a CLI reader sees it from
+`compile`.
+
+### 3.5 Tests (minimum)
+
+- A two-spec cycle is a `V-014` error naming `010-a -> 011-b -> 010-a`,
+  anchored at the first spec's path, with validation failing and no `V-010`.
+- A self-dependency is a cycle.
+- A cycle reached through a longer chain names only the loop.
+- A cycle authored with short ids is reported with resolved ids.
+- A dangling `depends_on` is `V-010` and never `V-014`.
+- A diamond (two paths to one dependency) is not a cycle.
+- With two disjoint cycles, the reported one is identical across runs and the
+  emitted JSON is byte-identical.
+- `V-014` appears in no shard's local violations, and
+  `load_committed_registry` re-derives exactly one, with the same message.
+
+## 4. Out of scope
+
+**Readiness, pinning, and invalidation.** Whether a dependency is *shipped*,
+what its contract hashed to when a dependent was built, and which dependents an
+amendment invalidates are all functions of merge history and a run journal.
+They cannot be computed from `(config, file contents)`, so they belong to the
+consumer that owns that state, not to the compiler. A consumer must keep its
+own cycle refusal too: it drives corpora compiled by spec-spine versions it
+does not choose, and this check is defense in depth for it, not a replacement.
+
+**Ordinal monotonicity.** Requiring every `depends_on` target to be
+lower-numbered makes the ordinal the build order, which is a useful convention
+for corpora that adopt it and false for ones that do not: a corpus can depend
+upward and still be perfectly executable, ordering itself by the graph rather
+than by the number. If it lands it is opt-in config, never a default, and it is
+a separate spec.
+
+**Cycles in the other edges.** `extends`, `refines`, `co_authority` and
+`constrains` form graphs too, and a cycle in them is a different question with
+a different answer (a mutual `co_authority` pair is ordinary and correct). This
+spec is about `depends_on` only.
+
+**Promoting `V-010`.** Whether a dangling `depends_on` should be an error
+rather than a warning is a defensible change and a breaking one for adopters
+who rely on the current tier. It is not bundled here.

--- a/specs/033-dependency-cycle-refusal/spec.md
+++ b/specs/033-dependency-cycle-refusal/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "033-dependency-cycle-refusal"
 title: "Dependency cycle refusal: the `V-014` corpus-wide check on `depends_on`"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-03"
 implementation: complete
@@ -37,8 +37,8 @@ summary: >
 
 ## 1. Purpose
 
-Of the eight typed edges, `depends_on` is the only one that describes an
-ordering. spec-spine validates that its targets exist (`V-010`, a warning since
+Beside the eight typed edges, `depends_on` is the one frontmatter relation that
+describes an ordering. spec-spine validates that its targets exist (`V-010`, a warning since
 spec 001) and nothing else about the shape of the graph they form. A cycle
 therefore compiled clean, before this spec:
 


### PR DESCRIPTION
Adds `V-014`, an error-tier, corpus-wide check that refuses a cycle in the
resolved `depends_on` graph, and files + ratifies spec 033 that governs it.

`depends_on` is the one frontmatter relation that describes an ordering, and
until now spec-spine checked only that its targets exist (`V-010`, a warning).
The shape of the graph went unchecked, so two specs depending on each other
compiled with zero warnings and linted clean at every severity: a corpus that
is green and structurally unexecutable. `V-014` reports the cycle and names the
path.

## Design

- The detector (`detect_dependency_cycle`) lives beside `V-010` in
  `compile.rs`, the first step of the gate chain and the step `compile --check`
  verifies, so a cycle fails at the earliest point. No new verb.
- `V-014` joins `CROSS_SPEC_CODES`, so it is never stored in a registry shard
  and is recomputed from the assembled records on read. Both the fresh-compile
  and the committed-shard path reach the one detector, so the two views cannot
  disagree.
- Scheduling semantics stay out of scope. Readiness, contract pinning and
  downstream invalidation need merge history and a run journal, which are not a
  pure function of the corpus and so are not spec-spine's to compute
  (constitution IV).

## Ratification

The second commit flips 033 to `approved` and restamps its two shards. Corpus:
34/34 approved.

It also corrects one claim in §1, caught before ratification so the wrong
vocabulary did not become durable: the section opened "Of the eight typed
edges, `depends_on` is the only one that describes an ordering", but
`depends_on` is not one of the eight. `frontmatter.rs` classes it as
optional-descriptive and `standards/spec/contract.md` fixes the eight as
`establishes` through `references`. Reworded to "Beside the eight typed edges,
`depends_on` is the one frontmatter relation that describes an ordering".

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 34 shards |
| `index check` | fresh |
| `lint --fail-on-warn --fail-on-info` | 0 / 0 / 0 |
| `couple --base origin/main --head HEAD` | OK, 3 paths, no drift |
| `registry status-report --nonzero-only` | `{ total: 34, approved: 34 }` |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace --locked` | all pass |

`compile.rs` and `tests/compile.rs` are claimed by 001 through 033's `extends`
edges, and 033's own `spec.md` changes in the same PR, so the coupling gate
self-clears. No waiver needed.
