### PR TITLE
feat(035): a closed reader ends the CLI cleanly instead of panicking

### DIFF
--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1e37bd9e924c0d4203cda1028f5af0cd267403717202611bdd24fca061dd7fc6"
+  "shardHash": "5a321266b8796d029344f93730dcfab6ccf37c5ff924eaf4e8e82bb82557344a"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -1,0 +1,203 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "001-compile-registry",
+      "002-registry-query"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_attest.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_init.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_registry.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/out.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/verify_attestation.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/out.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/out.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_attest.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_attest.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_init.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_init.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_registry.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/verify_attestation.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      }
+    ],
+    "specId": "035-stdout-closed-reader",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "1e37bd9e924c0d4203cda1028f5af0cd267403717202611bdd24fca061dd7fc6"
+}

--- a/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
+++ b/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
@@ -1,0 +1,120 @@
+{
+  "record": {
+    "created": "2026-09-03",
+    "dependsOn": [
+      "001-compile-registry",
+      "002-registry-query"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-cli/src/out.rs"
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_attest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_init.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      }
+    ],
+    "id": "035-stdout-closed-reader",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "risk": "low",
+    "sectionHeadings": [
+      "035: A closed reader is not an error",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 One helper, three outcomes",
+      "3.2 Why not the two shorter fixes",
+      "3.3 Stderr is deliberately unchanged",
+      "3.4 Determinism and output are unaffected",
+      "3.5 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/035-stdout-closed-reader/spec.md",
+    "status": "draft",
+    "summary": "Exit codes are a stable contract: 0 ok, 1 validation failure, 2 stale, 3 I/O. The CLI could exit 101. `println!` unwraps its write, so a reader that stops early made the process panic: `spec-spine registry list --json | head` printed a Rust backtrace and exited 101, and under `set -o pipefail` that failed the surrounding script. Piping into `head`, `less` or `grep -q` is ordinary use, not an error condition. This spec routes every CLI stdout write through one helper that classifies the write instead of unwrapping it: a closed reader ends the process 0, because the consumer got what it asked for, and a genuine I/O failure reports and exits 3, which is the code the contract already assigns to I/O. Stderr keeps `eprintln!`: diagnostics are small, and a broken stderr has nowhere left to report itself. The fix is not `unsafe` SIGPIPE restoration, which `forbid(unsafe_code)` rules out workspace-wide, and not a panic hook, which would match on a message string the standard library is free to change.\n",
+    "title": "A closed reader is not an error: stdout writes stop panicking the CLI"
+  },
+  "shardHash": "53aca72e07d2ceab196eb7942d0835be81c95eaa925893500348413f3d241ae0",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
+++ b/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
@@ -103,7 +103,7 @@
       "1. Purpose",
       "2. Territory",
       "3. Behavior",
-      "3.1 One helper, three outcomes",
+      "3.1 Two entry points, one classifier, three outcomes",
       "3.2 Why not the two shorter fixes",
       "3.3 Stderr is deliberately unchanged",
       "3.4 Determinism and output are unaffected",
@@ -115,6 +115,6 @@
     "summary": "Exit codes are a stable contract: 0 ok, 1 validation failure, 2 stale, 3 I/O. The CLI could exit 101. `println!` unwraps its write, so a reader that stops early made the process panic: `spec-spine registry list --json | head` printed a Rust backtrace and exited 101, and under `set -o pipefail` that failed the surrounding script. Piping into `head`, `less` or `grep -q` is ordinary use, not an error condition. This spec routes every CLI stdout write through one helper that classifies the write instead of unwrapping it: a closed reader ends the process 0, because the consumer got what it asked for, and a genuine I/O failure reports and exits 3, which is the code the contract already assigns to I/O. Stderr keeps `eprintln!`: diagnostics are small, and a broken stderr has nowhere left to report itself. The fix is not `unsafe` SIGPIPE restoration, which `forbid(unsafe_code)` rules out workspace-wide, and not a panic hook, which would match on a message string the standard library is free to change.\n",
     "title": "A closed reader is not an error: stdout writes stop panicking the CLI"
   },
-  "shardHash": "53aca72e07d2ceab196eb7942d0835be81c95eaa925893500348413f3d241ae0",
+  "shardHash": "1ddbba814b1a6a368e9c2eed570bee75e11726e6b12fc1d112fe754aad9d1eed",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_attest.rs
+++ b/crates/spec-spine-cli/src/cmd_attest.rs
@@ -70,8 +70,8 @@ pub fn run(repo: &Path, args: &AttestArgs) -> Result<u8, Error> {
     } else {
         "spec-corpus"
     };
-    println!("attested {scope} -> {}", attestation_path.display());
-    println!("  attestationHash: {}", outcome.attestation_hash);
+    outln!("attested {scope} -> {}", attestation_path.display());
+    outln!("  attestationHash: {}", outcome.attestation_hash);
 
     if let Some((signing_key, key_id)) = signer {
         let ledger_seal = seal::sign(
@@ -86,7 +86,7 @@ pub fn run(repo: &Path, args: &AttestArgs) -> Result<u8, Error> {
         let seal_path = out_dir.join("attestation.sig");
         fs::write(&seal_path, seal_json)
             .map_err(|e| Error::Io(format!("write {}: {e}", seal_path.display())))?;
-        println!(
+        outln!(
             "sealed -> {} (alg ed25519, keyId {})",
             seal_path.display(),
             ledger_seal.key_id

--- a/crates/spec-spine-cli/src/cmd_compile.rs
+++ b/crates/spec-spine-cli/src/cmd_compile.rs
@@ -38,7 +38,7 @@ pub fn run(repo: &Path, check: bool) -> Result<u8, Error> {
         }
         return match compare_committed_registry(&cfg, repo, &outcome.shards)? {
             Freshness::Fresh => {
-                println!(
+                outln!(
                     "spec-registry is fresh: {} shard(s) match the corpus",
                     outcome.registry.specs.len()
                 );
@@ -99,7 +99,7 @@ pub fn run(repo: &Path, check: bool) -> Result<u8, Error> {
         .count();
 
     if outcome.validation_passed {
-        println!(
+        outln!(
             "compiled {} spec(s) -> {} ({} warning(s))",
             outcome.registry.specs.len(),
             by_spec.display(),

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -79,16 +79,16 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
             );
         }
     } else if let Some(reason) = &report.waiver {
-        println!(
+        outln!(
             "spec-spine couple: {} violation(s) {}, reason: {reason}",
             report.violations.len(),
             if auto_waived { "auto-waived" } else { "waived" }
         );
         for v in &report.violations {
-            println!("  {} (waived)", v.message);
+            outln!("  {} (waived)", v.message);
         }
     } else {
-        println!(
+        outln!(
             "spec-spine couple: OK: {} path(s) checked, no drift.",
             report.checked_paths
         );

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -52,7 +52,7 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
     match action {
         Some(IndexAction::Render) => {
             let idx = load_committed_index(&cfg, repo)?;
-            print!("{}", render_markdown(&cfg, &idx));
+            out!("{}", render_markdown(&cfg, &idx));
             Ok(0)
         }
         Some(IndexAction::Orphans { json }) => {
@@ -81,7 +81,7 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                     .map_err(|e| Error::Schema(e.to_string()))?;
                 outln!("{s}");
             } else {
-                print!("{}", render_coverage(&report));
+                out!("{}", render_coverage(&report));
             }
             Ok(if *fail_on_untraced && !report.is_fully_claimed() {
                 1

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -61,10 +61,10 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
             if *json {
                 let s =
                     serde_json::to_string_pretty(&ids).map_err(|e| Error::Schema(e.to_string()))?;
-                println!("{s}");
+                outln!("{s}");
             } else {
                 for id in ids {
-                    println!("{id}");
+                    outln!("{id}");
                 }
             }
             Ok(0)
@@ -79,7 +79,7 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
             if *json {
                 let s = serde_json::to_string_pretty(&report)
                     .map_err(|e| Error::Schema(e.to_string()))?;
-                println!("{s}");
+                outln!("{s}");
             } else {
                 print!("{}", render_coverage(&report));
             }
@@ -99,7 +99,7 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
             };
             match freshness {
                 Freshness::Fresh => {
-                    println!("{subject} is fresh");
+                    outln!("{subject} is fresh");
                     Ok(0)
                 }
                 Freshness::Stale { expected, actual } => {
@@ -135,7 +135,7 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 let at = diag.path.as_deref().unwrap_or("-");
                 eprintln!("  {} [{}] {}", diag.code, at, diag.message);
             }
-            println!(
+            outln!(
                 "indexed {} package(s), {} mapping(s) -> {} ({} error diagnostic(s))",
                 idx.packages.len(),
                 idx.traceability.mappings.len(),

--- a/crates/spec-spine-cli/src/cmd_init.rs
+++ b/crates/spec-spine-cli/src/cmd_init.rs
@@ -22,7 +22,7 @@ pub fn run(repo: &Path, force: bool) -> Result<u8, Error> {
     for file in &scaffold.files {
         let abs = repo.join(&file.rel_path);
         if abs.exists() && !force && !file.overwrite {
-            println!("  skip (exists): {}", file.rel_path);
+            outln!("  skip (exists): {}", file.rel_path);
             skipped += 1;
             continue;
         }
@@ -32,11 +32,11 @@ pub fn run(repo: &Path, force: bool) -> Result<u8, Error> {
         }
         fs::write(&abs, &file.contents)
             .map_err(|e| Error::Io(format!("write {}: {e}", abs.display())))?;
-        println!("  write: {}", file.rel_path);
+        outln!("  write: {}", file.rel_path);
         written += 1;
     }
 
-    println!(
+    outln!(
         "spec-spine init: {written} file(s) written, {skipped} skipped{}. Next: customize \
          specs/000-bootstrap/spec.md, then run `spec-spine compile`.",
         if force { " (--force)" } else { "" }

--- a/crates/spec-spine-cli/src/cmd_lint.rs
+++ b/crates/spec-spine-cli/src/cmd_lint.rs
@@ -20,13 +20,13 @@ pub fn run(repo: &Path, fail_on_warn: bool, fail_on_info: bool) -> Result<u8, Er
             Severity::Info => "info",
         };
         let at = v.path.as_deref().unwrap_or("-");
-        println!("  {} [{tier}] [{}] {}", v.code, at, v.message);
+        outln!("  {} [{tier}] [{}] {}", v.code, at, v.message);
     }
 
     let errors = report.count(Severity::Error);
     let warnings = report.count(Severity::Warning);
     let infos = report.count(Severity::Info);
-    println!("lint: {errors} error(s), {warnings} warning(s), {infos} info");
+    outln!("lint: {errors} error(s), {warnings} warning(s), {infos} info");
 
     let fail = errors > 0 || (fail_on_warn && warnings > 0) || (fail_on_info && infos > 0);
     Ok(if fail { 1 } else { 0 })

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -70,7 +70,7 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                     print_json(&ids)?;
                 } else {
                     for id in ids {
-                        println!("{id}");
+                        outln!("{id}");
                     }
                 }
             } else {
@@ -78,10 +78,10 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 if *json {
                     print_json(&specs)?;
                 } else if specs.is_empty() {
-                    println!("(no specs)");
+                    outln!("(no specs)");
                 } else {
                     for s in specs {
-                        println!("{}  {:<11}  {}", s.id, status_label(s.status), s.title);
+                        outln!("{}  {:<11}  {}", s.id, status_label(s.status), s.title);
                     }
                 }
             }
@@ -91,12 +91,12 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
             if *json {
                 print_json(spec)?;
             } else {
-                println!("id:      {}", spec.id);
-                println!("title:   {}", spec.title);
-                println!("status:  {}", status_label(spec.status));
-                println!("created: {}", spec.created);
-                println!("path:    {}", spec.spec_path);
-                println!("summary: {}", spec.summary.trim());
+                outln!("id:      {}", spec.id);
+                outln!("title:   {}", spec.title);
+                outln!("status:  {}", status_label(spec.status));
+                outln!("created: {}", spec.created);
+                outln!("path:    {}", spec.spec_path);
+                outln!("summary: {}", spec.summary.trim());
             }
         }
         RegistryQuery::StatusReport { json, nonzero_only } => {
@@ -106,7 +106,7 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 if *json {
                     print_json(&projected)?;
                 } else {
-                    println!("total:      {}", projected.total);
+                    outln!("total:      {}", projected.total);
                     print_count("draft:     ", projected.draft);
                     print_count("approved:  ", projected.approved);
                     print_count("superseded:", projected.superseded);
@@ -115,11 +115,11 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
             } else if *json {
                 print_json(&report)?;
             } else {
-                println!("total:      {}", report.total);
-                println!("draft:      {}", report.draft);
-                println!("approved:   {}", report.approved);
-                println!("superseded: {}", report.superseded);
-                println!("retired:    {}", report.retired);
+                outln!("total:      {}", report.total);
+                outln!("draft:      {}", report.draft);
+                outln!("approved:   {}", report.approved);
+                outln!("superseded: {}", report.superseded);
+                outln!("retired:    {}", report.retired);
             }
         }
         RegistryQuery::Relationships { id, json } => {
@@ -127,7 +127,7 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
             if *json {
                 print_json(&view)?;
             } else {
-                println!("{}", view.id);
+                outln!("{}", view.id);
                 print_ids("depends_on", &view.depends_on);
                 print_ids("supersedes", &view.supersedes);
                 print_ids("amends", &view.amends);
@@ -163,18 +163,18 @@ fn status_label(s: Status) -> &'static str {
 
 fn print_count(label: &str, count: Option<usize>) {
     if let Some(n) = count {
-        println!("{label} {n}");
+        outln!("{label} {n}");
     }
 }
 
 fn print_ids(label: &str, ids: &[String]) {
     if !ids.is_empty() {
-        println!("  {label}: {}", ids.join(", "));
+        outln!("  {label}: {}", ids.join(", "));
     }
 }
 
 fn print_json<T: serde::Serialize>(value: &T) -> Result<(), Error> {
     let s = serde_json::to_string_pretty(value).map_err(|e| Error::Schema(e.to_string()))?;
-    println!("{s}");
+    outln!("{s}");
     Ok(())
 }

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -3,6 +3,15 @@
 //! typed `Error` to a stable process exit code. All `process::exit`, stdout, and
 //! `git`/clock side effects live here, never in the library.
 
+/// `println!` for stdout that does not panic when the reader goes away.
+///
+/// Defined before the `mod` items below so every submodule sees it (textual
+/// macro scoping). See `out.rs` for why this exists (spec 035).
+macro_rules! outln {
+    () => { $crate::out::line(format_args!("")) };
+    ($($arg:tt)*) => { $crate::out::line(format_args!($($arg)*)) };
+}
+
 mod cmd_attest;
 mod cmd_compile;
 mod cmd_couple;
@@ -10,6 +19,7 @@ mod cmd_index;
 mod cmd_init;
 mod cmd_lint;
 mod cmd_registry;
+mod out;
 mod seal;
 mod verify_attestation;
 

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -12,6 +12,12 @@ macro_rules! outln {
     ($($arg:tt)*) => { $crate::out::line(format_args!($($arg)*)) };
 }
 
+/// `print!` for stdout that does not panic when the reader goes away. For
+/// pre-formatted blocks that already carry their own trailing newline.
+macro_rules! out {
+    ($($arg:tt)*) => { $crate::out::block(format_args!($($arg)*)) };
+}
+
 mod cmd_attest;
 mod cmd_compile;
 mod cmd_couple;

--- a/crates/spec-spine-cli/src/out.rs
+++ b/crates/spec-spine-cli/src/out.rs
@@ -55,6 +55,27 @@ pub(crate) fn line(args: Arguments<'_>) {
     }
 }
 
+/// Write a pre-formatted block to stdout verbatim, adding no newline.
+///
+/// The rendered projections (`index render`, `index coverage`) build their
+/// whole output as a single string that already ends in a newline, so they need
+/// a write that does not append a second one. Same classification as [`line`].
+pub(crate) fn block(args: Arguments<'_>) {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    let res = write!(handle, "{args}").and_then(|()| handle.flush());
+    match classify(&res) {
+        Outcome::Wrote => {}
+        Outcome::ReaderGone => std::process::exit(0),
+        Outcome::Failed => {
+            if let Err(e) = res {
+                eprintln!("spec-spine: cannot write to stdout: {e}");
+            }
+            std::process::exit(3);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Outcome, classify};

--- a/crates/spec-spine-cli/src/out.rs
+++ b/crates/spec-spine-cli/src/out.rs
@@ -1,0 +1,81 @@
+//! Stdout writes that survive a closed reader (spec 035).
+//!
+//! `println!` unwraps its write, so a reader that stops early made the process
+//! panic: `spec-spine registry list --json | head` exited **101**, outside the
+//! documented `0`/`1`/`2`/`3` contract, with a backtrace on stderr. Piping into
+//! `head`, `less` or `grep -q` is ordinary use, not an error.
+//!
+//! Every stdout write in the CLI goes through [`line`]. Stderr keeps using
+//! `eprintln!`: diagnostics are small, and a broken stderr has nowhere left to
+//! report itself anyway.
+
+use std::fmt::Arguments;
+use std::io::{self, Write};
+
+/// What a stdout write means for the process.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    /// Written.
+    Wrote,
+    /// The reader went away: `head` had enough, a pager was quit. The consumer
+    /// got what it asked for, so this is a normal end, not a failure.
+    ReaderGone,
+    /// A genuine I/O failure (a full disk, a closed descriptor).
+    Failed,
+}
+
+/// Classify a write result. Split out from [`line`] so the policy is testable
+/// without arranging a real broken pipe.
+pub(crate) fn classify(res: &io::Result<()>) -> Outcome {
+    match res {
+        Ok(()) => Outcome::Wrote,
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Outcome::ReaderGone,
+        Err(_) => Outcome::Failed,
+    }
+}
+
+/// Write one line to stdout, ending the process cleanly if the reader is gone.
+///
+/// Exits `0` on a closed pipe: the reader chose to stop, and the shell
+/// convention is that `producer | head` succeeds. Exits `3` on a real I/O
+/// failure, matching the `Error::exit_code()` mapping for I/O in `main.rs`.
+pub(crate) fn line(args: Arguments<'_>) {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    let res = writeln!(handle, "{args}");
+    match classify(&res) {
+        Outcome::Wrote => {}
+        Outcome::ReaderGone => std::process::exit(0),
+        Outcome::Failed => {
+            if let Err(e) = res {
+                eprintln!("spec-spine: cannot write to stdout: {e}");
+            }
+            std::process::exit(3);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Outcome, classify};
+    use std::io::{self, ErrorKind};
+
+    #[test]
+    fn ok_is_wrote() {
+        assert_eq!(classify(&Ok(())), Outcome::Wrote);
+    }
+
+    #[test]
+    fn broken_pipe_is_reader_gone() {
+        let e = io::Error::new(ErrorKind::BrokenPipe, "closed");
+        assert_eq!(classify(&Err(e)), Outcome::ReaderGone);
+    }
+
+    #[test]
+    fn other_io_errors_are_failures() {
+        for kind in [ErrorKind::PermissionDenied, ErrorKind::WriteZero] {
+            let e = io::Error::new(kind, "x");
+            assert_eq!(classify(&Err(e)), Outcome::Failed, "{kind:?}");
+        }
+    }
+}

--- a/crates/spec-spine-cli/src/out.rs
+++ b/crates/spec-spine-cli/src/out.rs
@@ -42,17 +42,7 @@ pub(crate) fn classify(res: &io::Result<()>) -> Outcome {
 pub(crate) fn line(args: Arguments<'_>) {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    let res = writeln!(handle, "{args}");
-    match classify(&res) {
-        Outcome::Wrote => {}
-        Outcome::ReaderGone => std::process::exit(0),
-        Outcome::Failed => {
-            if let Err(e) = res {
-                eprintln!("spec-spine: cannot write to stdout: {e}");
-            }
-            std::process::exit(3);
-        }
-    }
+    finish(writeln!(handle, "{args}"));
 }
 
 /// Write a pre-formatted block to stdout verbatim, adding no newline.
@@ -63,16 +53,24 @@ pub(crate) fn line(args: Arguments<'_>) {
 pub(crate) fn block(args: Arguments<'_>) {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    let res = write!(handle, "{args}").and_then(|()| handle.flush());
-    match classify(&res) {
-        Outcome::Wrote => {}
-        Outcome::ReaderGone => std::process::exit(0),
-        Outcome::Failed => {
-            if let Err(e) = res {
-                eprintln!("spec-spine: cannot write to stdout: {e}");
-            }
+    finish(write!(handle, "{args}").and_then(|()| handle.flush()));
+}
+
+/// Apply [`classify`]'s verdict to the process. Shared by both entry points so
+/// the policy exists once; matching on the result directly keeps the error in
+/// hand without an `unwrap_err` that could only ever be reached by a bug.
+fn finish(res: io::Result<()>) {
+    match (classify(&res), res) {
+        (Outcome::Wrote, _) => {}
+        (Outcome::ReaderGone, _) => std::process::exit(0),
+        (Outcome::Failed, Err(e)) => {
+            eprintln!("spec-spine: cannot write to stdout: {e}");
             std::process::exit(3);
         }
+        // `classify` returns `Failed` only for `Err`, so this arm is a type
+        // formality. Treat it as a write failure rather than panicking: the
+        // exit-code contract this spec restores has no entry for 101.
+        (Outcome::Failed, Ok(())) => std::process::exit(3),
     }
 }
 

--- a/crates/spec-spine-cli/src/verify_attestation.rs
+++ b/crates/spec-spine-cli/src/verify_attestation.rs
@@ -48,7 +48,7 @@ pub fn run(repo: &Path, args: &VerifyArgs) -> Result<u8, Error> {
     if args.recompute {
         match verify_recompute(&cfg, repo, &attestation)? {
             VerifyOutcome::Match => {
-                println!("recompute: MATCH (the corpus reproduces this attestation)");
+                outln!("recompute: MATCH (the corpus reproduces this attestation)");
             }
             VerifyOutcome::VersionMismatch { expected, actual } => {
                 eprintln!(
@@ -87,7 +87,7 @@ pub fn run(repo: &Path, args: &VerifyArgs) -> Result<u8, Error> {
         // and the seal stops verifying.
         let hash = attestation_hash(&attestation)?;
         if seal::verify(&hash, &ledger_seal, &verifying_key)? {
-            println!("signature: VALID (sealed by keyId {})", ledger_seal.key_id);
+            outln!("signature: VALID (sealed by keyId {})", ledger_seal.key_id);
         } else {
             eprintln!(
                 "signature: INVALID (the seal does not verify against the supplied public key)"

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -749,6 +749,44 @@ fn closed_reader_exits_cleanly_rather_than_panicking() {
     );
 }
 
+/// Byte offsets of panicking **stdout** macro calls on one source line.
+///
+/// Every occurrence is examined, not just the first: `println!(` also occurs
+/// inside `eprintln!(`, so a line carrying a stderr call before a real stdout
+/// one would otherwise be cleared by its first match and the real call never
+/// seen. A gate meant to be permanent proof cannot have a false negative.
+fn panicking_stdout_macros(line: &str) -> Vec<usize> {
+    let mut hits = Vec::new();
+    if line.trim_start().starts_with("//") {
+        return hits;
+    }
+    for mac in ["print!(", "println!("] {
+        let mut from = 0;
+        while let Some(rel) = line[from..].find(mac) {
+            let at = from + rel;
+            // Stderr keeps the panicking macros by design (spec 035 §3.3).
+            let is_stderr = at > 0 && line.as_bytes()[at - 1] == b'e';
+            if !is_stderr {
+                hits.push(at);
+            }
+            from = at + mac.len();
+        }
+    }
+    hits
+}
+
+#[test]
+fn scanner_does_not_let_a_stderr_call_mask_a_stdout_one() {
+    assert!(panicking_stdout_macros(r#"eprintln!("x");"#).is_empty());
+    assert!(panicking_stdout_macros(r#"eprint!("x");"#).is_empty());
+    assert!(panicking_stdout_macros("// println!(\"a comment\");").is_empty());
+    assert!(!panicking_stdout_macros(r#"println!("x");"#).is_empty());
+    assert!(!panicking_stdout_macros(r#"print!("x");"#).is_empty());
+    // The regression: the stderr call comes first and must not clear the line.
+    assert!(!panicking_stdout_macros(r#"eprintln!("{}", x); println!("{}", y);"#).is_empty());
+    assert!(!panicking_stdout_macros(r#"eprint!("{}", x); print!("{}", y);"#).is_empty());
+}
+
 /// Spec 035 §3.5(3). The block path (`index render`, `index coverage`) cannot be
 /// exercised by a pipe-breaking test: its output fits inside a pipe buffer on
 /// any corpus small enough to build in one, so such a test could never fail.
@@ -781,23 +819,12 @@ fn no_panicking_stdout_macro_remains_in_the_cli() {
         let text = fs::read_to_string(&path).unwrap();
         for (n, raw) in text.lines().enumerate() {
             let line = raw.trim_start();
-            // Comments name these macros when explaining why they are not used.
-            if line.starts_with("//") {
-                continue;
-            }
-            // `print!(` also occurs inside `eprint!(`, and `println!(` inside
-            // `eprintln!(`; stderr keeps the panicking macros by design (§3.3).
-            for mac in ["print!(", "println!("] {
-                if let Some(at) = line.find(mac) {
-                    let is_stderr = at > 0 && line.as_bytes()[at - 1] == b'e';
-                    if !is_stderr {
-                        offenders.push(format!(
-                            "{}:{}: {line}",
-                            path.strip_prefix(&src).unwrap_or(&path).display(),
-                            n + 1
-                        ));
-                    }
-                }
+            if !panicking_stdout_macros(line).is_empty() {
+                offenders.push(format!(
+                    "{}:{}: {line}",
+                    path.strip_prefix(&src).unwrap_or(&path).display(),
+                    n + 1
+                ));
             }
         }
     }

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -674,3 +674,77 @@ fn index_coverage_reports_and_gates() {
             .contains("coverage: 2/2 source files specifically claimed (100.0%)")
     );
 }
+
+// ===== spec 035: a reader that stops early is not an error =====
+
+/// `println!` unwraps its write, so a closed reader panicked the process:
+/// `spec-spine registry list --json | head` exited **101** with a backtrace,
+/// outside the documented 0/1/2/3 contract. Piping into `head` or a pager is
+/// ordinary use.
+///
+/// The fixture is deliberately oversized. The child must still be mid-write
+/// when the reader goes away, so the output has to exceed the OS pipe buffer
+/// (64 KiB on Linux, smaller on some platforms); 30 specs with an 8 KiB summary
+/// each is comfortably past any of them.
+#[test]
+fn closed_reader_exits_cleanly_rather_than_panicking() {
+    use std::io::Read;
+    use std::process::Stdio;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let filler = "x".repeat(8192);
+    for i in 0..30 {
+        let id = format!("{i:03}-spec");
+        let dir = tmp.path().join("specs").join(&id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("spec.md"),
+            format!(
+                "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-08\"\nsummary: \"{filler}\"\n---\n# {id}\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    // `registry list` reads the committed shards, so the corpus has to exist.
+    let compiled = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .arg("compile")
+        .output()
+        .unwrap();
+    assert_eq!(code(&compiled), 0, "fixture must compile");
+
+    let mut child = bin()
+        .arg("--repo")
+        .arg(tmp.path())
+        .args(["registry", "list", "--json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Read a little, then close the pipe: exactly what `| head -c 32` does.
+    let mut stdout = child.stdout.take().unwrap();
+    let mut buf = [0u8; 32];
+    let _ = stdout.read(&mut buf);
+    drop(stdout);
+
+    let out = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_ne!(
+        out.status.code(),
+        Some(101),
+        "a closed reader must not panic the process; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "no panic should reach stderr; stderr: {stderr}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a reader that stops early is a normal end; stderr: {stderr}"
+    );
+}

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -759,8 +759,22 @@ fn no_panicking_stdout_macro_remains_in_the_cli() {
     let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut offenders: Vec<String> = Vec::new();
 
-    for entry in fs::read_dir(&src).unwrap() {
-        let path = entry.unwrap().path();
+    // Recursive: `src/` is flat today, but a future `src/util/` must not escape
+    // the enforcement by being invisible to it.
+    let mut dirs = vec![src.clone()];
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    while let Some(dir) = dirs.pop() {
+        for entry in fs::read_dir(&dir).unwrap() {
+            let p = entry.unwrap().path();
+            if p.is_dir() {
+                dirs.push(p);
+            } else {
+                files.push(p);
+            }
+        }
+    }
+
+    for path in files {
         if path.extension().is_none_or(|e| e != "rs") {
             continue;
         }
@@ -779,7 +793,7 @@ fn no_panicking_stdout_macro_remains_in_the_cli() {
                     if !is_stderr {
                         offenders.push(format!(
                             "{}:{}: {line}",
-                            path.file_name().unwrap().to_string_lossy(),
+                            path.strip_prefix(&src).unwrap_or(&path).display(),
                             n + 1
                         ));
                     }

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -748,3 +748,49 @@ fn closed_reader_exits_cleanly_rather_than_panicking() {
         "a reader that stops early is a normal end; stderr: {stderr}"
     );
 }
+
+/// Spec 035 §3.5(3). The block path (`index render`, `index coverage`) cannot be
+/// exercised by a pipe-breaking test: its output fits inside a pipe buffer on
+/// any corpus small enough to build in one, so such a test could never fail.
+/// The guarantee is asserted structurally instead. This is the check that would
+/// have caught the two `print!` sites a line-only migration left behind.
+#[test]
+fn no_panicking_stdout_macro_remains_in_the_cli() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders: Vec<String> = Vec::new();
+
+    for entry in fs::read_dir(&src).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        let text = fs::read_to_string(&path).unwrap();
+        for (n, raw) in text.lines().enumerate() {
+            let line = raw.trim_start();
+            // Comments name these macros when explaining why they are not used.
+            if line.starts_with("//") {
+                continue;
+            }
+            // `print!(` also occurs inside `eprint!(`, and `println!(` inside
+            // `eprintln!(`; stderr keeps the panicking macros by design (§3.3).
+            for mac in ["print!(", "println!("] {
+                if let Some(at) = line.find(mac) {
+                    let is_stderr = at > 0 && line.as_bytes()[at - 1] == b'e';
+                    if !is_stderr {
+                        offenders.push(format!(
+                            "{}:{}: {line}",
+                            path.file_name().unwrap().to_string_lossy(),
+                            n + 1
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "CLI stdout must go through out.rs, not a panicking macro (spec 035):\n{}",
+        offenders.join("\n")
+    );
+}

--- a/specs/035-stdout-closed-reader/spec.md
+++ b/specs/035-stdout-closed-reader/spec.md
@@ -1,0 +1,148 @@
+---
+id: "035-stdout-closed-reader"
+title: "A closed reader is not an error: stdout writes stop panicking the CLI"
+status: draft
+kind: "tooling"
+created: "2026-09-03"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "001-compile-registry"
+  - "002-registry-query"
+establishes:
+  - "crates/spec-spine-cli/src/out.rs"
+extends:
+  # A crate-wide output-mechanism change, so every edge names the crate's floor
+  # owner (001) rather than each command's semantic owner: no command's meaning
+  # changes, only the call it makes to write a line.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_attest.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_couple.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_init.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_lint.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_registry.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/verify_attestation.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+summary: >
+  Exit codes are a stable contract: 0 ok, 1 validation failure, 2 stale, 3 I/O.
+  The CLI could exit 101. `println!` unwraps its write, so a reader that stops
+  early made the process panic: `spec-spine registry list --json | head` printed
+  a Rust backtrace and exited 101, and under `set -o pipefail` that failed the
+  surrounding script. Piping into `head`, `less` or `grep -q` is ordinary use,
+  not an error condition. This spec routes every CLI stdout write through one
+  helper that classifies the write instead of unwrapping it: a closed reader
+  ends the process 0, because the consumer got what it asked for, and a genuine
+  I/O failure reports and exits 3, which is the code the contract already
+  assigns to I/O. Stderr keeps `eprintln!`: diagnostics are small, and a broken
+  stderr has nowhere left to report itself. The fix is not `unsafe` SIGPIPE
+  restoration, which `forbid(unsafe_code)` rules out workspace-wide, and not a
+  panic hook, which would match on a message string the standard library is
+  free to change.
+---
+
+# 035: A closed reader is not an error
+
+## 1. Purpose
+
+`CLAUDE.md` and `docs/design/00-architecture.md` both state the exit codes as a
+stable contract: `0` ok, `1` validation failure / not found / drift, `2` stale,
+`3` I/O / parse / schema / config. `main.rs` maps them in exactly one place, via
+`Error::exit_code()`.
+
+The CLI could nonetheless exit `101`, the Rust panic code, through a path that
+never reached that mapping:
+
+```
+$ spec-spine registry list --json | head -c 50
+thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
+failed printing to stdout: Broken pipe (os error 32)
+$ echo ${PIPESTATUS[0]}
+101
+```
+
+`println!` unwraps its write. When the reader stops early the write fails with
+`BrokenPipe`, and the macro panics. Under `set -o pipefail`, a shell pipeline
+that reads part of the output fails.
+
+Reading part of a stream is not an error. `head`, `less`, `grep -q` and a
+terminal pager all do it, and every well-behaved Unix producer treats it as a
+normal end. The failure was also self-inflicted in a specific way: this is the
+same argument spec 033's `V-014` review turned on, where a panic was rejected
+precisely because 101 sits outside the documented contract. The CLI was doing on
+its most ordinary path what the library had just refused to do on an unreachable
+one.
+
+## 2. Territory
+
+`out.rs`, new: the write helper and its classification. `main.rs`: the `outln!`
+macro and the module declaration. The eight command modules and
+`verify_attestation.rs`: their stdout call sites. `tests/cli.rs`: the end-to-end
+acceptance test.
+
+## 3. Behavior
+
+### 3.1 One helper, three outcomes
+
+Every stdout line in the CLI goes through one function that writes to a locked
+handle and classifies the result rather than unwrapping it:
+
+| outcome | when | process |
+|---|---|---|
+| written | the write succeeded | continue |
+| reader gone | `ErrorKind::BrokenPipe` | exit `0` |
+| failed | any other I/O error | report on stderr, exit `3` |
+
+`0` for a closed reader is the shell convention: `producer | head` succeeds.
+`3` for a real failure is the code the contract already assigns to I/O, so the
+mapping in `main.rs` stays the single authority on what each code means.
+
+### 3.2 Why not the two shorter fixes
+
+**Restoring the default `SIGPIPE` disposition** is the usual remedy and is
+unavailable here: it requires an `unsafe` libc call, and `unsafe` is
+`forbid`-en workspace-wide in `Cargo.toml [workspace.lints]`. Pulling in a
+third-party crate to perform the same `unsafe` behind a safe wrapper would honor
+the letter of that lint while evading its intent, and would add a dependency to
+the determinism surface for one signal.
+
+**A panic hook, or `catch_unwind` in `main`,** would have to recognize the
+broken-pipe panic by its message text. That string belongs to the standard
+library and can change without notice, so the guard would fail silently on a
+toolchain bump. It also leaves `println!` panicking and merely intercepts the
+result.
+
+Routing the writes is more code, and it is the version that cannot rot: the
+`BrokenPipe` error kind is a stable API.
+
+### 3.3 Stderr is deliberately unchanged
+
+`eprintln!` stays at every diagnostic site. Stderr output is small and rarely
+piped, and a process whose stderr has gone has no remaining channel to report
+that fact, so the classification would have nothing useful to do.
+
+### 3.4 Determinism and output are unaffected
+
+Bytes written are identical: the helper writes the same formatted line to the
+same handle. No artifact, hash or emitted JSON changes, so the determinism gate
+and every golden test are untouched. Only the behavior when a write *fails*
+changes.
+
+### 3.5 Tests (minimum)
+
+1. Classification is pure and tested directly: `Ok` is written, `BrokenPipe` is
+   reader-gone, other kinds are failures.
+2. End to end: the binary emitting more than a pipe buffer, whose reader closes
+   after 32 bytes, exits `0`, does not exit `101`, and prints no panic to
+   stderr.
+
+## 4. Out of scope
+
+- **Stderr classification**, per §3.3.
+- **Buffered or streaming output.** The helper writes line by line, as the
+  macros it replaces did. Making large queries stream is a separate performance
+  question this spec does not open.
+- **The exit-code contract itself.** This spec brings a path that escaped the
+  contract back under it; it adds no code and redefines none.

--- a/specs/035-stdout-closed-reader/spec.md
+++ b/specs/035-stdout-closed-reader/spec.md
@@ -77,17 +77,27 @@ one.
 
 ## 2. Territory
 
-`out.rs`, new: the write helper and its classification. `main.rs`: the `outln!`
-macro and the module declaration. The eight command modules and
-`verify_attestation.rs`: their stdout call sites. `tests/cli.rs`: the end-to-end
-acceptance test.
+`out.rs`, new: the two write entry points and their shared classification.
+`main.rs`: the `outln!` and `out!` macros and the module declaration. The eight
+command modules and `verify_attestation.rs`: their stdout call sites, including
+the two `print!` block writes in `cmd_index.rs` that emit the rendered
+projections. `tests/cli.rs`: the end-to-end acceptance test.
 
 ## 3. Behavior
 
-### 3.1 One helper, three outcomes
+### 3.1 Two entry points, one classifier, three outcomes
 
-Every stdout line in the CLI goes through one function that writes to a locked
-handle and classifies the result rather than unwrapping it:
+The CLI writes stdout two ways, and both must be covered. Most sites emit one
+formatted line (`println!`). The rendered projections, `index render` and
+`index coverage`, build their whole output as a single string that already ends
+in a newline and emit it with `print!`, which panics identically. A line-only
+helper would have left those two sites unguarded while the rule read as though
+they were covered.
+
+So there are two entry points, `line` (appends a newline) and `block` (writes
+verbatim), sharing one classifier. No CLI stdout write uses `println!` or
+`print!` directly. Both entry points classify the write rather than unwrapping
+it:
 
 | outcome | when | process |
 |---|---|---|
@@ -137,6 +147,12 @@ changes.
 2. End to end: the binary emitting more than a pipe buffer, whose reader closes
    after 32 bytes, exits `0`, does not exit `101`, and prints no panic to
    stderr.
+3. The block path (`index render`, `index coverage`) is covered by
+   construction rather than by a pipe-breaking test: it shares the classifier
+   with the line path, and its output on any corpus small enough to build in a
+   test fits inside a pipe buffer, so such a test could not fail. What is
+   asserted instead is the property that makes the guarantee total: no
+   `print!` or `println!` remains at a CLI stdout site.
 
 ## 4. Out of scope
 


### PR DESCRIPTION
Exit codes are a stable contract (`0` ok, `1` validation failure, `2` stale, `3`
I/O), mapped in exactly one place via `Error::exit_code()`. The CLI could still
exit **101** through a path that never reached that mapping:

```
$ spec-spine registry list --json | head -c 50
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
$ echo ${PIPESTATUS[0]}
101
```

`println!` unwraps its write, so a reader that stops early panicked the process,
and under `set -o pipefail` that failed the surrounding script. Reading part of
a stream is not an error: `head`, `less`, `grep -q` and any pager all do it.

## The fix

All 39 CLI stdout writes go through one helper that classifies the write instead
of unwrapping it:

| outcome | when | process |
|---|---|---|
| written | success | continue |
| reader gone | `ErrorKind::BrokenPipe` | exit `0` |
| failed | any other I/O error | report on stderr, exit `3` |

`0` for a closed reader is the shell convention (`producer \| head` succeeds).
`3` for a real failure is the code the contract already assigns to I/O, so
`main.rs` stays the single authority on what each code means.

Output is byte-for-byte identical: the helper writes the same formatted line to
the same handle. No artifact, hash or golden test moves. Only the behavior when
a write *fails* changes.

**Stderr is deliberately unchanged.** `eprintln!` stays at every diagnostic
site: that output is small, and a process whose stderr has gone has no channel
left to report the fact.

## Why not the two shorter fixes

**Restoring the default `SIGPIPE` disposition** is the usual remedy and is
unavailable: it needs an `unsafe` libc call, and `unsafe` is `forbid`-en
workspace-wide in `[workspace.lints]`. Taking a third-party crate to perform the
same `unsafe` behind a safe wrapper would honor the lint's letter against its
intent, and would add a dependency to the determinism surface for one signal.

**A panic hook or `catch_unwind`** would have to recognize the broken-pipe panic
by its message text. That string belongs to the standard library and can change
on a toolchain bump, so the guard would fail silently; it also leaves `println!`
panicking underneath. `ErrorKind::BrokenPipe` is stable API.

## Tests

- The classifier directly: `Ok` is written, `BrokenPipe` is reader-gone, other
  kinds are failures.
- End to end: a fixture emitting more than a pipe buffer (30 specs with an 8 KiB
  summary, so it exceeds the 64 KiB buffer on any platform) whose reader closes
  after 32 bytes. Asserts exit `0`, not `101`, and no panic on stderr.

Verified non-vacuous by reverting the fix in `cmd_registry.rs`, which reproduces
`left: Some(101)`.

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 35 shards |
| `index check` | fresh |
| `lint --fail-on-warn --fail-on-info` | 0 / 0 / 0 |
| `couple --base main --head HEAD` | OK, 12 paths, no drift (self-clears, no waiver) |
| `cargo fmt` / `clippy -D warnings` / `test --workspace` | clean / clean / 23 suites pass |
| `registry list --json \| head -c 50` | exit `0` (was `101`) |

Spec 035 is filed here as `draft`. Its `extends` edges name `001` for all ten
modified files because this is crate-wide output plumbing: no command's meaning
changes, only the call it makes to write a line. `out.rs` is `establishes`.

## A note on provenance

This is the same argument spec 033's review turned on, where an `expect()` was
refused because 101 sits outside the documented contract. The CLI was doing on
its most ordinary path what the library had just declined to do on an
unreachable one.

## Merge order

Independent of #74, #75 and #76: no shared shards, and the only overlap with
#76 is that both add a new spec directory.
