### PR TITLE
chore(049): ratify the declared-acceptance spec (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -236,8 +236,8 @@
       }
     ],
     "specId": "049-verify-declared-acceptance",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9942e9990ef1d7db0680dd870d5ccbe797b66cb8d962fc31960d044ae7a73c68"
+  "shardHash": "3a64244c143dc0e21298c0d78768a4932cc51a14763a1dca354fb8e47716db27"
 }

--- a/.derived/spec-registry/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/spec-registry/by-spec/049-verify-declared-acceptance.json
@@ -129,10 +129,10 @@
       "5. Verification"
     ],
     "specPath": "specs/049-verify-declared-acceptance/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "A spec's `## Verification` section states what would make its claims true, and nothing runs it. Three adopters independently wrote the same 78-line `scripts/verify-spec.sh` to close that gap, and spec 048 added a fourth copy to this repository, so the kit now ships the workaround it exists to retire. Spec 043 4 named this \"the most substantial thing the adoption invented and the one most worth having\" and deferred filing it. This is that filing. `spec-spine verify <id>` reads the spec's `## Verification` section, runs each line of its `verify:cli` fences from the repository root in order, and stops at the first failure. Two things make it a spec-spine verb rather than a script: the parse becomes a typed, tested read of authored markdown that the library owns, and the outcome becomes a spec 037 verdict envelope instead of a sentence a caller must string-match. The engine never spawns a process. Core returns a `VerifyPlan`, the commands it found and the fence tags it declined, and the CLI executes it, which is the same seam `couple` already uses for `git`. Two behaviours diverge deliberately from the ported script, both to keep an older contract intact: a missing spec exits 1, not the script's 2, because 2 means stale; and a failing command exits 1 with its own code carried in the payload, rather than propagating a code the exit contract does not define. `not-declared` stays an honest zero and is distinguishable from a pass in the payload, never by parsing prose.\n",
     "title": "`spec-spine verify <id>`: run a spec's declared acceptance"
   },
-  "shardHash": "abee2869bb6e409e1da62da696d1f11b4fcad01d35603a171aa5b9c9ae029372",
+  "shardHash": "35599376172b5d20ffccfeeed539c29bcd32d8e863096fb3e3b74af0c310aa2c",
   "specVersion": "1.1.0"
 }

--- a/specs/049-verify-declared-acceptance/spec.md
+++ b/specs/049-verify-declared-acceptance/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "049-verify-declared-acceptance"
 title: "`spec-spine verify <id>`: run a spec's declared acceptance"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete


### PR DESCRIPTION
Ratifies **spec 049** (`spec-spine verify <id>`), merged in #110.

Corpus goes to **50/50 approved**. Three files: the status line and its two regenerated shards, the same shape as #105 and #108.

Gate green before the push, no waiver: `compile --check` fresh (50 shards) · `index check` fresh · `lint --fail-on-warn` 0/0/0 · `couple` OK, no drift.

The 049 follow-on that retires both copies of `scripts/verify-spec.sh` stays deferred until a release ships the verb, per spec 049 §4: pulling the script out of `kit/` now would strand every adopter pinned below v0.16.0.