### PR TITLE
feat(034): `references` seeds no implementing path (C-001 ownership leak)

### DIFF
--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -46,10 +46,6 @@
       {
         "path": "crates/spec-spine-types/src/lib.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -108,18 +108,6 @@
       {
         "path": "crates/spec-spine-types/tests/dtos.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
-      },
-      {
-        "path": "specs/012-index-hash-slices/spec.md",
-        "source": "spec-edge"
-      },
-      {
-        "path": "specs/020-derived-artifact-merge-driver/spec.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -24,10 +24,6 @@
       {
         "path": "crates/spec-spine-types/tests/dtos.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -20,10 +20,6 @@
       {
         "path": "crates/spec-spine-core/tests/index.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -19,10 +19,6 @@
       {
         "path": "crates/spec-spine-types/tests/grammar.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -28,14 +28,6 @@
       {
         "path": "crates/spec-spine-core/tests/compile.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
-      },
-      {
-        "path": "specs/004-codebase-index/spec.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -57,10 +57,6 @@
       {
         "path": "crates/spec-spine-types/src/lib.rs",
         "source": "spec-edge"
-      },
-      {
-        "path": "docs/design/00-architecture.md",
-        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -1,20 +1,15 @@
 {
   "mapping": {
     "amends": [
-      "004-codebase-index",
-      "017-directory-crate-module-units"
+      "004-codebase-index"
     ],
     "dependsOn": [
       "004-codebase-index",
-      "017-directory-crate-module-units"
+      "005-coupling-gate"
     ],
     "implementingPaths": [
       {
         "path": "crates/spec-spine-core/src/index.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-core/src/symbols.rs",
         "source": "spec-edge"
       },
       {
@@ -39,19 +34,6 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/symbols.rs"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": "crates/spec-spine-core/src/symbols.rs"
-        }
-      },
-      {
-        "locations": [
-          {
             "file": "crates/spec-spine-core/tests/index.rs"
           }
         ],
@@ -61,24 +43,11 @@
           "kind": "file",
           "path": "crates/spec-spine-core/tests/index.rs"
         }
-      },
-      {
-        "locations": [
-          {
-            "file": "docs/design/00-architecture.md"
-          }
-        ],
-        "ownership": false,
-        "sourceField": "references",
-        "unit": {
-          "kind": "file",
-          "path": "docs/design/00-architecture.md"
-        }
       }
     ],
-    "specId": "027-symbol-resolution-feature-gate",
-    "specStatus": "approved"
+    "specId": "034-references-non-owning-paths",
+    "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b5f52280dcb9b41ac036c791c7288b06480ca51da93f0ce098a2f7f828dd8b7c"
+  "shardHash": "f9c3302d28e923cda61c908a9fc20bb111f0622604b112c352297d2e07a0971a"
 }

--- a/.derived/spec-registry/by-spec/034-references-non-owning-paths.json
+++ b/.derived/spec-registry/by-spec/034-references-non-owning-paths.json
@@ -1,0 +1,53 @@
+{
+  "record": {
+    "amends": [
+      "004-codebase-index"
+    ],
+    "created": "2026-09-03",
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      }
+    ],
+    "id": "034-references-non-owning-paths",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "risk": "medium",
+    "sectionHeadings": [
+      "034: `references` seeds no implementing path",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The rule",
+      "3.2 Fix at the source, not at the consumers",
+      "3.3 Provenance is preserved",
+      "3.4 Shape and compatibility",
+      "3.5 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/034-references-non-owning-paths/spec.md",
+    "status": "draft",
+    "summary": "The contract says `references` is the only non-owning edge and that the coupling gate ignores it. The indexer did not implement that. It seeded a spec's `implementingPaths` from every resolved unit location, owning or not, so a file a spec merely cited became a file it claimed. Every consumer reads that field as a claim: `couple.rs` treats a listed path as whole-file ownership, the indexer's own `owners_of_unit` does the same, and `orphaned_specs` and coverage read a non-empty list as \"this spec claims something\". One wrong seed made all of them wrong together. The observable defect is that a spec could not edit its own `spec.md` without a waiver once any other spec referenced it: on this corpus, changing `specs/020-derived-artifact-merge-driver/spec.md` was refused as `C-001` with `024-index-sharding`, which only cites it, named as the sole owner. This spec filters the seed by the `ownership` flag the loop already holds, at the single source rather than at each consumer. The citation is not lost: it stays in `resolvedUnits` with `ownership: false`, so provenance is preserved and only the ownership view changes. No DTO or schema shape changes.\n",
+    "title": "`references` seeds no implementing path: closing the C-001 ownership leak"
+  },
+  "shardHash": "e65bc1a8286f01eab71f0cc6f40c2d67ad3da355637d3ebd52ca9355da4c8fa6",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -176,11 +176,23 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
                 &mut unit_diags,
             );
             classify_unresolved(&mut spec_diags, unit_diags, *ownership, in_flight);
-            for loc in &locations {
-                paths
-                    .entry(loc.file.clone())
-                    .or_default()
-                    .insert(TraceSource::SpecEdge);
+            // Only an owning edge contributes an implementing path (spec 034).
+            // `references` is non-owning by definition, so a file a spec merely
+            // cites is not a file it implements. Every consumer of
+            // `implementing_paths` reads it as a claim: `owners_for_path` and
+            // `owners_of_unit` treat a listed path as whole-file ownership, and
+            // `orphaned_specs` / coverage read it as "this spec claims
+            // something". Seeding it from a non-owning unit made all of them
+            // wrong at once, so the filter belongs here at the single source
+            // rather than at each consumer. The reference itself is not lost:
+            // it stays in `resolved_units` with `ownership: false`.
+            if *ownership {
+                for loc in &locations {
+                    paths
+                        .entry(loc.file.clone())
+                        .or_default()
+                        .insert(TraceSource::SpecEdge);
+                }
             }
             resolved_units.push(ResolvedUnit {
                 unit: unit.clone(),

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -787,6 +787,24 @@ fn references_unit_survives_in_resolved_units() {
         .expect("the reference is still recorded");
     assert!(!cited.ownership, "a `references` unit is non-owning");
     assert_eq!(cited.locations.len(), 1, "and it still resolves");
+
+    // This spec now claims nothing, so it is orphaned. That is the intended
+    // reading (it implements nothing), and it must stay a report, not a
+    // refusal: an orphan is surfaced by `index orphans`, never as a blocking
+    // diagnostic, or dropping the spurious claim would have turned into a gate
+    // failure for every spec that only cites.
+    assert!(
+        idx.traceability
+            .orphaned_specs
+            .contains(&"001-x".to_string()),
+        "a spec with only `references` implements nothing: {:?}",
+        idx.traceability.orphaned_specs
+    );
+    assert!(
+        idx.diagnostics.errors.is_empty(),
+        "being orphaned is reported, never blocking: {:?}",
+        idx.diagnostics.errors
+    );
 }
 
 /// AC-3, the reported defect end to end: a spec that merely `references`

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -723,3 +723,105 @@ fn unresolved_module_unit_is_blocking_diagnostic_i008() {
     let idx = index(&Config::default(), fx.path()).unwrap().index;
     assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-008"));
 }
+
+// ===== spec 034: `references` is non-owning, so it seeds no implementing path =====
+
+/// AC-1: an owning edge contributes an implementing path; a `references` edge to
+/// an equally-real file does not.
+#[test]
+fn references_unit_does_not_seed_implementing_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(tmp.path(), "src/owned.rs", "pub fn a() {}\n");
+    write(tmp.path(), "src/cited.rs", "pub fn b() {}\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "establishes:\n  - \"src/owned.rs\"\nreferences:\n  - { unit: { kind: file, path: \"src/cited.rs\" }, role: context }\n",
+        ),
+    );
+
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    let m = mapping(&idx, "001-x");
+    let paths: Vec<&str> = m
+        .implementing_paths
+        .iter()
+        .map(|p| p.path.as_str())
+        .collect();
+
+    assert!(
+        paths.contains(&"src/owned.rs"),
+        "owning edge must claim: {paths:?}"
+    );
+    assert!(
+        !paths.contains(&"src/cited.rs"),
+        "`references` is non-owning and must not claim: {paths:?}"
+    );
+}
+
+/// AC-2: the reference is filtered from the ownership view only. Its provenance
+/// survives in `resolved_units`, flagged `ownership: false`, so a consumer can
+/// still see that the spec cites the file.
+#[test]
+fn references_unit_survives_in_resolved_units() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(tmp.path(), "src/cited.rs", "pub fn b() {}\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec(
+            "001-x",
+            "references:\n  - { unit: { kind: file, path: \"src/cited.rs\" }, role: context }\n",
+        ),
+    );
+
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    let m = mapping(&idx, "001-x");
+    let cited = m
+        .resolved_units
+        .iter()
+        .find(|u| matches!(&u.unit, Unit::File { path } if path == "src/cited.rs"))
+        .expect("the reference is still recorded");
+    assert!(!cited.ownership, "a `references` unit is non-owning");
+    assert_eq!(cited.locations.len(), 1, "and it still resolves");
+}
+
+/// AC-3, the reported defect end to end: a spec that merely `references`
+/// another spec's `spec.md` was named its `C-001` owner, so that spec could not
+/// be edited without either touching an unrelated spec or filing a waiver.
+#[test]
+fn references_does_not_confer_c001_ownership() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(tmp.path(), "specs/001-x/spec.md", &spec("001-x", ""));
+    write(
+        tmp.path(),
+        "specs/002-y/spec.md",
+        &spec(
+            "002-y",
+            "references:\n  - { unit: { kind: file, path: \"specs/001-x/spec.md\" }, role: context }\n",
+        ),
+    );
+
+    let cfg = Config::default();
+    let registry = spec_spine_core::compile(&cfg, tmp.path()).unwrap().registry;
+    let idx = index(&cfg, tmp.path()).unwrap().index;
+
+    // 001 edits its own spec.md and nothing else.
+    let diff = spec_spine_core::DiffInput {
+        files: vec![spec_spine_core::DiffFile {
+            path: "specs/001-x/spec.md".to_string(),
+            hunks: vec![],
+            deleted: false,
+        }],
+    };
+    let report = spec_spine_core::couple_with(&cfg, &registry, &idx, &diff, None).unwrap();
+    assert!(
+        !report.has_blocking_drift(),
+        "a spec editing its own spec.md must clear; 002 only cites it: {:?}",
+        report.violations
+    );
+}

--- a/specs/034-references-non-owning-paths/spec.md
+++ b/specs/034-references-non-owning-paths/spec.md
@@ -1,0 +1,145 @@
+---
+id: "034-references-non-owning-paths"
+title: "`references` seeds no implementing path: closing the C-001 ownership leak"
+status: draft
+kind: "tooling"
+created: "2026-09-03"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "004-codebase-index"
+  - "005-coupling-gate"
+amends:
+  - "004-codebase-index"
+extends:
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/tests/index.rs", nature: additive }
+summary: >
+  The contract says `references` is the only non-owning edge and that the
+  coupling gate ignores it. The indexer did not implement that. It seeded a
+  spec's `implementingPaths` from every resolved unit location, owning or not,
+  so a file a spec merely cited became a file it claimed. Every consumer reads
+  that field as a claim: `couple.rs` treats a listed path as whole-file
+  ownership, the indexer's own `owners_of_unit` does the same, and
+  `orphaned_specs` and coverage read a non-empty list as "this spec claims
+  something". One wrong seed made all of them wrong together. The observable
+  defect is that a spec could not edit its own `spec.md` without a waiver once
+  any other spec referenced it: on this corpus, changing
+  `specs/020-derived-artifact-merge-driver/spec.md` was refused as `C-001` with
+  `024-index-sharding`, which only cites it, named as the sole owner. This spec
+  filters the seed by the `ownership` flag the loop already holds, at the single
+  source rather than at each consumer. The citation is not lost: it stays in
+  `resolvedUnits` with `ownership: false`, so provenance is preserved and only
+  the ownership view changes. No DTO or schema shape changes.
+---
+
+# 034: `references` seeds no implementing path
+
+## 1. Purpose
+
+`standards/spec/contract.md` states the rule in one line: eight typed edges,
+"`references` is the only non-owning one (the coupling gate ignores it)". The
+constitution's spec-first principle rests on it, because ownership is what
+decides whose `spec.md` must change when a file changes.
+
+The indexer did not implement that rule. Building each spec's traceability
+mapping, it walked the spec's units and seeded the mapping's `implementingPaths`
+from every resolved location, with the unit's `ownership` flag in hand and
+unused. A `references` edge therefore produced a claim indistinguishable from an
+`establishes` one.
+
+The consequence is not cosmetic, because `implementingPaths` is read as an
+authority claim in four places:
+
+| reader | reads a listed path as |
+|---|---|
+| `couple.rs::owners_for_path` | whole-file `C-001` ownership |
+| `index.rs::owners_of_unit` | ownership of a file unit |
+| `orphaned_specs` | "this spec claims something" |
+| coverage (spec 032) | a claimed source file |
+
+The `resolvedUnits` loops beside the first two check `ownership` correctly. The
+`implementingPaths` loops did not, so the mistake bypassed the guard that was
+already there.
+
+On this corpus the defect is reachable today. `024-index-sharding` references
+`specs/020-derived-artifact-merge-driver/spec.md` for context. Changing spec
+020's own `spec.md` was therefore refused:
+
+```
+C-001 'specs/020-derived-artifact-merge-driver/spec.md' changed without an
+authoring edit to any owning spec (024-index-sharding)
+```
+
+A spec could not be edited without touching an unrelated spec that has no
+authority over it, or filing a waiver. That inverts the model: citing a document
+conferred power over it.
+
+## 2. Territory
+
+`index.rs`: the unit loop that seeds `paths` for a spec's mapping. `tests/index.rs`:
+the acceptance fixtures. Nothing in `couple.rs` changes; its reading of
+`implementingPaths` was always correct given a correct field.
+
+## 3. Behavior
+
+### 3.1 The rule
+
+An authority unit contributes to a mapping's `implementingPaths` **only when its
+edge is owning**. `references` is the sole non-owning edge, so in practice this
+excludes exactly `references` units and nothing else.
+
+The other two seed sources are unaffected and remain owning by construction: a
+package manifest naming a spec (`[package.metadata.*].spec`), and a `# Spec:`
+comment header in a file. Both are a file declaring its own owner.
+
+### 3.2 Fix at the source, not at the consumers
+
+The filter belongs in the indexer, at the one place the field is built, not in
+each of the four readers. Fixing the consumers would mean repeating the same
+predicate four times and leaving the emitted index still asserting a claim that
+is not true. `implementingPaths` means "paths this spec implements"; a cited
+file is not one, and the field should not say it is.
+
+### 3.3 Provenance is preserved
+
+The citation is filtered out of the ownership view only. The unit remains in
+`resolvedUnits` with `ownership: false` and its resolved locations intact, so
+"which files does this spec cite" stays answerable from the index. Nothing that
+was recorded stops being recorded; a claim that was never true stops being
+asserted.
+
+### 3.4 Shape and compatibility
+
+No DTO field is added, removed or retyped, and no JSON Schema changes, so
+`INDEX_SCHEMA_VERSION` does not move. Only content changes: a mapping whose spec
+has `references` units loses those paths from `implementingPaths`, which
+restamps the affected index shards.
+
+Downstream effects are the intended ones. A spec whose only units were
+`references` now reports as orphaned, which is correct: it implements nothing.
+Coverage is unchanged on this corpus, because every referenced target here is a
+document or a `spec.md`, not a source file.
+
+### 3.5 Tests (minimum)
+
+1. An owning edge and a `references` edge to two equally-real files: only the
+   owning path appears in `implementingPaths`.
+2. The `references` unit is still present in `resolvedUnits` with
+   `ownership: false` and one resolved location.
+3. End to end: a spec that only `references` another spec's `spec.md` is not an
+   owner of it, so editing that `spec.md` alone clears the gate.
+
+## 4. Out of scope
+
+- **The `specs/` prefix hardcoded in `couple.rs`** (lines 337 and 422) while
+  `Config::specs_dir` is configurable. A real defect for an adopter who moves
+  their corpus, and a separate one: it is about locating a spec's authoring
+  file, not about which edges confer ownership.
+- **Whether a `spec.md` should be ownable by another spec at all.** Amends and
+  supersedes deliberately transfer authority over another spec's territory, and
+  this spec does not revisit that. It removes only the non-owning edge from the
+  ownership computation.
+- **Any change to `couple.rs`.** Its ownership logic was correct given a correct
+  index, and this spec keeps the fix to the field's producer.


### PR DESCRIPTION
`standards/spec/contract.md` states the rule in one line: eight typed edges,
"`references` is the only non-owning one (**the coupling gate ignores it**)."
The indexer did not implement that.

Building each spec's traceability mapping, it seeded `implementingPaths` from
every resolved unit location, holding the unit's `ownership` flag and not using
it. A `references` edge produced a claim indistinguishable from an `establishes`
one.

## Why that matters in four places

`implementingPaths` is read as an authority claim by:

| reader | reads a listed path as |
|---|---|
| `couple.rs::owners_for_path` | whole-file `C-001` ownership |
| `index.rs::owners_of_unit` | ownership of a file unit |
| `orphaned_specs` | "this spec claims something" |
| coverage (spec 032) | a claimed source file |

The `resolvedUnits` loops sitting beside the first two check `ownership`
correctly. The `implementingPaths` loops did not, so one bad seed bypassed a
guard that already existed.

## The defect is live on this corpus

`024-index-sharding` references `specs/020-derived-artifact-merge-driver/spec.md`
for context. So editing spec 020's **own** `spec.md` was refused:

```
$ spec-spine couple --paths-from <(echo specs/020-derived-artifact-merge-driver/spec.md)
C-001 'specs/020-derived-artifact-merge-driver/spec.md' changed without an
authoring edit to any owning spec (024-index-sharding)
exit 1
```

A spec could not be edited without touching an unrelated spec that has no
authority over it, or filing a waiver. Citing a document conferred power over
it. After this change the same command is `OK: 1 path(s) checked, no drift`.

## The fix

One `if *ownership` around the seed, in the indexer, at the single place the
field is built. Not in the four readers: that would repeat one predicate four
times and leave the emitted index still asserting a claim that is not true.
`implementingPaths` means "paths this spec implements", and a cited file is not
one.

**Provenance is preserved.** The unit stays in `resolvedUnits` with
`ownership: false` and its resolved locations, so "which files does this spec
cite" is still answerable from the index. Nothing recorded stops being recorded;
a claim that was never true stops being asserted.

## Blast radius

No DTO field added, removed or retyped, and no JSON Schema change, so
`INDEX_SCHEMA_VERSION` does not move. Eight index shards restamp: exactly the
specs carrying `references` edges (023, 024, 025, 026, 027, 028, 031, 032).

Orphans and coverage are unchanged here, because every referenced target in this
corpus is a document or a `spec.md`, not a source file. A spec whose only units
were `references` would now report as orphaned, which is correct: it implements
nothing.

## Tests

Three, in `tests/index.rs`. Verified non-vacuous by reverting the fix: the first
and third fail without it, and the second is a provenance regression guard that
should pass either way.

1. An owning edge and a `references` edge to two equally-real files: only the
   owning path is claimed.
2. The citation survives in `resolvedUnits` with `ownership: false`.
3. End to end: a spec that only references another spec's `spec.md` is not its
   owner, so editing that `spec.md` alone clears the gate.

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 35 shards |
| `index check` | fresh |
| `lint --fail-on-warn --fail-on-info` | 0 / 0 / 0 |
| `couple --base main --head HEAD` | OK, 3 paths, no drift |
| `index orphans` | unchanged, exit 0 |
| `index coverage` | unchanged, 59/64 |
| `cargo fmt` / `clippy -D warnings` / `test --workspace` | clean / clean / all pass |

Spec 034 is filed here as `draft`.

## Note on merge order

This PR and #74 both restamp the `025` and `026` index shards, so whichever
lands second needs a regenerate. That is the same-shard case spec 020's merge
driver exists for; a plain `compile && index` on the merged tree resolves it.

## Out of scope, deliberately

- `couple.rs` hardcodes `"specs/"` at lines 337 and 422 while `Config::specs_dir`
  is configurable, which breaks the gate for an adopter who moves their corpus.
  Real, but it is about locating a spec's authoring file, not about which edges
  confer ownership.
- Whether a `spec.md` should be ownable by another spec at all. `amends` and
  `supersedes` deliberately transfer authority, and this PR does not revisit
  that.
