### PR TITLE
chore(036): ratify spec 036 (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -63,8 +63,8 @@
       }
     ],
     "specId": "036-configured-corpus-root",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "08438df14685c0a8fd905009dd123781a12eec4e7319c3335e3120a509c59c15"
+  "shardHash": "6456f2ca363cc328b511b7df0e0bc99867cbb34b891340fe9a2cc54262707b31"
 }

--- a/.derived/spec-registry/by-spec/036-configured-corpus-root.json
+++ b/.derived/spec-registry/by-spec/036-configured-corpus-root.json
@@ -52,10 +52,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/036-configured-corpus-root/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`layout.specs_dir` is configuration, and every other consumer reads it: `compile` scans it, `index` builds each spec's `spec.md` path from it, and `init` scaffolds into it. The coupling gate did not. Two functions in `couple.rs` hardcoded the literal `specs/`, and both are load-bearing. The primary-owner heuristic asked whether `specs/<id>/spec.md` was in the diff, so for an adopter whose corpus lives anywhere else the answer was permanently no: no edit to an owning spec could clear `C-001`, and every governed change was refused with the owner named and no reachable way to satisfy it, short of a waiver on every PR. The amends-awareness parser had the same literal, so amendment expansion silently never fired. Both now take the configured root, and the builder is shared with the indexer (`spec_md_rel`, promoted to `pub(crate)`) so a path constructor and its parser cannot drift apart again. A trailing slash on the configured value is trimmed, making `specs` and `specs/` name one corpus root instead of the second yielding `specs//<id>/spec.md`. No DTO, schema, or config shape changes; a default-layout repo is byte-identical.\n",
     "title": "The coupling gate honors `layout.specs_dir`"
   },
-  "shardHash": "1c13694709312e905acbf40bb3be79e0a556d25b0324869e84808423727d1a15",
+  "shardHash": "52a6e9b5643c01889caeae5a08946cdcae09e68fa52f69f8175ff57ea0e544a0",
   "specVersion": "1.1.0"
 }

--- a/specs/036-configured-corpus-root/spec.md
+++ b/specs/036-configured-corpus-root/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "036-configured-corpus-root"
 title: "The coupling gate honors `layout.specs_dir`"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-03"
 implementation: complete


### PR DESCRIPTION
Flips `036-configured-corpus-root` to `approved` now that #82 has landed, and
restamps its two shards (`compile` + `index`).

**Corpus: 37/37 approved** (was 36 approved / 1 draft).

The diff is the usual ratify shape: one line of frontmatter plus the two shards
that carry the status.

| file | change |
|---|---|
| `specs/036-configured-corpus-root/spec.md` | `status: draft` -> `status: approved` |
| `.derived/spec-registry/by-spec/036-configured-corpus-root.json` | restamped |
| `.derived/codebase-index/by-spec/036-configured-corpus-root.json` | restamped |

## Verification

- `compile --check` fresh (37 shards), `index check` fresh.
- `lint --fail-on-warn`: 0 / 0 / 0.
- `index coverage --fail-on-untraced`: 65/65, exit 0. First ratify PR under the
  ownership ratchet turned on in #83; it touches no source file, so `C-002` has
  nothing to say about it.
- `couple --base origin/main`: 1 path checked, **no drift, no waiver needed**.
- `registry status-report --nonzero-only` reports `{"total": 37, "approved": 37}`.