### PR TITLE
chore(032): retire the ownership-coverage debt and turn on the ratchet

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c135b262914b24ce48ecf6ed8ac63dbe58d4455a10929c294986608a18113834"
+  "shardHash": "8006cb8037ca63977ae2b3751a3b162cada7bd4016e04a23592134cdcb359a87"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cd339450ec106dd82aacc001b2a03fc63b028bd57ece69d9740f2e1dc9d0fc5c"
+  "shardHash": "522740fe406f781ff5168a23c2c915c7dee41d42ed0510c48768b5959be2fd82"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "faa60a6df25cdda9dcc273ad36e845d6c300c4d7a2c8a81b165fc3fbb95f0eaf"
+  "shardHash": "19d049ae3ee3696b57ba057196640d27dfd3255e1453ca1ea4a6224b76a35fc8"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.12.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "52b6b168d54c2a0ecba6cc896009c6e671bc814df8ca030dbec5bfa82b47f4d2"
+  "shardHash": "91724e6ea98f6f5a83b655e6ac6d104cfbb72bccfe3df3a909453fecbb219ef0"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -4,11 +4,27 @@
       {
         "path": "crates/spec-spine-types",
         "source": "manifest-metadata"
+      },
+      {
+        "path": "crates/spec-spine-types/src/error.rs",
+        "source": "comment-header"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/config.rs",
+        "source": "comment-header"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/dogfood.rs",
+        "source": "comment-header"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/schema.rs",
+        "source": "comment-header"
       }
     ],
     "specId": "000-spec-spine-bootstrap",
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e33c2bc84127b084737102fff6bf56a4f374019589cc67f4d0d2bd4d106d1019"
+  "shardHash": "8dbf2ce0a95323d16e647f5ab8c71d5b6746ffb6032ab66d670c37baf5c6a19f"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "850667ec9596d345330777b87e3bab24f148fd5f55625c1d8f9d773b8d208360"
+  "shardHash": "8da9f1c500c61d138073f1df22c87599962be7d884d857c85f4f05dc419ad3d4"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -15,6 +15,10 @@
       {
         "path": "crates/spec-spine-core/src/query.rs",
         "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/query.rs",
+        "source": "comment-header"
       }
     ],
     "resolvedUnits": [
@@ -62,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5f74cb99bb80d40d8c2c6a8092d560d8025b522017184b2ee5b3d00dcaf47def"
+  "shardHash": "54be2356dce69ca45c056d1b6da37985e71178ceb6545a5708dbd830d574abfa"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "194141431cb2141433d1ace06fc603975b2bfd8e43f24b5cbe5abf70933e7432"
+  "shardHash": "d5e516fad73c1276cd12eb2090dd3592159d61b3611393c7992a8ccc39328b06"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "456198bf1f5d176c524a5f5c91e05ca758b11dc7542da21ec564edd75f505680"
+  "shardHash": "18a72a8132458954b3792b1491a33a7614e826b409a674bc362d8978a0f8b86b"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "84ceca6ab8f693c8b81a70f1463b7ded5ea5cae0d684b619eedc408a0829495d"
+  "shardHash": "1cd4e2b9cd3ec8b06ff2cc76ff4261233f3bcb11b72631dc2046d96fb59bdf56"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c661ea1984ec622c1a4ca560e19fe59b5d67b66f93170315e8dc7aca3f1b7b61"
+  "shardHash": "92756568427234bdc4d1d921b1c28e045cab0506c5a95d0640482fc09919d67d"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "535b10c5f861be197848218b474946b75744a30cbb4e8e98549f6bcfc76061db"
+  "shardHash": "96fa7f0e2b3701ec2599aa536746caf41b4f298c89197432cc1bb65b2145b216"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d5c0a6805cbd5a5f9a7ba3d8c677c436507d8a47f9578103bf94a598ff9ca04e"
+  "shardHash": "afa4f154e107ac8a41cab90bd248ddc4f2ccd93acd86be3773c9d3e0c9b05af5"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0efdaec691446db63917051e979d82652f969eac4b4ae83a97d20c40047e3392"
+  "shardHash": "05e1fd3a3affc61c33e11e08358821e0905b83746df2415606226e2763b5cf3f"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cba73e1629ddf900d00d9571a7a6eb3ac0b71498a8a5211abd7fdb3a57e9d554"
+  "shardHash": "5c9547caab057931f16e744a3e5a6e703fb34ec26c4151fddff9ac82b4d217d0"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ebda840d5c87e818ac9e3264966769fbdaca1dd39a71daafefa771b2f8463e14"
+  "shardHash": "6233d74a1a4d9c1e2cf94f4275d9f0d0df7d30a36030325ae7e587252a6c3abd"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "200a13a21c45e0401f15769903f5839e5bab4e7f924ea245a71cd58b83e81f53"
+  "shardHash": "cafbdfa7407e989ce67f9698a1c9f27b4abc37b891beaae59279771ada813e38"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "36a163fd7f745fdbeb2fc31470a7e5c43afd91b704eb2790c83cd9e4fd126d07"
+  "shardHash": "5e98a18025b89fc8fb231a252bed3ceb638e6d3113f7d50e55f333d1d0ca9a46"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce7b00dabc407583bf42049f2c36e238c33076c6aadcecadf1b7cec88f422fdb"
+  "shardHash": "b1b250483c3a89ad848d287572564b23cd034adcf12a80cccf599982249a1b60"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce2814ef040b9af6fffa4f1087302c463f183055bcb0a15d3dbd633ac356a375"
+  "shardHash": "cf03d4c444bb4e6e91a0b905c685fbcab332261d6677a9d7b202ecda9f177eb2"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9fd49a986f999166878807e12d89466ce14e2c62c93d680faa99fa62eed71ab4"
+  "shardHash": "a6a9c195030d0b06d06b6ea134dc1a30a0d22c1cf66abb9128159cc5065aad31"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb53f5b724620a10acc7ba591b903e42cfac50cb24bb658a2e47f4aed57ffdd3"
+  "shardHash": "7b0c290447e1e953922740ea8a19982a3170f188d94c5f6738a478544b1d1197"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e65a55e267f2351daf4ba9dbcf724e0d516088f500125c671954fec10c422bc"
+  "shardHash": "80f9e9a78f8f07eaff2ba193c525d361e71c599e1801af647890bcdcaddc28a8"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7e5c82400027b0141a8a979e25b02970a79467409fdd306d358d665593572780"
+  "shardHash": "c27f5d31ad7c0030291293be4bf8c978f8bc5919e7f8b7ab00bfda78c6b06183"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5317143e8bf76a2c93f2fccdb6b8c94aeb44b8aa2a9bfa3a899b436a1e8e912f"
+  "shardHash": "9aa95c3ef0eaf9252183faa0a885b1e8ad7d6188d1bfe44fd34ff2b9675713b6"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22c25741c9b46c9b9a79863b442a15d8ef74b88e3afd43c7266de453cd5e3d5a"
+  "shardHash": "92997ae9a0047b13513828bdcefa348bbcbb0f82271028d69d66d00636af1db7"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a0954a3214e080d26a068de2fbab962023b72bd230a6346bcb7e851622d6401b"
+  "shardHash": "5e1bff65d84c6cd97f80483f6fccd2980a41806bcfaff381267f788c02b5e119"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6b6b657df4028d60149abe9f8827d1e799da9cf171781626d8bc653907909c32"
+  "shardHash": "5a6611e97a72eb3cba5a4013023427035c34b47a9fd416145c11c91a3b92df7c"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "54b3d9907c1c7852ba3c5ee7be1840ac843b72fd1a9f6e6f6fa3c7228e4b1ebd"
+  "shardHash": "a6b0ce1eddb06bb9235e9d478c427f696ec8ab0d68900fcbda66d10977e7d146"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a566c04426ea123a19faccf4b3e7705d9a310fd54e76d795f0fe038f6d3f056a"
+  "shardHash": "a1b0c67f20bab3dd8485f0f687b20bfcd9741fb94a181ce56ec74a74d2f85370"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0ca35f3653561762635123808f64ea03d4c92250ebfa6ad605c07f2695c4c0ee"
+  "shardHash": "6a3c2d9f819f07bd58a3276412a1ed116894892cacc336faebefacbbadafd61f"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0c87d1adaf6e09204b8eb87e042dd6da7ff4d7a4cba4b46125a208d570d49247"
+  "shardHash": "60f60fab5e74355a0a629815caff7d94f2b39d8b33521f3311321312561d6546"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4a0fa37d2c818217fc53fc495d1e4360e64a7bfaa5451775f037f042a67e11ab"
+  "shardHash": "bb753855856d241cd0b11d56e9b2cbef493697e7d88cc91a48bd0551151c417f"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7eb035bf890d3163676d97c8ba8eea749fe5689191ea46c5f6ab830eba1ef4d0"
+  "shardHash": "4ab68de86e873b5a5f9b8de433a381bab573b7385de71a08ef11c86e56098714"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09e735704f54b5502ccafec5a669c35d95b10c0ae7e7dea2804137be811dc748"
+  "shardHash": "4ce683ee112298a1fc196a4f73e9f4244c75b5a8d242cc2899ffc8df469d7c75"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05164c2eb91aaa170c06cfa1ef9ec848845a8032e1dd1c4314c6d0169fda5396"
+  "shardHash": "c5475ac1b64d77232bf6d6feb6c6f7881e67b3751408bd21330fc614cb998a2b"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0c92b3acf88b157dfca204f0f9555cf78bd1593fb34d2659027a6ed2b86fd777"
+  "shardHash": "d91dbdc0a0cba26c550a06117d1d20a90f76df69423ab47bef68c99e04d4df2b"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ee6d9d4d4122561caa76b2e07c941bca8bd27d50d3ad1bda1e29f93c16e58126"
+  "shardHash": "00445e9c59f15d637a4b137e9fdd59a7ac1044e1fb732580d88f254ddb6d20ab"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e62d2b5724d9d7f593245bd84230db7b4493dca6153c3bd56c3cfe0c1eee9fab"
+  "shardHash": "b3d025686460d2e6096571c291e7011e5633028f025eccbd84bf3ca1b0474cd5"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b919c10c0408ab154b63b0aa18b63b5a2f3a5166a383d6ad1910a987fada262a"
+  "shardHash": "4baf9edf3ffe4c07a779e33a87b9d9ee454351f1176a09a23894e13f4bb7fbce"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d385021f8e40e700b5c77b2121a7e8256ab6b389a4368bba608b479b035ff4f1"
+  "shardHash": "08438df14685c0a8fd905009dd123781a12eec4e7319c3335e3120a509c59c15"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,17 @@ jobs:
         run: ./target/debug/spec-spine compile --check
       - name: Codebase index freshness (committed artifacts must be current)
         run: ./target/debug/spec-spine index check
-      # Informational (spec 032): which source files no spec specifically
-      # claims. Exit 0 on a report (2 only when stale, which the step above
-      # already refuses). The gate form is `[coupling] require_ownership`
-      # (off here by decision, see spec-spine.toml) and, once the lists are
-      # empty, `index coverage --fail-on-untraced`.
-      - name: Ownership coverage (report)
-        run: ./target/debug/spec-spine index coverage
+      # Enforced (spec 032): every source file must be specifically claimed by
+      # a spec, not merely covered by its package's manifest floor. This repo
+      # drove the floor-only list to empty by annotating the last five files
+      # with `// Spec:` headers, so the ratchet's final step now applies:
+      # `--fail-on-untraced` exits 1 on any new debt, defending 65/65 instead of
+      # reporting it. The PR-time half is `[coupling] require_ownership` in
+      # spec-spine.toml, which refuses a *changed* unclaimed file; this step is
+      # the whole-tree half, which also catches a file added with no diff
+      # context. Exit 2 remains staleness, already refused by the step above.
+      - name: Ownership coverage (enforced)
+        run: ./target/debug/spec-spine index coverage --fail-on-untraced
       - name: Conformance lint (fail on warn)
         run: ./target/debug/spec-spine lint --fail-on-warn
       # The coupling gate is a PR-time gate (spec 005 §1): it joins the spec and

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -1,3 +1,4 @@
+// Spec: specs/002-registry-query/spec.md
 //! Query: load_registry version gating + list / show / status_report /
 //! relationships over a compiled registry.
 

--- a/crates/spec-spine-types/src/error.rs
+++ b/crates/spec-spine-types/src/error.rs
@@ -1,3 +1,4 @@
+// Spec: specs/000-spec-spine-bootstrap/spec.md
 //! The single, stable error type for spec-spine.
 //!
 //! Every variant maps to a stable CLI exit code (see [`Error::exit_code`]); the

--- a/crates/spec-spine-types/tests/config.rs
+++ b/crates/spec-spine-types/tests/config.rs
@@ -1,3 +1,4 @@
+// Spec: specs/000-spec-spine-bootstrap/spec.md
 //! Config tests: absent (defaults), minimal, full, malformed (clean error).
 
 use spec_spine_types::{Config, Error, load_config};

--- a/crates/spec-spine-types/tests/dogfood.rs
+++ b/crates/spec-spine-types/tests/dogfood.rs
@@ -1,3 +1,4 @@
+// Spec: specs/000-spec-spine-bootstrap/spec.md
 //! Dogfood: this repo's own bootstrap spec must parse through the types crate.
 //!
 //! The authored frontmatter of `specs/000` must conform to the grammar this

--- a/crates/spec-spine-types/tests/schema.rs
+++ b/crates/spec-spine-types/tests/schema.rs
@@ -1,3 +1,4 @@
+// Spec: specs/000-spec-spine-bootstrap/spec.md
 //! The embedded schemas must be valid JSON and aligned with the version consts.
 
 use spec_spine_types::{

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -46,12 +46,15 @@ indexer_id  = "spec-spine"
 bypass_prefixes = ["**/README.md"]
 waiver_keyword = "Spec-Drift-Waiver:"
 # Spec 032: refuse a changed source file that no spec specifically claims
-# (C-002). Off here on purpose: `spec-spine index coverage` reports this repo at
-# 60/65 (five files owned only by their crate's manifest floor, see 032 §3.8),
-# and claiming them means editing the tier-1 bootstrap spec, a human's call.
-# The path to adopt is: read the report, flip this on to stop new debt, drive
-# the lists to empty, then add `index coverage --fail-on-untraced` to CI.
-require_ownership = false
+# (C-002). ON here: the debt 032 §3.8 named is retired. Those five files are
+# claimed by `// Spec: specs/<id>/spec.md` headers in the files themselves
+# rather than by new frontmatter units, because a header is a file naming the
+# spec that already governs it, which is exactly what was true and never
+# written down. That also keeps the claim out of the tier-1 bootstrap spec:
+# nothing in specs/000 changed. `index coverage` now reports 65/65, and CI
+# defends it with `index coverage --fail-on-untraced`. This knob is the PR-time
+# half: a changed source file no spec specifically claims is C-002.
+require_ownership = true
 
 # Spec 005 §3.5, extended to cargo and workflow manifests by spec 030: clear a
 # change whose every non-bypassed path is a dependency-only manifest edit, with


### PR DESCRIPTION
> Stacked on #82. Base retargets to `main` when #82 merges; review only the second commit.

Spec 032 shipped `index coverage` and the `C-002` ownership ratchet, measured this
repo at 59/64, and named the five files owned only by their crate's manifest floor.
It then left the knob off, because claiming them looked like it meant editing `002`
and the tier-1 `000`, which §3.8 correctly called a governance decision for a human.
We built the ratchet and left it off at home, the same way spec 030 sat unused until
#79.

## It never required editing either spec

A `// Spec: specs/<id>/spec.md` header is the mechanism for **a file naming the spec
that governs it**, and the classifier has always read one as specific ownership
(`coverage.rs`, branch 2). This repo had never used it. Each of the five files now
carries one:

| file | header | why that spec |
|---|---|---|
| `core/tests/query.rs` | `002-registry-query` | tests `query.rs`, which 002 establishes |
| `types/src/error.rs` | `000-spec-spine-bootstrap` | had **no claim at all**; 000 is the base owner of the types substrate |
| `types/tests/config.rs` | `000-spec-spine-bootstrap` | tests `types/src/config.rs`, extended against 000 by 012 and 032 |
| `types/tests/dogfood.rs` | `000-spec-spine-bootstrap` | parses `specs/000` frontmatter by name |
| `types/tests/schema.rs` | `000-spec-spine-bootstrap` | the embedded schemas and version consts |

**Nothing in `specs/000` or `specs/002` changed**, and no spec was invented to hold
claims over files it has nothing to say about. The header records what was already
true and had simply never been written down: the floor asserted these owners blanket
-wide, and the header says it specifically.

## The ratchet's last step

`index coverage` now reports **65/65 (100.0%), 0 floor-only, 0 unclaimed**.

- `[coupling] require_ownership = true` is the **PR-time half**: a changed source file
  no spec specifically claims is `C-002`.
- CI's coverage step moves from informational to `--fail-on-untraced`, the
  **whole-tree half**, which also catches a file added with no diff context.

Together they defend 100% rather than report it.

## Verification

Both halves were proven to bite, not just to pass:

```
# an unclaimed file added to core/src
index coverage --fail-on-untraced   -> exit 1  (65/66, 1 floor-only)
couple --paths-from <that file>     -> C-002 'scratch_probe.rs' has no specific
                                       owning spec; only the package floor of
                                       001-compile-registry covers it
# with it removed
index coverage --fail-on-untraced   -> exit 0
```

`cargo test --workspace --locked` green, `fmt --check` clean, `lint --fail-on-warn`
0/0/0, `index check` fresh. Editing `spec-spine.toml` restales every index shard (it
feeds the global-inputs hash), so all 41 are regenerated and committed.

This is adoption of a shipped mechanism on its own repo, so it carries **no new
spec**, exactly as #79 did for spec 030.

## The waiver

The gate reports five `C-001`s here, and they are `C-001` rather than `C-002`, which
is the point: the headers satisfied the ratchet, so the only drift left is the
annotation edit itself.

Spec-Drift-Waiver: The only change to these five files is a one-line `// Spec:` ownership header. No behavior, no test, and no assertion changed. Amending the tier-1 `000-spec-spine-bootstrap` (or `002`) to satisfy a mechanical annotation is exactly what `.claude/rules/adversarial-prompt-refusal.md` forbids, so the drift is waived with the reason cited instead.