### PR TITLE
chore(deps): put the documentation site under Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,17 @@ updates:
     directory: "/py"
     schedule:
       interval: weekly
+
+  # The Docusaurus documentation site. It ships in no released artifact (the
+  # crate, the npm shim and the wheel carry none of it), so it was left
+  # unmonitored and its lockfile drifted: issue #81 found `image-size` 2.0.2
+  # there, carrying two advisories that have no patched release yet. Grouped
+  # weekly so a docs-only tree does not generate one PR per package, and so the
+  # patch is proposed automatically whenever upstream ships one.
+  - package-ecosystem: npm
+    directory: "/website"
+    schedule:
+      interval: weekly
+    groups:
+      website:
+        patterns: ["*"]


### PR DESCRIPTION
Closes nothing on its own; this is the actionable half of #81.

## What #81 got right, and what it did not

@begininvoke reported `image-size` 2.0.2 in `website/package-lock.json`. That part
is accurate, and it is a real advisory:

| advisory | vector | affected | patched |
|---|---|---|---|
| CVE-2025-71329 (GHSA-5p2g-fcmc-qvqq) | JXL / HEIF infinite loop | `<= 2.0.2` | **none yet** |
| CVE-2025-71330 (GHSA-w3rx-r6r6-pgpr) | ICNS infinite loop | `<= 2.0.2` | **none yet** |
| CVE-2025-71319 | earlier infinite loop | `>= 2.0.0, < 2.0.2` | already fixed in 2.0.2 |

The suggested remediation is not actionable: both open advisories report
`first_patched_version: null`, so there is no version to upgrade to. Nor is the
vulnerability reachable here. `image-size` is a build-time transitive dependency of
`@docusaurus/mdx-loader`, invoked to measure images committed to this repository;
the deployed site is static HTML on Pages with no Node runtime accepting
user-supplied images, and the repo contains no JXL, HEIF or ICNS assets (1 jpg,
1 png, 4 svg). Nothing in a released artifact is affected: the crate, the npm shim
and the wheel carry none of the site.

## The gap it did expose

`website/` was monitored by nothing. Dependabot covered `/` (actions, cargo),
`/npm` and `/py`, every one of which feeds a released artifact. The docs site feeds
none, so it was never added, and its lockfile has been drifting unattended since it
was created. That is why a two-advisory package could sit there without anything
noticing.

This adds the ecosystem, grouped and weekly to match the existing entries, so a
docs-only tree does not open one PR per package and the `image-size` patch is
proposed automatically whenever upstream ships one.

Issue #81 stays open until that patch lands.