### PR TITLE
chore(048): ratify the kit skill-set spec (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -214,8 +214,8 @@
       }
     ],
     "specId": "048-kit-ships-the-governed-loop-skills",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e252fb3fd07d9ac2ecc707e94f2cfac52ce3cb6867ebf9ef1fc26f48c62abd5c"
+  "shardHash": "94917f840ee503e32a221f2ea217f515b4dcbfd6d114fddacfb8a95be8fd6a23"
 }

--- a/.derived/spec-registry/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/spec-registry/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -112,10 +112,10 @@
       "3.5 The verify script"
     ],
     "specPath": "specs/048-kit-ships-the-governed-loop-skills/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Four adopters of the kit had each written the same five skills the kit did not ship (next, build, verify, spec, shepherd), three of them from one shared template, and every adopter's copy of the ten the kit did ship had drifted from the kit's, which had itself gone stale: a renamed tool, a rule frontmatter format Claude Code does not read, a \"read-only\" review that ran the writing compile, a commit skill missing the two house rules that land in public history, and a drift remedy that contradicted the refusal rule spec 047 had just fixed. This spec makes the kit ship one repository-invariant set of fifteen skills built around the orchestrated loop (spec-spine's registry plan and the coupling gate on one side, an orchestrator's build, ship, shepherd, and verify stages on the other), moves every project-specific fact into AGENTS.md and the path-scoped rules so the skills copy byte for byte, ships the verify script the loop needs, ports the substrate-level agent improvements the adopters made, and makes this repository run the same fifteen on itself, pinned by a test.\n",
     "title": "The kit ships one skill set for the governed loop, and this repository runs it"
   },
-  "shardHash": "98edc97a5ddade4c5e53b3e1314b366f1d8250c06961f3a0a87ab6b7fc0d1371",
+  "shardHash": "1acd724352ca7eb7cf03c20876b386448e9cd6c8ef88be07961a2a114cf5f4cc",
   "specVersion": "1.1.0"
 }

--- a/specs/048-kit-ships-the-governed-loop-skills/spec.md
+++ b/specs/048-kit-ships-the-governed-loop-skills/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "048-kit-ships-the-governed-loop-skills"
 title: "The kit ships one skill set for the governed loop, and this repository runs it"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete


### PR DESCRIPTION
## What

Flips spec `048-kit-ships-the-governed-loop-skills` from `status: draft` to
`approved`, following #107 landing with green CI. The registry and index shards
for the spec are regenerated in the same commit.

Corpus: **49/49 approved** (was 48 approved + 1 draft).

## Why now

048's `implementation` was already `complete` when #107 merged; the spec's
`## Verification` block holds against the tree on `main`. Ratification is the
separate second PR this repository's "Working the backlog" loop calls for, so
the flip is not mixed into the change it describes.

## Testing

- `compile --check`: fresh, 49 shards match the corpus.
- `index check`: fresh.
- `lint --fail-on-warn`: 0 errors, 0 warnings, 0 info.
- `couple --base origin/main --head HEAD`: OK, 1 path checked, no drift. No waiver.
- `registry status-report --json --nonzero-only`: `{ "total": 49, "approved": 49 }`.
- `registry plan`: `(nothing ready), blocked: 0`.
- `cargo test --workspace --locked`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all --check`: all clean.