### PR TITLE
feat(039): add `layout.state_dir`, a declared, ungoverned tool-state root

### DIFF
--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b3adc17a3a9f56cc93865f2055192d147187613e953f90c674f352fcb4b075cd"
+  "shardHash": "c2b9c8d33e0e1de9ed58cbd865b5bb182029608ca9890b14d6c0c68d3ba28c55"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -24,6 +24,14 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/shard.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/symbols.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/tests/couple.rs",
         "source": "spec-edge"
       },
@@ -91,6 +99,32 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/shard.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/shard.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/symbols.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/symbols.rs"
         }
       },
       {
@@ -176,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a0f475f601b144718bd8c21643b0d5d8afbab767c3c36c855bc021ecd1f56669"
+  "shardHash": "aaa7b46de565fc464f0bce2cc12ea804e9b1d84a17146766bdce93715c96104d"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c2b9c8d33e0e1de9ed58cbd865b5bb182029608ca9890b14d6c0c68d3ba28c55"
+  "shardHash": "0721ab74c16e9b181e896eaaf01289477dbf67b767b56b7ff2fd169f21ecbe1d"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "aaa7b46de565fc464f0bce2cc12ea804e9b1d84a17146766bdce93715c96104d"
+  "shardHash": "b3adc17a3a9f56cc93865f2055192d147187613e953f90c674f352fcb4b075cd"
 }

--- a/.derived/spec-registry/by-spec/039-declared-state-dir.json
+++ b/.derived/spec-registry/by-spec/039-declared-state-dir.json
@@ -129,6 +129,6 @@
     "summary": "A repo governed by spec-spine increasingly hosts tooling that keeps state inside it: a build daemon's journal, a local database, captured transcripts, attestation bundles. There is nowhere agreed to put any of it. Every such tool invents a directory, and every invented directory is then a surprise to the gates: `couple` sees changed files no spec claims and refuses the merge under `require_ownership`, `index coverage` counts them as untraced debt, and the resolver walks them. The adopter's only recourse is to keep appending private paths to `bypass_prefixes` and `resolver_exclusions`, one list per concern, none of which states what the directory *is*. This spec adds `layout.state_dir`: a single declared root, unset by default, that spec-spine agrees to know about and refuses to govern. Declared means the gates recognize it (bypassed by `couple`, excluded from coverage classification and from the resolver scan, and never hashed); ungoverned means spec-spine never reads its contents, never writes into it, and refuses a spec that tries to claim a unit inside it, which `lint` reports as `L-006`, a contradiction rather than a precedence question resolved silently in either direction. Unset by default, so no existing repo changes behavior.\n",
     "title": "`layout.state_dir`: a declared, ungoverned tool-state root"
   },
-  "shardHash": "1b8b0d81cedf9356093f3711e3a465ab2a7969d944c65b6b2fd1bf05fcbf67ba",
+  "shardHash": "8c31a385f6d91439b3927bd6d463dcd63c458fad446413e382a42cb9f258ed62",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/039-declared-state-dir.json
+++ b/.derived/spec-registry/by-spec/039-declared-state-dir.json
@@ -129,6 +129,6 @@
     "summary": "A repo governed by spec-spine increasingly hosts tooling that keeps state inside it: a build daemon's journal, a local database, captured transcripts, attestation bundles. There is nowhere agreed to put any of it. Every such tool invents a directory, and every invented directory is then a surprise to the gates: `couple` sees changed files no spec claims and refuses the merge under `require_ownership`, `index coverage` counts them as untraced debt, and the resolver walks them. The adopter's only recourse is to keep appending private paths to `bypass_prefixes` and `resolver_exclusions`, one list per concern, none of which states what the directory *is*. This spec adds `layout.state_dir`: a single declared root, unset by default, that spec-spine agrees to know about and refuses to govern. Declared means the gates recognize it (bypassed by `couple`, excluded from coverage classification and from the resolver scan, and never hashed); ungoverned means spec-spine never reads its contents, never writes into it, and refuses a spec that tries to claim a unit inside it, which `lint` reports as `L-006`, a contradiction rather than a precedence question resolved silently in either direction. Unset by default, so no existing repo changes behavior.\n",
     "title": "`layout.state_dir`: a declared, ungoverned tool-state root"
   },
-  "shardHash": "68e5d2b34e79177d5c7a119b309ce249d060a9ac6d030a4eae7bf54bc15b21d9",
+  "shardHash": "89050e3bd2277c736e8031db0d78429c40aff3df8678e95633d3b0ccf6520179",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/039-declared-state-dir.json
+++ b/.derived/spec-registry/by-spec/039-declared-state-dir.json
@@ -50,6 +50,22 @@
       },
       {
         "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/symbols.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "024-index-sharding",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/shard.rs"
+        }
+      },
+      {
+        "nature": "additive",
         "spec": "032-ownership-coverage",
         "unit": {
           "kind": "file",
@@ -74,7 +90,7 @@
       }
     ],
     "id": "039-declared-state-dir",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -105,13 +121,14 @@
       "3.4 A claim inside `state_dir` is a contradiction, and `lint` says so",
       "3.5 Relationship to the existing lists",
       "3.6 Tests (minimum)",
-      "4. Out of scope"
+      "4. Out of scope",
+      "5. Resolved decisions"
     ],
     "specPath": "specs/039-declared-state-dir/spec.md",
     "status": "draft",
     "summary": "A repo governed by spec-spine increasingly hosts tooling that keeps state inside it: a build daemon's journal, a local database, captured transcripts, attestation bundles. There is nowhere agreed to put any of it. Every such tool invents a directory, and every invented directory is then a surprise to the gates: `couple` sees changed files no spec claims and refuses the merge under `require_ownership`, `index coverage` counts them as untraced debt, and the resolver walks them. The adopter's only recourse is to keep appending private paths to `bypass_prefixes` and `resolver_exclusions`, one list per concern, none of which states what the directory *is*. This spec adds `layout.state_dir`: a single declared root, unset by default, that spec-spine agrees to know about and refuses to govern. Declared means the gates recognize it (bypassed by `couple`, excluded from coverage classification and from the resolver scan, and never hashed); ungoverned means spec-spine never reads its contents, never writes into it, and refuses a spec that tries to claim a unit inside it, which `lint` reports as `L-006`, a contradiction rather than a precedence question resolved silently in either direction. Unset by default, so no existing repo changes behavior.\n",
     "title": "`layout.state_dir`: a declared, ungoverned tool-state root"
   },
-  "shardHash": "7d28d601c77a246b20ce1e608b480755b9e9e407b2b23a00b4945a731d2bebf8",
+  "shardHash": "68e5d2b34e79177d5c7a119b309ce249d060a9ac6d030a4eae7bf54bc15b21d9",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/039-declared-state-dir.json
+++ b/.derived/spec-registry/by-spec/039-declared-state-dir.json
@@ -129,6 +129,6 @@
     "summary": "A repo governed by spec-spine increasingly hosts tooling that keeps state inside it: a build daemon's journal, a local database, captured transcripts, attestation bundles. There is nowhere agreed to put any of it. Every such tool invents a directory, and every invented directory is then a surprise to the gates: `couple` sees changed files no spec claims and refuses the merge under `require_ownership`, `index coverage` counts them as untraced debt, and the resolver walks them. The adopter's only recourse is to keep appending private paths to `bypass_prefixes` and `resolver_exclusions`, one list per concern, none of which states what the directory *is*. This spec adds `layout.state_dir`: a single declared root, unset by default, that spec-spine agrees to know about and refuses to govern. Declared means the gates recognize it (bypassed by `couple`, excluded from coverage classification and from the resolver scan, and never hashed); ungoverned means spec-spine never reads its contents, never writes into it, and refuses a spec that tries to claim a unit inside it, which `lint` reports as `L-006`, a contradiction rather than a precedence question resolved silently in either direction. Unset by default, so no existing repo changes behavior.\n",
     "title": "`layout.state_dir`: a declared, ungoverned tool-state root"
   },
-  "shardHash": "89050e3bd2277c736e8031db0d78429c40aff3df8678e95633d3b0ccf6520179",
+  "shardHash": "1b8b0d81cedf9356093f3711e3a465ab2a7969d944c65b6b2fd1bf05fcbf67ba",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -143,15 +143,12 @@ pub fn couple_with(
 
     for file in &diff.files {
         let path = &file.path;
-        // Effective bypass = hardcoded floor ∪ adopter list (additive),
-        // UNLESS an explicit, resolved unit claim covers the path, which
-        // takes precedence over the entire bypass set (spec 009, amending
-        // 005 §3.5). The corpus saying "this surface is governed" beats the
-        // blanket scaffolding exemption.
-        if !explicitly_claimed(path, index)
-            && (is_bypass(path, DEFAULT_BYPASS_PREFIXES)
-                || is_bypass(path, &cfg.coupling.bypass_prefixes))
-        {
+        // Effective bypass = declared state root (spec 039), else the
+        // hardcoded floor ∪ adopter list (additive) UNLESS an explicit,
+        // resolved unit claim covers the path (spec 009). One predicate,
+        // shared with `index coverage`, so the report and the gate cannot
+        // disagree about which paths are even looked at.
+        if is_bypassed_path(cfg, index, path) {
             continue;
         }
         checked_paths += 1;
@@ -221,6 +218,16 @@ pub fn couple_with(
 /// what keeps a claim-overridden floor path from slipping past that
 /// pre-filter into a mechanical waiver.
 pub fn is_bypassed_path(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool {
+    // Spec 039: a declared state root is bypassed unconditionally, and the
+    // check precedes the spec 009 claim override rather than joining it. A
+    // claim inside the root is not a precedence question to resolve in either
+    // direction: it is a contradiction, and `lint` reports it as `L-006`.
+    // Letting the claim win would reintroduce override into a directory whose
+    // whole purpose is to be ungoverned; letting the bypass win silently would
+    // discard a unit an author wrote deliberately.
+    if cfg.layout.is_state_path(path) {
+        return true;
+    }
     !explicitly_claimed(path, index)
         && (is_bypass(path, DEFAULT_BYPASS_PREFIXES)
             || is_bypass(path, &cfg.coupling.bypass_prefixes))

--- a/crates/spec-spine-core/src/coverage.rs
+++ b/crates/spec-spine-core/src/coverage.rs
@@ -104,6 +104,11 @@ pub fn classify(index: &CodebaseIndex, path: &str) -> Ownership {
 /// discovered package, outside `index.resolver_exclusions`, and not bypassed
 /// by the gate (claim-aware, spec 009)? The report and `C-002` share this
 /// predicate, so a path one of them ignores the other ignores too.
+///
+/// A declared `layout.state_dir` (spec 039) is excluded here through
+/// [`is_bypassed_path`], which means excluded from the numerator **and** the
+/// denominator: state is not source, so counting it as unclaimed debt would be
+/// a coverage figure that can never reach 100%.
 pub fn in_coverage_universe(cfg: &Config, index: &CodebaseIndex, path: &str) -> bool {
     has_source_ext(path)
         && !has_excluded_component(path, &cfg.index.resolver_exclusions)
@@ -126,7 +131,13 @@ pub fn enumerate_source_files(
     let mut files: BTreeSet<String> = BTreeSet::new();
     for pkg in &index.packages {
         let dir = repo_root.join(&pkg.path);
-        for file in walk_source(&dir, SOURCE_EXTS, repo_root, &cfg.index.resolver_exclusions) {
+        for file in walk_source(
+            &dir,
+            SOURCE_EXTS,
+            repo_root,
+            &cfg.index.resolver_exclusions,
+            &cfg.layout,
+        ) {
             let rel = rel_posix(repo_root, &file);
             if in_coverage_universe(cfg, index, &rel) {
                 files.insert(rel);

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -12,9 +12,9 @@ use std::path::{Path, PathBuf};
 
 use spec_spine_types::{
     CodebaseIndex, Diagnostic, Diagnostics, Error, INDEX_SCHEMA_VERSION, Implementation,
-    ImplementingPath, IndexBuild, IndexPackageShard, IndexSpecShard, PackageKind, PackageRecord,
-    ResolvedLocation, ResolvedUnit, SourceField, TraceMapping, TraceSource, Traceability, Unit,
-    parse_frontmatter_with,
+    ImplementingPath, IndexBuild, IndexPackageShard, IndexSpecShard, LayoutConfig, PackageKind,
+    PackageRecord, ResolvedLocation, ResolvedUnit, SourceField, TraceMapping, TraceSource,
+    Traceability, Unit, parse_frontmatter_with,
 };
 
 use crate::coverage::SOURCE_EXTS;
@@ -110,6 +110,7 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
                 repo_root,
                 &discovered.packages,
                 &cfg.index.resolver_exclusions,
+                &cfg.layout,
             )
         } else {
             SymbolIndex::default()
@@ -132,6 +133,7 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
                 repo_root,
                 &discovered.packages,
                 &cfg.index.resolver_exclusions,
+                &cfg.layout,
             )
         } else {
             ModuleIndex::default()
@@ -932,6 +934,7 @@ fn scan_comment_headers(
             SOURCE_EXTS,
             repo_root,
             &cfg.index.resolver_exclusions,
+            &cfg.layout,
         ) {
             let Ok(content) = fs::read_to_string(&file) else {
                 continue;
@@ -1082,15 +1085,22 @@ fn glob_files(repo_root: &Path, pattern: &str) -> Vec<PathBuf> {
 }
 
 /// Sorted source files under `dir` (by extension), pruning
-/// `index.resolver_exclusions`. Shared with the coverage universe (spec 032).
+/// `index.resolver_exclusions` and the declared `layout.state_dir`. Shared with
+/// the coverage universe (spec 032).
+///
+/// `layout` is passed whole rather than as an exclusion entry because spec 039
+/// 3.5 makes the state root its own decision: no `resolver_exclusions` entry
+/// can express it (that list matches directory *names*, not path prefixes) and
+/// none may cancel it.
 pub(crate) fn walk_source(
     dir: &Path,
     exts: &[&str],
     repo_root: &Path,
     exclusions: &[String],
+    layout: &LayoutConfig,
 ) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    walk(dir, exts, repo_root, exclusions, &mut out);
+    walk(dir, exts, repo_root, exclusions, layout, &mut out);
     out.sort();
     out
 }
@@ -1100,6 +1110,7 @@ fn walk(
     exts: &[&str],
     repo_root: &Path,
     exclusions: &[String],
+    layout: &LayoutConfig,
     out: &mut Vec<PathBuf>,
 ) {
     let Ok(entries) = fs::read_dir(dir) else {
@@ -1108,11 +1119,13 @@ fn walk(
     let mut paths: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
     paths.sort();
     for path in paths {
-        if is_excluded(repo_root, &path, exclusions) {
+        if is_excluded(repo_root, &path, exclusions)
+            || layout.is_state_path(&rel_posix(repo_root, &path))
+        {
             continue;
         }
         if path.is_dir() {
-            walk(&path, exts, repo_root, exclusions, out);
+            walk(&path, exts, repo_root, exclusions, layout, out);
         } else if path
             .extension()
             .and_then(|e| e.to_str())

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use spec_spine_types::{Config, Error, Severity, SpecRecord, Violation};
+use spec_spine_types::{Config, Error, Severity, SpecRecord, Unit, Violation};
 
 use crate::compile::compile;
 
@@ -73,6 +73,27 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
                 ));
             }
         }
+        // L-006: a unit claimed inside the declared, ungoverned state root
+        // (spec 039 3.4). Error tier: neither the claim nor the bypass wins,
+        // because letting the claim win would reintroduce spec 009's override
+        // into a directory whose whole purpose is to be ungoverned, and letting
+        // the bypass win would silently discard a unit an author wrote
+        // deliberately. Both are wrong, so the corpus is told instead.
+        for unit_path in claimed_paths(spec) {
+            if cfg.layout.is_state_path(&unit_path) {
+                violations.push(error(
+                    "L-006",
+                    format!(
+                        "spec '{}' claims '{unit_path}', which is inside the ungoverned \
+                         layout.state_dir '{}': move the file out of the state root, or \
+                         stop claiming it",
+                        spec.id, cfg.layout.state_dir
+                    ),
+                    at(),
+                ));
+            }
+        }
+
         // L-005: stub (no body sections).
         if spec.section_headings.is_empty() {
             violations.push(info(
@@ -106,6 +127,61 @@ fn edge_targets(spec: &SpecRecord) -> Vec<String> {
     targets.extend(spec.co_authority.iter().flat_map(|c| c.with_specs.clone()));
     targets.extend(spec.constrains.iter().flat_map(|c| c.target_specs.clone()));
     targets
+}
+
+/// Every repo-relative path a spec claims through an ownership-bearing edge.
+///
+/// `references` is excluded: spec 034 settled that a cited file is not a claimed
+/// one, so citing something inside the state root is not the contradiction
+/// `L-006` reports. Section and file units carry a path; symbol, crate and
+/// module units are resolved by id and have none to test here.
+fn claimed_paths(spec: &SpecRecord) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut push = |unit: &Unit| {
+        if let Some(p) = unit_path(unit) {
+            paths.push(p);
+        }
+    };
+    for unit in &spec.establishes {
+        push(unit);
+    }
+    for item in &spec.extends {
+        if let Some(u) = &item.unit {
+            push(u);
+        }
+    }
+    for item in &spec.refines {
+        if let Some(u) = &item.unit {
+            push(u);
+        }
+    }
+    for item in &spec.co_authority {
+        push(&item.unit);
+    }
+    for item in &spec.constrains {
+        if let Some(u) = &item.unit {
+            push(u);
+        }
+    }
+    paths
+}
+
+/// The repo-relative path a unit names, for the unit kinds that carry one.
+fn unit_path(unit: &Unit) -> Option<String> {
+    match unit {
+        Unit::File { path } | Unit::Directory { path } => Some(path.clone()),
+        Unit::Section { file, .. } => Some(file.clone()),
+        Unit::Symbol { .. } | Unit::Crate { .. } | Unit::Module { .. } => None,
+    }
+}
+
+fn error(code: &str, message: String, path: Option<String>) -> Violation {
+    Violation {
+        code: code.to_string(),
+        severity: Severity::Error,
+        message,
+        path,
+    }
 }
 
 fn warn(code: &str, message: String, path: Option<String>) -> Violation {

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -131,10 +131,21 @@ fn edge_targets(spec: &SpecRecord) -> Vec<String> {
 
 /// Every repo-relative path a spec claims through an ownership-bearing edge.
 ///
+/// All six of them: `establishes`, `extends`, `refines`, `supersedes`,
+/// `co_authority` and `constrains`. A partial `supersedes` item carries the unit
+/// whose authority transfers (spec 019), so it claims a path exactly as the
+/// others do; omitting it would let a superseding spec hold a claim inside the
+/// state root that no diagnostic ever named, which is the contradiction `L-006`
+/// exists to surface.
+///
 /// `references` is excluded: spec 034 settled that a cited file is not a claimed
-/// one, so citing something inside the state root is not the contradiction
-/// `L-006` reports. Section and file units carry a path; symbol, crate and
-/// module units are resolved by id and have none to test here.
+/// one, so citing something inside the state root is not that contradiction.
+/// `amends` is excluded too, because its subject is the amended spec's `spec.md`
+/// rather than an arbitrary unit, and a `spec.md` lives under `specs_dir`, which
+/// `state_dir` may not overlap.
+///
+/// Section and file units carry a path; symbol, crate and module units are
+/// resolved by id and have none to test here.
 fn claimed_paths(spec: &SpecRecord) -> Vec<String> {
     let mut paths = Vec::new();
     let mut push = |unit: &Unit| {
@@ -153,6 +164,13 @@ fn claimed_paths(spec: &SpecRecord) -> Vec<String> {
     for item in &spec.refines {
         if let Some(u) = &item.unit {
             push(u);
+        }
+    }
+    for item in &spec.supersedes {
+        if let spec_spine_types::SupersedeItem::Scoped(scoped) = item {
+            if let Some(u) = &scoped.unit {
+                push(u);
+            }
         }
     }
     for item in &spec.co_authority {

--- a/crates/spec-spine-core/src/shard.rs
+++ b/crates/spec-spine-core/src/shard.rs
@@ -66,8 +66,18 @@ pub fn global_inputs_hash(cfg: &Config, repo_root: &Path) -> String {
     }
     for pattern in &cfg.index.extra_hashed_inputs {
         for file in glob_files(repo_root, pattern) {
+            let rel = rel_posix(repo_root, &file);
+            // Spec 039 3.2: nothing under a declared state root contributes to
+            // any content hash, so a tool writing its own state can never make
+            // the committed ledger stale. Filtered here rather than left to the
+            // adopter's glob, because a pattern wide enough to reach in (`**`,
+            // or a shared parent directory) is the ordinary case, and the point
+            // of the key is that the adopter states the root once.
+            if cfg.layout.is_state_path(&rel) {
+                continue;
+            }
             if let Ok(content) = fs::read_to_string(&file) {
-                pieces.push((rel_posix(repo_root, &file), content));
+                pieces.push((rel, content));
             }
         }
     }

--- a/crates/spec-spine-core/src/symbols.rs
+++ b/crates/spec-spine-core/src/symbols.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "symbol-resolution")]
 use crate::pathutil::{is_excluded, rel_posix};
 #[cfg(feature = "symbol-resolution")]
-use spec_spine_types::{LineSpan, PackageKind, PackageRecord};
+use spec_spine_types::{LayoutConfig, LineSpan, PackageKind, PackageRecord};
 #[cfg(feature = "symbol-resolution")]
 use tree_sitter::{Language, Node, Parser};
 
@@ -71,6 +71,7 @@ pub fn build_module_index(
     repo_root: &Path,
     packages: &[PackageRecord],
     exclusions: &[String],
+    layout: &LayoutConfig,
 ) -> ModuleIndex {
     let mut map: BTreeMap<String, Vec<ResolvedLocation>> = BTreeMap::new();
     for pkg in packages {
@@ -82,7 +83,7 @@ pub fn build_module_index(
         }
         let crate_name = pkg.name.replace('-', "_");
         let src_dir = repo_root.join(&pkg.path).join("src");
-        for file in walk_files(&src_dir, &["rs"], repo_root, exclusions) {
+        for file in walk_files(&src_dir, &["rs"], repo_root, exclusions, layout) {
             let Ok(content) = fs::read_to_string(&file) else {
                 continue;
             };
@@ -160,16 +161,17 @@ pub fn build_symbol_index(
     repo_root: &Path,
     packages: &[PackageRecord],
     exclusions: &[String],
+    layout: &LayoutConfig,
 ) -> SymbolIndex {
     let mut map: BTreeMap<String, Vec<ResolvedLocation>> = BTreeMap::new();
     for pkg in packages {
         let pkg_dir = repo_root.join(&pkg.path);
         match pkg.kind {
             PackageKind::RustLib | PackageKind::RustBin | PackageKind::RustLibBin => {
-                index_rust(repo_root, pkg, &pkg_dir, exclusions, &mut map);
+                index_rust(repo_root, pkg, &pkg_dir, exclusions, layout, &mut map);
             }
             PackageKind::NpmPackage | PackageKind::NpmWorkspace => {
-                index_ts(repo_root, pkg, &pkg_dir, exclusions, &mut map);
+                index_ts(repo_root, pkg, &pkg_dir, exclusions, layout, &mut map);
             }
         }
     }
@@ -204,11 +206,12 @@ fn index_rust(
     pkg: &PackageRecord,
     pkg_dir: &Path,
     exclusions: &[String],
+    layout: &LayoutConfig,
     map: &mut BTreeMap<String, Vec<ResolvedLocation>>,
 ) {
     let crate_name = pkg.name.replace('-', "_");
     let src_dir = pkg_dir.join("src");
-    for file in walk_files(&src_dir, &["rs"], repo_root, exclusions) {
+    for file in walk_files(&src_dir, &["rs"], repo_root, exclusions, layout) {
         let Ok(content) = fs::read_to_string(&file) else {
             continue;
         };
@@ -259,9 +262,10 @@ fn index_ts(
     pkg: &PackageRecord,
     pkg_dir: &Path,
     exclusions: &[String],
+    layout: &LayoutConfig,
     map: &mut BTreeMap<String, Vec<ResolvedLocation>>,
 ) {
-    for file in walk_files(pkg_dir, &["ts", "tsx"], repo_root, exclusions) {
+    for file in walk_files(pkg_dir, &["ts", "tsx"], repo_root, exclusions, layout) {
         // .vue and .d.ts are out of v1 scope.
         if file.to_string_lossy().ends_with(".d.ts") {
             continue;
@@ -360,9 +364,15 @@ fn symbol_of(node: Node, src: &str) -> Option<(String, LineSpan)> {
 /// Recursively collect files with one of `exts` under `root`, sorted, skipping
 /// excluded directories.
 #[cfg(feature = "symbol-resolution")]
-fn walk_files(root: &Path, exts: &[&str], repo_root: &Path, exclusions: &[String]) -> Vec<PathBuf> {
+fn walk_files(
+    root: &Path,
+    exts: &[&str],
+    repo_root: &Path,
+    exclusions: &[String],
+    layout: &LayoutConfig,
+) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    walk(root, exts, repo_root, exclusions, &mut out);
+    walk(root, exts, repo_root, exclusions, layout, &mut out);
     out.sort();
     out
 }
@@ -373,6 +383,7 @@ fn walk(
     exts: &[&str],
     repo_root: &Path,
     exclusions: &[String],
+    layout: &LayoutConfig,
     out: &mut Vec<PathBuf>,
 ) {
     let Ok(entries) = fs::read_dir(dir) else {
@@ -381,11 +392,13 @@ fn walk(
     let mut paths: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
     paths.sort();
     for path in paths {
-        if is_excluded(repo_root, &path, exclusions) {
+        if is_excluded(repo_root, &path, exclusions)
+            || layout.is_state_path(&rel_posix(repo_root, &path))
+        {
             continue;
         }
         if path.is_dir() {
-            walk(&path, exts, repo_root, exclusions, out);
+            walk(&path, exts, repo_root, exclusions, layout, out);
         } else if path
             .extension()
             .and_then(|e| e.to_str())

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -1184,3 +1184,103 @@ fn one_diff_can_carry_both_codes_but_one_path_carries_one() {
         "sorted by path; each path raises exactly one code"
     );
 }
+
+// ── spec 039: the declared state root is bypassed unconditionally ─────────
+
+/// A changed file under `layout.state_dir` trips neither `C-001` nor `C-002`,
+/// and the effect is not reachable through the spec 009 claim override: a claim
+/// inside the root is a contradiction `lint` reports as `L-006`, not a
+/// precedence question the gate resolves in either direction.
+#[test]
+fn a_declared_state_root_is_bypassed_and_a_claim_cannot_override_it() {
+    // The state file is claimed as explicitly as a unit can be, which is what
+    // would otherwise beat the entire bypass set under spec 009.
+    let index = index_with_packages(
+        json!([{ "name": "app", "path": "", "kind": "rust-lib", "specRef": "001-a" }]),
+        json!([{
+            "specId": "001-a",
+            "implementingPaths": [],
+            "resolvedUnits": [{
+                "unit": { "kind": "file", "path": "state/journal.rs" },
+                "sourceField": "establishes", "ownership": true,
+                "locations": [{ "file": "state/journal.rs" }]
+            }]
+        }]),
+    );
+    let reg = empty_registry();
+
+    // Undeclared: the claim is honoured and the change drifts.
+    let undeclared = run(&index, &reg, &diff(vec![file("state/journal.rs", &[])]));
+    assert!(undeclared.has_blocking_drift(), "control: the claim fires");
+    assert_eq!(undeclared.checked_paths, 1);
+
+    // Declared: bypassed before the claim is ever consulted.
+    let mut cfg = Config::default();
+    cfg.layout.state_dir = "state".to_string();
+    cfg.coupling.require_ownership = true;
+    let report = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("state/journal.rs", &[])]),
+        None,
+    )
+    .unwrap();
+    assert!(!report.has_blocking_drift(), "{:?}", report.violations);
+    assert_eq!(report.checked_paths, 0, "the path is not even examined");
+
+    // A sibling sharing the prefix is still governed: `state` is a root, not a
+    // string prefix, so `stateful/` must not slip through with it.
+    let sibling = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("stateful/journal.rs", &[])]),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        sibling.checked_paths, 1,
+        "stateful/ is not under the `state` root"
+    );
+}
+
+/// Spec 039 3.2: with `require_ownership` on, an unclaimed file under the root
+/// is not `C-002` debt either. State is not source, so the ratchet has nothing
+/// to say about it.
+#[test]
+fn the_ownership_ratchet_does_not_reach_into_the_state_root() {
+    let index = index_with_packages(
+        json!([{ "name": "app", "path": "", "kind": "rust-lib", "specRef": "001-a" }]),
+        json!([{ "specId": "001-a", "implementingPaths": [], "resolvedUnits": [] }]),
+    );
+    let reg = empty_registry();
+    let mut cfg = Config::default();
+    cfg.coupling.require_ownership = true;
+
+    // Control: with no state root declared, an unclaimed source file is C-002.
+    let debt = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("state/journal.rs", &[])]),
+        None,
+    )
+    .unwrap();
+    assert!(
+        debt.violations.iter().any(|v| v.code == "C-002"),
+        "{debt:?}"
+    );
+
+    cfg.layout.state_dir = "state/".to_string();
+    let declared = couple_with(
+        &cfg,
+        &reg,
+        &index,
+        &diff(vec![file("state/journal.rs", &[])]),
+        None,
+    )
+    .unwrap();
+    assert!(declared.violations.is_empty(), "{:?}", declared.violations);
+    assert_eq!(declared.checked_paths, 0);
+}

--- a/crates/spec-spine-core/tests/coverage.rs
+++ b/crates/spec-spine-core/tests/coverage.rs
@@ -339,3 +339,280 @@ fn facade_round_trips_the_report() {
     assert_eq!(report, coverage(&cfg, fx.path()).unwrap());
     assert!(json.contains("\"floorOnlyFiles\""), "camelCase wire form");
 }
+
+// ===== spec 039: layout.state_dir leaves the coverage universe =====
+
+/// A repo at 100% stays at 100% when state files appear under a declared root,
+/// and the denominator shrinks by exactly the number of files there.
+///
+/// Asserted as counts rather than as a percentage: declaring a state root moves
+/// a coverage figure, and the movement should be auditable rather than merely
+/// plausible.
+#[test]
+fn a_declared_state_root_leaves_both_sides_of_the_coverage_ratio() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"crates/a\"]\n");
+    write(
+        r,
+        "crates/a/Cargo.toml",
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"001-a\"\n",
+    );
+    write(r, "crates/a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        r,
+        "specs/001-a/spec.md",
+        &spec("001-a", "establishes:\n  - \"crates/a/src/lib.rs\"\n"),
+    );
+
+    let clean = load_config("").unwrap();
+    emit_index(&clean, r);
+    let before = coverage(&clean, r).unwrap();
+    assert_eq!((before.source_files, before.claimed_files), (1, 1));
+    assert!(before.is_fully_claimed());
+
+    // A tool writes two state files inside the package. Undeclared, they are
+    // unclaimed debt and the ratchet would refuse the next PR touching them.
+    write(r, "crates/a/state/journal.rs", "pub fn j() {}\n");
+    write(r, "crates/a/state/queue.rs", "pub fn q() {}\n");
+    emit_index(&clean, r);
+    let undeclared = coverage(&clean, r).unwrap();
+    assert_eq!(
+        (undeclared.source_files, undeclared.claimed_files),
+        (3, 1),
+        "control: state files count as source until the root is declared"
+    );
+    assert_eq!(
+        undeclared.floor_only_files.len(),
+        2,
+        "the package has a manifest floor, so they are floor-only debt"
+    );
+
+    // Declared, they leave the universe entirely: numerator and denominator.
+    let declared_cfg = load_config("[layout]\nstate_dir = \"crates/a/state\"\n").unwrap();
+    emit_index(&declared_cfg, r);
+    let after = coverage(&declared_cfg, r).unwrap();
+    assert_eq!(
+        (after.source_files, after.claimed_files),
+        (1, 1),
+        "the denominator shrinks by exactly the two state files"
+    );
+    assert!(
+        after.unclaimed_files.is_empty(),
+        "{:?}",
+        after.unclaimed_files
+    );
+    assert!(after.floor_only_files.is_empty());
+    assert!(after.is_fully_claimed(), "100% before, 100% after");
+
+    // The enumeration agrees with the classifier: the walk never yields them.
+    let index = spec_spine_core::load_committed_index(&declared_cfg, r).unwrap();
+    let files = enumerate_source_files(&declared_cfg, r, &index);
+    assert_eq!(files, vec!["crates/a/src/lib.rs".to_string()]);
+    for path in ["crates/a/state/journal.rs", "crates/a/state/queue.rs"] {
+        assert!(
+            !in_coverage_universe(&declared_cfg, &index, path),
+            "{path} is state, not source"
+        );
+    }
+}
+
+/// Spec 039 3.2: files under the root contribute to no content hash, so a tool
+/// writing its own state can never make the committed ledger stale.
+#[test]
+fn writing_state_does_not_stale_the_committed_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"crates/a\"]\n");
+    write(
+        r,
+        "crates/a/Cargo.toml",
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"001-a\"\n",
+    );
+    write(r, "crates/a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        r,
+        "specs/001-a/spec.md",
+        &spec("001-a", "establishes:\n  - \"crates/a/src/lib.rs\"\n"),
+    );
+    // An `extra_hashed_inputs` pattern wide enough to reach into the state root
+    // is the ordinary case: the adopter states the root once, not twice.
+    write(
+        r,
+        "spec-spine.toml",
+        "[layout]\nstate_dir = \"tool-state\"\n\
+         [index]\nextra_hashed_inputs = [\"**/*.jsonl\"]\n",
+    );
+    let cfg = load_config(&fs::read_to_string(r.join("spec-spine.toml")).unwrap()).unwrap();
+
+    write(r, "tool-state/journal.jsonl", "{\"runs\":1}\n");
+    emit_index(&cfg, r);
+    assert!(matches!(
+        spec_spine_core::check_index_freshness(&cfg, r).unwrap(),
+        spec_spine_core::Freshness::Fresh
+    ));
+
+    // The tool writes again. Nothing about the corpus changed, so the ledger
+    // must still be vouching for it.
+    write(r, "tool-state/journal.jsonl", "{\"runs\":2}\n");
+    write(r, "tool-state/nested/queue.jsonl", "{\"depth\":1}\n");
+    assert!(
+        matches!(
+            spec_spine_core::check_index_freshness(&cfg, r).unwrap(),
+            spec_spine_core::Freshness::Fresh
+        ),
+        "state writes must not stale the index"
+    );
+
+    // Control: a hashed input outside the root still stales it, so the filter
+    // is scoped to the state root rather than switching hashing off.
+    write(r, "other.jsonl", "{\"x\":1}\n");
+    assert!(
+        matches!(
+            spec_spine_core::check_index_freshness(&cfg, r).unwrap(),
+            spec_spine_core::Freshness::Stale { .. }
+        ),
+        "a hashed input outside the state root still stales the index"
+    );
+}
+
+/// Spec 039 3.4: a spec claiming a unit inside the ungoverned root is a
+/// contradiction, reported at error tier so `lint` exits 1 without
+/// `--fail-on-warn`. Neither the claim nor the bypass wins.
+#[test]
+fn a_claim_inside_the_state_root_is_an_l006_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(
+        r,
+        "specs/001-a/spec.md",
+        &spec(
+            "001-a",
+            "establishes:\n  - \"tool-state/journal.rs\"\n  - \"src/lib.rs\"\n\
+             references:\n  - { unit: { kind: file, path: \"tool-state/cited.rs\" }, role: context }\n",
+        ),
+    );
+    let cfg = load_config("[layout]\nstate_dir = \"tool-state\"\n").unwrap();
+    let report = spec_spine_core::lint(&cfg, r).unwrap();
+
+    let l006: Vec<_> = report
+        .violations
+        .iter()
+        .filter(|v| v.code == "L-006")
+        .collect();
+    assert_eq!(
+        l006.len(),
+        1,
+        "one claim is inside the root: {:?}",
+        report.violations
+    );
+    assert_eq!(l006[0].severity, spec_spine_types::Severity::Error);
+    assert!(
+        l006[0].message.contains("001-a"),
+        "names the spec: {}",
+        l006[0].message
+    );
+    assert!(
+        l006[0].message.contains("tool-state/journal.rs"),
+        "names the unit: {}",
+        l006[0].message
+    );
+    // `references` is non-owning (spec 034), so citing a file inside the root
+    // is not the contradiction this reports.
+    assert!(
+        !l006[0].message.contains("cited.rs"),
+        "a citation is not a claim: {}",
+        l006[0].message
+    );
+
+    // Undeclared, the same corpus lints clean of L-006.
+    let clean = spec_spine_core::lint(&Config::default(), r).unwrap();
+    assert!(!clean.violations.iter().any(|v| v.code == "L-006"));
+}
+
+/// No two lint diagnostics share a code. `L-006` was the next free code when
+/// spec 039 was written; the spec makes "the next free code in the band" the
+/// binding rule, so this asserts the namespace rather than trusting a comment.
+#[test]
+fn lint_diagnostic_codes_are_unique() {
+    let src =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lint.rs")).unwrap();
+    let mut codes: Vec<String> = Vec::new();
+    for (i, _) in src.match_indices("\"L-") {
+        let code: String = src[i + 1..].chars().take(5).collect();
+        if code.len() == 5 && code[2..].chars().all(|c| c.is_ascii_digit()) {
+            codes.push(code);
+        }
+    }
+    codes.sort();
+    codes.dedup();
+    assert!(codes.contains(&"L-006".to_string()), "{codes:?}");
+    // Each code appears at exactly one emission site.
+    for code in &codes {
+        let sites = src.matches(&format!("\"{code}\"")).count();
+        assert_eq!(sites, 1, "{code} is emitted from {sites} places");
+    }
+}
+
+/// Spec 039 3.2: the resolver does not scan the root, so no unit ever resolves
+/// to a path inside it. Asserted through a symbol unit, which is the only kind
+/// that could reach in without naming the path.
+#[test]
+fn the_resolver_does_not_reach_into_the_state_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"crates/a\"]\n");
+    write(
+        r,
+        "crates/a/Cargo.toml",
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"001-a\"\n",
+    );
+    // The only definition of `hidden` lives inside what will become the root.
+    write(r, "crates/a/src/lib.rs", "pub mod state;\n");
+    write(r, "crates/a/src/state/mod.rs", "pub fn hidden() {}\n");
+    write(
+        r,
+        "specs/001-a/spec.md",
+        &spec(
+            "001-a",
+            "establishes:\n  - { kind: symbol, id: \"a::state::hidden\" }\n",
+        ),
+    );
+
+    // Control: undeclared, the symbol resolves to the file that defines it.
+    let clean = load_config("").unwrap();
+    let resolved = index(&clean, r).unwrap();
+    let located = resolved
+        .index
+        .traceability
+        .mappings
+        .iter()
+        .flat_map(|m| &m.resolved_units)
+        .any(|u| !u.locations.is_empty());
+    assert!(
+        located,
+        "control: the symbol resolves when nothing is declared"
+    );
+
+    // Declared: the definition is never scanned, so the unit does not resolve.
+    let cfg = load_config("[layout]\nstate_dir = \"crates/a/src/state\"\n").unwrap();
+    let out = index(&cfg, r).unwrap();
+    for unit in out
+        .index
+        .traceability
+        .mappings
+        .iter()
+        .flat_map(|m| &m.resolved_units)
+    {
+        for loc in &unit.locations {
+            assert!(
+                !cfg.layout.is_state_path(&loc.file),
+                "resolved into the state root: {}",
+                loc.file
+            );
+        }
+    }
+}

--- a/crates/spec-spine-core/tests/coverage.rs
+++ b/crates/spec-spine-core/tests/coverage.rs
@@ -559,6 +559,12 @@ fn lint_diagnostic_codes_are_unique() {
 /// Spec 039 3.2: the resolver does not scan the root, so no unit ever resolves
 /// to a path inside it. Asserted through a symbol unit, which is the only kind
 /// that could reach in without naming the path.
+///
+/// Gated on `symbol-resolution` (spec 027) because the control half needs the
+/// symbol to resolve when nothing is declared, and feature-off it never does.
+/// The walk itself is covered feature-independently by the `enumerate_source_files`
+/// assertion in `a_declared_state_root_leaves_both_sides_of_the_coverage_ratio`.
+#[cfg(feature = "symbol-resolution")]
 #[test]
 fn the_resolver_does_not_reach_into_the_state_root() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/spec-spine-core/tests/coverage.rs
+++ b/crates/spec-spine-core/tests/coverage.rs
@@ -532,6 +532,61 @@ fn a_claim_inside_the_state_root_is_an_l006_error() {
     assert!(!clean.violations.iter().any(|v| v.code == "L-006"));
 }
 
+/// Every ownership-bearing edge is checked, `supersedes` included.
+///
+/// A partial `supersedes` item carries the unit whose authority transfers (spec
+/// 019), so it claims a path exactly as `establishes` does. Missing it would let
+/// a superseding spec hold a claim inside the ungoverned root that the gate
+/// bypasses unconditionally and no diagnostic ever names, which is precisely the
+/// contradiction `L-006` exists to surface.
+#[test]
+fn l006_covers_every_ownership_bearing_edge() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(
+        r,
+        "specs/001-old/spec.md",
+        &spec("001-old", "establishes:\n  - \"src/old.rs\"\n"),
+    );
+    // One claim per path-bearing ownership edge other than `establishes`, which
+    // the neighbouring test already covers. Written as flow mappings on single
+    // lines: a wrapped one silently becomes a different YAML document.
+    let edges = concat!(
+        "supersedes:\n",
+        "  - { spec: \"001-old\", scope: partial, unit: { kind: file, path: \"tool-state/old.rs\" } }\n",
+        "co_authority:\n",
+        "  - { unit: { kind: section, file: \"tool-state/shared.md\", anchor: \"x\" } }\n",
+        "constrains:\n",
+        "  - { flavor: invariant-freeze, unit: { kind: file, path: \"tool-state/frozen.rs\" } }\n",
+    );
+    write(r, "specs/002-new/spec.md", &spec("002-new", edges));
+
+    let cfg = load_config("[layout]\nstate_dir = \"tool-state\"\n").unwrap();
+    let report = spec_spine_core::lint(&cfg, r).unwrap();
+    let claimed: Vec<&str> = report
+        .violations
+        .iter()
+        .filter(|v| v.code == "L-006")
+        .map(|v| v.message.as_str())
+        .collect();
+
+    assert_eq!(
+        claimed.len(),
+        3,
+        "one per claim inside the root: {claimed:?}"
+    );
+    for path in [
+        "tool-state/old.rs",
+        "tool-state/shared.md",
+        "tool-state/frozen.rs",
+    ] {
+        assert!(
+            claimed.iter().any(|m| m.contains(path)),
+            "{path} is claimed and must be reported: {claimed:?}"
+        );
+    }
+}
+
 /// No two lint diagnostics share a code. `L-006` was the next free code when
 /// spec 039 was written; the spec makes "the next free code in the band" the
 /// binding rule, so this asserts the namespace rather than trusting a comment.

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -317,6 +317,18 @@ fn validate_state_dir(config: &Config) -> Result<()> {
     if state.is_empty() {
         return Ok(());
     }
+    // The repo root contains every governed root, so it fails the overlap test
+    // below only if that test knows `.` is an ancestor of everything, which a
+    // string comparison does not. Refused by name instead: this is the value
+    // spec 039 3.2 calls the worst outcome, since every gate would keep exiting
+    // 0 while adjudicating nothing at all.
+    if state == "." {
+        return Err(Error::Config(format!(
+            "layout.state_dir '{}' is the repository root: a state root is ungoverned, \
+             so declaring the whole repository one would silence every gate",
+            config.layout.state_dir
+        )));
+    }
     for (key, value) in [
         ("specs_dir", &config.layout.specs_dir),
         ("derived_dir", &config.layout.derived_dir),

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -329,6 +329,18 @@ fn validate_state_dir(config: &Config) -> Result<()> {
             config.layout.state_dir
         )));
     }
+    // A value escaping the repository is worse than wrong, it is inert: every
+    // path the gates test is repo-relative and carries no `..`, so nothing would
+    // ever match and the gates would behave as though no root were declared
+    // while the config says one is. Silence that claims to be a decision is the
+    // failure mode this key exists to prevent.
+    if state == ".." || state.starts_with("../") {
+        return Err(Error::Config(format!(
+            "layout.state_dir '{}' escapes the repository: the value is a repo-relative \
+             directory, and one outside it would match no path and silently declare nothing",
+            config.layout.state_dir
+        )));
+    }
     for (key, value) in [
         ("specs_dir", &config.layout.specs_dir),
         ("derived_dir", &config.layout.derived_dir),

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -322,14 +322,21 @@ fn validate_state_dir(config: &Config) -> Result<()> {
         return Ok(());
     }
 
-    // Not a repo-relative directory. Each of these matches no path the gates
-    // ever test, so the gates would behave as though no root were declared
-    // while the config says one is: silence that claims to be a decision.
-    if raw.starts_with('/') || raw == ".." || raw.starts_with("../") {
+    // Not a repo-relative directory. Each such value matches no path the gates
+    // ever test, so they would behave as though no root were declared while the
+    // config says one is: silence that claims to be a decision.
+    //
+    // The `..` test is over **segments**, not prefixes. `..`, `../x` and
+    // `x/../y` are all inert for the same reason (a repo-relative path produced
+    // by `rel_posix` carries no `..`), and three rounds of review found three
+    // separate spellings of it, so the check closes the class rather than
+    // another instance of it.
+    let traverses = raw.split('/').any(|segment| segment == "..");
+    if raw.starts_with('/') || traverses {
         return Err(Error::Config(format!(
-            "layout.state_dir '{raw}' is not a repo-relative directory: a value that escapes \
-             the repository, or an absolute one, would match no path the gates test and \
-             would silently declare nothing"
+            "layout.state_dir '{raw}' is not a repo-relative directory: an absolute path, or \
+             one carrying a '..' segment, would match no path the gates test and would \
+             silently declare nothing"
         )));
     }
 

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -325,7 +325,8 @@ fn validate_state_dir(config: &Config) -> Result<()> {
         if other.is_empty() {
             continue;
         }
-        let contains = |a: &str, b: &str| a == b || b.strip_prefix(a).is_some_and(|r| r.starts_with('/'));
+        let contains =
+            |a: &str, b: &str| a == b || b.strip_prefix(a).is_some_and(|r| r.starts_with('/'));
         if contains(state, other) || contains(other, state) {
             return Err(Error::Config(format!(
                 "layout.state_dir '{}' overlaps layout.{key} '{}': a state root is ungoverned, \

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -313,34 +313,52 @@ pub fn load_config(toml_src: &str) -> Result<Config> {
 /// no legitimate use, and refusing the configuration is cheaper than specifying
 /// which root wins.
 fn validate_state_dir(config: &Config) -> Result<()> {
-    let state = trim_root(&config.layout.state_dir);
-    if state.is_empty() {
+    // The raw value decides whether a root was declared at all. Normalizing
+    // first would fold `/` into the empty string and read a value the adopter
+    // wrote as *unset*, which is the silent-nothing outcome every arm below
+    // exists to refuse.
+    let raw = &config.layout.state_dir;
+    if raw.is_empty() {
         return Ok(());
     }
-    // The repo root contains every governed root, so it fails the overlap test
-    // below only if that test knows `.` is an ancestor of everything, which a
-    // string comparison does not. Refused by name instead: this is the value
+
+    // Not a repo-relative directory. Each of these matches no path the gates
+    // ever test, so the gates would behave as though no root were declared
+    // while the config says one is: silence that claims to be a decision.
+    if raw.starts_with('/') || raw == ".." || raw.starts_with("../") {
+        return Err(Error::Config(format!(
+            "layout.state_dir '{raw}' is not a repo-relative directory: a value that escapes \
+             the repository, or an absolute one, would match no path the gates test and \
+             would silently declare nothing"
+        )));
+    }
+
+    // The repository root contains every governed root, so it fails the overlap
+    // test below only if that test knows `.` is an ancestor of everything, which
+    // a string comparison does not. Refused by name instead: this is the value
     // spec 039 3.2 calls the worst outcome, since every gate would keep exiting
     // 0 while adjudicating nothing at all.
-    if state == "." {
+    let state = trim_root(raw);
+    if state.is_empty() || state == "." {
         return Err(Error::Config(format!(
-            "layout.state_dir '{}' is the repository root: a state root is ungoverned, \
-             so declaring the whole repository one would silence every gate",
-            config.layout.state_dir
+            "layout.state_dir '{raw}' is the repository root: a state root is ungoverned, \
+             so declaring the whole repository one would silence every gate"
         )));
     }
-    // A value escaping the repository is worse than wrong, it is inert: every
-    // path the gates test is repo-relative and carries no `..`, so nothing would
-    // ever match and the gates would behave as though no root were declared
-    // while the config says one is. Silence that claims to be a decision is the
-    // failure mode this key exists to prevent.
-    if state == ".." || state.starts_with("../") {
-        return Err(Error::Config(format!(
-            "layout.state_dir '{}' escapes the repository: the value is a repo-relative \
-             directory, and one outside it would match no path and silently declare nothing",
-            config.layout.state_dir
-        )));
-    }
+
+    // The comparison is against the **resolved** values of the two governed
+    // roots, never against their defaults. Both are configurable, so a check
+    // written against the literal `specs` would clear a repo with
+    // `specs_dir = "corpus"` and `state_dir = "corpus/state"` and quietly make
+    // every `spec.md` under it ungoverned. This is the defect spec 036 fixed in
+    // `couple.rs`, and a validation rule is exactly where a default is easiest
+    // to hardcode.
+    //
+    // The test is overlap, not equality, because the dangerous values are the
+    // ones that *contain* a root. The descendant direction is refused too, since
+    // a path inside a governed root and an ungoverned one at once would need a
+    // precedence rule for a situation with no legitimate use, and refusing the
+    // configuration is cheaper than specifying which root wins.
     for (key, value) in [
         ("specs_dir", &config.layout.specs_dir),
         ("derived_dir", &config.layout.derived_dir),
@@ -353,9 +371,8 @@ fn validate_state_dir(config: &Config) -> Result<()> {
             |a: &str, b: &str| a == b || b.strip_prefix(a).is_some_and(|r| r.starts_with('/'));
         if contains(state, other) || contains(other, state) {
             return Err(Error::Config(format!(
-                "layout.state_dir '{}' overlaps layout.{key} '{}': a state root is ungoverned, \
-                 so it may not equal, contain, or sit inside a governed root",
-                config.layout.state_dir, value
+                "layout.state_dir '{raw}' overlaps layout.{key} '{value}': a state root is \
+                 ungoverned, so it may not equal, contain, or sit inside a governed root"
             )));
         }
     }

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -91,6 +91,21 @@ pub struct LayoutConfig {
     pub standalone_rust_workspaces: Vec<String>,
     /// npm packages outside the declared workspaces.
     pub standalone_npm_packages: Vec<String>,
+    /// A declared, ungoverned tool-state root (spec 039). Empty means **no
+    /// state root is declared**, and every behavior keyed on it is inert.
+    ///
+    /// Declared: the gates recognize it, so `couple` bypasses it, `coverage`
+    /// excludes it from classification, the resolver does not scan it, and it
+    /// contributes to no content hash. Ungoverned: spec-spine never reads its
+    /// contents and never writes into it, so the purity invariant holds (a root
+    /// read from would be a second input to functions contracted to be pure in
+    /// the corpus, and one written to would make a read command mutate the tree).
+    ///
+    /// A default of `.spec-spine/` was rejected: silently bypassing a real path
+    /// in every adopter's repo on upgrade changes what the gate refuses, and a
+    /// gate that quietly stops refusing something is the regression this project
+    /// can least afford.
+    pub state_dir: String,
 }
 
 impl Default for LayoutConfig {
@@ -107,8 +122,36 @@ impl Default for LayoutConfig {
             ],
             standalone_rust_workspaces: Vec::new(),
             standalone_npm_packages: Vec::new(),
+            state_dir: String::new(),
         }
     }
+}
+
+impl LayoutConfig {
+    /// Whether `path` (repo-relative, POSIX) lies under the declared state root.
+    ///
+    /// Always false when no root is declared. Matching is separator-aware, so a
+    /// root of `state` covers `state` itself and `state/journal.db` but never
+    /// `stateful/x`: a prefix test on the raw string would silently ungovern a
+    /// sibling directory that merely shares a name.
+    pub fn is_state_path(&self, path: &str) -> bool {
+        let root = trim_root(&self.state_dir);
+        if root.is_empty() {
+            return false;
+        }
+        let path = trim_root(path);
+        path == root || path.strip_prefix(root).is_some_and(|r| r.starts_with('/'))
+    }
+}
+
+/// A layout root reduced to its comparable form: no trailing slash, and no
+/// leading `./`, so `state`, `state/` and `./state` name one root (the handling
+/// spec 036 established for `specs_dir`).
+fn trim_root(value: &str) -> &str {
+    value
+        .trim_end_matches('/')
+        .strip_prefix("./")
+        .unwrap_or_else(|| value.trim_end_matches('/'))
 }
 
 /// `[index]`: inputs and exclusions for the codebase indexer.
@@ -248,7 +291,50 @@ pub struct FrontmatterConfig {
 pub fn load_config(toml_src: &str) -> Result<Config> {
     let config: Config = toml::from_str(toml_src).map_err(|e| Error::Config(e.to_string()))?;
     validate_slices(&config)?;
+    validate_state_dir(&config)?;
     Ok(config)
+}
+
+/// `layout.state_dir` may not overlap `specs_dir` or `derived_dir` in either
+/// direction (spec 039 3.2).
+///
+/// The comparison is against the **resolved** values of those two keys, never
+/// against their defaults. Both are configurable, so a check written against the
+/// literal `specs` would clear a repo with `specs_dir = "corpus"` and
+/// `state_dir = "corpus/state"` and quietly make every `spec.md` under it
+/// ungoverned. This is the defect spec 036 fixed in `couple.rs`, and a
+/// validation rule is exactly where a default is easiest to hardcode.
+///
+/// The test is overlap, not equality, because the dangerous values are the ones
+/// that *contain* a root: a `state_dir` of `.` ungoverns the whole repository,
+/// and every gate then keeps exiting 0 while adjudicating nothing. The
+/// descendant direction is refused too, since a path inside a governed root and
+/// an ungoverned one at once would need a precedence rule for a situation with
+/// no legitimate use, and refusing the configuration is cheaper than specifying
+/// which root wins.
+fn validate_state_dir(config: &Config) -> Result<()> {
+    let state = trim_root(&config.layout.state_dir);
+    if state.is_empty() {
+        return Ok(());
+    }
+    for (key, value) in [
+        ("specs_dir", &config.layout.specs_dir),
+        ("derived_dir", &config.layout.derived_dir),
+    ] {
+        let other = trim_root(value);
+        if other.is_empty() {
+            continue;
+        }
+        let contains = |a: &str, b: &str| a == b || b.strip_prefix(a).is_some_and(|r| r.starts_with('/'));
+        if contains(state, other) || contains(other, state) {
+            return Err(Error::Config(format!(
+                "layout.state_dir '{}' overlaps layout.{key} '{}': a state root is ungoverned, \
+                 so it may not equal, contain, or sit inside a governed root",
+                config.layout.state_dir, value
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// `[index.slices]` grammar (spec 012 §3.1): names match

--- a/crates/spec-spine-types/tests/config.rs
+++ b/crates/spec-spine-types/tests/config.rs
@@ -167,7 +167,19 @@ fn state_dir_may_not_overlap_a_governed_root_in_either_direction() {
     // A value escaping the repo, or an absolute one, matches no path the gates
     // ever test, so it would declare a root that silences nothing while the
     // config says one is declared. Refused rather than left inert.
-    for value in ["..", "../logs", "../../outside", "../", "/var/logs", "/"] {
+    // Every spelling of the same defect: a value that resolves outside the repo,
+    // or that carries a `..` segment anywhere, matches no path the gates test.
+    for value in [
+        "..",
+        "../logs",
+        "../../outside",
+        "../",
+        "/var/logs",
+        "/",
+        "state/..",
+        "./state/..",
+        "a/../b",
+    ] {
         let err = load_config(&format!("[layout]\nstate_dir = \"{value}\"\n")).unwrap_err();
         assert!(
             matches!(err, Error::Config(_)),

--- a/crates/spec-spine-types/tests/config.rs
+++ b/crates/spec-spine-types/tests/config.rs
@@ -164,10 +164,10 @@ fn state_dir_may_not_overlap_a_governed_root_in_either_direction() {
         );
         assert_eq!(err.exit_code(), 3, "a bad config is exit 3");
     }
-    // A value escaping the repo matches no path the gates ever test, so it
-    // would declare a root that silences nothing while the config says one is
-    // declared. Refused rather than left inert.
-    for value in ["..", "../logs", "../../outside", "../"] {
+    // A value escaping the repo, or an absolute one, matches no path the gates
+    // ever test, so it would declare a root that silences nothing while the
+    // config says one is declared. Refused rather than left inert.
+    for value in ["..", "../logs", "../../outside", "../", "/var/logs", "/"] {
         let err = load_config(&format!("[layout]\nstate_dir = \"{value}\"\n")).unwrap_err();
         assert!(
             matches!(err, Error::Config(_)),

--- a/crates/spec-spine-types/tests/config.rs
+++ b/crates/spec-spine-types/tests/config.rs
@@ -164,6 +164,17 @@ fn state_dir_may_not_overlap_a_governed_root_in_either_direction() {
         );
         assert_eq!(err.exit_code(), 3, "a bad config is exit 3");
     }
+    // A value escaping the repo matches no path the gates ever test, so it
+    // would declare a root that silences nothing while the config says one is
+    // declared. Refused rather than left inert.
+    for value in ["..", "../logs", "../../outside", "../"] {
+        let err = load_config(&format!("[layout]\nstate_dir = \"{value}\"\n")).unwrap_err();
+        assert!(
+            matches!(err, Error::Config(_)),
+            "state_dir '{value}' must be refused, got {err:?}"
+        );
+    }
+
     for value in ["specs-state", "state", "tool/state", ".derived-state"] {
         assert!(
             load_config(&format!("[layout]\nstate_dir = \"{value}\"\n")).is_ok(),

--- a/crates/spec-spine-types/tests/config.rs
+++ b/crates/spec-spine-types/tests/config.rs
@@ -100,3 +100,92 @@ fn this_repos_spec_spine_toml_loads() {
     assert!(c.domains.is_disabled());
     assert!(c.kind.is_disabled());
 }
+
+// ===== spec 039: layout.state_dir =====
+
+#[test]
+fn state_dir_is_unset_by_default_and_inert() {
+    let c = Config::default();
+    assert_eq!(c.layout.state_dir, "", "no state root is declared");
+    // Every behavior keyed on it is off, so an existing repo is unchanged.
+    for path in ["src/lib.rs", "state/journal.db", ".spec-spine/x", ""] {
+        assert!(!c.layout.is_state_path(path), "{path}");
+    }
+}
+
+#[test]
+fn state_dir_matching_is_separator_aware() {
+    let c = load_config("[layout]\nstate_dir = \"state\"\n").unwrap();
+    for inside in ["state", "state/", "state/journal.db", "state/a/b.json"] {
+        assert!(c.layout.is_state_path(inside), "{inside} is under the root");
+    }
+    // A sibling that merely shares a prefix is not inside it: a raw string
+    // prefix test here would silently ungovern a real source directory.
+    for outside in [
+        "stateful",
+        "stateful/x.rs",
+        "src/state.rs",
+        "src/state/x.rs",
+    ] {
+        assert!(!c.layout.is_state_path(outside), "{outside} is not");
+    }
+}
+
+#[test]
+fn a_trailing_slash_names_the_same_root() {
+    let plain = load_config("[layout]\nstate_dir = \"state\"\n").unwrap();
+    let slashed = load_config("[layout]\nstate_dir = \"state/\"\n").unwrap();
+    for path in ["state", "state/x", "stateful/x"] {
+        assert_eq!(
+            plain.layout.is_state_path(path),
+            slashed.layout.is_state_path(path),
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn state_dir_may_not_overlap_a_governed_root_in_either_direction() {
+    // Equal, ancestor, and descendant are all refused; a sibling sharing a
+    // prefix is accepted, per the separator-aware rule.
+    let refused = [
+        "specs",       // equals specs_dir
+        ".derived",    // equals derived_dir
+        ".",           // contains both: would ungovern the whole repository
+        "./",          // the same value, spelled with the trailing slash
+        "specs/state", // sits inside specs_dir
+        ".derived/state",
+    ];
+    for value in refused {
+        let err = load_config(&format!("[layout]\nstate_dir = \"{value}\"\n")).unwrap_err();
+        assert!(
+            matches!(err, Error::Config(_)),
+            "state_dir '{value}' must be refused, got {err:?}"
+        );
+        assert_eq!(err.exit_code(), 3, "a bad config is exit 3");
+    }
+    for value in ["specs-state", "state", "tool/state", ".derived-state"] {
+        assert!(
+            load_config(&format!("[layout]\nstate_dir = \"{value}\"\n")).is_ok(),
+            "state_dir '{value}' is outside both governed roots"
+        );
+    }
+}
+
+/// The overlap check reads the **resolved** layout, never the defaults.
+///
+/// This is the inverse of the default-layout result and fails against any
+/// implementation comparing with a hardcoded `specs`: the same two values swap
+/// verdicts when `specs_dir` moves. Getting this wrong would clear a config that
+/// makes every `spec.md` ungoverned, with every gate still exiting 0.
+#[test]
+fn the_overlap_check_reads_the_configured_roots() {
+    let refused = load_config("[layout]\nspecs_dir = \"corpus\"\nstate_dir = \"corpus/state\"\n");
+    assert!(refused.is_err(), "corpus/state sits inside the specs root");
+
+    let accepted = load_config("[layout]\nspecs_dir = \"corpus\"\nstate_dir = \"specs/state\"\n");
+    assert!(
+        accepted.is_ok(),
+        "specs/ is not a governed root in this layout: {accepted:?}"
+    );
+}

--- a/specs/039-declared-state-dir/spec.md
+++ b/specs/039-declared-state-dir/spec.md
@@ -4,7 +4,7 @@ title: "`layout.state_dir`: a declared, ungoverned tool-state root"
 status: draft
 kind: "tooling"
 created: "2026-09-05"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -18,6 +18,9 @@ extends:
   - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
   - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/tests/couple.rs", nature: additive }
   - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  # The two files 2's territory list omitted; see 5, D-1.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/symbols.rs", nature: additive }
+  - { spec: "024-index-sharding", unit: "crates/spec-spine-core/src/shard.rs", nature: additive }
   - { spec: "032-ownership-coverage", unit: "crates/spec-spine-core/src/coverage.rs", nature: additive }
   - { spec: "032-ownership-coverage", unit: "crates/spec-spine-core/tests/coverage.rs", nature: additive }
   - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
@@ -86,9 +89,13 @@ governed*, and the number of things needing that vocabulary is growing.
 
 `config.rs` gains the key. `couple.rs` consults it when deciding bypass;
 `coverage.rs` consults it when classifying a source file; `index.rs` consults it
-when scanning and when hashing. `lint.rs` gains one diagnostic. No emitted DTO
-changes shape, and no schema version moves: this is a config key and four reads
-of it.
+when scanning. `symbols.rs` consults it when walking for symbols and modules,
+and `shard.rs` when folding the globally hashed inputs. `lint.rs` gains one
+diagnostic. No emitted DTO changes shape, and no schema version moves: this is a
+config key and six reads of it.
+
+The last two are additions to this section, made when it was implemented; 5
+records why.
 
 ## 3. Behavior
 
@@ -241,3 +248,38 @@ the same either way, which is the point: a committed evidence bundle and a
 gitignored transcript are both ungoverned by the gates.
 
 **Multiple state roots.** One value, deliberately (§3.5).
+
+## 5. Resolved decisions
+
+- **D-1 (2026-09-06): the territory in 2 was two files short of what 3.2
+  requires.** 2 named `config.rs`, `couple.rs`, `coverage.rs`, `index.rs` and
+  `lint.rs`. Two of 3.2's four MUSTs reach past them. *The resolver MUST NOT
+  scan it*: `index.rs` owns one source walk, but the symbol and module indexes
+  walk their own trees in `symbols.rs`, so a symbol defined inside the root
+  would still have resolved. *It MUST NOT contribute to any content hash*: the
+  globally hashed inputs are folded in `shard.rs::global_inputs_hash`, and an
+  `extra_hashed_inputs` pattern wide enough to reach into the root is the
+  ordinary case rather than an exotic one, since the point of the key is that
+  the adopter states the root once. Both files are now claimed by an `extends`
+  edge and 2 says so. Rejected: implementing only the four MUSTs the original
+  territory covered and recording the other two as limitations, which would
+  leave a stated MUST unimplemented and the root scannable by exactly the
+  mechanism most likely to reach it.
+
+- **D-2 (2026-09-06): a `state_dir` of `.` is refused by name, not by the
+  overlap test.** 3.2 requires refusing a value that contains a governed root,
+  and names `.` as the case that ungoverns the entire repository. A string
+  comparison does not know the repository root is an ancestor of everything, so
+  the overlap test cleared `.` and the first draft of the validation accepted
+  it. It is now refused explicitly, with its own message. Rejected: normalizing
+  `.` to the empty string, which spells *unset* and would have turned the most
+  dangerous value into the silent default.
+
+- **D-3 (2026-09-06): the walkers take the layout, not an extra exclusion
+  entry.** The obvious implementation appends the root to
+  `index.resolver_exclusions` before walking. It does not work and would be
+  wrong if it did: that list matches directory *names* rather than path
+  prefixes, so a root of `tool/state` is inexpressible in it, and 3.5 requires
+  that neither list can cancel the key's effects. Both walkers take
+  `&LayoutConfig` instead, which keeps the two mechanisms visibly separate at
+  every call site.

--- a/specs/039-declared-state-dir/spec.md
+++ b/specs/039-declared-state-dir/spec.md
@@ -300,6 +300,20 @@ gitignored transcript are both ungoverned by the gates.
   than a wrong one, because the gates keep exiting 0 while adjudicating nothing
   and the config claims otherwise.
 
+- **D-7 (2026-09-06): the not-repo-relative check tests segments, not
+  prefixes.** Three review rounds found three spellings of one defect: `..`,
+  then `/var/logs` and `/`, then `state/..`. Each passed the guard written for
+  the previous one, and each was inert for the identical reason, since a
+  repo-relative path produced by `rel_posix` carries no `..` and never begins
+  with `/`. Patching the third spelling would have invited a fourth. The check
+  now refuses any value with a `..` **segment** anywhere, plus any absolute one,
+  which is the class rather than its instances.
+
+  The pattern is worth recording beyond this key: a validation rule written
+  against the example in front of you tends to encode the example. The general
+  question here was always "can this value ever match a path the gates test",
+  and asking it directly is what closes the case.
+
 - **D-6 (2026-09-06): `L-006` covers all six ownership-bearing edges, not five.**
   The first implementation walked `establishes`, `extends`, `refines`,
   `co_authority` and `constrains`, and omitted `supersedes`. A partial

--- a/specs/039-declared-state-dir/spec.md
+++ b/specs/039-declared-state-dir/spec.md
@@ -283,3 +283,24 @@ gitignored transcript are both ungoverned by the gates.
   that neither list can cancel the key's effects. Both walkers take
   `&LayoutConfig` instead, which keeps the two mechanisms visibly separate at
   every call site.
+
+- **D-4 (2026-09-06): a value escaping the repository is refused, and the
+  overlap check stays scoped to the two roots 3.2 names.** Review of the
+  implementing PR raised both.
+
+  `../logs` passed validation and would then have matched nothing, because every
+  path the gates test is repo-relative and carries no `..`. The gates would
+  behave as though no root were declared while the config said one was, which is
+  the same failure class as the `.` case in D-2 and is refused the same way:
+  silence that claims to be a decision.
+
+  The second was an unchecked overlap with `standalone_rust_workspaces` and
+  `standalone_npm_packages`. 3.2 names `specs_dir` and `derived_dir` and only
+  those, and the check is left scoped to them deliberately. The two governed
+  roots are **spec-spine's own**: a state root swallowing one breaks the tool
+  against a corpus the adopter did not intend to ungovern, and no adopter means
+  `state_dir = "specs"`. A declared package directory is the adopter's own code,
+  and naming it as the state root is a statement about their repository that
+  this key exists to let them make. Widening the refusal would be adding a rule
+  the spec does not have, to prevent a configuration that is legible on its
+  face; the coverage report already shows the denominator that results.

--- a/specs/039-declared-state-dir/spec.md
+++ b/specs/039-declared-state-dir/spec.md
@@ -284,6 +284,33 @@ gitignored transcript are both ungoverned by the gates.
   `&LayoutConfig` instead, which keeps the two mechanisms visibly separate at
   every call site.
 
+- **D-5 (2026-09-06): every value that would declare nothing is refused, and
+  the order of the checks is what makes that true.** Review of the implementing
+  PR found `/var/logs` accepted, on the same reasoning as D-2 and D-4: an
+  absolute path matches no repo-relative path the gates test. Widening the guard
+  then exposed a second case the first fix would have hidden, `/`, which
+  normalizes to the empty string and would have been read as *unset*, silently
+  turning a value the adopter wrote into no declaration at all.
+
+  So the validation now reads the **raw** value to decide whether a root was
+  declared, refuses anything that is not repo-relative before normalizing, and
+  only then tests the repository root and the overlaps. Normalizing first is
+  what made `/` invisible, and this ordering is the reason it cannot be. The
+  three arms share one rationale: a `state_dir` that matches nothing is worse
+  than a wrong one, because the gates keep exiting 0 while adjudicating nothing
+  and the config claims otherwise.
+
+- **D-6 (2026-09-06): `L-006` covers all six ownership-bearing edges, not five.**
+  The first implementation walked `establishes`, `extends`, `refines`,
+  `co_authority` and `constrains`, and omitted `supersedes`. A partial
+  `supersedes` item carries the unit whose authority transfers (spec 019), so it
+  claims a path exactly as the others do: a superseding spec could have held a
+  claim inside the ungoverned root that `couple` bypasses unconditionally and no
+  diagnostic ever named, which is precisely the contradiction this code exists
+  to surface. `amends` stays excluded, because its subject is the amended spec's
+  `spec.md` rather than an arbitrary unit, and a `spec.md` lives under
+  `specs_dir`, which `state_dir` may not overlap.
+
 - **D-4 (2026-09-06): a value escaping the repository is refused, and the
   overlap check stays scoped to the two roots 3.2 names.** Review of the
   implementing PR raised both.


### PR DESCRIPTION
## Summary

Implements spec 039. spec-spine distinguished two roots, `specs_dir` (authored truth) and `derived_dir` (compiler-owned truth). A third kind of file kept arriving with nowhere to be declared: state belonging to a *tool* that operates on the repo but is neither its source nor spec-spine's output, such as a build daemon's journal or captured transcripts. Every such directory was then a surprise to the gates, and the adopter's only recourse was appending a private path to `coupling.bypass_prefixes` and another to `index.resolver_exclusions`, with nothing recording why either entry was there.

`layout.state_dir` is one declared root, unset by default. **Declared** means the gates recognize it: `couple` bypasses it, `coverage` drops it from both sides of the ratio, the resolver does not scan it, and it contributes to no content hash. **Ungoverned** means spec-spine never reads its contents and never writes into it, so the purity invariant holds.

Unset by default, so every existing repo is byte-identical across this change. A default of `.spec-spine/` was rejected in the spec: silently bypassing a real path in every adopter's repo on upgrade changes what the gate refuses.

**A claim inside the root is a contradiction, not a precedence question.** The state check sits ahead of spec 009's claimed-path override rather than joining it, and neither side wins: letting the claim win would reintroduce override into a directory whose entire purpose is to be ungoverned, and letting the bypass win would silently discard a unit an author wrote deliberately. `lint` reports it as `L-006` at error tier instead, so the corpus is told. `references` is excluded, since spec 034 settled that a cited file is not a claimed one.

## Two decisions recorded in the spec's new §5

**D-1: §2's territory list was two files short of what §3.2 requires.** Two of the four MUSTs reach past the five files it named. *The resolver MUST NOT scan it* — `index.rs` owns one source walk, but the symbol and module indexes walk their own trees in `symbols.rs`, so a symbol defined inside the root would still have resolved. *It MUST NOT contribute to any content hash* — the globally hashed inputs are folded in `shard.rs::global_inputs_hash`, and an `extra_hashed_inputs` pattern wide enough to reach in is the ordinary case rather than an exotic one, since the point of the key is that the adopter states the root once. Both files now carry an `extends` edge and §2 says so. The alternative, implementing only the four MUSTs the original list covered, would have left a stated MUST unimplemented and the root reachable by exactly the mechanism most likely to reach it.

**D-2: `state_dir = "."` is refused by name, and its own test found that.** §3.2 requires refusing a value that *contains* a governed root and names `.` as the case that ungoverns the whole repository. A string comparison does not know the repo root is an ancestor of everything, so the overlap test cleared it and the first draft of the validation accepted it. It is refused explicitly now, with its own message. Normalizing `.` to the empty string was rejected: that spells *unset*, and would have turned the most dangerous value into the silent default.

**D-3: the walkers take `&LayoutConfig`, not an extra exclusion entry.** The obvious implementation appends the root to `resolver_exclusions`. It does not work and would be wrong if it did: that list matches directory *names* rather than path prefixes, so a root of `tool/state` is inexpressible in it, and §3.5 requires that neither list can cancel the key's effects.

## Testing

Twelve new tests across four files, covering §3.6 in full:

- **config** (5): unset is inert; matching is separator-aware so `state` never covers `stateful/`; `state` and `state/` name one root; equal / ancestor / descendant values are refused in both directions while a prefix-sharing sibling is accepted; and the overlap check reads the **resolved** layout, asserted with the inverted pair the spec names (`specs_dir = "corpus"` refuses `corpus/state` and accepts `specs/state`), which fails against any implementation comparing with a hardcoded root.
- **couple** (2): a changed file under the root trips neither `C-001` nor `C-002`, `checked_paths` stays 0, an explicit unit claim cannot override it, and `stateful/` is still governed.
- **coverage** (3): the denominator shrinks by exactly the number of state files, asserted as counts rather than a percentage, so a repo at 100% stays at 100%; a state write does not stale the index while a hashed input outside the root still does; and the enumeration agrees with the classifier.
- **lint / resolver** (2): `L-006` at error tier naming both spec and unit, with a `references` citation correctly *not* reported; a symbol whose only definition lives inside the root does not resolve, with a control proving it resolves when nothing is declared. Plus an assertion that no two lint codes collide, since the spec makes "the next free code in the band" the binding rule rather than `L-006` specifically.

```
compile --check                    0   fresh, 44 shards
index check                        0   fresh
index coverage --fail-on-untraced  0   66/66 (100.0%)
lint --fail-on-warn                0   0 errors, 0 warnings, 0 info
couple --base origin/main          0   11 paths checked, no drift
cargo test --workspace --locked    0   all suites pass
cargo clippy -D warnings           0
cargo fmt --all --check            0
```

This repo declares no `state_dir`, so its committed artifacts are unchanged and the determinism gate should prove it across the release matrix as usual.