### PR TITLE
chore(034,035): ratify specs 034 and 035 (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -46,8 +46,8 @@
       }
     ],
     "specId": "034-references-non-owning-paths",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f9c3302d28e923cda61c908a9fc20bb111f0622604b112c352297d2e07a0971a"
+  "shardHash": "f7571a9d6f31bedd2853f2812e15534a0bb1287c7e6bef6482f5ebe1d6b3eb0e"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -196,8 +196,8 @@
       }
     ],
     "specId": "035-stdout-closed-reader",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5a321266b8796d029344f93730dcfab6ccf37c5ff924eaf4e8e82bb82557344a"
+  "shardHash": "e09a0deee43509d610dd1f612b7b7c570105d019c3bd06bc7f2d2d44e97e8f93"
 }

--- a/.derived/spec-registry/by-spec/034-references-non-owning-paths.json
+++ b/.derived/spec-registry/by-spec/034-references-non-owning-paths.json
@@ -44,10 +44,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/034-references-non-owning-paths/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The contract says `references` is the only non-owning edge and that the coupling gate ignores it. The indexer did not implement that. It seeded a spec's `implementingPaths` from every resolved unit location, owning or not, so a file a spec merely cited became a file it claimed. Every consumer reads that field as a claim: `couple.rs` treats a listed path as whole-file ownership, the indexer's own `owners_of_unit` does the same, and `orphaned_specs` and coverage read a non-empty list as \"this spec claims something\". One wrong seed made all of them wrong together. The observable defect is that a spec could not edit its own `spec.md` without a waiver once any other spec referenced it: on this corpus, changing `specs/020-derived-artifact-merge-driver/spec.md` was refused as `C-001` with `024-index-sharding`, which only cites it, named as the sole owner. This spec filters the seed by the `ownership` flag the loop already holds, at the single source rather than at each consumer. The citation is not lost: it stays in `resolvedUnits` with `ownership: false`, so provenance is preserved and only the ownership view changes. No DTO or schema shape changes.\n",
     "title": "`references` seeds no implementing path: closing the C-001 ownership leak"
   },
-  "shardHash": "e65bc1a8286f01eab71f0cc6f40c2d67ad3da355637d3ebd52ca9355da4c8fa6",
+  "shardHash": "54c4e2be071d742b419ccdc8b70ecadd39892f1a48caeb37901f21565e5eb805",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
+++ b/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
@@ -111,10 +111,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/035-stdout-closed-reader/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Exit codes are a stable contract: 0 ok, 1 validation failure, 2 stale, 3 I/O. The CLI could exit 101. `println!` unwraps its write, so a reader that stops early made the process panic: `spec-spine registry list --json | head` printed a Rust backtrace and exited 101, and under `set -o pipefail` that failed the surrounding script. Piping into `head`, `less` or `grep -q` is ordinary use, not an error condition. This spec routes every CLI stdout write through one helper that classifies the write instead of unwrapping it: a closed reader ends the process 0, because the consumer got what it asked for, and a genuine I/O failure reports and exits 3, which is the code the contract already assigns to I/O. Stderr keeps `eprintln!`: diagnostics are small, and a broken stderr has nowhere left to report itself. The fix is not `unsafe` SIGPIPE restoration, which `forbid(unsafe_code)` rules out workspace-wide, and not a panic hook, which would match on a message string the standard library is free to change.\n",
     "title": "A closed reader is not an error: stdout writes stop panicking the CLI"
   },
-  "shardHash": "1ddbba814b1a6a368e9c2eed570bee75e11726e6b12fc1d112fe754aad9d1eed",
+  "shardHash": "b006c12e017e714dfbedbb313d4e8e033030efdd0b64760460360fabb296bd1f",
   "specVersion": "1.1.0"
 }

--- a/specs/034-references-non-owning-paths/spec.md
+++ b/specs/034-references-non-owning-paths/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "034-references-non-owning-paths"
 title: "`references` seeds no implementing path: closing the C-001 ownership leak"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-03"
 implementation: complete

--- a/specs/035-stdout-closed-reader/spec.md
+++ b/specs/035-stdout-closed-reader/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "035-stdout-closed-reader"
 title: "A closed reader is not an error: stdout writes stop panicking the CLI"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-03"
 implementation: complete


### PR DESCRIPTION
Flips `034-references-non-owning-paths` and `035-stdout-closed-reader` to `approved` now that #76 and #77 have landed, and restamps their four shards (`compile` + `index`).

**Corpus: 36/36 approved** (was 34 approved / 2 draft).

Both specs already carried `implementation: complete`; this is the lifecycle flip only, with no prose or edge changes.

## Verification

| check | result |
|---|---|
| `compile --check` | fresh, 36 shards |
| `index check` | fresh |
| `lint --fail-on-warn` | 0 errors / 0 warnings / 0 info |
| `couple --base origin/main --head HEAD` | OK, 2 paths checked, no drift |
| `registry status-report --nonzero-only` | `{ total: 36, approved: 36 }` |

## Changed files

Six, and only the expected six:

- `specs/034-references-non-owning-paths/spec.md` (one line: `status`)
- `specs/035-stdout-closed-reader/spec.md` (one line: `status`)
- the four matching `.derived/{spec-registry,codebase-index}/by-spec/*.json` shards

Each spec's own edit clears the coupling gate, so no waiver is needed.