### PR TITLE
chore(release): bump package version to 0.13.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "91724e6ea98f6f5a83b655e6ac6d104cfbb72bccfe3df3a909453fecbb219ef0"
+  "shardHash": "a39aaa8a01550defcc672721b7af056b5998ee0be862caf3a2648ffa7a273b9f"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "3"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.12.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.12.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.13.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.13.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.12.0",
-    "@spec-spine/cli-darwin-x64": "0.12.0",
-    "@spec-spine/cli-linux-x64": "0.12.0",
-    "@spec-spine/cli-linux-arm64": "0.12.0",
-    "@spec-spine/cli-win32-x64": "0.12.0"
+    "@spec-spine/cli-darwin-arm64": "0.13.0",
+    "@spec-spine/cli-darwin-x64": "0.13.0",
+    "@spec-spine/cli-linux-x64": "0.13.0",
+    "@spec-spine/cli-linux-arm64": "0.13.0",
+    "@spec-spine/cli-win32-x64": "0.13.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.12.0"
+version = "0.13.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares **v0.13.0**. Version-bump only; the tag is pushed after this merges.

## What ships

**Spec 036 (#82): the coupling gate honors `layout.specs_dir`.** This is the
adopter-facing reason to cut a release. `layout.specs_dir` is configuration, and
`compile`, `index` and `init` all read it. `couple.rs` did not: it hardcoded the
literal `specs/` in the primary-owner heuristic, the single mechanism that clears
a `C-001`. An adopter whose corpus lives anywhere else could not clear a
violation **by any means**, because the gate searched for the owning spec's edit
at a path their repo does not contain:

```
C-001 'src/lib.rs' changed without an authoring edit to any owning spec (001-a)
```

with `contracts/001-a/spec.md` in the same diff. The only exits were a waiver on
every PR or moving the corpus back to `specs/`. Amends-awareness carried the same
literal and was dead code under the same condition. The fix also repairs an
indexer latent bug: `specs_dir = "specs/"` produced `specs//<id>/spec.md`, which
silently dropped a spec's own source from its shard hash.

Also in this release, both **repo-internal** and not adopter-visible:

- **#83** the ownership ratchet is on at home: 65/65 specifically claimed,
  `require_ownership = true`, and CI's coverage step enforced with
  `--fail-on-untraced`.
- **#84** the documentation site is under Dependabot (it was monitored by
  nothing, which is how issue #81's finding went unnoticed).

## Version axes

**Package version only: 0.12.0 -> 0.13.0.** No schema change. Registry and index
stay at **1.1.0** and no DTO moved, so the two axes stay decoupled exactly as
`docs/schema-versioning.md` requires.

## Pre-flight (runbook `docs/releasing.md`)

| check | result |
|---|---|
| `cargo test --workspace --locked` | green |
| `bump_version.py --check 0.13.0` | all four locations agree |
| `Cargo.lock` regenerated after the bump | yes, 3 workspace entries |
| `cargo package --workspace --locked` | exit 0, all three crates verify from packaged sources |
| `compile --check` / `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `index coverage --fail-on-untraced` | 65/65, exit 0 |
| corpus | 37/37 approved |

Only one derived shard moved (`by-package/spec-spine.json`, which records the npm
package version); sharding kept the bump from touching the other 40.

## Waiver

The gate reports the two violations every version-bump PR reports. Spec 030's
auto-waiver correctly does **not** fire here: a package's own `version` field is
not a dependency edit, so this needs the standing manual waiver.

Spec-Drift-Waiver: A release version bump. `npm/package.json` and `py/pyproject.toml` change only their `version` field and the version-locked `optionalDependencies` pins, which specs 007 and 008 require to track the tag; neither spec's behavior changes, so there is nothing to author in them. This is the standing waiver every version-bump PR carries (cf. #57, #80).