### PR TITLE
feat(044): make `implementation: in-progress` in flight

### DIFF
--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -1,0 +1,79 @@
+{
+  "mapping": {
+    "amends": [
+      "041-completion-held-to-claims"
+    ],
+    "dependsOn": [
+      "025-unresolved-unit-severity",
+      "041-completion-held-to-claims"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/index.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "specs/025-unresolved-unit-severity/spec.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "specs/025-unresolved-unit-severity/spec.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "specs/041-completion-held-to-claims/spec.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "specs/041-completion-held-to-claims/spec.md"
+        }
+      }
+    ],
+    "specId": "044-in-progress-is-in-flight",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "a7c3e775432360fbb81bc01c732801cd29d9358307dc56c0de649771ae985021"
+}

--- a/.derived/spec-registry/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/spec-registry/by-spec/044-in-progress-is-in-flight.json
@@ -1,0 +1,70 @@
+{
+  "record": {
+    "amends": [
+      "041-completion-held-to-claims"
+    ],
+    "created": "2026-09-06",
+    "dependsOn": [
+      "025-unresolved-unit-severity",
+      "041-completion-held-to-claims"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      }
+    ],
+    "id": "044-in-progress-is-in-flight",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "specs/041-completion-held-to-claims/spec.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "specs/025-unresolved-unit-severity/spec.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "044: `in-progress` is in flight",
+      "1. Purpose",
+      "1.1 The two values make the same claim",
+      "1.2 It bites the ratify-then-build corpus, and one exists",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The predicate",
+      "3.2 Why this does not weaken spec 041",
+      "3.3 What is deliberately not added",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/044-in-progress-is-in-flight/spec.md",
+    "status": "draft",
+    "summary": "Spec 025 grants an in-flight spec leniency: an unresolved owning unit is a counted `W-001` warning rather than a blocking error, because work under way may legitimately claim territory that does not exist yet. Its predicate names `status: draft` and `implementation: pending` and does not name `in-progress`, so a spec whose implementation is openly underway gets hard errors for every file it has not written. Spec 041 3.1 wrote that cell down and 4 called it very likely a defect, then left it alone on the grounds that one spec should not both tighten and loosen the same predicate. This is the spec 4 deferred. `in-progress` and `pending` are the same claim about the filesystem, that the work is not finished, and only one of them buys the leniency designed for exactly that state. The asymmetry has no argument behind it: 025 never discussed `in-progress`, which is what makes the omission look accidental rather than chosen. It bites a corpus that ratifies a design before building it, which lives in `approved` + `in-progress` for the whole build; the rahi corpus is in that state today.\n",
+    "title": "`implementation: in-progress` is in flight"
+  },
+  "shardHash": "77f235a00b72614f266f38c8c316d0b5d9aaf7ff5cd0d6bcebedd431bfdcd492",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -83,17 +83,20 @@ impl SpecInfo {
     /// |---|---|---|
     /// | draft | pending / in-progress / n-a / deferred / absent | yes |
     /// | draft | **complete** | **no** |
-    /// | approved | pending | yes |
-    /// | approved | anything else, or absent | no |
+    /// | approved | pending / in-progress | yes |
+    /// | approved | complete / n-a / deferred / absent | no |
     ///
-    /// `complete` is decisive because it is a **falsifiable assertion about the
-    /// filesystem**, volunteered by the author. `status: draft` says the design
-    /// is unratified, which is a statement about review and knows nothing about
-    /// whether the files exist; letting it silence a check on the other axis is
-    /// not leniency toward work in progress, it is declining to read what the
-    /// author wrote. `n-a` and `deferred` assert nothing about code existing, so
-    /// there is nothing to hold them to and they keep taking their answer from
-    /// `status`, as does an absent key.
+    /// The rule under both arms is that **the field is read as what it says**.
+    /// `complete` is a falsifiable assertion that the files exist, so the
+    /// indexer checks it (spec 041); `pending` and `in-progress` both say the
+    /// claimed territory is not finished, which is the condition the leniency
+    /// exists for, so it does not (spec 044). `status: draft` says the design is
+    /// unratified, a statement about review that knows nothing about whether the
+    /// files exist; letting it silence a check on the other axis is not leniency
+    /// toward work in progress, it is declining to read what the author wrote.
+    /// `n-a` and `deferred` assert nothing about code existing, so there is
+    /// nothing to hold them to and they keep taking their answer from `status`,
+    /// as does an absent key.
     ///
     /// This window is the normal state rather than a corner: a spec here is
     /// filed as `draft` + `complete` in the PR that lands its code and stays
@@ -108,7 +111,11 @@ impl SpecInfo {
         if matches!(self.implementation, Some(Implementation::Complete)) {
             return false;
         }
-        self.status == "draft" || matches!(self.implementation, Some(Implementation::Pending))
+        self.status == "draft"
+            || matches!(
+                self.implementation,
+                Some(Implementation::Pending | Implementation::InProgress)
+            )
     }
 }
 

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -849,8 +849,22 @@ fn references_does_not_confer_c001_ownership() {
 /// Index a one-spec corpus whose frontmatter is exactly `status` +
 /// `implementation`, so the two axes are varied independently.
 fn lifecycle_index(status: &str, implementation: Option<&str>) -> spec_spine_types::CodebaseIndex {
+    lifecycle_index_with(status, implementation, false)
+}
+
+/// As [`lifecycle_index`], but `built` writes the claimed file so the unit
+/// resolves, which separates "leniency applied" from "nothing to be lenient
+/// about".
+fn lifecycle_index_with(
+    status: &str,
+    implementation: Option<&str>,
+    built: bool,
+) -> spec_spine_types::CodebaseIndex {
     let tmp = tempfile::tempdir().unwrap();
     write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    if built {
+        write(tmp.path(), "src/not_built_yet.rs", "pub fn built() {}\n");
+    }
     let lifecycle = implementation
         .map(|i| format!("implementation: {i}\n"))
         .unwrap_or_default();
@@ -877,8 +891,10 @@ fn counts(idx: &spec_spine_types::CodebaseIndex) -> (usize, usize) {
     )
 }
 
-/// Spec 041 3.1: a spec asserting its own completion is never in flight,
-/// whatever its `status`, so its unresolved owning unit is a hard error.
+/// Specs 041 and 044: the lifecycle fields are read as what they say. A spec
+/// asserting completion is never in flight whatever its `status` (041); one
+/// declaring the work unfinished always is, whether `pending` or `in-progress`
+/// (044).
 ///
 /// All twelve cells: two `status` values against the five `implementation`
 /// variants plus an absent key. Exhaustive on purpose, and literally so, since
@@ -897,7 +913,10 @@ fn completion_defeats_draft_leniency_across_both_axes() {
         ("draft", Some("deferred"), true),
         ("draft", None, true),
         ("approved", Some("pending"), true),
-        ("approved", Some("in-progress"), false),
+        // Spec 044: the one cell that spec moves. `pending` and `in-progress`
+        // make the same claim about the filesystem, that the work is not
+        // finished, and only one of them used to buy the leniency built for it.
+        ("approved", Some("in-progress"), true),
         ("approved", Some("complete"), false),
         ("approved", Some("n-a"), false),
         ("approved", Some("deferred"), false),
@@ -967,8 +986,10 @@ fn a_non_owning_reference_stays_w002_in_every_combination() {
     for (status, implementation) in [
         ("draft", "complete"),
         ("draft", "pending"),
+        ("draft", "in-progress"),
         ("approved", "complete"),
         ("approved", "pending"),
+        ("approved", "in-progress"),
     ] {
         let tmp = tempfile::tempdir().unwrap();
         write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
@@ -1002,4 +1023,24 @@ fn a_non_owning_reference_stays_w002_in_every_combination() {
             "{label}"
         );
     }
+}
+
+/// Spec 044 3.2: leniency is not a pass. A spec at `in-progress` whose units
+/// all resolve is silent, and one whose units do not resolve still reports each
+/// missing unit by name as a counted `W-001`.
+#[test]
+fn in_progress_leniency_reports_rather_than_ignores() {
+    let silent = lifecycle_index_with("approved", Some("in-progress"), true);
+    assert_eq!(counts(&silent), (0, 0), "{:?}", silent.diagnostics);
+
+    let reported = lifecycle_index("approved", Some("in-progress"));
+    let (errors, warnings) = counts(&reported);
+    assert_eq!((errors, warnings), (0, 1), "a warning, not an error");
+    assert!(
+        reported.diagnostics.warnings[0]
+            .message
+            .contains("not_built_yet.rs"),
+        "the unit is named, so the warning is a report: {:?}",
+        reported.diagnostics.warnings
+    );
 }

--- a/specs/044-in-progress-is-in-flight/spec.md
+++ b/specs/044-in-progress-is-in-flight/spec.md
@@ -1,0 +1,179 @@
+---
+id: "044-in-progress-is-in-flight"
+title: "`implementation: in-progress` is in flight"
+status: draft
+kind: "tooling"
+created: "2026-09-06"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "025-unresolved-unit-severity"
+  - "041-completion-held-to-claims"
+amends:
+  # 041 3.1's table states the current behavior for `approved` + `in-progress`
+  # and 4 argues it is very likely a defect while deliberately not fixing it.
+  # This is the fix it deferred. 041's text is unchanged (spec 040).
+  - "041-completion-held-to-claims"
+extends:
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/tests/index.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "specs/041-completion-held-to-claims/spec.md" }, role: context }
+  - { unit: { kind: file, path: "specs/025-unresolved-unit-severity/spec.md" }, role: context }
+summary: >
+  Spec 025 grants an in-flight spec leniency: an unresolved owning unit is a
+  counted `W-001` warning rather than a blocking error, because work under way
+  may legitimately claim territory that does not exist yet. Its predicate names
+  `status: draft` and `implementation: pending` and does not name `in-progress`,
+  so a spec whose implementation is openly underway gets hard errors for every
+  file it has not written. Spec 041 3.1 wrote that cell down and 4 called it
+  very likely a defect, then left it alone on the grounds that one spec should
+  not both tighten and loosen the same predicate. This is the spec 4 deferred.
+  `in-progress` and `pending` are the same claim about the filesystem, that the
+  work is not finished, and only one of them buys the leniency designed for
+  exactly that state. The asymmetry has no argument behind it: 025 never
+  discussed `in-progress`, which is what makes the omission look accidental
+  rather than chosen. It bites a corpus that ratifies a design before building
+  it, which lives in `approved` + `in-progress` for the whole build; the rahi
+  corpus is in that state today.
+---
+
+# 044: `in-progress` is in flight
+
+## 1. Purpose
+
+Spec 025 3.1 arm 2 downgrades an unresolved **owning** unit from a blocking
+`I-0xx` error to a counted `W-001` warning while a spec is *in flight*, because
+work under way may legitimately claim territory that does not exist yet. Spec
+041 made `implementation: complete` defeat that leniency, and left the predicate
+otherwise as it found it:
+
+```rust
+fn in_flight(&self) -> bool {
+    if matches!(self.implementation, Some(Implementation::Complete)) {
+        return false;
+    }
+    self.status == "draft" || matches!(self.implementation, Some(Implementation::Pending))
+}
+```
+
+`Implementation::InProgress` never enters the expression. An `approved` spec at
+`in-progress` is therefore **not** in flight, and every unit it claims but has
+not yet written is a hard error.
+
+### 1.1 The two values make the same claim
+
+`pending` says the work has not started. `in-progress` says it has started and
+has not finished. Both are statements that the claimed territory is incomplete,
+which is precisely the condition 025's leniency exists to accommodate. Granting
+it to one and refusing it to the other requires an argument, and 025 does not
+make one: it names `draft` and `pending` and never discusses `in-progress` at
+all. That silence is what distinguishes this from a deliberate asymmetry.
+
+Compare the case spec 041 *did* argue. `complete` is a claim that the work is
+finished, so holding it to its territory tests something the author asserted.
+Refusing leniency to `in-progress` tests the opposite of what its author
+asserted.
+
+### 1.2 It bites the ratify-then-build corpus, and one exists
+
+This repository files a spec as `draft`, builds it, then ratifies, so nothing
+here is ever `approved` + `in-progress` and the defect is invisible locally.
+That is not true of every adopter, and spec 041 4 said so before an example was
+in hand:
+
+> a corpus that ratifies a design before building it lives in that state for the
+> whole build, which is the same class of adopter-flow problem the OAP dry run
+> raised against 025 in the first place.
+
+The rahi corpus works that way, and `specs/013-ledger-decision-chain` is
+`status: approved` with `implementation: in-progress` while a driven session
+builds it. It is the only `in-progress` spec in that corpus. For the whole
+duration of such a build, every not-yet-written claimed unit is a blocking
+diagnostic, and the gate chain refuses a corpus whose only fault is that the
+work is honestly declared as under way.
+
+The severity of that is worth stating precisely rather than overstating. The
+window is transient and closes as the files land, and a corpus can route around
+it by leaving `implementation` at `pending` until the work is done, which is
+what a scheduler would then read as "not started". The cost is that the field
+becomes less honest the more carefully an adopter avoids the defect.
+
+## 2. Territory
+
+`index.rs::in_flight` and its acceptance fixtures. No DTO changes, no schema
+version moves, and no emitted field is added or removed: this changes which
+tier an existing diagnostic lands in, for one combination of two existing
+fields, exactly as spec 041 did for a different combination.
+
+## 3. Behavior
+
+### 3.1 The predicate
+
+A spec MUST be treated as in flight when its `implementation` is `in-progress`,
+unless it also asserts completion, which cannot both hold.
+
+The table is exhaustive over both enums, as 041 3.1's is, so that the one cell
+this spec moves is legible against every cell it does not:
+
+| `status` | `implementation` | in flight | change |
+|---|---|---|---|
+| draft | pending | yes | unchanged |
+| draft | in-progress | yes | unchanged |
+| draft | complete | no | unchanged (spec 041) |
+| draft | n-a / deferred / absent | yes | unchanged |
+| approved | pending | yes | unchanged |
+| approved | **in-progress** | **yes** | **this spec** |
+| approved | complete | no | unchanged |
+| approved | n-a / deferred / absent | no | unchanged |
+
+`n-a` and `deferred` still assert nothing about code existing, so they keep
+taking their answer from `status`. An absent key is unchanged.
+
+### 3.2 Why this does not weaken spec 041
+
+041 made a completion claim falsifiable. This makes an incompleteness claim
+believed. They are the same rule applied consistently: **the field is read as
+what it says.** `complete` says the files exist, so the indexer checks;
+`in-progress` says they do not all exist yet, so it does not.
+
+The two specs would conflict only if `in-progress` were treated as evidence of
+completeness, and nothing here does that. A spec at `in-progress` whose units
+all resolve produces no diagnostic either way; a spec at `in-progress` whose
+units do not resolve produces a counted warning naming each one, which is a
+report, not a pass.
+
+### 3.3 What is deliberately not added
+
+There is no time limit, no staleness on the flag, and no gate that refuses a
+spec for sitting at `in-progress` too long. A lifecycle value that expired on
+its own would be a clock in a system contracted to be a pure function of
+`(config, file contents)`, and 023 3.2's split is explicit about where the only
+wall clock lives.
+
+Nor does this make `implementation` mandatory. An absent key still behaves as
+`pending` for this purpose (spec 038 3.1 reads it the same way for scheduling).
+
+## 4. Out of scope
+
+**The `approved` + `pending` combination.** Already in flight, unchanged, and
+spec 041 4 explains why it stays that way.
+
+**Verifying that code matches a spec's prose.** No gate does this. Spec 041 3.3
+is explicit and this spec adds nothing to it.
+
+**Any change to `status`.** Ratification stays a human act on its own axis, and
+the whole point of both this spec and 041 is that the two axes are read
+separately.
+
+## 5. Verification
+
+- The `approved` + `in-progress` cell yields `W-001`, not `I-0xx`, and `index`
+  exits 0 on it.
+- Every other cell of the 3.1 table is unchanged, asserted exhaustively.
+- A spec at `in-progress` whose units all resolve produces no diagnostic.
+- An unresolved **non-owning** `references` unit stays `W-002` in every
+  combination: this touches the lifecycle arm only, never edge authority.
+- This repo's committed index is unchanged, since nothing here is
+  `approved` + `in-progress`.


### PR DESCRIPTION
## Summary

Implements spec 044, the fix spec 041 §4 explicitly deferred.

Spec 025 §3.1 arm 2 downgrades an unresolved **owning** unit from a blocking `I-0xx` error to a counted `W-001` warning while a spec is *in flight*, because work under way may legitimately claim territory that does not exist yet. Its predicate names `status: draft` and `implementation: pending`, and never mentions `in-progress`. So a spec whose implementation is openly underway got hard errors for every file it had not yet written.

**`pending` and `in-progress` make the same claim about the filesystem** — that the claimed territory is not finished — and that is precisely the condition the leniency exists to accommodate. Granting it to one and refusing it to the other needs an argument, and 025 does not make one: it names `draft` and `pending` and does not discuss `in-progress` at all. That silence is what marks the omission accidental rather than chosen, and it is why spec 041 §4 called this "very likely a defect" while declining to fix it in a spec that was tightening the same predicate.

## This does not weaken spec 041

That was the thing to get right, since 041 moved this predicate in the opposite direction three commits ago. Both apply **one rule: the field is read as what it says.**

| claim | what it asserts | so the indexer |
|---|---|---|
| `complete` | the files exist | checks it (041) |
| `pending` / `in-progress` | they do not all exist yet | does not (044) |

The two would conflict only if `in-progress` were treated as evidence of completeness, and nothing here does that. I rewrote the shared doc comment on `in_flight` to state the single rule, rather than leaving two arms that read as pulling against each other.

**Leniency is not a pass.** A spec at `in-progress` whose units all resolve is silent; one whose units do not resolve reports each missing unit by name as a counted warning. The new test separates those two outcomes, because "no diagnostic" and "a warning nobody blocks on" are different things and only the second is leniency.

## Evidence, kept proportionate

This repo files a spec as `draft`, builds, then ratifies, so nothing here is ever `approved` + `in-progress` and the defect is invisible locally. Spec 041 §4 predicted it would bite a corpus that ratifies before building. One exists: rahi's `specs/013-ledger-decision-chain` is `approved` + `in-progress` right now while a driven session builds it, and it is the only `in-progress` spec in that corpus.

§1.2 states the limits rather than overselling: the window is transient and closes as files land, and an adopter can route around it by leaving `implementation` at `pending` until the work is done. The cost of that workaround is that the field becomes less honest the more carefully an adopter avoids the defect, which is the actual argument for fixing it.

## Testing

The lifecycle table in `tests/index.rs` is exhaustive over both enums (all twelve cells), so the one cell this spec moves is legible against every cell it does not:

| `status` | `implementation` | in flight | change |
|---|---|---|---|
| draft | pending / in-progress / n-a / deferred / absent | yes | unchanged |
| draft | complete | no | unchanged (041) |
| approved | pending | yes | unchanged |
| approved | **in-progress** | **yes** | **this spec** |
| approved | complete / n-a / deferred / absent | no | unchanged |

Plus: the leniency-is-not-a-pass test above, and the `references` invariant extended to `in-progress` in both `status` values, since this touches the lifecycle arm only and never edge authority.

```
compile --check                       0   fresh, 45 shards
index check                           0   fresh
index coverage --fail-on-untraced     0   66/66 (100.0%)
lint --fail-on-warn                   0   0 errors, 0 warnings, 0 info
couple --base origin/main             0   3 paths checked, no drift
cargo test --workspace --locked       0   all suites pass (32 in tests/index.rs)
cargo test -p core --no-default-features  0
cargo clippy -D warnings              0
cargo fmt --all --check               0
```

**§5's blast-radius claim is verified, not asserted:** after the predicate change the only shard that differs is 044's own. Nothing here is `approved` + `in-progress`, so the committed index does not move.

§3.3 records what is deliberately absent: no time limit and no staleness on the flag. A lifecycle value that expired on its own would be a clock in a system contracted to be a pure function of `(config, file contents)`.