### PR TITLE
docs: catch the docs surface up with specs 037-044 and tidy two loose ends

### DIFF
--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8dbf2ce0a95323d16e647f5ab8c71d5b6746ffb6032ab66d670c37baf5c6a19f"
+  "shardHash": "acc0a3ae7a54ea0972bc6d8fa48a095fc9e810f8635c0f23ffa63ea66201c4e7"
 }

--- a/.derived/spec-registry/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/spec-registry/by-spec/000-spec-spine-bootstrap.json
@@ -5,6 +5,7 @@
     ],
     "created": "2026-06-08",
     "id": "000-spec-spine-bootstrap",
+    "implementation": "complete",
     "kind": "constitutional-bootstrap",
     "origin": {
       "retroactive": true
@@ -38,6 +39,6 @@
       "refusal-rule"
     ]
   },
-  "shardHash": "8a81c6d20b380f4f2c8beee60b6520a2044beaffd853f3b149f2059164e6357d",
+  "shardHash": "46f7dde94b700dd3376c3392cc0fd5ed66c5508b0e2ef9fb9bb6f5911c0429df",
   "specVersion": "1.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ The protocol drives the library through its own built binary, `target/release/sp
    - `spec-spine index render`: markdown projection of the committed index
    - `spec-spine index coverage`: which source files no spec specifically claims (spec 032; non-fatal, exit 2 if the index is stale)
    - `spec-spine registry status-report --json --nonzero-only`: lifecycle counts per status
+   - `spec-spine registry plan`: the ready set (spec 038): which specs can be worked on now and what blocks the rest; `(nothing ready)` in a finished corpus
    - `spec-spine registry list --ids-only`: spec id list (for latest-spec detection)
    - `ls crates/`: library crate layout
    - `ls specs/`: the spec corpus
@@ -36,7 +37,8 @@ The protocol drives the library through its own built binary, `target/release/sp
    - `git diff --stat HEAD~1`: last change summary
 2. **Emit** the `## initialized: spec-spine` summary block: a layer/crate
    overview, a `## lifecycle:` sub-section populated from the
-   `registry status-report --nonzero-only` output, recent activity, and a
+   `registry status-report --nonzero-only` output (with the `registry plan`
+   ready/blocked line beneath it), recent activity, and a
    "ready to help with" line.
 
 **Read discipline:** the init protocol MUST NOT parse `.derived/**/*.json` directly (no `python`, `jq`, `awk`, `sed` against compiled artifacts). All structural and lifecycle data comes from the `spec-spine` subcommands (`registry`, `index`) and the rendered markdown view. See `.claude/rules/governed-artifact-reads.md`.

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -151,17 +151,27 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                     .map_err(|e| Error::Io(format!("remove {}: {e}", legacy.display())))?;
             }
 
+            // Print both tiers. Spec 025 downgrades an unresolved unit on an
+            // in-flight spec (or a `references` edge) to a counted `W-001` /
+            // `W-002`; those land in the shard either way, but a warning the
+            // operator never sees is a unit that quietly went unresolved.
             let idx = &outcome.index;
-            for diag in &idx.diagnostics.errors {
+            for diag in idx
+                .diagnostics
+                .errors
+                .iter()
+                .chain(idx.diagnostics.warnings.iter())
+            {
                 let at = diag.path.as_deref().unwrap_or("-");
                 eprintln!("  {} [{}] {}", diag.code, at, diag.message);
             }
             outln!(
-                "indexed {} package(s), {} mapping(s) -> {} ({} error diagnostic(s))",
+                "indexed {} package(s), {} mapping(s) -> {} ({} error diagnostic(s), {} warning(s))",
                 idx.packages.len(),
                 idx.traceability.mappings.len(),
                 dir.display(),
-                idx.diagnostics.errors.len()
+                idx.diagnostics.errors.len(),
+                idx.diagnostics.warnings.len()
             );
             Ok(0)
         }

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -236,6 +236,7 @@ divergence observed across the reference repos. Every sub-table is
 | `domains.allowed` | closed enum for the optional `domain` field; **empty ⇒ disabled** (free-text) | `[]` |
 | `kind.allowed` | closed enum for the optional `kind` field; symmetric with `domains` | `[]` |
 | `layout.specs_dir` / `derived_dir` / `standards_dir` / `schemas_dir` | path conventions, never hardcoded | `specs` / `.derived` / `standards/spec` / `standards/schemas` |
+| `layout.state_dir` | one repo-relative directory for the state of tools built around spec-spine (spec 039); bypassed by `couple`, excluded from `coverage`, never resolved or hashed, never read or written by spec-spine; must not overlap `specs_dir` / `derived_dir` | `""` (nothing declared) |
 | `layout.cargo_workspace` | root Cargo workspace manifest | `Cargo.toml` |
 | `layout.npm_workspaces` | manifests that *declare* npm/pnpm workspace members | `["package.json", "pnpm-workspace.yaml"]` |
 | `layout.standalone_rust_workspaces` / `standalone_npm_packages` | crates/packages outside the root workspace | `[]` |

--- a/docs/api.md
+++ b/docs/api.md
@@ -235,6 +235,7 @@ pub fn compile_json        (config_json: &str, repo_root: &str) -> Result<String
 pub fn index_json          (config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn lint_json           (config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error>;
+pub fn check_registry_freshness_json(config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn coverage_json       (config_json: &str, repo_root: &str) -> Result<String, Error>;
 pub fn couple_json         (request_json: &str)                 -> Result<String, Error>;
 pub fn query_json          (request_json: &str)                 -> Result<String, Error>;
@@ -242,16 +243,35 @@ pub fn render_json         (config_json: &str, index_json: &str) -> Result<Strin
 pub fn orphans_json        (index_json: &str)                    -> Result<String, Error>;
 pub fn load_config_json    (toml_src: &str)                     -> Result<String, Error>;
 pub fn scaffold_init_json  (config_json: &str)                  -> Result<String, Error>;
+pub fn attest_json         (config_json: &str, repo_root: &str, with_coupling: bool) -> Result<String, Error>;
+pub fn attest_spec_json    (config_json: &str, repo_root: &str, spec_id: &str)       -> Result<String, Error>;
+pub fn verify_attestation_json     (request_json: &str)         -> Result<String, Error>;
+pub fn verify_spec_attestation_json(request_json: &str)         -> Result<String, Error>;
 ```
 
 - `config_json` is a JSON object matching `Config`; `"{}"` ⇒ `Config::default()`.
 - `query_json` request: `{ "registry": "<registry.json text>", "op":
-  "list" | "show" | "status-report" | "relationships", "id"?: string,
+  "list" | "show" | "status-report" | "relationships" | "plan", "id"?: string,
   "status"?: string, "idsOnly"?: bool, "nonzeroOnly"?: bool }` (the projection
-  fields, spec 010, default to `false`).
+  fields, spec 010, default to `false`). `plan` (spec 038) returns
+  `{ "ready": [ids], "blocked": [{ "id", "blockedBy": [{ "id", "state" }] }] }`.
 - `couple_json` request: `{ "config"?: Config, "repoRoot": string, "diff":
   DiffInput, "waiver"?: { "reason": string } }`.
 - `check_freshness_json` returns `{ "fresh": bool, "expected"?, "actual"? }`.
+  `check_registry_freshness_json` (spec 031) returns the same shape for the
+  committed registry shards; staleness only, the validation verdict rides on
+  `compile_json`.
+- `attest_json` (spec 023) and `attest_spec_json` (spec 042) return
+  `{ "attestation": <CorpusAttestation | SpecAttestation>, "attestationHash":
+  "<hex>" }`. Both are pure: no key, no clock (signing is a CLI post-pass). A
+  failing verdict still yields a payload; attestation is a record, not a gate.
+- `verify_attestation_json` / `verify_spec_attestation_json` request:
+  `{ "config"?: Config, "repoRoot": string, "attestation": <...> }`; they return
+  `{ "outcome": "match" }`, `{ "outcome": "versionMismatch", "expected",
+  "actual" }`, or `{ "outcome": "contentMismatch", "differences": [...] }`.
+- The CLI's `--json` verdict envelope (spec 037) wraps these payloads verbatim
+  under `report`, versioned by `VERDICT_SCHEMA_VERSION`; see
+  `specs/037-machine-readable-verdicts/spec.md`.
 - `coverage_json` (spec 032) returns the `CoverageReport`: `sourceFiles`,
   `claimedFiles`, the sorted `floorOnlyFiles` / `unclaimedFiles` lists, and
   per-package counts. A stale committed index is `Error::Stale`, not a report.

--- a/kit/AGENTS.md
+++ b/kit/AGENTS.md
@@ -37,6 +37,7 @@ picked up on the next init.
    - `spec-spine compile --check`: freshness gate for the spec registry (non-fatal; see **Registry freshness** below)
    - `spec-spine index check`: staleness gate for the codebase index (non-fatal)
    - `spec-spine registry status-report --json --nonzero-only`: lifecycle counts
+   - `spec-spine registry plan`: the ready set (spec 038): which specs can be worked on now and what blocks the rest
    - `spec-spine registry list --ids-only`: spec inventory (for latest-spec detection)
    - `ls <your source dirs>`: application surface discovery
    - `ls docs/`: docs surface

--- a/specs/000-spec-spine-bootstrap/spec.md
+++ b/specs/000-spec-spine-bootstrap/spec.md
@@ -2,6 +2,7 @@
 id: "000-spec-spine-bootstrap"
 title: "Bootstrap spec system (markdown → compiled JSON authority ledger)"
 status: approved
+implementation: complete
 kind: "constitutional-bootstrap"
 created: "2026-06-08"
 authors:

--- a/website/docs/claude-code/session-init.md
+++ b/website/docs/claude-code/session-init.md
@@ -43,6 +43,7 @@ frontmatter), then dispatch simultaneously:
 - your contract and constitution documents under `standards/`
 - `spec-spine index check` (staleness gate, non-fatal)
 - `spec-spine registry status-report --json --nonzero-only` (lifecycle counts)
+- `spec-spine registry plan` (the ready set: what can be worked on now, and what blocks the rest)
 - `spec-spine registry list --ids-only` (spec id list)
 - directory listings for your source surfaces
 - `git log --oneline -10` and `git diff --stat HEAD~1`

--- a/website/docs/cli/attest.md
+++ b/website/docs/cli/attest.md
@@ -1,0 +1,106 @@
+---
+id: attest
+title: spec-spine attest
+sidebar_position: 8
+---
+
+# spec-spine attest / verify-attestation
+
+A signed, reproducible record of what the corpus (or one spec) looked like and
+what the gates said about it. `attest` writes the record; `verify-attestation`
+checks that a record still reproduces from the tree, or that its detached seal
+verifies against a public key.
+
+## Usage
+
+```bash
+spec-spine attest [--with-coupling] [--sign --key FILE [--key-id ID]] [--json]
+spec-spine attest --spec <id> [--sign --key FILE] [--json]
+spec-spine verify-attestation --recompute [--attestation FILE] [--json]
+spec-spine verify-attestation --signature --public-key FILE [--seal FILE] [--json]
+spec-spine verify-attestation --spec <id> --recompute [--json]
+```
+
+## Description
+
+### Corpus scope (spec 023)
+
+`attest` compiles the corpus in memory, records the compile, lint and (with
+`--with-coupling`) coupling verdicts together with the registry content hash,
+and writes `<derived_dir>/attestation/attestation.json`. The payload is a pure
+function of the tree: no clock, no signer, no environment. With `--sign` the CLI
+adds a detached Ed25519 seal (`attestation.json.sig`) over the attestation hash.
+The seal, not the payload, is where the key and any timestamp live, so the
+payload stays byte-reproducible by anyone.
+
+### Per-spec scope (spec 042)
+
+`attest --spec <id>` narrows the subject to one spec and writes
+`<derived_dir>/attestation/by-spec/<id>.json`. The payload carries:
+
+- `specSourceHash`: the normalized `spec.md` bytes.
+- `lifecycle`: the spec's declared `status` and `implementation`.
+- `units`: every **owning** unit, in registry order, with the content hash of
+  what it resolved to. Non-owning `references` units are excluded.
+- `verdicts`: `compile`, `resolution` (did every owning unit resolve) and `lint`
+  (with a hash over that spec's canonical findings).
+
+This is the artifact an autonomous builder hands over when it says a spec is
+done: the yardstick records the claim and the evidence, the builder does not
+grade itself. **A failing verdict still yields a payload.** `attest` is a record,
+not a gate, so exit `0` means only that an attestation was written. Read
+`verdicts` (or the `--json` envelope) for the outcome. No lint rule consumes a
+per-spec attestation, so the record can never feed back into the verdict it
+records.
+
+Neither file is committed: `.derived/attestation/` is gitignored. A per-spec
+attestation hashes every claimed unit's bytes, so committing it would restale on
+every code edit and would need its own freshness gate.
+
+### `verify-attestation`
+
+- **`--recompute`** re-reads the corpus and checks that the attestation
+  reproduces, keyless. A `tool.version` mismatch is reported as its own outcome
+  (`versionMismatch`), never as a false content mismatch.
+- **`--signature`** checks the detached seal against `--public-key`.
+- Both modes accept `--spec <id>` to verify the per-spec record instead.
+
+## Flags
+
+| Flag | Verb | Effect |
+|---|---|---|
+| `--spec <id>` | both | Scope to one spec (`by-spec/<id>.json`). |
+| `--with-coupling` | attest | Also record the coupling (specs-and-code-in-sync) verdict. |
+| `--sign` / `--key <PATH>` | attest | Produce a detached Ed25519 seal. The key is a 32-byte seed, raw or hex. |
+| `--key-id <ID>` | attest | Override the seal's key id (defaults to the hex public key). |
+| `--recompute` | verify | Recompute from the tree and compare. |
+| `--signature` / `--public-key <PATH>` | verify | Check the seal. The key is 32 bytes, raw or hex. |
+| `--attestation <PATH>` / `--seal <PATH>` | verify | Override the default file locations. |
+| `--json` | both | Emit the [verdict envelope](./overview.md#machine-readable-verdicts---json) on stdout. |
+
+## Exit Codes
+
+- **`attest`:** `0` an attestation was written (regardless of the verdicts it
+  records) · `1` the spec id was not found · `3` I/O, parse, schema, or config
+  error.
+- **`verify-attestation`:** `0` the attestation reproduces / the seal verifies ·
+  `1` verification failed · `3` I/O, parse, schema, or config error.
+
+## Example
+
+```bash
+$ spec-spine attest --spec 042-per-spec-attestation
+attested 042-per-spec-attestation -> .derived/attestation/by-spec/042-per-spec-attestation.json
+  attestationHash: cf10f56d53f98d2ba12c7b60510c6f089cb219458965be2f32669cd4761e2a97
+
+$ spec-spine verify-attestation --spec 042-per-spec-attestation --recompute --json
+{
+  "exitCode": 0,
+  "ok": true,
+  "report": {
+    "outcome": "match"
+  },
+  "schemaVersion": "0.1.0",
+  "verb": "verify-attestation"
+}
+```

--- a/website/docs/cli/compile.md
+++ b/website/docs/cli/compile.md
@@ -11,7 +11,7 @@ Validates spec frontmatter and emits the deterministic registry.
 ## Usage
 
 ```bash
-spec-spine compile [--check]
+spec-spine compile [--check [--json]]
 ```
 
 ## Description
@@ -29,6 +29,8 @@ The output is written as per-unit registry shards to `.derived/spec-registry/by-
 - **orphaned**: a committed shard with no matching spec (a spec was removed without recompiling).
 
 Use it in CI if you commit `.derived/`. It never writes: no shard, no `build-meta.json`, no pruning.
+
+`--check --json` emits the [verdict envelope](./overview.md#machine-readable-verdicts---json) (`verb: "compile.check"`, `report: { "fresh": bool, ... }`) instead of prose. The writing form has no `--json`.
 
 :::warning
 Do not run `compile --check` after a plain `spec-spine compile` in the same job. The check would compare the committed shards against files that run just overwrote, and would pass unconditionally. `--check` compiles on its own, so it replaces the plain `compile` step rather than following it.

--- a/website/docs/cli/couple.md
+++ b/website/docs/cli/couple.md
@@ -11,7 +11,7 @@ The PR-time drift gate. It joins the registry and index against a Git diff and r
 ## Usage
 
 ```bash
-spec-spine couple --base <ref> --head <ref> [--pr-body FILE] [--paths-from FILE]
+spec-spine couple --base <ref> --head <ref> [--pr-body FILE] [--paths-from FILE] [--json]
 ```
 
 ## Description
@@ -30,6 +30,7 @@ It uses `git diff --no-color -U0 base...head` to determine the changed paths.
 | `--head` | Git ref | Yes | The head commit of the PR (e.g., `HEAD`). |
 | `--pr-body` | File path | No | A file containing the PR body text, used to scan for waivers. |
 | `--paths-from` | File path | No | Read a list of changed paths from a file instead of running `git diff`. |
+| `--json` | None | No | Emit the [verdict envelope](./overview.md#machine-readable-verdicts---json) (`verb: "couple"`, `report` = the coupling report) instead of prose. The exit code is unchanged. |
 
 ## Waivers
 

--- a/website/docs/cli/index.md
+++ b/website/docs/cli/index.md
@@ -12,7 +12,7 @@ Scans manifests and specs to emit the codebase index, and provides staleness che
 
 ```bash
 spec-spine index
-spec-spine index check [--slice NAME]
+spec-spine index check [--slice NAME] [--json]
 spec-spine index render
 spec-spine index orphans [--json]
 spec-spine index coverage [--json] [--fail-on-untraced]
@@ -29,6 +29,7 @@ Scans the repository for manifests (e.g., `Cargo.toml`, `package.json`) and spec
 The staleness gate. It recomputes the content hash of the current inputs and compares it against the committed index shards.
 
 - **`--slice NAME`**: Checks staleness for a specific named slice defined in `[index.slices]` in the config, rather than the global content hash.
+- **`--json`**: Emit the [verdict envelope](./overview.md#machine-readable-verdicts---json) (`verb: "index.check"`) instead of prose.
 
 ### `index render`
 

--- a/website/docs/cli/lint.md
+++ b/website/docs/cli/lint.md
@@ -11,7 +11,7 @@ Checks the corpus for conformance and well-formedness.
 ## Usage
 
 ```bash
-spec-spine lint [--fail-on-warn] [--fail-on-info]
+spec-spine lint [--fail-on-warn] [--fail-on-info] [--json]
 ```
 
 ## Description
@@ -26,6 +26,7 @@ By default, it exits with status `1` only if there are error-tier violations.
 |---|---|---|---|
 | `--fail-on-warn` | None | false | Exit 1 if there are any warn-tier violations. |
 | `--fail-on-info` | None | false | Exit 1 if there are any info-tier violations. |
+| `--json` | None | false | Emit the [verdict envelope](./overview.md#machine-readable-verdicts---json) (`verb: "lint"`, `report` = the findings list) instead of prose. The exit code is unchanged. |
 
 ## Exit Codes
 

--- a/website/docs/cli/overview.md
+++ b/website/docs/cli/overview.md
@@ -22,7 +22,7 @@ Exit codes are a stable contract across the entire CLI surface:
 |---|---|
 | `0` | Success / OK. |
 | `1` | Validation failure, not-found, or coupling drift. |
-| `2` | Staleness (committed index is out of date). |
+| `2` | Staleness (a committed registry or index shard is out of date). |
 | `3` | I/O, parse, schema, or config error. |
 
 ## Command Surface
@@ -32,8 +32,30 @@ Exit codes are a stable contract across the entire CLI surface:
 | [`spec-spine init`](init.md) | Scaffold a new adopter (config, standards, specs/000, rules). |
 | [`spec-spine compile`](compile.md) | Validate frontmatter and emit the deterministic registry. |
 | [`spec-spine index`](index.md) | Scan manifests and specs to emit the codebase index. Includes `check`, `render`, and `orphans` subcommands. |
-| [`spec-spine registry`](registry.md) | Typed read-only queries against the compiled registry. Includes `list`, `show`, `status-report`, and `relationships`. |
+| [`spec-spine registry`](registry.md) | Typed read-only queries against the compiled registry. Includes `list`, `show`, `status-report`, `relationships`, and `plan` (the ready set). |
 | [`spec-spine lint`](lint.md) | Check corpus conformance. |
 | [`spec-spine couple`](couple.md) | The PR-time drift gate. |
+| [`spec-spine attest` / `verify-attestation`](attest.md) | A signed, reproducible record of the gate verdicts over the corpus or one spec (`--spec`), and its verification. |
 
-*(Note: Additional commands like `attest` and `verify-attestation` may be present in the binary but are considered advanced/experimental surface outside the core workflow.)*
+## Machine-readable verdicts (`--json`)
+
+The verbs that render a **verdict** (`compile --check`, `index check`, `lint`, `couple`, `attest`, `verify-attestation`) take `--json` (spec 037). Under the flag a verb writes exactly one JSON object to stdout:
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "verb": "couple",
+  "ok": false,
+  "exitCode": 1,
+  "report": { }
+}
+```
+
+- `verb` is the stable dotted command path (`compile.check`, `index.check`, `lint`, `couple`, `attest`, `verify-attestation`).
+- `ok` always equals `exitCode == 0`.
+- `report` carries the verb's library facade output verbatim (the same bytes the matching `*_json` function returns), so there is one payload shape per verb.
+- On failure `error` replaces `report`: `{ "kind", "message" }`, where `kind` is one of `config`, `validation`, `not-found`, `stale`, `io`, `parse`, `schema`. Exactly one of `report` / `error` is present.
+
+**The flag changes what is written, never what is decided.** Every exit code is identical with and without it, so a driver reads the exit code for control flow and the envelope for reasons, and the two can never disagree. The envelope carries its own `schemaVersion` (`VERDICT_SCHEMA_VERSION`, independent of the registry and index versions) under the usual MINOR-is-additive discipline.
+
+`spec-spine compile` (the writing form) deliberately has no `--json`: it mutates `.derived/`, and the verdict that is machine-readable is `compile --check`.

--- a/website/docs/cli/registry.md
+++ b/website/docs/cli/registry.md
@@ -15,6 +15,7 @@ spec-spine registry list [--status S] [--ids-only] [--json]
 spec-spine registry show <id> [--json]
 spec-spine registry status-report [--nonzero-only] [--json]
 spec-spine registry relationships <id> [--json]
+spec-spine registry plan [--json]
 ```
 
 ## Subcommands
@@ -46,6 +47,18 @@ Shows the relationship neighborhood (incoming and outgoing edges) for a specific
 
 - **`--json`**: Output as JSON.
 
+### `registry plan`
+
+The ready set (spec 038): which specs a scheduler may hand out now, and what blocks the rest.
+
+- **Excluded** from the output entirely: `status` is `superseded` or `retired`, or `implementation` is `complete`, `n-a` or `deferred`. A spec with no `implementation` key counts as `pending`.
+- **Blocked**: at least one `depends_on` target is not finished (neither `complete` nor `n-a`). Each blocker is named with its `state`; a `depends_on` target that does not resolve to a spec blocks with `state: "unresolved"` rather than being ignored.
+- **Ready**: everything else, in dependency (topological) order, ties broken by id.
+
+`implementation` is a hint to the scheduler, never evidence that a spec is done; the evidence is the indexer's verdict, recorded by [`attest --spec`](./attest.md). See [Lifecycle and Completion](../concepts/lifecycle.md).
+
+- **`--json`**: Output `{ "ready": [ids], "blocked": [{ "id", "blockedBy": [{ "id", "state" }] }] }`.
+
 ## Exit Codes
 
 - `0`: OK.
@@ -59,4 +72,8 @@ $ spec-spine registry list --status approved --ids-only
 000-bootstrap
 001-compile-registry
 002-registry-query
+
+$ spec-spine registry plan
+045-next-thing
+ready: 1, blocked: 0
 ```

--- a/website/docs/concepts/lifecycle.md
+++ b/website/docs/concepts/lifecycle.md
@@ -1,0 +1,105 @@
+---
+id: lifecycle
+title: Lifecycle and Completion
+sidebar_position: 8
+---
+
+# Lifecycle and Completion
+
+Three frontmatter keys describe where a spec is in its life, and since specs
+038, 041, 043 and 044 they are **lifecycle keys with mechanical consequences**,
+not descriptive metadata:
+
+| Key | Values | What the tool does with it |
+|---|---|---|
+| `status` | `draft`, `approved`, `superseded`, `retired` | The ratification state. Drives `registry list --status` and the in-flight predicate below. |
+| `implementation` | `pending`, `in-progress`, `complete`, `n-a`, `deferred` (or absent) | How far the work has got. Drives `registry plan` and the in-flight predicate below. |
+| `depends_on` | spec ids | Which specs must land first. A cycle is a compile-time refusal (spec 033); the acyclic graph orders `registry plan`. |
+
+## Done is not self-authored
+
+The central rule (spec 041): **a spec that declares itself complete is held to
+its claims.** `implementation: complete` is a claim that every owning unit
+exists and resolves, and the indexer checks it. If a complete spec owns a file
+that is not there, that is a hard `I-0xx` error on `spec-spine index`, whatever
+the spec's `status`. Draft leniency does not survive a completion claim.
+
+The opposite side is that openly unfinished work is legal. A spec that is
+**in flight** gets a counted, non-blocking `W-001` warning for an owning unit
+that does not exist yet (spec 025), so a spec can be filed, and even ratified,
+before its code is written.
+
+## The in-flight predicate
+
+| `status` | `implementation` | in flight | unresolved owning unit |
+|---|---|---|---|
+| draft | pending, in-progress, n-a, deferred, absent | yes | `W-001` warning |
+| draft | **complete** | **no** | **`I-0xx` error** |
+| approved | pending | yes | `W-001` warning |
+| approved | **in-progress** | **yes** (spec 044) | `W-001` warning |
+| approved | complete, n-a, deferred, absent | no | `I-0xx` error |
+
+Two things fall out of the table:
+
+- `complete` is decisive on both sides of the `status` flip. Ratifying a
+  complete spec changes nothing about how its units are judged.
+- `approved` + `in-progress` is in flight (spec 044). A corpus that ratifies
+  first and builds second, which is the natural shape for an autonomous builder,
+  is not forced to leave its specs as `draft` to stay green.
+
+## The ready set: `registry plan`
+
+`spec-spine registry plan` (spec 038) partitions the registry into what a
+scheduler may hand out now and what it may not:
+
+- **Excluded** (absent from the output): `status` is `superseded` or `retired`,
+  or `implementation` is `complete`, `n-a` or `deferred`. A spec with no
+  `implementation` key counts as `pending`.
+- **Blocked**: at least one `depends_on` target is not finished (neither
+  `complete` nor `n-a`). Every blocker is named with its state; a target that
+  does not resolve to a spec blocks with `state: "unresolved"` rather than being
+  ignored.
+- **Ready**: everything else, in dependency order.
+
+`deferred` is the one value that records a decision rather than a state, so a
+deferred spec is never offered as ready and never silently returns to the
+schedule when its dependencies land. Un-deferring is a human edit.
+
+`implementation` is a hint to the scheduler, never evidence of completion. The
+evidence is the indexer's verdict, and the record of it is
+[`attest --spec`](../cli/attest.md).
+
+## Amending without editing the predecessor
+
+Spec 040 fixes the authoring rule for `amends`: the edge is declared in the
+**amending** spec's frontmatter, and only there. The amended `spec.md` is never
+edited to record that it has been amended: no back-pointer, no "narrowed by NNN"
+note. Discovery is a compiled read (`registry relationships <id>` shows incoming
+`amends` edges), not a prose pointer, so the predecessor's source hash stays
+stable and its history stays honest. The coupling gate is unchanged: a path
+owned by the predecessor still clears through either spec.
+
+The constitution is the case `amends` does not cover (spec 043). It is not a
+spec, so an ordinary approved spec changes it by **claiming the affected
+constitution text as an authority unit**: `establishes` a `section` unit on the
+anchor for a principle it adds, `refines` it (with a named `aspect`) for one it
+tightens, `co_authority` where a principle is shared, never contradicting an
+`unamendable` anchor of spec 000. The constitution itself is then edited in
+place. That claim is a ledger fact, not a gate refusal: `standards/spec/` sits on
+the coupling gate's bypass floor, so the edge buys discoverability
+(`registry relationships`, `index render`), not enforcement.
+
+## Adopted code is specced as found
+
+Spec 043 gives constitution principle V its operational half. Code adopted from
+outside the corpus is specced **as found**: the adopting spec describes the
+behavior that exists and records the behavior it would not have chosen under a
+`## Known defects` heading, with each defect named. A defect recorded there is
+not blessed; it is the reason a later spec can be written against it.
+`origin.retroactive: true` still marks *when* the authority began, and is
+orthogonal.
+
+The scaffold `spec-spine init` writes carries all of this: the constitution it
+generates states the amendment mechanism and principle V in this form, and the
+contract points at it, so an adopter's first corpus does not inherit the gaps the
+first adopter hit.

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -32,6 +32,9 @@ allowed = []
 [layout]
 specs_dir = "specs"
 derived_dir = ".derived"
+# Optional: one repo-relative directory where tools around spec-spine keep
+# their state. Declared so the gates recognize it; never read or written.
+state_dir = ""
 standards_dir = "standards/spec"
 schemas_dir = "standards/schemas"
 cargo_workspace = "Cargo.toml"
@@ -82,6 +85,7 @@ extra_known_keys = []
 
 ### `[layout]`
 - Defines the directory structure conventions. 
+- **`state_dir`** (spec 039): one repo-relative directory that tools built around spec-spine (an autonomous builder, a driver) may use for their own state. Unset (the default, `""`) declares nothing and changes nothing. When set, every path beneath it is bypassed by `couple`, excluded from `index coverage` entirely (not counted in the denominator), never scanned by the resolver, and never folded into a content hash, so a tool writing its own state can never restale the committed ledger. spec-spine never reads or writes it. It must not overlap `specs_dir` or `derived_dir` in either direction (equal, containing, or contained); config load refuses such a value. A spec that claims a unit inside it is a lint finding. Matching is separator-aware (`state` does not match `stateful/`).
 - **`npm_workspaces`**: Manifests that declare npm/pnpm workspace members. The indexer reads member globs from whichever exists.
 - **`standalone_*`**: Use these arrays to specify crates or packages that live outside the root workspace.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
         'concepts/determinism',
         'concepts/constitutional-hierarchy',
         'concepts/waivers',
+        'concepts/lifecycle',
       ],
     },
     {
@@ -34,6 +35,7 @@ const sidebars: SidebarsConfig = {
         'cli/registry',
         'cli/lint',
         'cli/couple',
+        'cli/attest',
       ],
     },
     {


### PR DESCRIPTION
## What

Pre-release docs sweep for v0.14.0, plus two small corrections.

The website, `docs/api.md`, the adoption guide and the `/init` protocol had no mention of anything specs 037–044 shipped. This PR closes that:

- **website**: new `cli/attest` page (spec 023 + 042, incl. `--spec`); new `concepts/lifecycle` page (the 041/044 in-flight predicate, `registry plan`, the 040 amendment rule, 043's constitution mechanism and "specced as found"); a `--json` verdict-envelope section on the CLI overview, with the flag listed on every adjudicating verb's page; `registry plan` on the registry page; `layout.state_dir` on the configuration page; the "attest is experimental" disclaimer removed. `npm run build` is clean (no broken links or anchors).
- **docs/api.md**: the facade functions added since the list was written (`check_registry_freshness_json`, `attest_json`, `attest_spec_json`, `verify_attestation_json`, `verify_spec_attestation_json`) and the `plan` query op.
- **docs/adoption-guide.md**: `layout.state_dir` in the knob table.
- **AGENTS.md / kit/AGENTS.md / session-init.md**: `/init` also reads `registry plan`, so a session opens knowing the ready set.

Two corrections found on the way:

- **specs/000 gains `implementation: complete`.** It was the only spec without the key, which spec 038 §3.1 reads as `pending`, so `registry plan` offered the bootstrap spec as the one thing ready to work on in a fully built corpus. Gate behavior is unchanged: `approved` + absent was already not in flight under 041 §3.1, and `complete` is not in flight either. Registry and index shards for 000 regenerated; `compile --check` and `index check` fresh.
- **`spec-spine index` now prints `diagnostics.warnings`** (W-001 / W-002) beside errors, and counts them in its summary line. Spec 025 FR-004 puts them in the shard (surface and count, never skip), but no verb displayed them, so the write verb reported "0 error diagnostic(s)" while silently recording warnings.

## Gate

```
compile --check   0  fresh, 45 shards
index check       0  fresh
lint --fail-on-warn  0
registry plan     (nothing ready), blocked: 0
cargo test / clippy -D warnings / fmt --check  green
```

Spec-Drift-Waiver: `crates/spec-spine-cli/src/cmd_index.rs` only prints the `diagnostics.warnings` tier that spec 025 FR-004 already requires the shard to record (a CLI projection of a specified field, no verdict or exit-code change); `kit/AGENTS.md` adds one `registry plan` read to the init step list, mirroring the same line in the root AGENTS.md (spec 029's kit is a vendored copy, no kit contract change).
