### PR TITLE
chore(release): bump package version to 0.14.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.13.0"
+    "version": "0.14.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a39aaa8a01550defcc672721b7af056b5998ee0be862caf3a2648ffa7a273b9f"
+  "shardHash": "9c0602009662f828a5a913e0b7a2c5bb2b5115de46d77081d6c8e3506a7caca2"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "3"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.13.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.13.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.14.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.14.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.13.0",
-    "@spec-spine/cli-darwin-x64": "0.13.0",
-    "@spec-spine/cli-linux-x64": "0.13.0",
-    "@spec-spine/cli-linux-arm64": "0.13.0",
-    "@spec-spine/cli-win32-x64": "0.13.0"
+    "@spec-spine/cli-darwin-arm64": "0.14.0",
+    "@spec-spine/cli-darwin-x64": "0.14.0",
+    "@spec-spine/cli-linux-x64": "0.14.0",
+    "@spec-spine/cli-linux-arm64": "0.14.0",
+    "@spec-spine/cli-win32-x64": "0.14.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.13.0"
+version = "0.14.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares **v0.14.0**. Version-bump only; the tag is pushed after this merges.

## What ships

The **agentic-builder substrate**, specs 037–044 (PRs #89–#101), ratified 45/45 approved in #101, plus the docs sweep and two tidy-ups in #102.

- **037 · machine-readable verdicts.** `compile --check`, `index check`, `lint`, `couple`, `attest` and `verify-attestation` take `--json` and write one versioned envelope (`schemaVersion`, `verb`, `ok`, `exitCode`, `report` | `error`). The flag changes what is written, never what is decided: exit codes are identical with and without it. New `VERDICT_SCHEMA_VERSION` (0.1.0), independent of the registry and index versions.
- **038 · `registry plan`.** The ready set in dependency order: which specs can be worked on now, and for each blocked one, every blocker and its state (`pending`, `in-progress`, `deferred`, or `unresolved` for a dangling `depends_on`). `deferred` records a decision and is never re-offered.
- **039 · `layout.state_dir`.** One declared, ungoverned root for the state of tools around spec-spine: bypassed by `couple`, excluded from `coverage`, never resolved, never hashed, never read or written by spec-spine. Refused if it overlaps `specs_dir` or `derived_dir`.
- **040 · amendment authoring.** `amends` lives in the amending spec's frontmatter and only there; the amended spec is never edited to record it. Discovery is a compiled read (`registry relationships`).
- **041 · completion is held to its claims.** `implementation: complete` defeats draft leniency: an unresolved owning unit on a complete spec is a hard error whatever the `status`. Done is not self-authored.
- **042 · per-spec attestation.** `attest --spec <id>` / `verify-attestation --spec <id>`: a signed, reproducible record of one spec's source hash, lifecycle, owning-unit content hashes and gate verdicts. A record, not a gate: exit 0 means an attestation was written. Not committed, by decision. New `SPEC_ATTESTATION_SCHEMA_VERSION` (0.1.0).
- **043 · governance document gaps.** The constitution now states its own amendment mechanism (claim the section as an authority unit; `amends` is not the instrument), `depends_on` and `implementation` are named lifecycle keys with mechanical consequences, and constitution V gains its operational half: adopted code is specced as found, defects recorded under `## Known defects`. The `init` scaffold ships all three.
- **044 · `in-progress` is in flight.** `approved` + `in-progress` is in flight, so a corpus that ratifies before building stays green while the work is openly underway.

Also: `spec-spine index` now prints the W-001/W-002 warnings it records, and the docs site gained `cli/attest` and `concepts/lifecycle` pages plus the `--json` envelope reference (#102).

## Version axes

**Package version only: 0.13.0 -> 0.14.0.** Registry and index schemas stay at **1.1.0**; no DTO in either moved. The two schema constants this series introduced (`VERDICT_SCHEMA_VERSION`, `SPEC_ATTESTATION_SCHEMA_VERSION`) start at 0.1.0 and are independent axes. `CONFIG_VERSION` stays 0.1.0, as it has for every additive config key. MINOR, not patch: 041 adds a refusal that can newly fail a previously-passing corpus (`complete` with a missing unit).

## Pre-flight (runbook `docs/releasing.md`)

| check | result |
|---|---|
| `cargo test --workspace --locked` | green |
| `cargo clippy -D warnings` / `cargo fmt --check` | green (on #102's tree; no Rust source changed here) |
| `bump_version.py --check 0.14.0` | all locations agree |
| `Cargo.lock` regenerated after the bump | yes |
| `cargo package --workspace --locked` | exit 0, all three crates verify from packaged sources |
| `compile --check` / `index check` | fresh |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `index coverage --fail-on-untraced` | 66/66, exit 0 |
| `registry plan` | (nothing ready), blocked: 0 |
| corpus | 45/45 approved |

Only one derived shard moved (`by-package/spec-spine.json`, which records the npm package version).

## Waiver

The gate reports the two violations every version-bump PR reports. Spec 030's auto-waiver correctly does **not** fire here: a package's own `version` field is not a dependency edit, so this needs the standing manual waiver.

Spec-Drift-Waiver: A release version bump. `npm/package.json` and `py/pyproject.toml` change only their `version` field and the version-locked `optionalDependencies` pins, which specs 007 and 008 require to track the tag; neither spec's behavior changes, so there is nothing to author in them. This is the standing waiver every version-bump PR carries (cf. #57, #80, #88).
