### PR TITLE
feat(036): the coupling gate honors `layout.specs_dir`

### DIFF
--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -1,0 +1,70 @@
+{
+  "mapping": {
+    "amends": [
+      "005-coupling-gate"
+    ],
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/couple.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/couple.rs"
+        }
+      }
+    ],
+    "specId": "036-configured-corpus-root",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "d385021f8e40e700b5c77b2121a7e8256ab6b389a4368bba608b479b035ff4f1"
+}

--- a/.derived/spec-registry/by-spec/036-configured-corpus-root.json
+++ b/.derived/spec-registry/by-spec/036-configured-corpus-root.json
@@ -1,0 +1,61 @@
+{
+  "record": {
+    "amends": [
+      "005-coupling-gate"
+    ],
+    "created": "2026-09-03",
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      }
+    ],
+    "id": "036-configured-corpus-root",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "risk": "medium",
+    "sectionHeadings": [
+      "036: The coupling gate honors `layout.specs_dir`",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 One constructor, one parser, one root",
+      "3.2 Prefix matching is separator-aware",
+      "3.3 A trailing slash names the same root",
+      "3.4 No change under the default layout",
+      "3.5 Tests (minimum)",
+      "4. Out of scope"
+    ],
+    "specPath": "specs/036-configured-corpus-root/spec.md",
+    "status": "draft",
+    "summary": "`layout.specs_dir` is configuration, and every other consumer reads it: `compile` scans it, `index` builds each spec's `spec.md` path from it, and `init` scaffolds into it. The coupling gate did not. Two functions in `couple.rs` hardcoded the literal `specs/`, and both are load-bearing. The primary-owner heuristic asked whether `specs/<id>/spec.md` was in the diff, so for an adopter whose corpus lives anywhere else the answer was permanently no: no edit to an owning spec could clear `C-001`, and every governed change was refused with the owner named and no reachable way to satisfy it, short of a waiver on every PR. The amends-awareness parser had the same literal, so amendment expansion silently never fired. Both now take the configured root, and the builder is shared with the indexer (`spec_md_rel`, promoted to `pub(crate)`) so a path constructor and its parser cannot drift apart again. A trailing slash on the configured value is trimmed, making `specs` and `specs/` name one corpus root instead of the second yielding `specs//<id>/spec.md`. No DTO, schema, or config shape changes; a default-layout repo is byte-identical.\n",
+    "title": "The coupling gate honors `layout.specs_dir`"
+  },
+  "shardHash": "1c13694709312e905acbf40bb3be79e0a556d25b0324869e84808423727d1a15",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use spec_spine_types::{CodebaseIndex, Config, Error, LineSpan, Registry, Severity, Violation};
 
 use crate::coverage::{Ownership, classify, in_coverage_universe};
-use crate::index::{Freshness, check_index_freshness};
+use crate::index::{Freshness, check_index_freshness, spec_md_rel};
 
 /// The hardcoded generic bypass floor (spec 005 §3.5): the **single built-in
 /// source** of bypass entries. The adopter's `config.coupling.bypass_prefixes`
@@ -134,6 +134,9 @@ pub fn couple_with(
 ) -> Result<CoupleReport, Error> {
     let diff_paths: BTreeSet<String> = diff.files.iter().map(|f| f.path.clone()).collect();
     let superseders = build_superseders(registry);
+    // Spec 036: every "is this a spec.md, and whose?" question below is asked
+    // against the configured corpus root, never a literal `specs/`.
+    let specs_dir = cfg.layout.specs_dir.as_str();
 
     let mut violations: Vec<Violation> = Vec::new();
     let mut checked_paths = 0usize;
@@ -181,11 +184,11 @@ pub fn couple_with(
             }
         }
 
-        let owners = owners_for_path(path, &file.hunks, index, &superseders);
+        let owners = owners_for_path(specs_dir, path, &file.hunks, index, &superseders);
         if owners.is_empty() {
             continue; // unclaimed path: not a drift concern (see the ratchet above)
         }
-        if any_owner_in_diff(&owners, &diff_paths) {
+        if any_owner_in_diff(specs_dir, &owners, &diff_paths) {
             continue; // primary-owner heuristic: any one owner's spec.md cleared it
         }
 
@@ -264,6 +267,7 @@ pub fn parse_waiver(cfg: &Config, body: &str) -> Option<Waiver> {
 /// resolved-unit ownership with whole-file `implementingPaths`, applies
 /// supersedes transfer, then amends-awareness under the FR-005 strict guard.
 fn owners_for_path(
+    specs_dir: &str,
     path: &str,
     hunks: &[LineSpan],
     index: &CodebaseIndex,
@@ -310,9 +314,9 @@ fn owners_for_path(
     }
 
     // 4. Amends-awareness, only when the base owner set is non-empty (FR-005
-    //    strict-expansion guard) and the path is `specs/<id>/spec.md`.
+    //    strict-expansion guard) and the path is `<specs_dir>/<id>/spec.md`.
     if !owners.is_empty() {
-        if let Some(amended_id) = spec_id_for_spec_md_path(path) {
+        if let Some(amended_id) = spec_id_for_spec_md_path(specs_dir, path) {
             for m in &index.traceability.mappings {
                 if m.amends.iter().any(|a| a == amended_id) {
                     owners.insert(m.spec_id.clone());
@@ -329,12 +333,16 @@ fn owners_for_path(
     owners
 }
 
-/// True when at least one owner's `specs/<id>/spec.md` is in the diff (the
+/// True when at least one owner's `<specs_dir>/<id>/spec.md` is in the diff (the
 /// primary-owner heuristic, ported from OAP `OwnerSet::any_owner_in_diff`).
-fn any_owner_in_diff(owners: &BTreeSet<String>, diff_paths: &BTreeSet<String>) -> bool {
+fn any_owner_in_diff(
+    specs_dir: &str,
+    owners: &BTreeSet<String>,
+    diff_paths: &BTreeSet<String>,
+) -> bool {
     owners
         .iter()
-        .any(|id| diff_paths.contains(&format!("specs/{id}/spec.md")))
+        .any(|id| diff_paths.contains(&spec_md_rel(specs_dir, id)))
 }
 
 /// Direct `predecessor → {superseders}` map from the registry's `supersedes`.
@@ -416,10 +424,17 @@ fn is_bypass<S: AsRef<str>>(path: &str, prefixes: &[S]) -> bool {
     })
 }
 
-/// Parse `specs/<id>/spec.md` into `<id>` (ported from OAP
+/// Parse `<specs_dir>/<id>/spec.md` into `<id>` (ported from OAP
 /// `spec_id_for_spec_md_path`). `None` for any other path.
-fn spec_id_for_spec_md_path(path: &str) -> Option<&str> {
-    let rest = path.strip_prefix("specs/")?;
+///
+/// The exact inverse of [`spec_md_rel`], against the configured
+/// `layout.specs_dir` rather than a literal `specs/` (spec 036). The prefix and
+/// the separator are stripped in two steps on purpose: a single
+/// `strip_prefix("specs")` would accept `specsX/005-x/spec.md`.
+fn spec_id_for_spec_md_path<'p>(specs_dir: &str, path: &'p str) -> Option<&'p str> {
+    let rest = path
+        .strip_prefix(specs_dir.trim_end_matches('/'))?
+        .strip_prefix('/')?;
     let (id, tail) = rest.split_once('/')?;
     if tail == "spec.md" { Some(id) } else { None }
 }
@@ -483,10 +498,59 @@ mod tests {
     #[test]
     fn spec_md_path_parse() {
         assert_eq!(
-            spec_id_for_spec_md_path("specs/005-x/spec.md"),
+            spec_id_for_spec_md_path("specs", "specs/005-x/spec.md"),
             Some("005-x")
         );
-        assert_eq!(spec_id_for_spec_md_path("specs/005-x/plan.md"), None);
-        assert_eq!(spec_id_for_spec_md_path("crates/core/src/lib.rs"), None);
+        assert_eq!(
+            spec_id_for_spec_md_path("specs", "specs/005-x/plan.md"),
+            None
+        );
+        assert_eq!(
+            spec_id_for_spec_md_path("specs", "crates/core/src/lib.rs"),
+            None
+        );
+    }
+
+    #[test]
+    fn spec_md_path_parse_honors_configured_dir() {
+        // Spec 036: the corpus root is configuration, not a literal.
+        assert_eq!(
+            spec_id_for_spec_md_path("contracts", "contracts/005-x/spec.md"),
+            Some("005-x")
+        );
+        // The default root is not privileged once another one is configured.
+        assert_eq!(
+            spec_id_for_spec_md_path("contracts", "specs/005-x/spec.md"),
+            None
+        );
+        // A nested root works, and a sibling that merely shares its prefix does
+        // not: the separator is stripped as its own step for exactly this.
+        assert_eq!(
+            spec_id_for_spec_md_path("docs/specs", "docs/specs/005-x/spec.md"),
+            Some("005-x")
+        );
+        assert_eq!(
+            spec_id_for_spec_md_path("specs", "specsX/005-x/spec.md"),
+            None
+        );
+        // A trailing slash names the same corpus root.
+        assert_eq!(
+            spec_id_for_spec_md_path("specs/", "specs/005-x/spec.md"),
+            Some("005-x")
+        );
+    }
+
+    #[test]
+    fn owner_in_diff_matches_the_configured_dir() {
+        let owners: BTreeSet<String> = ["005-x".to_string()].into_iter().collect();
+        let under_contracts: BTreeSet<String> = ["contracts/005-x/spec.md".to_string()]
+            .into_iter()
+            .collect();
+        let under_specs: BTreeSet<String> =
+            ["specs/005-x/spec.md".to_string()].into_iter().collect();
+
+        assert!(any_owner_in_diff("contracts", &owners, &under_contracts));
+        assert!(!any_owner_in_diff("contracts", &owners, &under_specs));
+        assert!(any_owner_in_diff("specs", &owners, &under_specs));
     }
 }

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -970,8 +970,14 @@ const GLOBAL_INPUTS_KEY: &str = "\u{0}global-inputs";
 
 /// Repo-relative POSIX path of a spec's `spec.md` (the dir name equals the id,
 /// enforced by compile's V-001), e.g. `specs/024-index-sharding/spec.md`.
-fn spec_md_rel(specs_dir: &str, id: &str) -> String {
-    format!("{specs_dir}/{id}/spec.md")
+///
+/// `pub(crate)` since spec 036: the coupling gate parses this same shape back
+/// into an id, and a builder and a parser that disagree about it is exactly the
+/// defect 036 fixes. A trailing slash on the configured `specs_dir` is trimmed,
+/// so `specs` and `specs/` name one file instead of the second producing
+/// `specs//<id>/spec.md`.
+pub(crate) fn spec_md_rel(specs_dir: &str, id: &str) -> String {
+    format!("{}/{id}/spec.md", specs_dir.trim_end_matches('/'))
 }
 
 /// The source files backing this mapping's resolved `symbol`/`section`/`module`

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -344,6 +344,130 @@ fn amends_expands_owners_when_base_set_nonempty() {
     assert!(!cleared.has_blocking_drift(), "{:?}", cleared.violations);
 }
 
+// ── the configured corpus root (spec 036) ─────────────────────────────────
+
+/// A repo whose corpus lives somewhere other than `specs/`.
+fn contracts_config() -> Config {
+    let mut cfg = Config::default();
+    cfg.layout.specs_dir = "contracts".to_string();
+    cfg
+}
+
+fn owns_lib_rs() -> CodebaseIndex {
+    index_from(json!([{
+        "specId": "001-a",
+        "implementingPaths": [],
+        "resolvedUnits": [{
+            "unit": { "kind": "file", "path": "src/lib.rs" },
+            "sourceField": "establishes",
+            "ownership": true,
+            "locations": [{ "file": "src/lib.rs" }]
+        }]
+    }]))
+}
+
+#[test]
+fn custom_specs_dir_clears_drift_via_the_owning_spec() {
+    // Before spec 036 the primary-owner heuristic looked for a literal
+    // `specs/<id>/spec.md`, so under a non-default `layout.specs_dir` NO edit to
+    // the owning spec could ever clear `C-001`: the path it searched for did not
+    // exist in the repo. The gate was unusable for such an adopter.
+    let index = owns_lib_rs();
+    let reg = empty_registry();
+    let cfg = contracts_config();
+
+    let drift = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("src/lib.rs", &[LineSpan::new(5, 8)])]),
+        None,
+    )
+    .unwrap();
+    assert!(drift.has_blocking_drift());
+
+    let cleared = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![
+            file("src/lib.rs", &[LineSpan::new(5, 8)]),
+            file("contracts/001-a/spec.md", &[]),
+        ]),
+        None,
+    )
+    .unwrap();
+    assert!(!cleared.has_blocking_drift(), "{:?}", cleared.violations);
+}
+
+#[test]
+fn default_specs_dir_does_not_clear_under_a_custom_root() {
+    // The mirror image: `specs/` carries no authority once the corpus root is
+    // configured elsewhere, so a file sitting there must not clear the gate.
+    let cleared = couple_with(
+        &contracts_config(),
+        &empty_registry(),
+        &owns_lib_rs(),
+        &diff(vec![
+            file("src/lib.rs", &[LineSpan::new(5, 8)]),
+            file("specs/001-a/spec.md", &[]),
+        ]),
+        None,
+    )
+    .unwrap();
+    assert!(cleared.has_blocking_drift(), "{:?}", cleared.violations);
+}
+
+#[test]
+fn custom_specs_dir_keeps_amends_awareness() {
+    // The second reader of the path shape: amends expansion parses
+    // `<specs_dir>/<id>/spec.md` back into an id. Under a custom root it must
+    // still recognize the amended spec, or the amender could not clear it.
+    let index = index_from(json!([
+        {
+            "specId": "200-claims-spec-md",
+            "implementingPaths": [],
+            "resolvedUnits": [{
+                "unit": { "kind": "file", "path": "contracts/100-x/spec.md" },
+                "sourceField": "constrains", "ownership": true,
+                "locations": [{ "file": "contracts/100-x/spec.md" }]
+            }]
+        },
+        {
+            "specId": "101-amender",
+            "amends": ["100-x"],
+            "implementingPaths": [],
+            "resolvedUnits": []
+        }
+    ]));
+    let reg = empty_registry();
+    let cfg = contracts_config();
+
+    let drift = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("contracts/100-x/spec.md", &[])]),
+        None,
+    )
+    .unwrap();
+    assert!(drift.has_blocking_drift());
+    assert!(drift.violations[0].message.contains("101-amender"));
+
+    let cleared = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![
+            file("contracts/100-x/spec.md", &[]),
+            file("contracts/101-amender/spec.md", &[]),
+        ]),
+        None,
+    )
+    .unwrap();
+    assert!(!cleared.has_blocking_drift(), "{:?}", cleared.violations);
+}
+
 // ── supersedes authority transfer ─────────────────────────────────────────
 
 #[test]

--- a/specs/036-configured-corpus-root/spec.md
+++ b/specs/036-configured-corpus-root/spec.md
@@ -1,0 +1,148 @@
+---
+id: "036-configured-corpus-root"
+title: "The coupling gate honors `layout.specs_dir`"
+status: draft
+kind: "tooling"
+created: "2026-09-03"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "004-codebase-index"
+  - "005-coupling-gate"
+amends:
+  - "005-coupling-gate"
+extends:
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/tests/couple.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+summary: >
+  `layout.specs_dir` is configuration, and every other consumer reads it:
+  `compile` scans it, `index` builds each spec's `spec.md` path from it, and
+  `init` scaffolds into it. The coupling gate did not. Two functions in
+  `couple.rs` hardcoded the literal `specs/`, and both are load-bearing. The
+  primary-owner heuristic asked whether `specs/<id>/spec.md` was in the diff, so
+  for an adopter whose corpus lives anywhere else the answer was permanently no:
+  no edit to an owning spec could clear `C-001`, and every governed change was
+  refused with the owner named and no reachable way to satisfy it, short of a
+  waiver on every PR. The amends-awareness parser had the same literal, so
+  amendment expansion silently never fired. Both now take the configured root,
+  and the builder is shared with the indexer (`spec_md_rel`, promoted to
+  `pub(crate)`) so a path constructor and its parser cannot drift apart again. A
+  trailing slash on the configured value is trimmed, making `specs` and `specs/`
+  name one corpus root instead of the second yielding `specs//<id>/spec.md`. No
+  DTO, schema, or config shape changes; a default-layout repo is byte-identical.
+---
+
+# 036: The coupling gate honors `layout.specs_dir`
+
+## 1. Purpose
+
+`Config::layout.specs_dir` names the corpus root. It defaults to `specs`, and
+the rest of the system treats it as configuration throughout: `compile` reads
+the directory from it (`compile.rs`), `index` builds each mapping's `spec.md`
+path from it (`index.rs::spec_md_rel`), and `init` scaffolds into it
+(`scaffold.rs`). An adopter who sets `specs_dir = "contracts"` gets a corpus
+that compiles, indexes, and lints correctly.
+
+The coupling gate then refuses their every change.
+
+Two functions in `couple.rs` spelled the root as a literal:
+
+| site | question it answers | with the literal |
+|---|---|---|
+| `any_owner_in_diff` | is an owning spec's `spec.md` in this diff? | looks for `specs/<id>/spec.md`, a path that does not exist in the repo |
+| `spec_id_for_spec_md_path` | is this path a `spec.md`, and whose? | `None` for every real corpus path |
+
+The first is the **primary-owner heuristic**: the single mechanism by which a
+`C-001` violation is cleared. Editing the owning spec is how an author says
+"this change is governed, and here is the governing text". Under a non-default
+root that mechanism could not fire, because the gate searched for a path the
+repo does not contain. The violation was reported correctly, named the correct
+owner, and was unclearable:
+
+```
+C-001 'src/lib.rs' changed without an authoring edit to any owning spec (001-a)
+```
+
+with `contracts/001-a/spec.md` sitting in the very same diff. The only exits
+were a `Spec-Drift-Waiver:` on every pull request, or moving the corpus back to
+`specs/`. Spec-first development, the constitution's principle III, was
+unavailable to that adopter.
+
+The second site made amends-awareness (005 §3.3) dead code under the same
+condition: the FR-005 expansion parses the changed path back into a spec id, and
+a parser that never matches never expands the owner set.
+
+This is a defect of reach, not of judgement. The gate's verdicts were right
+about the corpus it was told to look at; it was told to look at the wrong place.
+
+## 2. Territory
+
+`couple.rs`: the two functions above, plus `owners_for_path` and `couple_with`,
+which thread the configured value to them. `index.rs`: `spec_md_rel` gains
+`pub(crate)` visibility and trims a trailing slash; its two existing callers are
+unchanged in behavior. `tests/couple.rs`: acceptance fixtures under a
+non-default root.
+
+Nothing about the emitted artifacts changes. This is a read of configuration
+that was previously not performed.
+
+## 3. Behavior
+
+### 3.1 One constructor, one parser, one root
+
+`spec_md_rel(specs_dir, id)` builds `<specs_dir>/<id>/spec.md`;
+`spec_id_for_spec_md_path(specs_dir, path)` is its exact inverse. The gate uses
+the same constructor the indexer uses rather than a second copy of the format
+string, because two spellings of one path shape is how this defect arose.
+
+`couple_with` binds `cfg.layout.specs_dir` once and passes it to both readers.
+The gate remains a pure function of `(config, registry, index, diff, waiver)`;
+the configured root was always part of that first argument, and is now actually
+consulted.
+
+### 3.2 Prefix matching is separator-aware
+
+The parser strips the configured root and the `/` separator as two steps. A
+single `strip_prefix("specs")` would accept `specsX/005-x/spec.md` and report
+its id as `005-x`, inventing authority for a directory that merely shares a
+prefix with the corpus root. The separator must be present for the path to be a
+corpus path.
+
+### 3.3 A trailing slash names the same root
+
+`specs` and `specs/` denote one corpus root. Both are trimmed before use. This
+also repairs the indexer, where `specs_dir = "specs/"` previously produced
+`specs//<id>/spec.md`: a path that hashes into the shard as a missing file, so
+a spec's own source stopped contributing to its shard hash. Nothing validated
+the trailing slash away, so this was reachable configuration.
+
+### 3.4 No change under the default layout
+
+For `specs_dir = "specs"`, every path this spec touches is the string the
+literal produced. The committed registry and index of a default-layout repo,
+this one included, are byte-identical across the change, and the determinism
+gate proves it across the release matrix as usual.
+
+### 3.5 Tests (minimum)
+
+- The parser accepts `<root>/<id>/spec.md` for a configured root, rejects the
+  default `specs/` once another root is configured, accepts a nested root
+  (`docs/specs`), rejects a sibling sharing the prefix (`specsX/`), and accepts
+  a root written with a trailing slash.
+- `any_owner_in_diff` matches under the configured root and only there.
+- End to end under `specs_dir = "contracts"`: a changed owned file drifts, and
+  editing `contracts/<owner>/spec.md` clears it (the regression this spec
+  fixes); a file at `specs/<owner>/spec.md` does **not** clear it; and amends
+  expansion still names the amender and still clears when the amender is edited.
+
+## 4. Out of scope
+
+**Validating `specs_dir` at config load.** Trimming at the point of use is
+sufficient and local. A normalizing constructor over the whole `layout` block is
+a larger change to the config contract and belongs to its own spec.
+
+**The other hardcoded corpus assumption.** `compile`'s V-001 requires a spec's
+directory name to equal its `id`; that is a tier-1 anchor
+(`directory-name-equals-id`), not a layout question, and is unaffected.


### PR DESCRIPTION
`layout.specs_dir` is configuration, and every other consumer reads it: `compile`
scans it, `index` builds each spec's `spec.md` path from it, and `init` scaffolds
into it. `couple.rs` did not. Two functions hardcoded the literal `specs/`, and
both are load-bearing.

| site | question it answers | with the literal |
|---|---|---|
| `any_owner_in_diff` | is an owning spec's `spec.md` in this diff? | looks for `specs/<id>/spec.md`, a path that does not exist in the repo |
| `spec_id_for_spec_md_path` | is this path a `spec.md`, and whose? | `None` for every real corpus path |

## Why this matters

The first is the **primary-owner heuristic**: the single mechanism by which a
`C-001` violation is cleared. Editing the owning spec is how an author says "this
change is governed, and here is the governing text". Under a non-default root
that mechanism could not fire, because the gate searched for a path the repo does
not contain. The violation was reported correctly, named the correct owner, and
was unclearable:

```
C-001 'src/lib.rs' changed without an authoring edit to any owning spec (001-a)
```

with `contracts/001-a/spec.md` sitting in the very same diff. The only exits were
a `Spec-Drift-Waiver:` on every pull request, or moving the corpus back to
`specs/`. Spec-first development, the constitution's principle III, was
unavailable to that adopter.

The second site made amends-awareness (005 §3.3) dead code under the same
condition: the FR-005 expansion parses the changed path back into a spec id, and
a parser that never matches never expands the owner set.

This is a defect of reach, not of judgement. The gate's verdicts were right about
the corpus it was told to look at; it was told to look at the wrong place.

## What changed

- Both readers take the configured root, bound once in `couple_with`.
- The builder is **shared with the indexer** (`index.rs::spec_md_rel`, promoted to
  `pub(crate)`) rather than copied. Two spellings of one path shape is how this
  defect arose; there is now one constructor and its exact inverse.
- The prefix and its `/` separator are stripped as **two steps**, so
  `specsX/005-x/spec.md` is not read as spec `005-x`.
- A **trailing slash is trimmed**. This also repairs the indexer, where
  `specs_dir = "specs/"` produced `specs//<id>/spec.md`: a path that hashes into
  the shard as a missing file, so a spec's own source silently stopped
  contributing to its shard hash. Nothing validated the trailing slash away, so
  this was reachable configuration.

## No change under the default layout

For `specs_dir = "specs"` every path this touches is the string the literal
produced. This repo's committed registry and index are byte-identical across the
change (only the new `036` shards are added), and the determinism gate proves it
across the release matrix as usual. No DTO, schema, or config shape changes.

## Verification

- The three new end-to-end tests were run against the pre-fix code and **all three
  fail**; they pass after it. Not vacuous coverage.
- `cargo test --workspace --locked` green; `clippy -D warnings` and `fmt --check` clean.
- Local gate chain green: `compile --check` fresh, `index check` fresh,
  `lint --fail-on-warn` 0/0/0, `couple --base main` 4 paths checked, **no drift and
  no waiver needed**.

Spec `036-configured-corpus-root` is filed as `draft`, per the usual flow; it
`amends` 005 and extends 005's `couple.rs` / `tests/couple.rs` and 004's
`index.rs`.