### PR TITLE
chore(030): enable the dependency-only auto-waiver on this repo

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "68beb3c91e6b39469e6808d60b896613eeb078654c9835935972cd57f0ad3a9b"
+  "shardHash": "c135b262914b24ce48ecf6ed8ac63dbe58d4455a10929c294986608a18113834"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0e351be024629a309510ae09e06e80f0dca3bd034e4997587c09b1d688b25074"
+  "shardHash": "cd339450ec106dd82aacc001b2a03fc63b028bd57ece69d9740f2e1dc9d0fc5c"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9dd1d6781a92ba8138cc5447a8929e075dea5c9ebc1750f33f2cfc5566db4a8c"
+  "shardHash": "faa60a6df25cdda9dcc273ad36e845d6c300c4d7a2c8a81b165fc3fbb95f0eaf"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.11.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5600c068b8bc900790f0b165df4eddf24a567b65f9c7564503ac0b8d42a19ec9"
+  "shardHash": "6a82fe968c15a1f869d03a6d9f69561867516c9246385ece16c860a430bdf0a5"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -10,5 +10,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "06b53a9b09e9d16e7a41bff4557a4639fdcbad274cd118ef81730992be354b6d"
+  "shardHash": "e33c2bc84127b084737102fff6bf56a4f374019589cc67f4d0d2bd4d106d1019"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6d4071580a9b41b5b2133d7905ae02d6a8e207e2957414c57fdc4d004dd80774"
+  "shardHash": "850667ec9596d345330777b87e3bab24f148fd5f55625c1d8f9d773b8d208360"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "33e425cace7ec6c983f92564d70a93c53fec8fe1c3e6234e4087ff1d42ecccaf"
+  "shardHash": "5f74cb99bb80d40d8c2c6a8092d560d8025b522017184b2ee5b3d00dcaf47def"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6159dfbf28390649bf62642b0838bff89d4d6eb751efccd5b89143aecd2cd3e1"
+  "shardHash": "194141431cb2141433d1ace06fc603975b2bfd8e43f24b5cbe5abf70933e7432"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8d77aea612adc4744db68450d5fbbebfd4a0e71ea41305bab331c3c1e6e91e21"
+  "shardHash": "456198bf1f5d176c524a5f5c91e05ca758b11dc7542da21ec564edd75f505680"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ddcd1af54f771be50008808ad8f821f7f8a8827bd13e851502610cc962145963"
+  "shardHash": "84ceca6ab8f693c8b81a70f1463b7ded5ea5cae0d684b619eedc408a0829495d"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a944da0ab00badf20a2d693ba66b221f316429d7888d2195f0d2afeb6e005a37"
+  "shardHash": "c661ea1984ec622c1a4ca560e19fe59b5d67b66f93170315e8dc7aca3f1b7b61"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b4fe3227f2db4c6e22109ea3daa578d250a22e6e3d55d8e4bdd10928f41cc9ae"
+  "shardHash": "535b10c5f861be197848218b474946b75744a30cbb4e8e98549f6bcfc76061db"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "250b0af071226f763166ddb53dd6b0a82736a2517eecf84d16da6daf449f27cd"
+  "shardHash": "d5c0a6805cbd5a5f9a7ba3d8c677c436507d8a47f9578103bf94a598ff9ca04e"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "710acc8378d83ad16122eb3f1f1db67f4bb224b9a810d8d317f1be5906b5c572"
+  "shardHash": "0efdaec691446db63917051e979d82652f969eac4b4ae83a97d20c40047e3392"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80dd1f30b8163b7da2456a1c7be804b4ac18fb66307ee327a0fb15c047c1047b"
+  "shardHash": "cba73e1629ddf900d00d9571a7a6eb3ac0b71498a8a5211abd7fdb3a57e9d554"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "728a3d5d2746e1b271a61372307a6edf6677c42e24dc841722695b25fac500fc"
+  "shardHash": "ebda840d5c87e818ac9e3264966769fbdaca1dd39a71daafefa771b2f8463e14"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "03de72c101237522ea593ed2aba39604f8e8b5c1a1cac02bf29bf7539dc504e6"
+  "shardHash": "200a13a21c45e0401f15769903f5839e5bab4e7f924ea245a71cd58b83e81f53"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e56d39752a5f5d564ead9e2444ccc932c4cc592cfaa6b8b5fff9ffc1f4c4087c"
+  "shardHash": "36a163fd7f745fdbeb2fc31470a7e5c43afd91b704eb2790c83cd9e4fd126d07"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6768b886ebd617119536721c0fdc007df374fed493d4c850e06ba86a936b0ca3"
+  "shardHash": "ce7b00dabc407583bf42049f2c36e238c33076c6aadcecadf1b7cec88f422fdb"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4923086b9e3f7eed78315cb60659a5f6377844887915730eabb8a331454e7d79"
+  "shardHash": "ce2814ef040b9af6fffa4f1087302c463f183055bcb0a15d3dbd633ac356a375"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "248fbb3960646084f14afdc80136e239b144e460409365360ef2232c726aee35"
+  "shardHash": "9fd49a986f999166878807e12d89466ce14e2c62c93d680faa99fa62eed71ab4"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8563c691252fa17d1f0d5dd737d7ba928759732a49e8c152e3136bb3ecc251a8"
+  "shardHash": "bb53f5b724620a10acc7ba591b903e42cfac50cb24bb658a2e47f4aed57ffdd3"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "392b66912accb3ff2a2cb22e026579f52379e14ec62edff7828f2027d1afebe3"
+  "shardHash": "5e65a55e267f2351daf4ba9dbcf724e0d516088f500125c671954fec10c422bc"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d2b76d73490724d06edbad5ef8cc037adf4744cdef31a6e9a71530f28b9dfc4e"
+  "shardHash": "7e5c82400027b0141a8a979e25b02970a79467409fdd306d358d665593572780"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "620a7cc0d0800e5043458f74b414a1114c260ad15326ff30c30ee33481248e82"
+  "shardHash": "5317143e8bf76a2c93f2fccdb6b8c94aeb44b8aa2a9bfa3a899b436a1e8e912f"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f2864b4b04267358fe8419fc9510d72a3fb8ee19b1d205186f9c8447446deab8"
+  "shardHash": "22c25741c9b46c9b9a79863b442a15d8ef74b88e3afd43c7266de453cd5e3d5a"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "565073d3a55a32c26020a126abeb2a40c16767b84827716c9bca5421365404e8"
+  "shardHash": "a0954a3214e080d26a068de2fbab962023b72bd230a6346bcb7e851622d6401b"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "77f11ab8ffa173ae85c1cdc74e1450529c2653e7c13d5b61080d3bd7386ac35b"
+  "shardHash": "6b6b657df4028d60149abe9f8827d1e799da9cf171781626d8bc653907909c32"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "718a64c503e965c2884bc1ac82b626aeb77fc2ee9f8b30fca8bed3a55d2fa410"
+  "shardHash": "54b3d9907c1c7852ba3c5ee7be1840ac843b72fd1a9f6e6f6fa3c7228e4b1ebd"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e028023928cdd8dfed4cb53ae7a919037af033d2c2ad44a3595777d620b94126"
+  "shardHash": "a566c04426ea123a19faccf4b3e7705d9a310fd54e76d795f0fe038f6d3f056a"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80e0ddbd50782c65ff1ae253698ab5c1327f6132459118ddbb0b54595bc1a187"
+  "shardHash": "0ca35f3653561762635123808f64ea03d4c92250ebfa6ad605c07f2695c4c0ee"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b5f52280dcb9b41ac036c791c7288b06480ca51da93f0ce098a2f7f828dd8b7c"
+  "shardHash": "0c87d1adaf6e09204b8eb87e042dd6da7ff4d7a4cba4b46125a208d570d49247"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1941d40c521ccd7d9fabcab1eeac00290c863fdc5f7175f4ea40df8daa20cec7"
+  "shardHash": "4a0fa37d2c818217fc53fc495d1e4360e64a7bfaa5451775f037f042a67e11ab"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "876200ffbc8bced69488d13cb479da4c30b39ed6ba38a5d25d570cc970c21e98"
+  "shardHash": "7eb035bf890d3163676d97c8ba8eea749fe5689191ea46c5f6ab830eba1ef4d0"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e9f3da5e1b79b16844deb5657547f17709da59414fc7746e1d23da95545fdab9"
+  "shardHash": "09e735704f54b5502ccafec5a669c35d95b10c0ae7e7dea2804137be811dc748"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1375aa489f0373fdb3b40535cd201cf4d22436265ebb619776119acc048386fc"
+  "shardHash": "05164c2eb91aaa170c06cfa1ef9ec848845a8032e1dd1c4314c6d0169fda5396"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1d93aa9bc737ab9b4220be0678eae5bea3563e0f72856291725cf9594064b0ce"
+  "shardHash": "0c92b3acf88b157dfca204f0f9555cf78bd1593fb34d2659027a6ed2b86fd777"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "41437c528ed2f1d2e921c9579807ce10ca75907d2c595853c353db89e49d8034"
+  "shardHash": "ee6d9d4d4122561caa76b2e07c941bca8bd27d50d3ad1bda1e29f93c16e58126"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f7571a9d6f31bedd2853f2812e15534a0bb1287c7e6bef6482f5ebe1d6b3eb0e"
+  "shardHash": "e62d2b5724d9d7f593245bd84230db7b4493dca6153c3bd56c3cfe0c1eee9fab"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e09a0deee43509d610dd1f612b7b7c570105d019c3bd06bc7f2d2d44e97e8f93"
+  "shardHash": "b919c10c0408ab154b63b0aa18b63b5a2f3a5166a383d6ad1910a987fada262a"
 }

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -47,11 +47,25 @@ bypass_prefixes = ["**/README.md"]
 waiver_keyword = "Spec-Drift-Waiver:"
 # Spec 032: refuse a changed source file that no spec specifically claims
 # (C-002). Off here on purpose: `spec-spine index coverage` reports this repo at
-# 59/64 (five files owned only by their crate's manifest floor, see 032 §3.8),
+# 60/65 (five files owned only by their crate's manifest floor, see 032 §3.8),
 # and claiming them means editing the tier-1 bootstrap spec, a human's call.
 # The path to adopt is: read the report, flip this on to stop new debt, drive
 # the lists to empty, then add `index coverage --fail-on-untraced` to CI.
 require_ownership = false
+
+# Spec 005 §3.5, extended to cargo and workflow manifests by spec 030: clear a
+# change whose every non-bypassed path is a dependency-only manifest edit, with
+# no other change in the diff. The waiver is mechanical, not a judgement: the
+# CLI re-reads each manifest at base and at head and refuses to waive unless the
+# only difference is dependency versions, and any git failure refuses it too.
+# On for the reason 030 was written. A Dependabot PR cannot add a
+# `Spec-Drift-Waiver:` line to its own body, and its restricted token has no
+# access to the secret store, so without this a routine `Cargo.toml` or
+# `.github/workflows/*.yml` version bump is unmergeable: it trips C-001 against
+# an owning spec that has nothing to say about a patch-level dependency bump.
+# Note this does NOT weaken the gate for source edits; a diff containing any
+# non-manifest change falls straight through to the ordinary drift check.
+auto_waive_dependency_only = true
 
 [provenance.uri_schemes]
 knowledge        = "knowledge://"


### PR DESCRIPTION
spec-spine shipped the mechanical dependency-only auto-waiver in spec 030 and never turned it on for itself.

`auto_waive_dependency_only` defaults to `false` (`crates/spec-spine-types/src/config.rs:213`) and this repo's `spec-spine.toml` never set it, so the pre-filter at `crates/spec-spine-cli/src/cmd_couple.rs:43` was skipped on every PR here. We built the mechanism and left it off at home.

The cost is visible in the PR queue: both open Dependabot PRs are blocked on exactly the cases 030 was written for, **#63 since 2026-07-23**. A bot cannot add a `Spec-Drift-Waiver:` line to its own body, and its restricted token has no access to the secret store, so a routine version bump was simply unmergeable.

## Verification

Both real PR heads were fetched and run through the gate with the knob on:

| PR | non-bypassed path | result |
|---|---|---|
| #71 actions | `.github/workflows/release.yml` | auto-waived, exit 0 |
| #63 cargo | `crates/spec-spine-core/Cargo.toml` | auto-waived, exit 0 |

**Fail-closed check.** A probe commit adding a source edit (`couple.rs`) on top of #63's dep bump is still refused, exit 1, and reports *both* paths, not just the source one. The waiver does not leak past the manifest that earned it: any non-manifest path in the diff drops the whole change through to the ordinary drift check.

| check | result |
|---|---|
| `compile --check` | fresh, 36 shards |
| `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `couple --base origin/main --head HEAD` | OK, 1 path checked, no drift |
| `cargo test --workspace` | 23 test binaries ok, 0 failed |
| `clippy -D warnings` / `fmt --check` | clean |

## Why 41 files

`spec-spine.toml` is a globally shared hashed input (spec 024), so touching it restales **every** index shard. Hence 40 regenerated `codebase-index` shards plus the config itself. The `spec-registry` is untouched, as the config feeds index hashing only.

## Why no spec edit

The mechanism is already governed by spec 030; this changes no behavior of the engine, only this repo's own posture. That posture is recorded inline in `spec-spine.toml`, following the precedent already set there by `require_ownership = false`. The gate agrees: `spec-spine.toml` is not claimed as an owning unit, so the change clears on its own merit rather than by amending a spec to fit it.

Also corrects the stale `require_ownership` comment, which still quoted `59/64` coverage; `index coverage` now reports `60/65`.