### PR TITLE
chore(045-047): ratify the adopter-audit specs (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -133,8 +133,8 @@
       }
     ],
     "specId": "045-absent-implementation-defers-to-status",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0cf266327d2e896df57570103177ad72ddb825136f8aa657f1a31349dc475079"
+  "shardHash": "e588f6fbc27a0c2963c13fd39e5fbdd0358bdc77b5e69ccd20748311908071a3"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -72,8 +72,8 @@
       }
     ],
     "specId": "046-kit-hooks-read-never-write",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "053a1397ee9eece4dd36478a6ca35cbf6b8e47721d17b97be446eb49e4a658ac"
+  "shardHash": "9d90e654b6546419797241162313375ed866df5f27eb17a2934928e8bc4260b8"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -197,8 +197,8 @@
       }
     ],
     "specId": "047-harness-rules-name-the-legitimate-edits",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f16fe6061b79ab1446c636fe350abd5781fa3080e0b57a9c2795ee2baded3fb7"
+  "shardHash": "0f84ba19e2de17aac48fdafc47fbe948151284cde3480cb8a1f1481e46c113ee"
 }

--- a/.derived/spec-registry/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/spec-registry/by-spec/045-absent-implementation-defers-to-status.json
@@ -93,10 +93,10 @@
       "5. Verification"
     ],
     "specPath": "specs/045-absent-implementation-defers-to-status/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`implementation` is optional, and two verbs read its absence in opposite directions. `registry plan` (spec 038) reads an absent key as `pending` and offers the spec as ready; the index's in-flight predicate (specs 041 and 044) reads `approved` + absent as settled and holds the spec to its claims. The one spec that routinely lacks the key is the bootstrap spec `spec-spine init` scaffolds, so every scaffolded corpus reports its bootstrap spec as the single ready item in an otherwise finished corpus, forever; one adopter does today, and this repository did until its own spec 000 was patched by hand. This spec fixes the rule rather than the instance: an absent key takes its answer from `status`. On a `draft` it reads as `pending`, as 038 intended; on anything ratified it reads as settled, as the gate already concludes. The scaffold's bootstrap spec declares `implementation: n-a` and the spec template states the key instead of commenting it out, so the absent case becomes rare as well as consistent.\n",
     "title": "An absent `implementation` key takes its answer from `status`"
   },
-  "shardHash": "40d94ad79b7dd45feb355faa18f7a0ad0e63a4376b0988fcfccd7679ed14a232",
+  "shardHash": "df169dcc67b3b05d4438e063c3a5976e0023b44f92dbd2ae9978caa48f89905a",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/spec-registry/by-spec/046-kit-hooks-read-never-write.json
@@ -65,10 +65,10 @@
       "5. Verification"
     ],
     "specPath": "specs/046-kit-hooks-read-never-write/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Three of the four Claude Code hooks the kit ships write into the tree they are meant to observe. `SessionStart` runs a bare `compile`, which repairs a stale committed registry as a side effect of checking it; the `PreToolUse` PR gate runs `index` and then blocks on the uncommitted output of its own write, which a hook cannot commit; `Stop` regenerates a stale index and asks a session that has already ended to commit it. All four also bind to the session's project directory rather than the repository the action targets, so a multi-checkout session judges one repo by another's state. An adopter running these hooks under an orchestrator stalled for eleven hours on a tree the `Stop` hook had dirtied, because the orchestrator refuses to start a session on a dirty tree and only a session cleans one. That adopter fixed every one of these in its own copy; this spec ports the fixes into the kit, adds the push gate the kit's prose rule had no enforcement for, and pins the read-only property with a test that scans every hook body for a writing subcommand.\n",
     "title": "The kit's hooks observe the tree; they do not repair it"
   },
-  "shardHash": "b8a838d8d66298a0f704062c478e1b2bcd9182712e8c053e204cd059125c186b",
+  "shardHash": "1dae2b9ba8cf627777be59d7ef6492c1396fb47f1d7674343491530503b3a90c",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/spec-registry/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -112,10 +112,10 @@
       "5. Verification"
     ],
     "specPath": "specs/047-harness-rules-name-the-legitimate-edits/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The three rules `spec-spine init` scaffolds and the kit ships are the floor every agent in an adopting repository reads first, and all three were ambiguous in the same places. `governed-artifact-reads` forbade ad-hoc parsing of derived JSON without saying that parsing a `spec-spine` verb's own `--json` output is a typed read, so read literally it outlawed `registry plan --json`, the spec 037 verdict envelope, and every adopter's tooling. `adversarial-prompt-refusal` said never edit the owning spec to clear the gate, but under the ownership ratchet adding a created file to `establishes` is editing the owning spec to clear the gate, so the rule as written was unimplementable and left agents to guess which edits were theirs. `orchestrator-rules` said to recompute the shards and not that they must be committed with the change. Three adopters that rewrote the rules made the same three fixes independently, in the same paragraphs. This spec makes those fixes in the scaffold constants, the kit, and this repository's own copies, adds the one-spec-per-session \"Working the backlog\" protocol that all three adopters wrote from nothing to the kit's `AGENTS.md`, and pins the kit and scaffold copies as identical.\n",
     "title": "The harness rules name the reads and the edits they permit"
   },
-  "shardHash": "4d316b4707674088759e767805d666fec59d9580dcfb63dbe59b0011c153e1e6",
+  "shardHash": "0a8ed2a93fbf168c303609b71c134d4ed0e990adbb6913ce737d63c58c4dae84",
   "specVersion": "1.1.0"
 }

--- a/specs/045-absent-implementation-defers-to-status/spec.md
+++ b/specs/045-absent-implementation-defers-to-status/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "045-absent-implementation-defers-to-status"
 title: "An absent `implementation` key takes its answer from `status`"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete

--- a/specs/046-kit-hooks-read-never-write/spec.md
+++ b/specs/046-kit-hooks-read-never-write/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "046-kit-hooks-read-never-write"
 title: "The kit's hooks observe the tree; they do not repair it"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete

--- a/specs/047-harness-rules-name-the-legitimate-edits/spec.md
+++ b/specs/047-harness-rules-name-the-legitimate-edits/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "047-harness-rules-name-the-legitimate-edits"
 title: "The harness rules name the reads and the edits they permit"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete


### PR DESCRIPTION
## What

Flips specs 045, 046 and 047 from `status: draft` to `approved`, following #104 landing with green CI. Registry shards for the three specs regenerated. Corpus: 48/48 approved.

## Testing

- `compile --check`, `index check`, `lint --fail-on-warn`: fresh and clean.
- `registry status-report --json --nonzero-only`: `{ total: 48, approved: 48 }`.
- `registry plan`: `(nothing ready), blocked: 0`.