### PR TITLE
fix(033): assert the V-014 DFS invariants instead of silently falling back

### DIFF
--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -439,28 +439,34 @@ fn detect_dependency_cycle(records: &[SpecRecord], out: &mut Vec<Violation>) {
                     // `child` is still on the current path, so everything from
                     // its position up to the top of the stack is the cycle;
                     // naming it once more closes the path into a loop.
-                    // GREY holds exactly while a node is on the current
-                    // stack: set on push, cleared to BLACK on pop. The search
-                    // therefore always hits. Assert it in debug, because the
-                    // fallback would still report a real cycle but would name
-                    // the DFS root instead of the spec the cycle re-enters.
+                    //
+                    // GREY holds exactly while a node is on the current stack:
+                    // set on push, cleared to BLACK on pop. The search
+                    // therefore always hits, and `debug_assert` makes a broken
+                    // invariant fail `cargo test` loudly. Release does not
+                    // panic (that would abort the gate outside its documented
+                    // exit codes) and does not invent a path either: reaching
+                    // this arm proves a cycle through `child` exists, so the
+                    // fallback reports that much and drops only the precision
+                    // it can no longer vouch for.
                     let entry = stack.iter().position(|&(n, _)| n == child);
                     debug_assert!(
                         entry.is_some(),
                         "V-014: GREY node absent from the current stack"
                     );
-                    let from = entry.unwrap_or(0);
-                    let mut cycle: Vec<&str> = stack[from..].iter().map(|&(n, _)| n).collect();
-                    cycle.push(child);
-                    let at_path = cycle
-                        .first()
-                        .and_then(|id| spec_paths.get(*id))
-                        .map(|p| p.to_string());
-                    out.push(error(
-                        "V-014",
-                        format!("depends_on cycle: {}", cycle.join(" -> ")),
-                        at_path,
-                    ));
+                    // `child` is the spec the cycle re-enters, so it is on the
+                    // cycle whichever branch below runs.
+                    let at_path = spec_paths.get(child).map(|p| p.to_string());
+                    let message = match entry {
+                        Some(from) => {
+                            let mut cycle: Vec<&str> =
+                                stack[from..].iter().map(|&(n, _)| n).collect();
+                            cycle.push(child);
+                            format!("depends_on cycle: {}", cycle.join(" -> "))
+                        }
+                        None => format!("depends_on cycle through '{child}'"),
+                    };
+                    out.push(error("V-014", message, at_path));
                     return;
                 }
                 _ => {}

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -408,14 +408,19 @@ fn detect_dependency_cycle(records: &[SpecRecord], out: &mut Vec<Violation>) {
     let mut color: BTreeMap<&str, u8> = ids.iter().map(|id| (*id, WHITE)).collect();
 
     for r in records {
-        // Every record id was seeded into `color` above, so the fallback is
-        // unreachable. Assert it in debug rather than let a future change
-        // silently skip a start node and miss a cycle entirely.
+        // `color` is seeded from `ids`, which is collected from these same
+        // `records` four lines up, and no later insert adds a key (every
+        // `child` is filtered through `ids`). The fallback is therefore
+        // unreachable. It defaults to WHITE rather than BLACK so that if it
+        // ever became reachable the node would still be walked: a redundant
+        // walk is harmless, whereas defaulting to BLACK would skip the node
+        // and miss a cycle rooted there, which is the one outcome a gate must
+        // never produce silently.
         debug_assert!(
             color.contains_key(r.id.as_str()),
-            "V-014: record id absent from the color map"
+            "dependency-cycle detector: record id absent from the color map"
         );
-        if color.get(r.id.as_str()).copied().unwrap_or(BLACK) != WHITE {
+        if color.get(r.id.as_str()).copied().unwrap_or(WHITE) != WHITE {
             continue;
         }
         // (spec id, index of the next depends_on entry to walk from it).
@@ -452,7 +457,7 @@ fn detect_dependency_cycle(records: &[SpecRecord], out: &mut Vec<Violation>) {
                     let entry = stack.iter().position(|&(n, _)| n == child);
                     debug_assert!(
                         entry.is_some(),
-                        "V-014: GREY node absent from the current stack"
+                        "dependency-cycle detector: GREY node absent from the stack"
                     );
                     // `child` is the spec the cycle re-enters, so it is on the
                     // cycle whichever branch below runs.

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -408,6 +408,13 @@ fn detect_dependency_cycle(records: &[SpecRecord], out: &mut Vec<Violation>) {
     let mut color: BTreeMap<&str, u8> = ids.iter().map(|id| (*id, WHITE)).collect();
 
     for r in records {
+        // Every record id was seeded into `color` above, so the fallback is
+        // unreachable. Assert it in debug rather than let a future change
+        // silently skip a start node and miss a cycle entirely.
+        debug_assert!(
+            color.contains_key(r.id.as_str()),
+            "V-014: record id absent from the color map"
+        );
         if color.get(r.id.as_str()).copied().unwrap_or(BLACK) != WHITE {
             continue;
         }
@@ -432,7 +439,17 @@ fn detect_dependency_cycle(records: &[SpecRecord], out: &mut Vec<Violation>) {
                     // `child` is still on the current path, so everything from
                     // its position up to the top of the stack is the cycle;
                     // naming it once more closes the path into a loop.
-                    let from = stack.iter().position(|&(n, _)| n == child).unwrap_or(0);
+                    // GREY holds exactly while a node is on the current
+                    // stack: set on push, cleared to BLACK on pop. The search
+                    // therefore always hits. Assert it in debug, because the
+                    // fallback would still report a real cycle but would name
+                    // the DFS root instead of the spec the cycle re-enters.
+                    let entry = stack.iter().position(|&(n, _)| n == child);
+                    debug_assert!(
+                        entry.is_some(),
+                        "V-014: GREY node absent from the current stack"
+                    );
+                    let from = entry.unwrap_or(0);
                     let mut cycle: Vec<&str> = stack[from..].iter().map(|&(n, _)| n).collect();
                     cycle.push(child);
                     let at_path = cycle


### PR DESCRIPTION
Follow-up to #72, from the AI review on that PR. Hardening only: no release
behavior changes.

`detect_dependency_cycle` has two fallbacks that are unreachable today and
would fail *quietly* rather than loudly if that ever stopped being true.

**The GREY arm.** `stack.iter().position(...).unwrap_or(0)` rests on the
invariant "GREY exactly while a node is on the current stack" (set on push,
cleared to BLACK on pop). If that broke, `from = 0` would still report a real
cycle, but would name the entire stack and point the violation at the DFS root
instead of the spec the cycle re-enters: a plausible-looking wrong path.

**The outer loop.** `color.get(...).unwrap_or(BLACK)` rests on `color` being
seeded from every record id. If that broke, the start node would be skipped
and its cycle missed entirely.

## Why `debug_assert!` and not `expect`

The review suggested `expect("V-014: GREY node not on stack")`. Same goal,
wrong instrument for this crate:

- Core is documented panic-free on user input (`CLAUDE.md`, and the
  constitution's determinism/validation principle). The only two `.expect()`
  calls in core production code, `query.rs:32` and `shard.rs:33`, both assert
  on a **compile-time constant**, never on runtime-derived state. An `expect`
  here would be the first panic in core gated on graph shape.
- `spec-spine` is a CI gate. Aborting the run with a backtrace is a worse
  outcome than the fallback, which still reports a genuine cycle (reaching the
  GREY arm at all means `child` is on the current path) and only misnames the
  path.

`debug_assert!` gets the review's actual intent without either cost: it is live
in every test and debug build, so a future refactor that breaks an invariant
fails `cargo test` loudly, and release keeps the graceful degradation. All 40
compile tests pass with both assertions active.

## Review findings not acted on

| finding | disposition |
|---|---|
| Self-dependency: increment before cycle detection is dead on the returning path | No change. The review itself calls it "not a bug". The increment is load-bearing for the WHITE and BLACK arms; hoisting it would complicate the loop for no gain. `X -> X` already reports correctly. |
| `016-short-id-resolution` asserted but not evidenced in the diff | False positive. It exists and is `approved` (`registry show 016-short-id-resolution`), and `lint --fail-on-warn --fail-on-info` is 0/0/0, so `V-010` does not fire. The review saw the diff, not the corpus. |
| `BTreeMap`/`BTreeSet` costs `O(log n)` where a hash map is `O(1)` | No change, as the review's own conclusion allows. On a 34-spec corpus the difference is unmeasurable, and `BTreeMap` is the file's uniform style in a crate whose central claim is deterministic output. Swapping in `HashMap` here is safe only because none of these maps is currently iterated; keeping the ordered type removes that as a trap for a future edit that does iterate. |

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 34 shards |
| `index check` | fresh (confirmed: regenerating both artifacts produces no diff) |
| `lint --fail-on-warn --fail-on-info` | 0 / 0 / 0 |
| `couple --base main --head HEAD` | 1 violation, waived below |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace --locked` | all pass |

Spec-Drift-Waiver: crates/spec-spine-core/src/compile.rs - adds two `debug_assert!` guards over already-unreachable fallbacks in `detect_dependency_cycle`. No release behavior changes and no claim in any of the nine owning specs (001, 013, 014, 016, 018, 019, 024, 031, 033) is affected, so amending one would be a mechanical refresh, which `.claude/rules/adversarial-prompt-refusal.md` explicitly forbids.
