### PR TITLE
chore(050): ratify the index-diagnostics spec (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -138,8 +138,8 @@
       }
     ],
     "specId": "050-index-diagnostics-reach-a-gate",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "20d0ffa1a4bef0343c0e3b4840f95d746ff9dc74efea3c66b7ce29a6157c59c0"
+  "shardHash": "f712bb663641f9c9f2ef0a2a591d280a76bd5a8d453581d28bd3e5e4cb211021"
 }

--- a/.derived/spec-registry/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/spec-registry/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -89,10 +89,10 @@
       "5. Verification"
     ],
     "specPath": "specs/050-index-diagnostics-reach-a-gate/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Spec 025 downgrades an unresolved unit to a counted `W-001` (owning unit on an in-flight spec) or `W-002` (non-owning `references` unit) instead of failing the index, because work under way legitimately claims territory that does not exist yet. That downgrade is right and this spec does not touch it. What 025 never gave the warning is a reader. The codes are deliberately absent from `BLOCKING_CODES`, `lint` counts a different set entirely (`L-001`..`L-006`), and `index check` prints one word, `fresh`. The only way to see them is to run the *writing* command, which mutates the tree, or to read `index render`'s markdown, which is the ad-hoc parsing constitution II forbids. So a corpus accumulates them without limit while every gate stays green: aicortex carries 248 that nothing reports. The asymmetry is exact, because error-tier diagnostics are gated: `I-003`..`I-009` mark their shard stale and `index check` exits 2. This spec gives the warning tier the same reachability without giving it the same force. `index check` reports the counts it already holds, `--fail-on-unresolved` turns them into exit 1 for a corpus past the specify-first stage, and `index diagnostics` lists them as typed output. All three read the committed shards and recompute nothing, so the answer always describes the ledger the corpus compiled to.\n",
     "title": "Index diagnostics reach a gate"
   },
-  "shardHash": "e4286848324966067889f59121c7a4a8f9161b72c9a5384ae4360cfae5156c57",
+  "shardHash": "e14ee4b3a94c32c6e52014b9e8bfb051e161554526884402914c7c1de19d98f2",
   "specVersion": "1.1.0"
 }

--- a/specs/050-index-diagnostics-reach-a-gate/spec.md
+++ b/specs/050-index-diagnostics-reach-a-gate/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "050-index-diagnostics-reach-a-gate"
 title: "Index diagnostics reach a gate"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-06"
 implementation: complete


### PR DESCRIPTION
Ratifies **spec 050** (index diagnostics reach a gate), merged in #112.

Corpus goes to **51/51 approved**. Three files: the status line and its two regenerated shards, the same shape as #105, #108 and #111.

Gate green before the push, no waiver: `compile --check` fresh (51 shards) · `index check --fail-on-unresolved` exit 0 · `lint --fail-on-warn` 0/0/0 · `couple` OK, no drift.

Note this is the first ratify PR whose gate ran `--fail-on-unresolved`, the flag 050 added. It passes because this corpus records no unresolved units.