### PR TITLE
chore(037-044): ratify the agentic-builder substrate (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -260,8 +260,8 @@
       }
     ],
     "specId": "037-machine-readable-verdicts",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bd91933857455123ef31ea9789e47deff53e19a342919335771f3db06308fb45"
+  "shardHash": "d91ea69a7f2f30eda7b36e016fe142c2eb3c0aef309527275d3bbf389910776f"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -123,8 +123,8 @@
       }
     ],
     "specId": "038-registry-plan-ready-set",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9e02825e95e46886efa10f54c5c265a434a823658e365ca96c1b8de3eb6f2237"
+  "shardHash": "fd19117bb017791f4528e27ccec25be8c6b5e1f21cc91c7666c7210b1a779ebd"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -207,8 +207,8 @@
       }
     ],
     "specId": "039-declared-state-dir",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0721ab74c16e9b181e896eaaf01289477dbf67b767b56b7ff2fd169f21ecbe1d"
+  "shardHash": "dbc362e8e3733c22bdc4949578aa5278ac922f1fd50eebd76232c2f1bdeef53e"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -69,8 +69,8 @@
       }
     ],
     "specId": "040-amendment-authoring",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2c9a843915a9d92671dc1c7688938a0aa13090608b118547a2d6ce7b45789ec"
+  "shardHash": "62c8af12a8da7f2f448cf221099c8fcbd512ee1caf08b3efefc12abdc940efe8"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -59,8 +59,8 @@
       }
     ],
     "specId": "041-completion-held-to-claims",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4cff0f7c2c454ba8b3311a209c0689294cf273c6463d68019911ec03acfa62c6"
+  "shardHash": "f364af53cbd0a4265490e3fab28954bec2194be8c600764a900e850eaa3daf83"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -226,8 +226,8 @@
       }
     ],
     "specId": "042-per-spec-attestation",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b4416dc720d30436f5bfe61dbdf3e1c13e2e0f01cec6566417fab2a918ea0255"
+  "shardHash": "ec96a86939a9211c1cb37f2b8ac8a85a27c72b245814179e86b74f6cf8659263"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -134,8 +134,8 @@
       }
     ],
     "specId": "043-governance-document-gaps",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cf6420fa0a88cd14ebc0c8f86caacd9f0af75addac49221ea6868efee90dad35"
+  "shardHash": "f41b21ea03f9d3352812bbee50b720e78beb58bdd12353e0ddb1a7ecea253ccb"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -72,8 +72,8 @@
       }
     ],
     "specId": "044-in-progress-is-in-flight",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a7c3e775432360fbb81bc01c732801cd29d9358307dc56c0de649771ae985021"
+  "shardHash": "cc29f79a24b6afbe79599f275a8f9d9bba96307de711e043f756d8767705450d"
 }

--- a/.derived/spec-registry/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/spec-registry/by-spec/037-machine-readable-verdicts.json
@@ -149,10 +149,10 @@
       "5. Resolved decisions"
     ],
     "specPath": "specs/037-machine-readable-verdicts/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The read verbs speak JSON; the verbs that render a verdict do not. `registry` (four subcommands), `index orphans` and `index coverage` have `--json`, while `couple`, `lint`, `compile --check`, `index check`, `attest` and `verify-attestation` emit prose to stdout and nothing else. A programmatic consumer of the gate chain is therefore forced to string-match sentences like `index is fresh` and to infer the reasons for a refusal from formatted text, which is precisely the ad-hoc parsing constitution §II forbids and the governed-artifact-reads rule was written against; the CLI currently leaves no alternative for exactly the commands whose output is a decision. The reports already exist: every one of these verbs is backed by a facade function returning a typed structure, and only the CLI surface is missing. This spec adds `--json` to each of them, behind one versioned envelope (`schemaVersion`, `verb`, `ok`, `exitCode`, and either `report` or `error`) whose `report` member is byte-identical to the corresponding facade output, so a consumer parses one header shape across the whole chain and one payload shape per verb, never two spellings of the same verdict. `--json` changes what is written, never what is decided: the exit code for every outcome is unchanged, and a failure is reported inside the envelope rather than as bare prose on stderr, so the machine consumer's happy path and error path have the same shape.\n",
     "title": "Machine-readable verdicts: `--json` on the adjudicating verbs"
   },
-  "shardHash": "83ca8e98bffd1e09b19cfff7f91bd9b35f070192caf4c2ebdc70648a2b7a55d4",
+  "shardHash": "5b32027ae3e446ab9e5e0541796dc9f0dea4bd49820fdbeb870a8b2a2787a7d6",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
@@ -85,10 +85,10 @@
       "5. Resolved decisions"
     ],
     "specPath": "specs/038-registry-plan-ready-set/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`depends_on` records the order specs must be built in, spec 033 guarantees that graph is acyclic, and `implementation` records how far each one has got, but nothing joins the three: there is no query that answers \"which specs can be worked on now, and in what order\". Every consumer that needs it (a contributor picking up the corpus, a release note, an autonomous driver taking one spec per session) recomputes it by reading frontmatter by hand, which is both tedious and exactly the ad-hoc traversal the typed read verbs exist to replace. This spec adds `registry plan`: a read-only projection that partitions the corpus into a `ready` set (nothing unfinished blocks it) emitted in deterministic topological order, and a `blocked` set, each entry naming the unfinished dependencies that block it, so the output explains itself rather than merely listing. It is a scheduling projection and nothing more: `implementation` is a self-declared field that no gate currently verifies, so `plan` treats it as a hint about intent and never as evidence about code, and this spec deliberately does not let a scheduling answer imply that anything is done.\n",
     "title": "`registry plan`: the ready set in dependency order"
   },
-  "shardHash": "a5b593314d7056a39c76ac4efb16b17b819c04dc81bf1dae4a3e64a2cbc98d3b",
+  "shardHash": "82f4d71319b7edb4f07a4a9061fe892a0ca0a0bbd577a6922fdd4fc04cc95415",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/039-declared-state-dir.json
+++ b/.derived/spec-registry/by-spec/039-declared-state-dir.json
@@ -125,10 +125,10 @@
       "5. Resolved decisions"
     ],
     "specPath": "specs/039-declared-state-dir/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "A repo governed by spec-spine increasingly hosts tooling that keeps state inside it: a build daemon's journal, a local database, captured transcripts, attestation bundles. There is nowhere agreed to put any of it. Every such tool invents a directory, and every invented directory is then a surprise to the gates: `couple` sees changed files no spec claims and refuses the merge under `require_ownership`, `index coverage` counts them as untraced debt, and the resolver walks them. The adopter's only recourse is to keep appending private paths to `bypass_prefixes` and `resolver_exclusions`, one list per concern, none of which states what the directory *is*. This spec adds `layout.state_dir`: a single declared root, unset by default, that spec-spine agrees to know about and refuses to govern. Declared means the gates recognize it (bypassed by `couple`, excluded from coverage classification and from the resolver scan, and never hashed); ungoverned means spec-spine never reads its contents, never writes into it, and refuses a spec that tries to claim a unit inside it, which `lint` reports as `L-006`, a contradiction rather than a precedence question resolved silently in either direction. Unset by default, so no existing repo changes behavior.\n",
     "title": "`layout.state_dir`: a declared, ungoverned tool-state root"
   },
-  "shardHash": "8c31a385f6d91439b3927bd6d463dcd63c458fad446413e382a42cb9f258ed62",
+  "shardHash": "2b44036ac42af89908ce214de94105a2ec512b5c790370b593c96b12dca2a280",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/040-amendment-authoring.json
+++ b/.derived/spec-registry/by-spec/040-amendment-authoring.json
@@ -51,10 +51,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/040-amendment-authoring/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The corpus has always authored amendments one way: the `amends` edge is declared in the amending spec's frontmatter, and the amended spec's `spec.md` is left alone. Spec 025 amends 004 without editing it; spec 036 amends 005 without editing it. The rule is enforced by nothing, stated by nothing, and visible only as a pattern in the history, so a reader looking at a diff cannot tell a deliberate convention from an omission. That is not hypothetical: the review of PR #89 asked six separate times for spec 033 to be edited to record that 038 had amended it, withdrew the request once on its own analysis, then raised it again, because nothing in the corpus says which answer is right. This spec writes it down, in the one-page contract where a reader checking the edge vocabulary will find it. It adds no mechanism, because the two mechanisms already exist and work: the gate's amends-awareness (005 §3.3) widens the owner set so editing the amender clears a violation on the amended spec's territory, and `registry relationships` reports `amended_by (incoming)` so the amendment is discoverable from the amended spec's side without that spec being touched.\n",
     "title": "An amendment is declared once, in the amending spec"
   },
-  "shardHash": "ee8f7dfbb54f33ffc82fd6c458019e7047b08aba769a735c2f685be69f3446df",
+  "shardHash": "2d5d4ca1b5b056d7863375cbc5c1699d3462a24cfb4fcbcc7540b5499c9cf3ee",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/041-completion-held-to-claims.json
+++ b/.derived/spec-registry/by-spec/041-completion-held-to-claims.json
@@ -55,10 +55,10 @@
       "5. Relationship to the design note"
     ],
     "specPath": "specs/041-completion-held-to-claims/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`index.rs::in_flight` is `status == \"draft\" || implementation == Pending`, and spec 025 uses it to downgrade an unresolved owning unit from a blocking `I-0xx` error to a counted `W-001` warning. The `Complete` arm of `implementation` is never consulted, so `status: draft` alone buys the leniency: a spec that states in its own frontmatter that its work is finished may claim units that do not exist, and the indexer counts a warning instead of refusing. That window is not an edge case in this corpus, it is the normal one. A spec is filed as `draft` with `implementation: complete` when its code lands (spec 036 did exactly that at 46474a3) and stays that way until a later ratification PR flips it to `approved`, so every spec passes through a period where its strongest claim about code is the one claim nothing checks. This spec makes `implementation: complete` decisive: a spec asserting completion is never in flight, whatever its `status`, and its unresolved owning units are hard errors. `status` and `implementation` are orthogonal axes (design ratification versus code existence), and where they disagree the more specific claim about code wins. It verifies existence, not behavior, and 3.3 is explicit that no gate can do more than that.\n",
     "title": "`implementation: complete` defeats draft leniency"
   },
-  "shardHash": "d85d84f971a1efc89ee180b1cf18d4c1fcd5631102a3801b8623b42a17e72eb8",
+  "shardHash": "d5ae7f2c3ac3f47fa23a9f6157a1eaaf76816f06a1cbddb47ba968fedaa17522",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/042-per-spec-attestation.json
+++ b/.derived/spec-registry/by-spec/042-per-spec-attestation.json
@@ -137,10 +137,10 @@
       "6. Resolved decisions"
     ],
     "specPath": "specs/042-per-spec-attestation/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Spec 023 attests the corpus: one payload, one hash, one optional Ed25519 seal over the whole ledger. The unit of work in a governed build is one spec, and a corpus-scoped attestation cannot answer \"was this spec's territory sound when its work was declared done\" without being reduced by hand. This spec adds `attest --spec <id>`, emitting a `SpecAttestation` scoped to a single spec: its own source hash, the resolved location and content hash of every owning unit it claims, and the verdicts restricted to it. It reuses 023's split exactly, the payload pure and reproducible with the wall clock and the signer identity in the detached seal, so the attested fact stays a function of `(config, file contents)` while the act of attesting is dated and attributed. It stays on-demand and gitignored like 023's, deliberately: the design note wanted a committed per-spec bundle, and committing one would restale on every edit to any claimed unit and would need its own freshness gate, which buys churn rather than assurance. A consumer that wants durable evidence receives the bundle; it does not need the repository to store it. One constraint is load-bearing and stated normatively: no lint rule may consume a `SpecAttestation`, because the payload records the lint verdict and a lint that read it would grade itself.\n",
     "title": "`attest --spec <id>`: a signed record scoped to one spec"
   },
-  "shardHash": "aa542bf021db1a76b0dec1f5fdafc4224f4a5b27520d3349209e9e0daebcade0",
+  "shardHash": "69a670d14ad15194c36e0f71aa4a04d98338bc4ba4d59951f1f5f7f9148e1718",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/043-governance-document-gaps.json
+++ b/.derived/spec-registry/by-spec/043-governance-document-gaps.json
@@ -91,10 +91,10 @@
       "4. Out of scope"
     ],
     "specPath": "specs/043-governance-document-gaps/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "hqgit is the first repository outside this one to adopt spec-spine, and what its author had to write by hand is a measurement of what the governance documents fail to supply. Three findings. First, the constitution's own Amendment clause names a mechanism that cannot be written: it says the constitution may be amended by \"an ordinary spec that `amends` it\", but `amends` resolves to spec ids and the constitution is not a spec, so the sentence has no implementation, and hqgit copied it verbatim into a corpus where it is equally unwritable. Spec 040 4 named this as an open question and deliberately did not answer it; this spec answers it. Second, spec 000 3 files `depends_on` and `implementation` under \"optional descriptive keys\", which was true when it was written and is now false: 033 refuses a cycle in one, and 038 and 041 make the other decide scheduling and diagnostic severity. hqgit had to write its own \"lifecycle as scheduling\" section because tier 1 reads as though the field were inert. Third, constitution V says pre-existing code is evidence but never says what to write about code adopted with defects; hqgit supplied the missing half. The scaffold learns all three, because the scaffolded constitution is four bullets with no tier statement, no normative hierarchy and no amendment clause, and the evidence is that the first adopter did not use it.\n",
     "title": "Three governance statements the first adopter could not act on"
   },
-  "shardHash": "a9d74e7f75fc07c3f6e8ccd210228fa225f3ee518c55d984daa095d6814ffdb1",
+  "shardHash": "08644e08a0280ce6a93b9c6bdbd7ee155b90a5b3fba5ab47f939d3b9a828fe42",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/spec-registry/by-spec/044-in-progress-is-in-flight.json
@@ -61,10 +61,10 @@
       "5. Verification"
     ],
     "specPath": "specs/044-in-progress-is-in-flight/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Spec 025 grants an in-flight spec leniency: an unresolved owning unit is a counted `W-001` warning rather than a blocking error, because work under way may legitimately claim territory that does not exist yet. Its predicate names `status: draft` and `implementation: pending` and does not name `in-progress`, so a spec whose implementation is openly underway gets hard errors for every file it has not written. Spec 041 3.1 wrote that cell down and 4 called it very likely a defect, then left it alone on the grounds that one spec should not both tighten and loosen the same predicate. This is the spec 4 deferred. `in-progress` and `pending` are the same claim about the filesystem, that the work is not finished, and only one of them buys the leniency designed for exactly that state. The asymmetry has no argument behind it: 025 never discussed `in-progress`, which is what makes the omission look accidental rather than chosen. It bites a corpus that ratifies a design before building it, which lives in `approved` + `in-progress` for the whole build; the rahi corpus is in that state today.\n",
     "title": "`implementation: in-progress` is in flight"
   },
-  "shardHash": "77f235a00b72614f266f38c8c316d0b5d9aaf7ff5cd0d6bcebedd431bfdcd492",
+  "shardHash": "b2e5db066e1426da641e27f5354629b375c526f41b11f03c5866de77e4c65fed",
   "specVersion": "1.1.0"
 }

--- a/specs/037-machine-readable-verdicts/spec.md
+++ b/specs/037-machine-readable-verdicts/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "037-machine-readable-verdicts"
 title: "Machine-readable verdicts: `--json` on the adjudicating verbs"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-05"
 implementation: complete

--- a/specs/038-registry-plan-ready-set/spec.md
+++ b/specs/038-registry-plan-ready-set/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "038-registry-plan-ready-set"
 title: "`registry plan`: the ready set in dependency order"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-05"
 implementation: complete

--- a/specs/039-declared-state-dir/spec.md
+++ b/specs/039-declared-state-dir/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "039-declared-state-dir"
 title: "`layout.state_dir`: a declared, ungoverned tool-state root"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-05"
 implementation: complete

--- a/specs/040-amendment-authoring/spec.md
+++ b/specs/040-amendment-authoring/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "040-amendment-authoring"
 title: "An amendment is declared once, in the amending spec"
-status: draft
+status: approved
 kind: "governance"
 created: "2026-09-06"
 implementation: complete

--- a/specs/041-completion-held-to-claims/spec.md
+++ b/specs/041-completion-held-to-claims/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "041-completion-held-to-claims"
 title: "`implementation: complete` defeats draft leniency"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete

--- a/specs/042-per-spec-attestation/spec.md
+++ b/specs/042-per-spec-attestation/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "042-per-spec-attestation"
 title: "`attest --spec <id>`: a signed record scoped to one spec"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete

--- a/specs/043-governance-document-gaps/spec.md
+++ b/specs/043-governance-document-gaps/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "043-governance-document-gaps"
 title: "Three governance statements the first adopter could not act on"
-status: draft
+status: approved
 kind: "governance"
 created: "2026-09-05"
 implementation: complete

--- a/specs/044-in-progress-is-in-flight/spec.md
+++ b/specs/044-in-progress-is-in-flight/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "044-in-progress-is-in-flight"
 title: "`implementation: in-progress` is in flight"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete


### PR DESCRIPTION
## Summary

Flips the eight specs shipped in this series from `draft` to `approved`, taking the corpus to **45/45**. Each is already `implementation: complete` with its code merged, so ratification is the only remaining transition.

| Spec | |
|---|---|
| 037 | machine-readable verdicts (`--json` on the six adjudicating verbs) |
| 038 | `registry plan`, the ready set in dependency order |
| 039 | `layout.state_dir`, a declared, ungoverned tool-state root |
| 040 | amendment authoring |
| 041 | completion held to its claims |
| 042 | per-spec attestation |
| 043 | governance-document gaps, from the first adoption |
| 044 | `in-progress` is in flight |

## This is the first ratification under spec 041

Which is the point of it. Before 041, `status: draft` alone bought the leniency spec 025 designed for work that has not started: a spec could assert `implementation: complete` while claiming units that did not exist, and the indexer counted a `W-001` warning in a shard nobody reads. Spec 041 §1.1 argued that window is the normal state here rather than a corner, since every spec passes through it between landing its code and being ratified.

So this commit is the check working rather than the check being skipped. All eight were `draft` + `complete`, which after 041 is **not** in flight, so every unit they claim had to resolve *before* this flip rather than after it. The evidence:

```
compile --check                    0   fresh, 45 shards
index check                        0   fresh
lint --fail-on-warn                0   0 errors, 0 warnings, 0 info
index coverage --fail-on-untraced  0   66/66 (100.0%)
index render                           no diagnostics at all
couple --base origin/main          0   0 paths checked, no drift
cargo test --workspace --locked    0   all suites pass
registry status-report                 { "total": 45, "approved": 45 }
```

`index render` reporting no diagnostics is the substantive line. Earlier in this series it carried a standing `W-001` for spec 037's not-yet-written `verdict.rs`; that cleared when the file landed, and nothing has replaced it.

`couple` checks 0 paths because every changed file is either a `spec.md` whose own spec moved or a `.derived/` shard on the bypass floor.

## What ratification does not assert

Spec 041 §3.3 is explicit and worth repeating at the moment the flip happens: this verifies **existence, not behavior**. `approved` + `complete` now means every claimed unit resolves to something real and the corpus compiles, lints and resolves around it. It does not mean the code does what the prose says, and no mechanical gate in this project can mean that.