### PR TITLE
feat(041): make `implementation: complete` defeat draft leniency

### DIFF
--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "85b838d25c8f4fa4c87e47c8e7e6d7ff602786dc72b8e9042b373aa7e7bfbb56"
+  "shardHash": "4cff0f7c2c454ba8b3311a209c0689294cf273c6463d68019911ec03acfa62c6"
 }

--- a/.derived/spec-registry/by-spec/041-completion-held-to-claims.json
+++ b/.derived/spec-registry/by-spec/041-completion-held-to-claims.json
@@ -27,7 +27,7 @@
       }
     ],
     "id": "041-completion-held-to-claims",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -59,6 +59,6 @@
     "summary": "`index.rs::in_flight` is `status == \"draft\" || implementation == Pending`, and spec 025 uses it to downgrade an unresolved owning unit from a blocking `I-0xx` error to a counted `W-001` warning. The `Complete` arm of `implementation` is never consulted, so `status: draft` alone buys the leniency: a spec that states in its own frontmatter that its work is finished may claim units that do not exist, and the indexer counts a warning instead of refusing. That window is not an edge case in this corpus, it is the normal one. A spec is filed as `draft` with `implementation: complete` when its code lands (spec 036 did exactly that at 46474a3) and stays that way until a later ratification PR flips it to `approved`, so every spec passes through a period where its strongest claim about code is the one claim nothing checks. This spec makes `implementation: complete` decisive: a spec asserting completion is never in flight, whatever its `status`, and its unresolved owning units are hard errors. `status` and `implementation` are orthogonal axes (design ratification versus code existence), and where they disagree the more specific claim about code wins. It verifies existence, not behavior, and 3.3 is explicit that no gate can do more than that.\n",
     "title": "`implementation: complete` defeats draft leniency"
   },
-  "shardHash": "f4db13eb90f6716dbcbc427c2f7582abdcad62aca0eeef50f1a919e0a6e80660",
+  "shardHash": "d85d84f971a1efc89ee180b1cf18d4c1fcd5631102a3801b8623b42a17e72eb8",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -72,9 +72,42 @@ struct SpecInfo {
 
 impl SpecInfo {
     /// True when the spec is still in flight, so an unresolved *owning* unit is a
-    /// counted warning rather than a blocking error (spec 025 §3.1 arm 2):
-    /// `status: draft` or `implementation: pending`.
+    /// counted warning rather than a blocking error (spec 025 §3.1 arm 2).
+    ///
+    /// `status` and `implementation` are orthogonal axes: the first is a claim
+    /// about design review, the second a claim about code. Where they disagree
+    /// about whether claimed code exists, the more specific claim wins, which is
+    /// what spec 041 added to this predicate.
+    ///
+    /// | `status` | `implementation` | in flight |
+    /// |---|---|---|
+    /// | draft | pending / in-progress / n-a / deferred / absent | yes |
+    /// | draft | **complete** | **no** |
+    /// | approved | pending | yes |
+    /// | approved | anything else, or absent | no |
+    ///
+    /// `complete` is decisive because it is a **falsifiable assertion about the
+    /// filesystem**, volunteered by the author. `status: draft` says the design
+    /// is unratified, which is a statement about review and knows nothing about
+    /// whether the files exist; letting it silence a check on the other axis is
+    /// not leniency toward work in progress, it is declining to read what the
+    /// author wrote. `n-a` and `deferred` assert nothing about code existing, so
+    /// there is nothing to hold them to and they keep taking their answer from
+    /// `status`, as does an absent key.
+    ///
+    /// This window is the normal state rather than a corner: a spec here is
+    /// filed as `draft` + `complete` in the PR that lands its code and stays
+    /// that way until a separate ratification PR, so every spec passes through
+    /// an interval in which its strongest claim about code was the one claim
+    /// nothing checked.
+    ///
+    /// It verifies **existence, not behavior**. After this, `complete` means
+    /// every claimed unit resolves to something real; it does not mean the code
+    /// does what the prose says, and no mechanical gate here can mean that.
     fn in_flight(&self) -> bool {
+        if matches!(self.implementation, Some(Implementation::Complete)) {
+            return false;
+        }
         self.status == "draft" || matches!(self.implementation, Some(Implementation::Pending))
     }
 }

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -843,3 +843,158 @@ fn references_does_not_confer_c001_ownership() {
         report.violations
     );
 }
+
+// ===== spec 041: `implementation: complete` defeats draft leniency =====
+
+/// Index a one-spec corpus whose frontmatter is exactly `status` +
+/// `implementation`, so the two axes are varied independently.
+fn lifecycle_index(status: &str, implementation: Option<&str>) -> spec_spine_types::CodebaseIndex {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    let lifecycle = implementation
+        .map(|i| format!("implementation: {i}\n"))
+        .unwrap_or_default();
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec_with_status(
+            "001-x",
+            status,
+            &format!("{lifecycle}establishes:\n  - \"src/not_built_yet.rs\"\n"),
+        ),
+    );
+    index(&Config::default(), tmp.path()).unwrap().index
+}
+
+fn counts(idx: &spec_spine_types::CodebaseIndex) -> (usize, usize) {
+    (
+        idx.diagnostics.errors.len(),
+        idx.diagnostics
+            .warnings
+            .iter()
+            .filter(|d| d.code == "W-001")
+            .count(),
+    )
+}
+
+/// Spec 041 3.1: a spec asserting its own completion is never in flight,
+/// whatever its `status`, so its unresolved owning unit is a hard error.
+///
+/// The table is exhaustive over both enums on purpose. Only the
+/// `draft` + `complete` row moves; every other cell states what the predicate
+/// already did, so a later reader cannot mistake a gap for a licence to guess.
+#[test]
+fn completion_defeats_draft_leniency_across_both_axes() {
+    // (status, implementation, in flight)
+    let cases: [(&str, Option<&str>, bool); 10] = [
+        ("draft", Some("pending"), true),
+        ("draft", Some("in-progress"), true),
+        ("draft", Some("complete"), false), // the only row this spec moves
+        ("draft", Some("n-a"), true),
+        ("draft", Some("deferred"), true),
+        ("draft", None, true),
+        ("approved", Some("pending"), true),
+        ("approved", Some("in-progress"), false),
+        ("approved", Some("complete"), false),
+        ("approved", None, false),
+    ];
+
+    for (status, implementation, in_flight) in cases {
+        let idx = lifecycle_index(status, implementation);
+        let (errors, warnings) = counts(&idx);
+        let label = format!("{status} + {implementation:?}");
+        if in_flight {
+            assert_eq!(
+                errors, 0,
+                "{label} must not block: {:?}",
+                idx.diagnostics.errors
+            );
+            assert_eq!(warnings, 1, "{label} is a counted W-001");
+        } else {
+            assert_eq!(warnings, 0, "{label} must not be downgraded");
+            assert_eq!(errors, 1, "{label} is a blocking error");
+            assert!(
+                idx.diagnostics
+                    .errors
+                    .iter()
+                    .all(|d| d.code.starts_with("I-")),
+                "{label}: {:?}",
+                idx.diagnostics.errors
+            );
+        }
+    }
+}
+
+/// A `draft` + `complete` spec whose units all resolve produces no diagnostic:
+/// the stricter test is one it can pass, not one it cannot.
+#[test]
+fn a_complete_draft_that_told_the_truth_is_silent() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(tmp.path(), "src/built.rs", "pub fn built() {}\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        &spec_with_status(
+            "001-x",
+            "draft",
+            "implementation: complete\nestablishes:\n  - \"src/built.rs\"\n",
+        ),
+    );
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        idx.diagnostics.errors.is_empty(),
+        "{:?}",
+        idx.diagnostics.errors
+    );
+    assert!(
+        idx.diagnostics.warnings.iter().all(|d| d.code != "W-001"),
+        "{:?}",
+        idx.diagnostics.warnings
+    );
+}
+
+/// Spec 041 3.5: this touches the lifecycle arm only, never edge authority. An
+/// unresolved **non-owning** `references` unit stays `W-002` in every
+/// combination, including the one row that moved.
+#[test]
+fn a_non_owning_reference_stays_w002_in_every_combination() {
+    for (status, implementation) in [
+        ("draft", "complete"),
+        ("draft", "pending"),
+        ("approved", "complete"),
+        ("approved", "pending"),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+        write(
+            tmp.path(),
+            "specs/001-x/spec.md",
+            &spec_with_status(
+                "001-x",
+                status,
+                &format!(
+                    "implementation: {implementation}\nestablishes:\n  - \"src/built.rs\"\n\
+                     references:\n  - {{ unit: {{ kind: file, path: \"docs/gone.md\" }}, role: context }}\n"
+                ),
+            ),
+        );
+        write(tmp.path(), "src/built.rs", "pub fn built() {}\n");
+        let idx = index(&Config::default(), tmp.path()).unwrap().index;
+        let label = format!("{status} + {implementation}");
+        assert!(
+            idx.diagnostics.errors.is_empty(),
+            "{label}: a citation is not a claim: {:?}",
+            idx.diagnostics.errors
+        );
+        assert_eq!(
+            idx.diagnostics
+                .warnings
+                .iter()
+                .filter(|d| d.code == "W-002")
+                .count(),
+            1,
+            "{label}"
+        );
+    }
+}

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -880,13 +880,16 @@ fn counts(idx: &spec_spine_types::CodebaseIndex) -> (usize, usize) {
 /// Spec 041 3.1: a spec asserting its own completion is never in flight,
 /// whatever its `status`, so its unresolved owning unit is a hard error.
 ///
-/// The table is exhaustive over both enums on purpose. Only the
-/// `draft` + `complete` row moves; every other cell states what the predicate
-/// already did, so a later reader cannot mistake a gap for a licence to guess.
+/// All twelve cells: two `status` values against the five `implementation`
+/// variants plus an absent key. Exhaustive on purpose, and literally so, since
+/// the point of the table is that a reader adding an `Implementation` variant
+/// can tell at a glance whether it is covered. Only the `draft` + `complete`
+/// row moves; every other cell states what the predicate already did, so a
+/// later reader cannot mistake a gap for a licence to guess.
 #[test]
 fn completion_defeats_draft_leniency_across_both_axes() {
     // (status, implementation, in flight)
-    let cases: [(&str, Option<&str>, bool); 10] = [
+    let cases: [(&str, Option<&str>, bool); 12] = [
         ("draft", Some("pending"), true),
         ("draft", Some("in-progress"), true),
         ("draft", Some("complete"), false), // the only row this spec moves
@@ -896,6 +899,8 @@ fn completion_defeats_draft_leniency_across_both_axes() {
         ("approved", Some("pending"), true),
         ("approved", Some("in-progress"), false),
         ("approved", Some("complete"), false),
+        ("approved", Some("n-a"), false),
+        ("approved", Some("deferred"), false),
         ("approved", None, false),
     ];
 

--- a/specs/041-completion-held-to-claims/spec.md
+++ b/specs/041-completion-held-to-claims/spec.md
@@ -4,7 +4,7 @@ title: "`implementation: complete` defeats draft leniency"
 status: draft
 kind: "tooling"
 created: "2026-09-06"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:


### PR DESCRIPTION
## Summary

Implements spec 041. `index.rs::in_flight` was `status == "draft" || implementation == Pending`, and spec 025 uses it to downgrade an unresolved **owning** unit from a blocking `I-0xx` error to a counted `W-001` warning. The `Complete` arm never entered the expression, so the `status == "draft"` disjunct decided the outcome alone: a spec stating in its own frontmatter that its work is finished could claim units that do not exist, and the indexer counted a warning in a shard nobody reads.

**That window is the normal state here, not a corner.** A spec is filed as `draft` + `complete` in the pull request that lands its code and stays that way until a separate ratification PR flips it to `approved`. Every spec in this corpus therefore passes through an interval, bounded only by how long ratification takes, in which the single strongest claim it makes about code is the one claim nothing verifies.

`status` and `implementation` are orthogonal axes — design review versus code existence — and where they disagree about whether claimed code exists, the more specific claim wins. `complete` is a falsifiable assertion about the filesystem that the author volunteered; `status: draft` says the design is unratified, which is a statement about review and knows nothing about whether the files are there. Letting the second silence a check on the first is not leniency toward work in progress, it is declining to read what the author wrote.

It verifies **existence, not behavior**. After this, `complete` means every claimed unit resolves to something real. It does not mean the code does what the prose says, and no mechanical gate in this project can mean that.

## The test is exhaustive over both enums, on purpose

| `status` | `implementation` | in flight |
|---|---|---|
| draft | pending / in-progress / n-a / deferred / absent | yes |
| draft | **complete** | **no** — the only row this spec moves |
| approved | pending | yes |
| approved | in-progress / complete / n-a / deferred / absent | no |

Only the `draft` + `complete` row changes. Every other cell asserts what the predicate already did, which matters because §4 deliberately leaves `approved` + `in-progress` alone while arguing it is "very likely a defect": stating the current behavior exactly is what gives a later spec something precise to amend. Bundling that widening with this tightening would make one spec argue in two directions on the same predicate.

`n-a` and `deferred` assert nothing about code existing, so there is nothing to hold them to; they keep taking their answer from `status`, as does an absent key. And §3.5's requirement that this touches the lifecycle arm only is covered separately: an unresolved **non-owning** `references` unit stays `W-002` in all four combinations, including the row that moved.

## Testing

```
compile --check                       0   fresh, 44 shards
index check                           0   fresh
index coverage --fail-on-untraced     0   66/66 (100.0%)
lint --fail-on-warn                   0   0 errors, 0 warnings, 0 info
couple --base origin/main             0   3 paths checked, no drift
cargo test --workspace --locked       0   all suites pass
cargo test -p core --no-default-features  0
cargo clippy -D warnings              0
cargo fmt --all --check               0
```

Three new tests in `tests/index.rs`: the exhaustive ten-case lifecycle table, a `draft` + `complete` spec whose units all resolve producing no diagnostic (the stricter test is one it can pass), and the `references` invariant across four combinations.

**§3.4's blast-radius claim holds.** After the predicate change the only shard that moves is 041's own, and that is from its `implementation` flip rather than from the new logic; every other spec's shard is byte-identical. The determinism gate should confirm it across the release matrix as usual.