### PR TITLE
feat(038): add `registry plan`, the ready set in dependency order

### DIFF
--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d2338df6acd8e0d5f866b25033ff3f858be2a5f3ca38ab1e6b424976f1bf9970"
+  "shardHash": "953deee753d9388a7b602c39ec5c0d3e6f3649ffadcff9c90e7a9be44e3c86e4"
 }

--- a/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
@@ -51,7 +51,7 @@
       }
     ],
     "id": "038-registry-plan-ready-set",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -88,6 +88,6 @@
     "summary": "`depends_on` records the order specs must be built in, spec 033 guarantees that graph is acyclic, and `implementation` records how far each one has got, but nothing joins the three: there is no query that answers \"which specs can be worked on now, and in what order\". Every consumer that needs it (a contributor picking up the corpus, a release note, an autonomous driver taking one spec per session) recomputes it by reading frontmatter by hand, which is both tedious and exactly the ad-hoc traversal the typed read verbs exist to replace. This spec adds `registry plan`: a read-only projection that partitions the corpus into a `ready` set (nothing unfinished blocks it) emitted in deterministic topological order, and a `blocked` set, each entry naming the unfinished dependencies that block it, so the output explains itself rather than merely listing. It is a scheduling projection and nothing more: `implementation` is a self-declared field that no gate currently verifies, so `plan` treats it as a hint about intent and never as evidence about code, and this spec deliberately does not let a scheduling answer imply that anything is done.\n",
     "title": "`registry plan`: the ready set in dependency order"
   },
-  "shardHash": "93778868d32f845778211aab2e1adb19f70a0a737dd5a4e1bdc17efb23ce15ed",
+  "shardHash": "6205d2a87e71ec1d31f428db28a6611aa12f167336df4ce86b70f0190e90d79d",
   "specVersion": "1.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -63,13 +63,19 @@ install → init → annotate → wire-CI walkthrough.
 |---|---|
 | `spec-spine compile` / `compile --check` | validate frontmatter, emit the deterministic registry / verify the committed shards match without writing |
 | `spec-spine index` / `index check` / `index render` / `index orphans` / `index coverage` | emit the codebase index / check staleness / render it as markdown / list orphaned specs / report which source files no spec specifically claims (`--fail-on-untraced` asserts full coverage) |
-| `spec-spine registry list\|show\|status-report\|relationships` | typed read-only queries |
+| `spec-spine registry list\|show\|status-report\|relationships\|plan` | typed read-only queries; `plan` (spec 038) partitions the corpus into what can be worked on now and what is blocked, naming each blocker's state |
 | `spec-spine lint [--fail-on-warn] [--fail-on-info]` | corpus well-formedness |
 | `spec-spine couple` | the PR-time coupling gate (refuses drift; with `[coupling] require_ownership` also refuses a changed source file no spec claims) |
 | `spec-spine init [--force]` | scaffold a new adopter |
 
 Exit codes: `0` ok · `1` validation failure / not found / drift · `2` stale ·
 `3` I/O / parse / schema / config.
+
+The verbs that render a **verdict** (`compile --check`, `index check`, `lint`,
+`couple`, `attest`, `verify-attestation`) take `--json` (spec 037), writing one
+canonical envelope (`schemaVersion`, `verb`, `ok`, `exitCode`, and either
+`report` or `error`) instead of prose. The flag changes what is written, never
+what is decided: every exit code is identical with and without it.
 
 ## Crates
 

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 
 use clap::Subcommand;
 use spec_spine_core::{
-    ListFilter, list, list_ids, load_committed_registry, relationships, show, status_report,
+    ListFilter, Plan, list, list_ids, load_committed_registry, plan, relationships, show,
+    status_report,
 };
 use spec_spine_types::{Error, Status};
 
@@ -42,6 +43,11 @@ pub enum RegistryQuery {
     /// Show a spec's relationship neighborhood.
     Relationships {
         id: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Which specs can be worked on now, and what blocks the rest (spec 038).
+    Plan {
         #[arg(long)]
         json: bool,
     },
@@ -122,6 +128,14 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 outln!("retired:    {}", report.retired);
             }
         }
+        RegistryQuery::Plan { json } => {
+            let plan = plan(&registry)?;
+            if *json {
+                print_json(&plan)?;
+            } else {
+                print_plan(&plan);
+            }
+        }
         RegistryQuery::Relationships { id, json } => {
             let view = relationships(&registry, id)?;
             if *json {
@@ -138,6 +152,26 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
         }
     }
     Ok(0)
+}
+
+/// The human form: the ready set in order, then one line of what is blocked.
+///
+/// The prose form counts rather than enumerating the blocked set, because the
+/// question a person asks at a terminal is "what can I do now"; `--json` carries
+/// every blocker and its state for the consumer that asks "why not that one".
+fn print_plan(plan: &Plan) {
+    if plan.ready.is_empty() {
+        outln!("(nothing ready)");
+    } else {
+        for id in &plan.ready {
+            outln!("{id}");
+        }
+    }
+    outln!(
+        "ready: {}, blocked: {}",
+        plan.ready.len(),
+        plan.blocked.len()
+    );
 }
 
 fn parse_status(s: &str) -> Result<Status, Error> {

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -160,18 +160,20 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
 /// question a person asks at a terminal is "what can I do now"; `--json` carries
 /// every blocker and its state for the consumer that asks "why not that one".
 fn print_plan(plan: &Plan) {
-    if plan.ready.is_empty() {
-        outln!("(nothing ready)");
-    } else {
-        for id in &plan.ready {
-            outln!("{id}");
-        }
+    for id in &plan.ready {
+        outln!("{id}");
     }
-    outln!(
-        "ready: {}, blocked: {}",
-        plan.ready.len(),
-        plan.blocked.len()
-    );
+    // One summary line either way: "(nothing ready)" already carries the count
+    // it would otherwise repeat as "ready: 0".
+    if plan.ready.is_empty() {
+        outln!("(nothing ready), blocked: {}", plan.blocked.len());
+    } else {
+        outln!(
+            "ready: {}, blocked: {}",
+            plan.ready.len(),
+            plan.blocked.len()
+        );
+    }
 }
 
 fn parse_status(s: &str) -> Result<Status, Error> {

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -1388,9 +1388,10 @@ fn registry_plan_partitions_the_corpus() {
     assert_eq!(code(&run_in(empty.path(), &["compile"])), 0);
     let out = run_in(empty.path(), &["registry", "plan"]);
     assert_eq!(code(&out), 0);
-    assert!(
-        String::from_utf8_lossy(&out.stdout).contains("(nothing ready)"),
-        "{}",
-        String::from_utf8_lossy(&out.stdout)
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        text.trim(),
+        "(nothing ready), blocked: 0",
+        "one summary line: the empty case does not also print `ready: 0`"
     );
 }

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -1310,3 +1310,87 @@ fn json_verify_attestation_with_no_mode_is_an_error_envelope() {
     assert_eq!(v["error"]["kind"], "config");
     assert!(v.get("report").is_none());
 }
+
+// ===== spec 038: `registry plan` =====
+
+/// The scheduling projection, end to end: prose lists the ready set and counts
+/// the rest, `--json` carries every blocker with the state that made it one.
+///
+/// Emitted **bare**, like every other `registry` projection: spec 037's verdict
+/// envelope wraps the adjudicating verbs, and 037 4 keeps it off the read verbs,
+/// so `plan` joins them rather than splitting the group into two output shapes.
+#[test]
+fn registry_plan_partitions_the_corpus() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let spec = |id: &str, body: &str| {
+        let dir = root.join("specs").join(id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("spec.md"),
+            format!(
+                "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-06\"\n\
+                 summary: \"s\"\n{body}---\n# {id}\n"
+            ),
+        )
+        .unwrap();
+    };
+    spec("001-done", "implementation: complete\n");
+    spec(
+        "002-now",
+        "implementation: pending\ndepends_on: [\"001-done\"]\n",
+    );
+    spec(
+        "003-later",
+        "implementation: pending\ndepends_on: [\"002-now\"]\n",
+    );
+    assert_eq!(code(&run_in(root, &["compile"])), 0);
+
+    let prose = run_in(root, &["registry", "plan"]);
+    assert_eq!(
+        code(&prose),
+        0,
+        "{}",
+        String::from_utf8_lossy(&prose.stderr)
+    );
+    let text = String::from_utf8_lossy(&prose.stdout);
+    assert!(text.starts_with("002-now\n"), "{text}");
+    assert!(text.contains("ready: 1, blocked: 1"), "{text}");
+    assert!(
+        !text.contains("001-done"),
+        "a finished spec is not offered: {text}"
+    );
+
+    let out = run_in(root, &["registry", "plan", "--json"]);
+    assert_eq!(code(&out), 0);
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    // Bare report, not a spec 037 envelope.
+    assert!(v.get("schemaVersion").is_none(), "{v}");
+    assert_eq!(v["ready"], serde_json::json!(["002-now"]));
+    assert_eq!(
+        v["blocked"],
+        serde_json::json!([
+            { "id": "003-later", "blockedBy": [{ "id": "002-now", "state": "pending" }] }
+        ])
+    );
+
+    // A corpus with nothing schedulable says so rather than printing an empty
+    // page: the prose form has a reader, and "(nothing ready)" is an answer.
+    let empty = tempfile::tempdir().unwrap();
+    let dir = empty.path().join("specs/001-done");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("spec.md"),
+        "---\nid: \"001-done\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-06\"\n\
+         summary: \"s\"\nimplementation: complete\n---\n# 001-done\n",
+    )
+    .unwrap();
+    assert_eq!(code(&run_in(empty.path(), &["compile"])), 0);
+    let out = run_in(empty.path(), &["registry", "plan"]);
+    assert_eq!(code(&out), 0);
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("(nothing ready)"),
+        "{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -68,8 +68,8 @@ pub use index::{
 };
 pub use lint::{LintReport, lint};
 pub use query::{
-    ListFilter, RelationshipView, StatusReport, StatusReportNonzero, list, list_ids, load_index,
-    load_registry, relationships, show, status_report,
+    BlockedSpec, Blocker, ListFilter, Plan, RelationshipView, StatusReport, StatusReportNonzero,
+    list, list_ids, load_index, load_registry, plan, relationships, show, status_report,
 };
 pub use render::{orphans, render_markdown};
 pub use scaffold::{Scaffold, ScaffoldFile, scaffold_init};
@@ -115,6 +115,7 @@ pub fn query_json(request_json: &str) -> Result<String, Error> {
         Show,
         StatusReport,
         Relationships,
+        Plan,
     }
 
     let request: Request = serde_json::from_str(request_json)
@@ -152,6 +153,11 @@ pub fn query_json(request_json: &str) -> Result<String, Error> {
                 .ok_or_else(|| Error::NotFound("missing 'id' for relationships".into()))?;
             to_json(&relationships(&registry, &id)?)?
         }
+        // Spec 038. Emitted bare, like every other `registry` projection: the
+        // spec 037 verdict envelope wraps the adjudicating verbs, and 037 4
+        // keeps it off the read verbs so a shipped read surface is not broken
+        // for symmetry alone.
+        Op::Plan => to_json(&plan(&registry)?)?,
     };
     Ok(json)
 }

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -439,7 +439,14 @@ fn find_cycle(by_id: &BTreeMap<&str, &SpecRecord>) -> Option<Vec<String>> {
             match colour.get(dep_id) {
                 // Re-entering a spec still on the path closes a cycle.
                 Some(Colour::Grey) => {
-                    let from = stack.iter().position(|f| f.id == *dep_id).unwrap_or(0);
+                    // Grey means "on the current path", so the frame is always
+                    // found. Asserted rather than trusted: the fallback would
+                    // otherwise report a path starting at the wrong frame, and
+                    // any cycle test still passes under that misattribution
+                    // because the whole stack contains the cycle's ids.
+                    let from = stack.iter().position(|f| f.id == *dep_id);
+                    debug_assert!(from.is_some(), "grey node absent from the walk stack");
+                    let from = from.unwrap_or(0);
                     let mut cycle: Vec<String> =
                         stack[from..].iter().map(|f| f.id.to_string()).collect();
                     cycle.push((*dep_id).to_string());

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -1,12 +1,15 @@
 //! The query capability (spec 002): typed, read-only access over a loaded
 //! registry. Because `Registry` is defined in `spec-spine-types`, these are free
 //! functions rather than inherent methods (the orphan rule), but the surface is
-//! the same: list / show / status_report / relationships, plus `load_registry`.
+//! the same: list / show / status_report / relationships / plan, plus
+//! `load_registry`.
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 use spec_spine_types::{
-    CodebaseIndex, Error, INDEX_SCHEMA_VERSION, REGISTRY_SCHEMA_VERSION, Registry, SpecRecord,
-    Status, parse_semver,
+    CodebaseIndex, Error, INDEX_SCHEMA_VERSION, Implementation, REGISTRY_SCHEMA_VERSION, Registry,
+    Severity, SpecRecord, Status, Violation, parse_semver,
 };
 
 /// Parse `registry.json` bytes into a typed [`Registry`], rejecting an unknown
@@ -183,4 +186,254 @@ pub fn relationships(registry: &Registry, id: &str) -> Result<RelationshipView, 
         amended_by: incoming(|s| &s.amends),
         depended_on_by: incoming(|s| &s.depends_on),
     })
+}
+
+// ===== spec 038: `registry plan` =====
+
+/// One unfinished dependency, with the state that makes it a blocker.
+///
+/// `state` is the blocker's `implementation` value, or the literal `unresolved`
+/// for a `depends_on` target absent from the registry. It is not decoration: a
+/// `deferred` blocker appears in neither output set while still blocking, so
+/// without its state that entry would name a spec the reader can find nowhere
+/// else in the document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Blocker {
+    pub id: String,
+    pub state: String,
+}
+
+/// A spec that cannot be scheduled yet, and every reason why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockedSpec {
+    pub id: String,
+    pub blocked_by: Vec<Blocker>,
+}
+
+/// The scheduling projection: what can be worked on now, and what cannot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Plan {
+    pub ready: Vec<String>,
+    pub blocked: Vec<BlockedSpec>,
+}
+
+/// Partition the corpus into the ready set and the blocked set (spec 038).
+///
+/// **This answers what is *claimed*, never what is done.** `implementation` is
+/// self-declared and no gate verifies that a spec marked `complete` has any
+/// implemented code, so `plan` is the correct input to scheduling and the wrong
+/// input to acceptance. A scheduler that reads a claim and an adjudicator that
+/// verifies one must stay different mechanisms, or the claim becomes its own
+/// proof.
+///
+/// A spec is **excluded** from both sets when the corpus has moved past it
+/// (`status` `superseded` or `retired`) or when someone has already answered
+/// "should this be scheduled" with no (`implementation` `complete`, `n-a` or
+/// `deferred`). An absent `implementation` reads as `pending`: an unstated
+/// intention is the same input to a scheduler as a stated intention to start.
+///
+/// Returns [`Error::Validation`] naming the path if `depends_on` contains a
+/// cycle. Spec 033 refuses one at compile time, so a registry that exists is
+/// acyclic; this guards a hand-edited shard or one written by another tool
+/// version, and it terminates rather than looping or truncating.
+pub fn plan(registry: &Registry) -> Result<Plan, Error> {
+    let by_id: BTreeMap<&str, &SpecRecord> =
+        registry.specs.iter().map(|s| (s.id.as_str(), s)).collect();
+
+    if let Some(cycle) = find_cycle(&by_id) {
+        return Err(Error::Validation(vec![Violation {
+            code: "V-014".to_string(),
+            severity: Severity::Error,
+            message: format!(
+                "depends_on cycle refuses scheduling: {}",
+                cycle.join(" -> ")
+            ),
+            path: None,
+        }]));
+    }
+
+    let mut ready: Vec<&str> = Vec::new();
+    let mut blocked: Vec<BlockedSpec> = Vec::new();
+
+    // `by_id` is a BTreeMap, so this walks ids in ascending order and both
+    // output vectors are built deterministically without a later sort.
+    for (id, spec) in &by_id {
+        if !schedulable(spec) {
+            continue;
+        }
+        let blocked_by: Vec<Blocker> = spec
+            .depends_on
+            .iter()
+            .filter_map(|dep| {
+                blocker_state(&by_id, dep).map(|state| Blocker {
+                    id: dep.clone(),
+                    state,
+                })
+            })
+            .collect();
+        if blocked_by.is_empty() {
+            ready.push(id);
+        } else {
+            blocked.push(BlockedSpec {
+                id: (*id).to_string(),
+                blocked_by,
+            });
+        }
+    }
+
+    Ok(Plan {
+        ready: topological(&ready, &by_id),
+        blocked,
+    })
+}
+
+/// Whether this spec should be offered to a scheduler at all.
+///
+/// `deferred` sits beside `complete` here, and the two carry opposite
+/// information about whether work remains, so the reason is worth stating.
+/// `plan` does not ask "is this finished", it asks "should this be scheduled",
+/// and to both the answer is no. `deferred` is the one value in the enum that is
+/// a **decision** rather than a report: someone looked at the spec and took it
+/// off the schedule. Offering it anyway would overrule that, and quietly
+/// returning it to `ready` when a dependency landed would make deferral expire
+/// on its own, which is not what deferring something means.
+fn schedulable(spec: &SpecRecord) -> bool {
+    if matches!(spec.status, Status::Superseded | Status::Retired) {
+        return false;
+    }
+    !matches!(
+        spec.implementation,
+        Some(Implementation::Complete | Implementation::Na | Implementation::Deferred)
+    )
+}
+
+/// The state of `dep` if it blocks, or `None` if it is finished.
+///
+/// A dependency is finished only when its `implementation` is `complete` or
+/// `n-a`. A target absent from the registry blocks as `unresolved`: a dangling
+/// dependency is a corpus defect, and reading "the blocker does not exist" as
+/// "the blocker is satisfied" would hand out work in an order the corpus does
+/// not sanction.
+fn blocker_state(by_id: &BTreeMap<&str, &SpecRecord>, dep: &str) -> Option<String> {
+    let Some(spec) = by_id.get(dep) else {
+        return Some("unresolved".to_string());
+    };
+    match spec.implementation {
+        Some(Implementation::Complete | Implementation::Na) => None,
+        Some(Implementation::InProgress) => Some("in-progress".to_string()),
+        Some(Implementation::Deferred) => Some("deferred".to_string()),
+        Some(Implementation::Pending) | None => Some("pending".to_string()),
+    }
+}
+
+/// The ready set in topological order over `depends_on`, ties by ascending id.
+///
+/// Kahn's algorithm with an id-ordered frontier, which is what makes the output
+/// a pure function of the corpus rather than of a hash-map iteration order.
+///
+/// The ready set contains no edges among its own members, because a spec
+/// depending on an unfinished spec is blocked rather than ready, so in practice
+/// every member enters the frontier at once and the result is ascending id
+/// order. The walk is kept rather than replaced by a sort so the ordering
+/// property is enforced by the code rather than assumed by a comment, and so
+/// that a later change to the partition cannot silently emit a dependent before
+/// its dependency.
+fn topological(ready: &[&str], by_id: &BTreeMap<&str, &SpecRecord>) -> Vec<String> {
+    let members: BTreeSet<&str> = ready.iter().copied().collect();
+    let mut remaining: BTreeMap<&str, BTreeSet<&str>> = members
+        .iter()
+        .map(|id| {
+            let deps = by_id[id]
+                .depends_on
+                .iter()
+                .map(String::as_str)
+                .filter(|d| members.contains(d))
+                .collect();
+            (*id, deps)
+        })
+        .collect();
+
+    let mut out: Vec<String> = Vec::with_capacity(members.len());
+    while !remaining.is_empty() {
+        // Ascending id among everything currently unblocked: the tiebreak.
+        let Some(next) = remaining
+            .iter()
+            .find(|(_, deps)| deps.is_empty())
+            .map(|(id, _)| *id)
+        else {
+            // Unreachable: `plan` refused a cycle before calling this, and the
+            // restriction to `members` cannot create one. Emitting the rest in
+            // id order beats looping if the invariant is ever broken elsewhere.
+            debug_assert!(false, "topological: no unblocked spec but work remains");
+            out.extend(remaining.keys().map(|id| (*id).to_string()));
+            break;
+        };
+        remaining.remove(next);
+        for deps in remaining.values_mut() {
+            deps.remove(next);
+        }
+        out.push(next.to_string());
+    }
+    out
+}
+
+/// The first `depends_on` cycle reachable in the graph, as the path that closes
+/// it, or `None` when the graph is acyclic.
+///
+/// Iterative-friendly three-colour DFS over ids in ascending order, so the cycle
+/// reported for a given registry is always the same one.
+fn find_cycle(by_id: &BTreeMap<&str, &SpecRecord>) -> Option<Vec<String>> {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Colour {
+        White,
+        Grey,
+        Black,
+    }
+    fn visit<'a>(
+        id: &'a str,
+        by_id: &BTreeMap<&'a str, &'a SpecRecord>,
+        colour: &mut BTreeMap<&'a str, Colour>,
+        stack: &mut Vec<&'a str>,
+    ) -> Option<Vec<String>> {
+        colour.insert(id, Colour::Grey);
+        stack.push(id);
+        for dep in &by_id[id].depends_on {
+            // A dangling dependency is not a cycle; `blocker_state` reports it.
+            let Some((dep_id, _)) = by_id.get_key_value(dep.as_str()) else {
+                continue;
+            };
+            match colour.get(dep_id).copied().unwrap_or(Colour::White) {
+                Colour::Grey => {
+                    let from = stack.iter().position(|n| n == dep_id).unwrap_or(0);
+                    let mut cycle: Vec<String> =
+                        stack[from..].iter().map(|n| (*n).to_string()).collect();
+                    cycle.push((*dep_id).to_string());
+                    return Some(cycle);
+                }
+                Colour::White => {
+                    if let Some(cycle) = visit(dep_id, by_id, colour, stack) {
+                        return Some(cycle);
+                    }
+                }
+                Colour::Black => {}
+            }
+        }
+        stack.pop();
+        colour.insert(id, Colour::Black);
+        None
+    }
+
+    let mut colour: BTreeMap<&str, Colour> = BTreeMap::new();
+    for id in by_id.keys() {
+        if colour.get(id).copied().unwrap_or(Colour::White) == Colour::White {
+            let mut stack = Vec::new();
+            if let Some(cycle) = visit(id, by_id, &mut colour, &mut stack) {
+                return Some(cycle);
+            }
+        }
+    }
+    None
 }

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -334,13 +334,17 @@ fn blocker_state(by_id: &BTreeMap<&str, &SpecRecord>, dep: &str) -> Option<Strin
 /// Kahn's algorithm with an id-ordered frontier, which is what makes the output
 /// a pure function of the corpus rather than of a hash-map iteration order.
 ///
-/// The ready set contains no edges among its own members, because a spec
-/// depending on an unfinished spec is blocked rather than ready, so in practice
-/// every member enters the frontier at once and the result is ascending id
-/// order. The walk is kept rather than replaced by a sort so the ordering
-/// property is enforced by the code rather than assumed by a comment, and so
-/// that a later change to the partition cannot silently emit a dependent before
-/// its dependency.
+/// Under the current partition this is **equivalent to sorting by id**, and the
+/// walk provides no ordering guarantee a `sort()` would not: the ready set
+/// contains no edges among its own members, because a spec depending on an
+/// unfinished spec is blocked rather than ready and a finished one is excluded,
+/// so every member's restricted dependency set is empty and all of them enter
+/// the frontier at once. `plan_ready_set_has_no_internal_edges` pins that.
+///
+/// It is kept rather than replaced by the sort because the degeneracy is a
+/// property of `schedulable` and `blocker_state`, not of this function: a later
+/// change to either could introduce an intra-set edge, and the walk is what
+/// keeps that from silently emitting a dependent before its dependency.
 fn topological(ready: &[&str], by_id: &BTreeMap<&str, &SpecRecord>) -> Vec<String> {
     let members: BTreeSet<&str> = ready.iter().copied().collect();
     let mut remaining: BTreeMap<&str, BTreeSet<&str>> = members
@@ -383,55 +387,71 @@ fn topological(ready: &[&str], by_id: &BTreeMap<&str, &SpecRecord>) -> Vec<Strin
 /// The first `depends_on` cycle reachable in the graph, as the path that closes
 /// it, or `None` when the graph is acyclic.
 ///
-/// Iterative-friendly three-colour DFS over ids in ascending order, so the cycle
-/// reported for a given registry is always the same one.
+/// Three-colour DFS over ids in ascending order, so the cycle reported for a
+/// given registry is always the same one.
+///
+/// The walk carries its own stack rather than recursing. This runs only on
+/// input `compile` refuses to emit, which is precisely the input that may be
+/// arbitrarily malformed: a recursive walk over a hand-edited shard with a long
+/// enough chain overflows the stack and aborts the process, which is a worse
+/// outcome than the looping this guard exists to prevent, and one outside the
+/// documented exit-code contract entirely.
 fn find_cycle(by_id: &BTreeMap<&str, &SpecRecord>) -> Option<Vec<String>> {
     #[derive(Clone, Copy, PartialEq)]
     enum Colour {
-        White,
         Grey,
         Black,
     }
-    fn visit<'a>(
+    // One frame per spec being explored: the spec, and how far through its
+    // `depends_on` list the walk has got.
+    struct Frame<'a> {
         id: &'a str,
-        by_id: &BTreeMap<&'a str, &'a SpecRecord>,
-        colour: &mut BTreeMap<&'a str, Colour>,
-        stack: &mut Vec<&'a str>,
-    ) -> Option<Vec<String>> {
-        colour.insert(id, Colour::Grey);
-        stack.push(id);
-        for dep in &by_id[id].depends_on {
+        next_dep: usize,
+    }
+
+    let mut colour: BTreeMap<&str, Colour> = BTreeMap::new();
+
+    for root in by_id.keys() {
+        if colour.contains_key(root) {
+            continue;
+        }
+        let mut stack: Vec<Frame<'_>> = vec![Frame {
+            id: root,
+            next_dep: 0,
+        }];
+        colour.insert(root, Colour::Grey);
+
+        while let Some(frame) = stack.last_mut() {
+            let deps = &by_id[frame.id].depends_on;
+            let Some(dep) = deps.get(frame.next_dep) else {
+                // Every dependency explored: this spec is off the current path.
+                colour.insert(frame.id, Colour::Black);
+                stack.pop();
+                continue;
+            };
+            frame.next_dep += 1;
+
             // A dangling dependency is not a cycle; `blocker_state` reports it.
             let Some((dep_id, _)) = by_id.get_key_value(dep.as_str()) else {
                 continue;
             };
-            match colour.get(dep_id).copied().unwrap_or(Colour::White) {
-                Colour::Grey => {
-                    let from = stack.iter().position(|n| n == dep_id).unwrap_or(0);
+            match colour.get(dep_id) {
+                // Re-entering a spec still on the path closes a cycle.
+                Some(Colour::Grey) => {
+                    let from = stack.iter().position(|f| f.id == *dep_id).unwrap_or(0);
                     let mut cycle: Vec<String> =
-                        stack[from..].iter().map(|n| (*n).to_string()).collect();
+                        stack[from..].iter().map(|f| f.id.to_string()).collect();
                     cycle.push((*dep_id).to_string());
                     return Some(cycle);
                 }
-                Colour::White => {
-                    if let Some(cycle) = visit(dep_id, by_id, colour, stack) {
-                        return Some(cycle);
-                    }
+                Some(Colour::Black) => {}
+                None => {
+                    colour.insert(dep_id, Colour::Grey);
+                    stack.push(Frame {
+                        id: dep_id,
+                        next_dep: 0,
+                    });
                 }
-                Colour::Black => {}
-            }
-        }
-        stack.pop();
-        colour.insert(id, Colour::Black);
-        None
-    }
-
-    let mut colour: BTreeMap<&str, Colour> = BTreeMap::new();
-    for id in by_id.keys() {
-        if colour.get(id).copied().unwrap_or(Colour::White) == Colour::White {
-            let mut stack = Vec::new();
-            if let Some(cycle) = visit(id, by_id, &mut colour, &mut stack) {
-                return Some(cycle);
             }
         }
     }

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -387,8 +387,9 @@ fn topological(ready: &[&str], by_id: &BTreeMap<&str, &SpecRecord>) -> Vec<Strin
 /// The first `depends_on` cycle reachable in the graph, as the path that closes
 /// it, or `None` when the graph is acyclic.
 ///
-/// Three-colour DFS over ids in ascending order, so the cycle reported for a
-/// given registry is always the same one.
+/// Colouring DFS over ids in ascending order, so the cycle reported for a given
+/// registry is always the same one. Unvisited is absence from `colour` rather
+/// than a third variant, so the map holds only what the walk has reached.
 ///
 /// The walk carries its own stack rather than recursing. This runs only on
 /// input `compile` refuses to emit, which is precisely the input that may be

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -88,3 +88,312 @@ fn relationships_show_incoming_and_outgoing() {
     assert_eq!(beta.depends_on, vec!["001-alpha".to_string()]);
     assert!(beta.depended_on_by.is_empty());
 }
+
+// ===== spec 038: `registry plan` =====
+
+/// Build a registry from `(id, status, implementation, depends_on)` rows.
+///
+/// Goes through the deserializer rather than a struct literal because that is
+/// the path a committed shard takes, and because it is the only way to reach the
+/// states `compile` refuses to emit (a cycle, a dangling dependency), which are
+/// exactly the ones `plan` has to survive.
+fn registry_of(rows: &[(&str, &str, Option<&str>, &[&str])]) -> spec_spine_types::Registry {
+    let specs: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|(id, status, implementation, deps)| {
+            let mut spec = serde_json::json!({
+                "id": id,
+                "title": "T",
+                "status": status,
+                "created": "2026-09-06",
+                "summary": "s",
+                "specPath": format!("specs/{id}/spec.md"),
+                "dependsOn": deps,
+            });
+            if let Some(impl_) = implementation {
+                spec["implementation"] = serde_json::json!(impl_);
+            }
+            spec
+        })
+        .collect();
+    serde_json::from_value(serde_json::json!({
+        "specVersion": spec_spine_types::REGISTRY_SCHEMA_VERSION,
+        "build": {
+            "compilerId": "spec-spine",
+            "compilerVersion": "0.0.0",
+            "inputRoot": ".",
+            "contentHash": "0".repeat(64),
+        },
+        "specs": specs,
+        "validation": { "passed": true, "violations": [] },
+    }))
+    .unwrap()
+}
+
+fn blockers(plan: &spec_spine_core::Plan, id: &str) -> Vec<(String, String)> {
+    plan.blocked
+        .iter()
+        .find(|b| b.id == id)
+        .unwrap_or_else(|| panic!("{id} is not blocked; plan: {plan:?}"))
+        .blocked_by
+        .iter()
+        .map(|b| (b.id.clone(), b.state.clone()))
+        .collect()
+}
+
+#[test]
+fn plan_walks_a_linear_chain_one_step_at_a_time() {
+    let reg = registry_of(&[
+        ("001-a", "approved", Some("pending"), &[]),
+        ("002-b", "approved", Some("pending"), &["001-a"]),
+        ("003-c", "approved", Some("pending"), &["002-b"]),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    assert_eq!(plan.ready, vec!["001-a"]);
+    assert_eq!(
+        blockers(&plan, "002-b"),
+        [("001-a".into(), "pending".into())]
+    );
+    assert_eq!(
+        blockers(&plan, "003-c"),
+        [("002-b".into(), "pending".into())]
+    );
+}
+
+#[test]
+fn plan_offers_both_arms_of_a_diamond_in_id_order() {
+    let reg = registry_of(&[
+        ("001-root", "approved", Some("complete"), &[]),
+        ("003-right", "approved", Some("pending"), &["001-root"]),
+        ("002-left", "approved", Some("pending"), &["001-root"]),
+        (
+            "004-join",
+            "approved",
+            Some("pending"),
+            &["002-left", "003-right"],
+        ),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    assert_eq!(plan.ready, vec!["002-left", "003-right"]);
+    assert_eq!(
+        blockers(&plan, "004-join"),
+        [
+            ("002-left".into(), "pending".into()),
+            ("003-right".into(), "pending".into())
+        ],
+        "every blocker is named, not just the first"
+    );
+}
+
+#[test]
+fn plan_treats_complete_and_n_a_as_finished_and_everything_else_as_blocking() {
+    // One dependent per dependency state, so each arm is asserted separately.
+    let reg = registry_of(&[
+        ("001-complete", "approved", Some("complete"), &[]),
+        ("002-na", "approved", Some("n-a"), &[]),
+        ("003-pending", "approved", Some("pending"), &[]),
+        ("004-inprogress", "approved", Some("in-progress"), &[]),
+        ("005-deferred", "approved", Some("deferred"), &[]),
+        (
+            "010-on-complete",
+            "approved",
+            Some("pending"),
+            &["001-complete"],
+        ),
+        ("011-on-na", "approved", Some("pending"), &["002-na"]),
+        (
+            "012-on-pending",
+            "approved",
+            Some("pending"),
+            &["003-pending"],
+        ),
+        (
+            "013-on-inprogress",
+            "approved",
+            Some("pending"),
+            &["004-inprogress"],
+        ),
+        (
+            "014-on-deferred",
+            "approved",
+            Some("pending"),
+            &["005-deferred"],
+        ),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+
+    assert_eq!(
+        plan.ready,
+        vec![
+            "003-pending",
+            "004-inprogress",
+            "010-on-complete",
+            "011-on-na",
+        ],
+        "only `complete` and `n-a` dependencies clear the way"
+    );
+    // The blocked entries carry the state that made each one a blocker, which is
+    // what lets a reader answer "why not that one" without a second lookup.
+    assert_eq!(
+        blockers(&plan, "012-on-pending"),
+        [("003-pending".into(), "pending".into())]
+    );
+    assert_eq!(
+        blockers(&plan, "013-on-inprogress"),
+        [("004-inprogress".into(), "in-progress".into())]
+    );
+    // A `deferred` blocker appears in neither output set while still blocking,
+    // so its entry is the only place it is named at all.
+    assert_eq!(
+        blockers(&plan, "014-on-deferred"),
+        [("005-deferred".into(), "deferred".into())]
+    );
+    let named: Vec<&str> = plan
+        .ready
+        .iter()
+        .map(String::as_str)
+        .chain(plan.blocked.iter().map(|b| b.id.as_str()))
+        .collect();
+    assert!(!named.contains(&"005-deferred"), "{named:?}");
+}
+
+#[test]
+fn plan_excludes_specs_the_corpus_has_moved_past_or_taken_off_the_schedule() {
+    let reg = registry_of(&[
+        ("001-superseded", "superseded", Some("pending"), &[]),
+        ("002-retired", "retired", Some("pending"), &[]),
+        ("003-complete", "approved", Some("complete"), &[]),
+        ("004-na", "approved", Some("n-a"), &[]),
+        ("005-deferred", "approved", Some("deferred"), &[]),
+        ("006-draft", "draft", Some("pending"), &[]),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    assert_eq!(
+        plan.ready,
+        vec!["006-draft"],
+        "a draft is schedulable; the other five are not"
+    );
+    assert!(plan.blocked.is_empty(), "{plan:?}");
+}
+
+#[test]
+fn plan_reads_an_absent_implementation_key_as_pending() {
+    let reg = registry_of(&[
+        ("001-silent", "approved", None, &[]),
+        (
+            "002-on-silent",
+            "approved",
+            Some("pending"),
+            &["001-silent"],
+        ),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    assert_eq!(plan.ready, vec!["001-silent"], "unstated is schedulable");
+    assert_eq!(
+        blockers(&plan, "002-on-silent"),
+        [("001-silent".into(), "pending".into())],
+        "and unstated blocks its dependents, reported as pending"
+    );
+}
+
+#[test]
+fn plan_blocks_on_a_dependency_that_is_not_in_the_corpus() {
+    let reg = registry_of(&[("002-b", "approved", Some("pending"), &["001-missing"])]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    assert!(plan.ready.is_empty(), "{plan:?}");
+    assert_eq!(
+        blockers(&plan, "002-b"),
+        [("001-missing".into(), "unresolved".into())],
+        "a dangling dependency is a corpus defect, never a satisfied one"
+    );
+}
+
+#[test]
+fn plan_is_stable_across_runs_and_independent_of_corpus_order() {
+    let rows: [(&str, &str, Option<&str>, &[&str]); 3] = [
+        ("001-a", "approved", Some("pending"), &[]),
+        ("002-b", "approved", Some("pending"), &[]),
+        ("003-c", "approved", Some("pending"), &["001-a", "002-b"]),
+    ];
+    let forward = spec_spine_core::plan(&registry_of(&rows)).unwrap();
+    let mut reversed = rows;
+    reversed.reverse();
+    let backward = spec_spine_core::plan(&registry_of(&reversed)).unwrap();
+    assert_eq!(forward, backward, "output is a function of the corpus");
+    assert_eq!(
+        forward,
+        spec_spine_core::plan(&registry_of(&rows)).unwrap(),
+        "and of nothing else"
+    );
+    assert_eq!(forward.ready, vec!["001-a", "002-b"]);
+    assert_eq!(
+        blockers(&forward, "003-c"),
+        [
+            ("001-a".into(), "pending".into()),
+            ("002-b".into(), "pending".into())
+        ],
+        "blockers are ordered by the spec's own depends_on list"
+    );
+}
+
+#[test]
+fn plan_refuses_a_cycle_rather_than_looping() {
+    // `compile` refuses a cycle (V-014), so this can only arrive from a
+    // hand-edited shard or another tool version; `plan` must terminate on it.
+    let reg = registry_of(&[
+        ("001-a", "approved", Some("pending"), &["003-c"]),
+        ("002-b", "approved", Some("pending"), &["001-a"]),
+        ("003-c", "approved", Some("pending"), &["002-b"]),
+    ]);
+    let err = spec_spine_core::plan(&reg).unwrap_err();
+    assert_eq!(
+        err.exit_code(),
+        1,
+        "a broken corpus is a validation failure"
+    );
+    let Error::Validation(violations) = &err else {
+        panic!("expected Error::Validation, got {err:?}");
+    };
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].code, "V-014", "033's classification, reused");
+    let message = &violations[0].message;
+    for id in ["001-a", "002-b", "003-c"] {
+        assert!(
+            message.contains(id),
+            "the path names every spec on it: {message}"
+        );
+    }
+}
+
+#[test]
+fn plan_over_a_compiled_corpus_only_offers_unfinished_specs() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "implementation: complete\n");
+    write_spec(
+        tmp.path(),
+        "002-beta",
+        "depends_on: [\"001-alpha\"]\nimplementation: pending\n",
+    );
+    write_spec(
+        tmp.path(),
+        "003-gamma",
+        "depends_on: [\"002-beta\"]\nimplementation: pending\n",
+    );
+    let reg = compile(&Config::default(), tmp.path()).unwrap().registry;
+
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    assert_eq!(plan.ready, vec!["002-beta"]);
+    assert_eq!(
+        blockers(&plan, "003-gamma"),
+        [("002-beta".into(), "pending".into())]
+    );
+    // Nothing `complete` is offered, which is the invariant a scheduler relies
+    // on and the one this projection must never violate.
+    let offered: Vec<&str> = plan
+        .ready
+        .iter()
+        .map(String::as_str)
+        .chain(plan.blocked.iter().map(|b| b.id.as_str()))
+        .collect();
+    assert!(!offered.contains(&"001-alpha"), "{offered:?}");
+}

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -397,3 +397,92 @@ fn plan_over_a_compiled_corpus_only_offers_unfinished_specs() {
         .collect();
     assert!(!offered.contains(&"001-alpha"), "{offered:?}");
 }
+
+/// The degeneracy `topological`'s doc comment claims: no ready spec depends on
+/// another ready spec, so the walk and an id sort agree.
+///
+/// Asserted rather than reasoned about in a comment, because it is a property of
+/// `schedulable` and `blocker_state` rather than of the ordering code, and a
+/// later change to either could break it silently.
+#[test]
+fn plan_ready_set_has_no_internal_edges() {
+    let reg = registry_of(&[
+        ("001-done", "approved", Some("complete"), &[]),
+        ("002-a", "approved", Some("pending"), &["001-done"]),
+        ("003-b", "approved", Some("pending"), &["001-done"]),
+        ("004-c", "approved", Some("pending"), &["002-a"]),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    let ready: std::collections::BTreeSet<&str> = plan.ready.iter().map(String::as_str).collect();
+    for id in &ready {
+        let deps = &reg.specs.iter().find(|s| s.id == *id).unwrap().depends_on;
+        for dep in deps {
+            assert!(
+                !ready.contains(dep.as_str()),
+                "{id} depends on {dep}, which is also ready"
+            );
+        }
+    }
+    let mut sorted = plan.ready.clone();
+    sorted.sort();
+    assert_eq!(plan.ready, sorted, "so the walk agrees with an id sort");
+}
+
+/// A long chain must terminate with the verdict, not abort the process.
+///
+/// This guard runs only on input `compile` refuses to emit, which is exactly the
+/// input that may be arbitrarily malformed, so a recursive walk would overflow
+/// the stack here and exit outside the documented `0`/`1`/`2`/`3` contract.
+#[test]
+fn plan_survives_a_very_long_cycle() {
+    const N: usize = 20_000;
+    let ids: Vec<String> = (0..N).map(|i| format!("{i:06}-spec")).collect();
+    let rows: Vec<(&str, &str, Option<&str>, Vec<&str>)> = (0..N)
+        .map(|i| {
+            // Each spec depends on the next; the last closes the loop.
+            let dep = ids[(i + 1) % N].as_str();
+            (ids[i].as_str(), "approved", Some("pending"), vec![dep])
+        })
+        .collect();
+    let borrowed: Vec<(&str, &str, Option<&str>, &[&str])> = rows
+        .iter()
+        .map(|(id, status, im, deps)| (*id, *status, *im, deps.as_slice()))
+        .collect();
+
+    let err = spec_spine_core::plan(&registry_of(&borrowed)).unwrap_err();
+    assert_eq!(err.exit_code(), 1);
+    let Error::Validation(violations) = &err else {
+        panic!("expected Error::Validation, got {err:?}");
+    };
+    assert_eq!(violations[0].code, "V-014");
+}
+
+/// The same depth, acyclic: the walk must complete rather than overflow on the
+/// way to reporting no cycle at all.
+#[test]
+fn plan_survives_a_very_long_acyclic_chain() {
+    const N: usize = 20_000;
+    let ids: Vec<String> = (0..N).map(|i| format!("{i:06}-spec")).collect();
+    let rows: Vec<(&str, &str, Option<&str>, Vec<&str>)> = (0..N)
+        .map(|i| {
+            let deps = if i == 0 {
+                Vec::new()
+            } else {
+                vec![ids[i - 1].as_str()]
+            };
+            (ids[i].as_str(), "approved", Some("pending"), deps)
+        })
+        .collect();
+    let borrowed: Vec<(&str, &str, Option<&str>, &[&str])> = rows
+        .iter()
+        .map(|(id, status, im, deps)| (*id, *status, *im, deps.as_slice()))
+        .collect();
+
+    let plan = spec_spine_core::plan(&registry_of(&borrowed)).unwrap();
+    assert_eq!(
+        plan.ready,
+        vec!["000000-spec"],
+        "only the head is unblocked"
+    );
+    assert_eq!(plan.blocked.len(), N - 1);
+}

--- a/specs/038-registry-plan-ready-set/spec.md
+++ b/specs/038-registry-plan-ready-set/spec.md
@@ -4,7 +4,7 @@ title: "`registry plan`: the ready set in dependency order"
 status: draft
 kind: "tooling"
 created: "2026-09-05"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:


### PR DESCRIPTION
## Summary

Implements spec 038. Three pieces of the answer already existed and were never joined: `depends_on` records the order specs must be built in, spec 033 guarantees that graph is acyclic, and `implementation` records how far each one has got. No verb answered the question anyone actually asks of a corpus, *what can be worked on now*, so every consumer recomputed it by reading frontmatter by hand: exactly the ad-hoc traversal the typed read verbs exist to replace.

`registry plan` partitions the corpus:

```
$ spec-spine registry plan
039-declared-state-dir
041-completion-held-to-claims
ready: 2, blocked: 1
```

```json
{
  "ready": ["039-declared-state-dir", "041-completion-held-to-claims"],
  "blocked": [
    { "id": "042-per-spec-attestation",
      "blockedBy": [{ "id": "041-completion-held-to-claims", "state": "pending" }] }
  ]
}
```

**`plan` answers what is claimed, never what is done.** §3.4 is load-bearing, so it is the first line of `plan()`'s doc comment: `implementation` is self-declared and no gate verifies it, which makes this the right input to scheduling and the wrong input to acceptance. A scheduler that reads a claim and an adjudicator that verifies one must stay different mechanisms, or the claim becomes its own proof.

**Blocker state is what makes the output diagnostic rather than enumerative.** A `deferred` spec is excluded from both sets while still blocking its dependents, so its blocker entry is the only place it is named at all; a bare id there would point at nothing. `deferred` sits beside `complete` in the excluded set even though the two say opposite things about whether work remains, because `plan` asks "should this be scheduled" and not "is this finished" — and `deferred` is the one value in the enum that is a decision rather than a report, so returning it to `ready` when a dependency landed would make deferral expire on its own.

**Emitted bare, not inside spec 037's envelope.** That envelope wraps the adjudicating verbs, and 037 §4 keeps it off the read verbs so a shipped read surface is not broken for symmetry alone. `plan` is a read verb and joins `list` / `show` / `status-report` / `relationships` rather than splitting the group into two output shapes. The two specs are independent and `depends_on` does not list 037.

## Two implementation choices worth naming

**The topological walk is kept rather than replaced by a sort.** The ready set provably contains no edges among its own members: a spec depending on an unfinished spec is blocked, not ready. So Kahn's algorithm with an id-ordered frontier degenerates to ascending-id order, and a plain sort would produce identical output today. The walk stays so the ordering property is enforced by the code rather than assumed by a comment, and so a later change to the partition cannot silently emit a dependent before its dependency.

**The cycle guard is reachable only from a corrupted registry**, since `compile` refuses one at `V-014`. It reuses that classification instead of inventing a second vocabulary for the same defect, returns `Error::Validation` with the path (exit 1 under the standing contract), and terminates rather than looping or truncating. Its test builds the registry through the deserializer rather than a struct literal, because that is the path a hand-edited shard takes and the only way to reach a state `compile` will not emit.

## Testing

Nine core tests in `tests/query.rs` and one end-to-end CLI test, covering §3.5 in full:

- linear chain yields one ready spec, each blocked entry naming its immediate blocker;
- diamond yields both middles ready in id order, the join blocked by both;
- `complete` and `n-a` dependencies clear the way, `pending` / `in-progress` / `deferred` block, each reported with its own state;
- `superseded`, `retired`, `complete`, `n-a` and `deferred` appear in neither set, and a `deferred` blocker is named only in its dependent's entry;
- an absent `implementation` key is schedulable *and* blocks, reported as `pending`;
- a `depends_on` target absent from the registry blocks as `unresolved`, never as satisfied;
- output is identical across repeated runs and across a reversed corpus order;
- a cycle is `V-014`, exit 1, path names every spec on it, and terminates;
- over a compiled corpus nothing `complete` is ever offered;
- the CLI prose form lists then counts, `--json` is a bare report with no `schemaVersion` envelope, and an all-finished corpus prints `(nothing ready)` rather than an empty page.

```
compile --check                    0   fresh, 44 shards
index check                        0   fresh
index coverage --fail-on-untraced  0   66/66 (100.0%)
lint --fail-on-warn                0   0 errors, 0 warnings, 0 info
couple --base origin/main          0   6 paths checked, no drift
cargo test --workspace --locked    0   all suites pass
cargo clippy -D warnings           0
cargo fmt --all --check            0
```

## One observation

Run against this repo, `plan` lists `000-spec-spine-bootstrap` as ready, because that spec carries no `implementation` key and §3.1 specifies an absent key reads as `pending`. That is faithful to the spec rather than a defect (the bootstrap spec genuinely never declared an intention), but it is worth knowing before a consumer treats the ready set as a work queue.

README's capability table also gains `plan` and, for spec 037, the `--json` flag its own PR left undocumented.