### PR TITLE
test(038): pin the cycle-scope agreement and `blocked`'s ordering

### DIFF
--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "953deee753d9388a7b602c39ec5c0d3e6f3649ffadcff9c90e7a9be44e3c86e4"
+  "shardHash": "9f49743ace77c7649a10bd564dab0bf5abc0becf6a432c99c35bdb3a359cbe22"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9f49743ace77c7649a10bd564dab0bf5abc0becf6a432c99c35bdb3a359cbe22"
+  "shardHash": "9e02825e95e46886efa10f54c5c265a434a823658e365ca96c1b8de3eb6f2237"
 }

--- a/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
@@ -89,6 +89,6 @@
     "summary": "`depends_on` records the order specs must be built in, spec 033 guarantees that graph is acyclic, and `implementation` records how far each one has got, but nothing joins the three: there is no query that answers \"which specs can be worked on now, and in what order\". Every consumer that needs it (a contributor picking up the corpus, a release note, an autonomous driver taking one spec per session) recomputes it by reading frontmatter by hand, which is both tedious and exactly the ad-hoc traversal the typed read verbs exist to replace. This spec adds `registry plan`: a read-only projection that partitions the corpus into a `ready` set (nothing unfinished blocks it) emitted in deterministic topological order, and a `blocked` set, each entry naming the unfinished dependencies that block it, so the output explains itself rather than merely listing. It is a scheduling projection and nothing more: `implementation` is a self-declared field that no gate currently verifies, so `plan` treats it as a hint about intent and never as evidence about code, and this spec deliberately does not let a scheduling answer imply that anything is done.\n",
     "title": "`registry plan`: the ready set in dependency order"
   },
-  "shardHash": "214dac0e0fbea554c2142e6e94d3979cbe4160d2ba744c35439dbe4afb542a6b",
+  "shardHash": "a5b593314d7056a39c76ac4efb16b17b819c04dc81bf1dae4a3e64a2cbc98d3b",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
@@ -81,13 +81,14 @@
       "3.3 Output",
       "3.4 `implementation` is a hint, never evidence",
       "3.5 Tests (minimum)",
-      "4. Out of scope"
+      "4. Out of scope",
+      "5. Resolved decisions"
     ],
     "specPath": "specs/038-registry-plan-ready-set/spec.md",
     "status": "draft",
     "summary": "`depends_on` records the order specs must be built in, spec 033 guarantees that graph is acyclic, and `implementation` records how far each one has got, but nothing joins the three: there is no query that answers \"which specs can be worked on now, and in what order\". Every consumer that needs it (a contributor picking up the corpus, a release note, an autonomous driver taking one spec per session) recomputes it by reading frontmatter by hand, which is both tedious and exactly the ad-hoc traversal the typed read verbs exist to replace. This spec adds `registry plan`: a read-only projection that partitions the corpus into a `ready` set (nothing unfinished blocks it) emitted in deterministic topological order, and a `blocked` set, each entry naming the unfinished dependencies that block it, so the output explains itself rather than merely listing. It is a scheduling projection and nothing more: `implementation` is a self-declared field that no gate currently verifies, so `plan` treats it as a hint about intent and never as evidence about code, and this spec deliberately does not let a scheduling answer imply that anything is done.\n",
     "title": "`registry plan`: the ready set in dependency order"
   },
-  "shardHash": "6205d2a87e71ec1d31f428db28a6611aa12f167336df4ce86b70f0190e90d79d",
+  "shardHash": "214dac0e0fbea554c2142e6e94d3979cbe4160d2ba744c35439dbe4afb542a6b",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -213,6 +213,15 @@ pub struct BlockedSpec {
 }
 
 /// The scheduling projection: what can be worked on now, and what cannot.
+///
+/// **Both sets are ordered, and both orderings are part of the contract.**
+/// `ready` is topological over `depends_on` with ties by ascending id;
+/// `blocked` is ascending id, and each entry's `blocked_by` follows that spec's
+/// own authored `depends_on` order. Spec 038 3.2 requires the report to be a
+/// pure function of the corpus rather than of a hash-map iteration order, and
+/// that covers the whole document: a `--json` consumer diffing `blocked` across
+/// runs is relying on a stated guarantee, not on the `BTreeMap` that happens to
+/// produce it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Plan {
@@ -239,6 +248,14 @@ pub struct Plan {
 /// cycle. Spec 033 refuses one at compile time, so a registry that exists is
 /// acyclic; this guards a hand-edited shard or one written by another tool
 /// version, and it terminates rather than looping or truncating.
+///
+/// That unreachability holds only while both walks cover the same specs.
+/// `compile` passes every record to its detector with no `status` filter, and
+/// this walks every entry in the registry, so the two agree today; nothing in
+/// either function enforces the pairing, which is why
+/// `plan_and_compile_agree_on_a_cycle_among_retired_specs` asserts it. If
+/// `compile`'s check were ever scoped to active specs, `plan` would begin
+/// refusing corpora `compile` accepts, and that test is what would catch it.
 pub fn plan(registry: &Registry) -> Result<Plan, Error> {
     let by_id: BTreeMap<&str, &SpecRecord> =
         registry.specs.iter().map(|s| (s.id.as_str(), s)).collect();

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -518,7 +518,11 @@ fn plan_and_compile_agree_on_a_cycle_among_retired_specs() {
     retired("001-a", "002-b");
     retired("002-b", "001-a");
 
-    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+    // The pivot of the whole test: `compile` returns `Ok` for a cycle, carrying
+    // V-014 in the report. Named here so a future change to `Err` fails saying
+    // that, rather than as an unexplained panic in a test about scope.
+    let outcome = compile(&Config::default(), tmp.path())
+        .expect("compile returns Ok on a cyclic corpus; the violation rides in the report");
 
     // The detector fires: it is not scoped to active specs. `compile` still
     // returns `Ok`, carrying the violation in the report rather than as an

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -486,3 +486,86 @@ fn plan_survives_a_very_long_acyclic_chain() {
     );
     assert_eq!(plan.blocked.len(), N - 1);
 }
+
+/// `plan`'s cycle guard and `compile`'s `V-014` must agree on which specs the
+/// walk covers, and the agreement is asserted rather than assumed.
+///
+/// `plan`'s guard is documented as unreachable on a registry `compile` accepts.
+/// That is true only while both walk the same set: `compile` passes every
+/// record to its detector with no `status` filter, and `plan` walks every entry
+/// in the registry. Nothing enforces that pairing, so if `compile`'s check were
+/// ever scoped to active specs, `plan` would start refusing a corpus `compile`
+/// accepts and no test would notice.
+///
+/// A cycle confined to retired specs is the case where the two would diverge
+/// first, so it is the one pinned here.
+#[test]
+fn plan_and_compile_agree_on_a_cycle_among_retired_specs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let retired = |id: &str, dep: &str| {
+        let dir = tmp.path().join("specs").join(id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("spec.md"),
+            format!(
+                "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: retired\ncreated: \"2026-09-06\"\n\
+                 summary: \"s\"\nretirement_rationale: \"superseded by nothing\"\n\
+                 depends_on: [\"{dep}\"]\n---\n# {id}\n## body\n"
+            ),
+        )
+        .unwrap();
+    };
+    retired("001-a", "002-b");
+    retired("002-b", "001-a");
+
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+
+    // `compile` refuses it: the detector is not scoped to active specs.
+    let compile_v014: Vec<_> = outcome
+        .registry
+        .validation
+        .violations
+        .iter()
+        .filter(|v| v.code == "V-014")
+        .collect();
+    assert_eq!(
+        compile_v014.len(),
+        1,
+        "compile must refuse a cycle among retired specs: {:?}",
+        outcome.registry.validation.violations
+    );
+
+    // ...and so does `plan`, over the same registry. Were `compile` ever scoped
+    // to active specs, this corpus would compile clean and this assertion would
+    // fail, which is exactly the divergence the guard's comment assumes away.
+    let err = spec_spine_core::plan(&outcome.registry).unwrap_err();
+    let Error::Validation(violations) = &err else {
+        panic!("expected Error::Validation, got {err:?}");
+    };
+    assert_eq!(violations[0].code, "V-014", "the same classification");
+    for id in ["001-a", "002-b"] {
+        assert!(
+            violations[0].message.contains(id),
+            "the path names every spec on it: {}",
+            violations[0].message
+        );
+    }
+}
+
+/// `blocked` is ordered by ascending spec id, and that is a promise rather than
+/// a `BTreeMap` side effect a consumer would be relying on by accident.
+#[test]
+fn plan_blocked_entries_are_ordered_by_id() {
+    let reg = registry_of(&[
+        ("001-root", "approved", Some("pending"), &[]),
+        ("004-d", "approved", Some("pending"), &["001-root"]),
+        ("002-b", "approved", Some("pending"), &["001-root"]),
+        ("003-c", "approved", Some("pending"), &["001-root"]),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    let ids: Vec<&str> = plan.blocked.iter().map(|b| b.id.as_str()).collect();
+    assert_eq!(ids, vec!["002-b", "003-c", "004-d"]);
+    let mut sorted = ids.clone();
+    sorted.sort();
+    assert_eq!(ids, sorted, "ascending id, as the contract states");
+}

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -520,7 +520,9 @@ fn plan_and_compile_agree_on_a_cycle_among_retired_specs() {
 
     let outcome = compile(&Config::default(), tmp.path()).unwrap();
 
-    // `compile` refuses it: the detector is not scoped to active specs.
+    // The detector fires: it is not scoped to active specs. `compile` still
+    // returns `Ok`, carrying the violation in the report rather than as an
+    // error, which is why the call above unwraps.
     let compile_v014: Vec<_> = outcome
         .registry
         .validation
@@ -528,6 +530,20 @@ fn plan_and_compile_agree_on_a_cycle_among_retired_specs() {
         .iter()
         .filter(|v| v.code == "V-014")
         .collect();
+    // Asserted before the count so a schema rejection of `depends_on` on a
+    // retired spec would fail here, naming its own cause, rather than surfacing
+    // as a confusing "no V-014 was raised".
+    let unexpected: Vec<_> = outcome
+        .registry
+        .validation
+        .violations
+        .iter()
+        .filter(|v| v.code != "V-014" && v.severity == spec_spine_types::Severity::Error)
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "the fixture must reach the cycle detector cleanly: {unexpected:?}"
+    );
     assert_eq!(
         compile_v014.len(),
         1,
@@ -568,4 +584,41 @@ fn plan_blocked_entries_are_ordered_by_id() {
     let mut sorted = ids.clone();
     sorted.sort();
     assert_eq!(ids, sorted, "ascending id, as the contract states");
+}
+
+/// The other half of 3.2's ordering contract: each entry's `blockedBy` follows
+/// that spec's own **authored** `depends_on` order, not ascending id.
+///
+/// The two orders are deliberately opposed in this fixture, so an implementation
+/// that collected blockers from the id-sorted map instead of from the spec's own
+/// list would fail rather than coincidentally agree.
+#[test]
+fn plan_blocked_by_follows_authored_depends_on_order() {
+    let reg = registry_of(&[
+        ("001-a", "approved", Some("pending"), &[]),
+        ("002-b", "approved", Some("pending"), &[]),
+        ("003-c", "approved", Some("pending"), &[]),
+        // Authored back to front: c, a, b.
+        (
+            "004-join",
+            "approved",
+            Some("pending"),
+            &["003-c", "001-a", "002-b"],
+        ),
+    ]);
+    let plan = spec_spine_core::plan(&reg).unwrap();
+    let blockers: Vec<&str> = plan
+        .blocked
+        .iter()
+        .find(|b| b.id == "004-join")
+        .expect("004-join is blocked")
+        .blocked_by
+        .iter()
+        .map(|b| b.id.as_str())
+        .collect();
+    assert_eq!(
+        blockers,
+        vec!["003-c", "001-a", "002-b"],
+        "authored order is preserved, not re-sorted by id"
+    );
 }

--- a/specs/038-registry-plan-ready-set/spec.md
+++ b/specs/038-registry-plan-ready-set/spec.md
@@ -116,7 +116,11 @@ corpus does not sanction.
 ### 3.2 Ordering is total and deterministic
 
 `ready` is emitted in topological order over `depends_on`, with ties broken by
-ascending spec id. The tiebreak is what makes the output a pure function of the
+ascending spec id. `blocked` is emitted in ascending spec id, and each entry's
+`blockedBy` follows that spec's own authored `depends_on` order. Both orderings
+are part of the contract: the determinism requirement below is a property of the
+whole report, so a consumer diffing either array across runs is relying on a
+stated guarantee rather than on an implementation's iteration order. The tiebreak is what makes the output a pure function of the
 corpus rather than of a hash-map iteration order, which the determinism contract
 requires of every output this project produces.
 
@@ -261,3 +265,30 @@ field. In particular it never advances `implementation`.
 That is the completion gate, filed separately.
 
 **Cross-repo planning.** One registry, one repo, one plan.
+
+## 5. Resolved decisions
+
+- **D-1 (2026-09-06): `plan`'s cycle guard agrees with `compile`'s by
+  construction, and that agreement is now tested.** 3.2 says the walk is
+  entitled to assume acyclicity because spec 033 refuses a cycle at compile
+  time. Review of the implementing PR asked what scopes that refusal.
+  `compile::detect_dependency_cycle` receives every compiled record with no
+  `status` filter, and `plan` walks every registry entry, so both cover the same
+  set and the guard is genuinely unreachable on a registry `compile` accepts.
+
+  Nothing in either function enforces the pairing. Were `compile`'s check ever
+  scoped to active specs, `plan` would start refusing corpora `compile` accepts,
+  and the divergence would surface as a scheduling failure with no test pointing
+  at its cause. `plan_and_compile_agree_on_a_cycle_among_retired_specs` pins it
+  on the case where the two would diverge first, converting a comment into a
+  checked property. This is the same correction the previous round applied to
+  `topological`'s degeneracy: an assumption a doc comment states is worth an
+  assertion when a later change elsewhere could quietly invalidate it.
+
+- **D-2 (2026-09-06): `blocked`'s ordering was true but unstated.** `ready`
+  carried an explicit ordering promise; `blocked` was ascending id only because
+  the walk iterates a `BTreeMap`, so a `--json` consumer diffing it across runs
+  would have been relying on an accident. 3.2's determinism requirement is a
+  property of the report rather than of one of its two arrays, so the guarantee
+  existed and only the sentence stating it was missing. 3.2 now states it and
+  `plan_blocked_entries_are_ordered_by_id` asserts it.

--- a/specs/038-registry-plan-ready-set/spec.md
+++ b/specs/038-registry-plan-ready-set/spec.md
@@ -120,7 +120,9 @@ ascending spec id. `blocked` is emitted in ascending spec id, and each entry's
 `blockedBy` follows that spec's own authored `depends_on` order. Both orderings
 are part of the contract: the determinism requirement below is a property of the
 whole report, so a consumer diffing either array across runs is relying on a
-stated guarantee rather than on an implementation's iteration order. The tiebreak is what makes the output a pure function of the
+stated guarantee rather than on an implementation's iteration order.
+
+The `ready` tiebreak is what makes the output a pure function of the
 corpus rather than of a hash-map iteration order, which the determinism contract
 requires of every output this project produces.
 


### PR DESCRIPTION
## Summary

Two follow-ups from the review of #95. Neither changes behavior on any corpus that exists; both convert an assumption into a checked property.

**1. `plan`'s cycle guard agrees with `compile`'s by construction, and that is now tested.**

The guard is documented as unreachable on a registry `compile` accepts. That holds only while both walks cover the same specs, and the review correctly noted the assumption was load-bearing and unverified. I checked it rather than trusting the comment: `compile::detect_dependency_cycle` receives every compiled record with no `status` filter, and `plan` walks every registry entry, so the two agree today and the guard is genuinely unreachable.

Nothing in either function enforces the pairing. If `compile`'s check were ever scoped to active specs, `plan` would begin refusing corpora `compile` accepts, and the divergence would surface as a scheduling failure with nothing pointing at its cause. `plan_and_compile_agree_on_a_cycle_among_retired_specs` pins it on a cycle confined to retired specs, which is where the two would diverge first: it asserts `compile` raises `V-014` on that corpus *and* that `plan` refuses the same registry with the same code.

This is the same correction the previous round applied to `topological`'s degeneracy. An assumption a doc comment states is worth an assertion when a change elsewhere could quietly invalidate it.

**2. `blocked`'s ordering was true but unstated.**

`ready` carried an explicit ordering promise; `blocked` was ascending id only because the walk iterates a `BTreeMap`, so a `--json` consumer diffing it across runs was relying on an accident. §3.2's determinism requirement is a property of the report rather than of one of its two arrays, so the guarantee already existed and only the sentence stating it was missing. The spec, the `Plan` doc comment and `plan_blocked_entries_are_ordered_by_id` now all state it, including that each entry's `blockedBy` follows that spec's own authored `depends_on` order.

## Testing

```
compile --check                    0   fresh, 44 shards
index check                        0   fresh
index coverage --fail-on-untraced  0   66/66 (100.0%)
lint --fail-on-warn                0   0 errors, 0 warnings, 0 info
couple --base origin/main          0   3 paths checked, no drift
cargo test --workspace --locked    0   all suites pass (20 in tests/query.rs)
cargo clippy -D warnings           0
cargo fmt --all --check            0
```

Both new tests pass, which is what confirms the invariant holds on the current code rather than merely being asserted about it.