### PR TITLE
chore(release): bump package version to 0.12.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6a82fe968c15a1f869d03a6d9f69561867516c9246385ece16c860a430bdf0a5"
+  "shardHash": "52b6b168d54c2a0ecba6cc896009c6e671bc814df8ca030dbec5bfa82b47f4d2"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "2"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.11.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.11.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.12.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.12.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.11.0",
-    "@spec-spine/cli-darwin-x64": "0.11.0",
-    "@spec-spine/cli-linux-x64": "0.11.0",
-    "@spec-spine/cli-linux-arm64": "0.11.0",
-    "@spec-spine/cli-win32-x64": "0.11.0"
+    "@spec-spine/cli-darwin-arm64": "0.12.0",
+    "@spec-spine/cli-darwin-x64": "0.12.0",
+    "@spec-spine/cli-linux-x64": "0.12.0",
+    "@spec-spine/cli-linux-arm64": "0.12.0",
+    "@spec-spine/cli-win32-x64": "0.12.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.11.0"
+version = "0.12.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release prep for **v0.12.0**. Mechanical version bump across the three distribution shims, plus the regenerated lockfile and the one index shard that carries a package version.

## What v0.12.0 ships

Three spec-approved, user-visible changes since v0.11.0, all now ratified (corpus 36/36 approved):

| spec | change |
|---|---|
| **033** | `V-014`: dependency cycle refusal on `depends_on` |
| **034** | `references` no longer seeds `implementingPaths`, closing the C-001 ownership leak |
| **035** | a closed reader exits `0` instead of panicking `101`, restoring the exit-code contract |

Minor rather than patch: 033 adds a refusal that can newly fail a previously-passing corpus, and 034 changes ownership outcomes.

**Upgrade note for adopters.** 034 changes emitted *content*, not only behavior. A corpus with `references` edges will see `implementingPaths` shrink on the next `index`, and coupling outcomes can change where a file loses an owner it should never have had. Provenance is preserved: the citation stays in `resolvedUnits` with `ownership: false`.

**No schema bump.** Nothing under `crates/spec-spine-types/src/version.rs` or `schemas/` changed since v0.11.0, so `REGISTRY_SCHEMA_VERSION` and `INDEX_SCHEMA_VERSION` stay at `1.1.0`. The two axes are decoupled by design.

## Pre-flight

| item | result |
|---|---|
| `bump_version.py 0.12.0` then `--check 0.12.0` | all five locations agree |
| `Cargo.lock` regenerated | yes; `--locked` fails until it is, per the runbook |
| `cargo test --workspace --locked` | 23 test binaries ok, 0 failed |
| `clippy --all-targets -D warnings` / `fmt --check` | clean |
| `compile --check` / `index check` / `lint --fail-on-warn` | fresh / fresh / 0-0-0 |
| `cargo package --workspace --locked` | all three crates build at 0.12.0 |
| `couple` without waiver | exit 1, as expected |
| `couple` with the waiver below | exit 0 |

## Changed files

`Cargo.toml`, `Cargo.lock`, `npm/package.json`, `py/pyproject.toml`, and `.derived/codebase-index/by-package/spec-spine.json` (the npm package shard is the only one carrying a version; the Rust package shards record `-`).

Spec-Drift-Waiver: mechanical version bump only; `npm/package.json` and `py/pyproject.toml` carry the release version required by specs 007 and 008, and no distribution behavior changes.