### PR TITLE
chore(025,026): mark two shipped specs `implementation: complete`

### DIFF
--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "30d0773f486bf48ffec22b0fd38a5283905a75039644bae6551a1c9f58b1cd7c"
+  "shardHash": "e028023928cdd8dfed4cb53ae7a919037af033d2c2ad44a3595777d620b94126"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -84,5 +84,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1b8eeafa462b73fc8f223ec3427767d6fbdc9c36ee5008f5f7cfd6e3ef2be483"
+  "shardHash": "80e0ddbd50782c65ff1ae253698ab5c1327f6132459118ddbb0b54595bc1a187"
 }

--- a/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
@@ -44,7 +44,7 @@
       }
     ],
     "id": "025-unresolved-unit-severity",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -78,6 +78,6 @@
     "summary": "Today the indexer hard-errors (I-003..I-009) on every declared unit that does not resolve, regardless of whether the edge is authoritative or whether the owning spec is even built yet. Two of those errors are not governance failures: an unresolved unit on a non-owning `references` edge is a stale provenance pointer, and an unresolved owning unit on a `draft` / `implementation: pending` spec is legitimate work-in-progress. This spec adds two orthogonal severity tiers over the same resolver, keyed on (a) edge authority and (b) owning-spec lifecycle, so those two cases become counted warnings (a fresh `W-001` / `W-002` band) instead of blocking errors, while an unresolved owning unit on an approved + implemented spec stays a hard error. The downgrade never skips: every such unit is still surfaced and counted, never silently dropped, so the authority-laundering / invisible-drift vector stays closed. The index never fabricates a code location for an unresolved path; authority remains a property of the registry relationship graph, which the coupling gate consults independently of index resolution. Additive: the `warnings` tier and the free-form diagnostic `code` already exist, so this is an `INDEX_SCHEMA_VERSION` MINOR (1.0.0 -> 1.1.0) with no schema-file edit and no registry change.\n",
     "title": "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
   },
-  "shardHash": "e3c677106b3d69bbcaa170009f097714944db9bb8243b3d147506d5ef9aef567",
+  "shardHash": "a153f204f3b57921b244fcdf256c934de8a03865e47af200fa4233245ba75f8f",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
@@ -36,7 +36,7 @@
       }
     ],
     "id": "026-resolution-discovery-fixes",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -66,6 +66,6 @@
     "summary": "Three mechanical correctness fixes surfaced by the OAP spec-217 Phase-0 dry run of 0.5.0, all in the indexer's resolution and discovery paths, none changing any schema or DTO shape. (1) Non-workflow YAML (Helm values, infra manifests) is dispatched to the CI-jobs parser, so its `# region:` markers never resolve and a declared section unit on one raises a spurious I-006; route foreign YAML to the region parser, which is exactly the whole-file / region ownership spec 022 §3.2 already promised foreign structured configs (retiring §4's deliberately-deferred D4). (2) A Makefile `## tag:` is silently overwritten when a second `## tag:` precedes any consuming target, so a tagged region is never emitted; make the pending tag deterministic so it is never silently lost. (3) Workspace-member globs declared in a NON-root workspace file (a nested `pnpm-workspace.yaml`) are resolved against the repo root instead of the declaration file's directory, so they match nothing; pre-join such globs with the declaration file's parent. A related lower-priority guard covers a `standalone_rust_workspaces` entry that ends in `Cargo.toml`. Pairs with spec 025 (the severity policy); these are the mechanical half of the 0.6.0 indexer work.\n",
     "title": "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
   },
-  "shardHash": "9e58738f6bd1670e3d89ab0e7bc11abefa48c2a7495383f58bdec19ab7a2327f",
+  "shardHash": "e2c011b1a493629bba2ae7656d3b8fd9cdc68fbb2cc9d87676f71cb8bbe87ebb",
   "specVersion": "1.1.0"
 }

--- a/specs/025-unresolved-unit-severity/spec.md
+++ b/specs/025-unresolved-unit-severity/spec.md
@@ -5,7 +5,7 @@ status: approved
 kind: "tooling"
 created: "2026-06-17"
 owner: "The spec-spine Authors"
-implementation: pending
+implementation: complete
 risk: medium
 depends_on:
   - "001-compile-registry"   # the registry relationship graph: the authority source

--- a/specs/026-resolution-discovery-fixes/spec.md
+++ b/specs/026-resolution-discovery-fixes/spec.md
@@ -5,7 +5,7 @@ status: approved
 kind: "tooling"
 created: "2026-06-18"
 owner: "The spec-spine Authors"
-implementation: pending
+implementation: complete
 risk: low
 depends_on:
   - "004-codebase-index"          # section resolution + manifest discovery


### PR DESCRIPTION
Ledger drift: two approved specs still declare `implementation: pending` while
their code has been on `main` since v0.6.0.

| spec | shipped in | evidence in the tree |
|---|---|---|
| `025-unresolved-unit-severity` | `bea2fc3` (#32) | `W-001` / `W-002` emitted from `crates/spec-spine-core/src/index.rs` |
| `026-resolution-discovery-fixes` | `302fef9` (#33) | the `## tag:` handling in `sections.rs` cites "spec 026 D2" by name |

`registry list` was therefore reporting two shipped specs as unbuilt.

## Not cosmetic

025 is the spec that defines the severity tiers keyed on this very field. Its
own normative text (the severity table, and "an unresolved unit whose owning
spec is `status: draft` OR `implementation: pending` MUST be emitted as a
warning") makes the marker downgrade unresolved owning units from `I-0xx`
errors to `W-001`.

Flipping it to `complete` therefore **tightens** the classification for these
two specs. That was verified rather than assumed: after the change `index`
reports 0 error diagnostics and `lint --fail-on-warn --fail-on-info` is 0/0/0.

## Scope

Only the frontmatter line changed in each file. 025 discusses `implementation:
pending` throughout its normative body, so a naive replace would have corrupted
the spec that defines the rule; the edit is anchored to the frontmatter block
and the nine body occurrences are untouched.

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 34 shards |
| `index check` | fresh |
| `index` | 4 packages, 34 mappings, 0 error diagnostics |
| `lint --fail-on-warn --fail-on-info` | 0 / 0 / 0 |
| `couple --base main --head HEAD` | OK, 2 paths, no drift |
| `registry list` implementation tally | 33 `complete`, 1 unset (`000`, which has no such field) |

Each spec's own `spec.md` is the only authored file that changes, so the
coupling gate self-clears. No waiver needed.
