### PR TITLE
chore(release): bump package version to 0.15.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.14.0"
+    "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9c0602009662f828a5a913e0b7a2c5bb2b5115de46d77081d6c8e3506a7caca2"
+  "shardHash": "94624da8ff32267563d1be3ff0fe19c7746c8caec1741636d5ae22ec975bedef"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "3"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.14.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.14.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.15.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.15.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.14.0",
-    "@spec-spine/cli-darwin-x64": "0.14.0",
-    "@spec-spine/cli-linux-x64": "0.14.0",
-    "@spec-spine/cli-linux-arm64": "0.14.0",
-    "@spec-spine/cli-win32-x64": "0.14.0"
+    "@spec-spine/cli-darwin-arm64": "0.15.0",
+    "@spec-spine/cli-darwin-x64": "0.15.0",
+    "@spec-spine/cli-linux-x64": "0.15.0",
+    "@spec-spine/cli-linux-arm64": "0.15.0",
+    "@spec-spine/cli-win32-x64": "0.15.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.14.0"
+version = "0.15.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares **v0.15.0**. Version-bump only; the tag is pushed after this merges.

## What ships

Specs **045, 046 and 047** (#104, ratified 48/48 in #105). All three landed *after* the v0.14.0 bump (#103), so they have never been in a release: every adopter pinned at 0.14.0 still runs the old behaviour of both files below.

- **045 · an absent `implementation` key takes its answer from `status`** (`query.rs`, +33). This is what `registry plan` reports as the ready set, so a corpus that never writes the key stops being read as though nothing were ever done.
- **046 · the kit's hooks read, never write** (`scaffold.rs`). The Stop and PR-gate hooks `init` scaffolds were mutating the tree; three of them shipped writing when they should read. They are now read-only and repo-scoped.
- **047 · the three rules name the legitimate mid-build spec edits** (`scaffold.rs`). `init` writes the rule text that says which two spec edits an agent may make mid-build (claiming a file it created, recording a dated decision) and which it may not, and that a waiver is a human instrument.

Spec **048** (the kit's fifteen governed-loop skills, #107, ratified in #108) touched no library source: it reaches adopters by copy from `kit/`, not through the binary. This tag marks that round but does not carry it.

The audit's own item 16 observed that all four adopters run two to four releases behind the fixes their experience motivated. Shipping now stops this round from repeating it.

## Version axes

**Package version only: 0.14.0 -> 0.15.0.** Registry and index schemas stay at **1.1.0**; no DTO in either moved. `VERDICT_SCHEMA_VERSION`, `SPEC_ATTESTATION_SCHEMA_VERSION` and `CONFIG_VERSION` are unchanged on their independent axes. MINOR, not patch: 045 changes what `registry plan` reports for a corpus that omits `implementation`, and 046 changes what `init` writes.

## Pre-flight (runbook `docs/releasing.md`)

| check | result |
|---|---|
| `cargo test --workspace --locked` | green, 20 suites |
| `cargo clippy --workspace --all-targets -D warnings` | green |
| `cargo fmt --all --check` | green |
| `bump_version.py --check 0.15.0` | all four locations agree |
| `Cargo.lock` regenerated after the bump | yes |
| `cargo package --workspace --locked` | exit 0, all three crates verify from packaged sources |
| `compile --check` / `index check` | fresh, 49 shards |
| `lint --fail-on-warn` | 0 / 0 / 0 |
| `index coverage` | 68/68 specifically claimed, 0 floor-only, 0 unclaimed |
| `registry plan` | (nothing ready), blocked: 0 |
| corpus | 49/49 approved |

Only one derived shard moved (`by-package/spec-spine.json`, which records the npm package version).

## Waiver

The gate reports the two violations every version-bump PR reports. Spec 030's auto-waiver correctly does **not** fire here: a package's own `version` field is not a dependency edit, so this needs the standing manual waiver. The diff to both files is confined to the `version` field and the version-locked pins.

Spec-Drift-Waiver: A release version bump. `npm/package.json` and `py/pyproject.toml` change only their `version` field and the version-locked `optionalDependencies` pins, which specs 007 and 008 require to track the tag; neither spec's behavior changes, so there is nothing to author in them. This is the standing waiver every version-bump PR carries (cf. #57, #80, #88, #103).
