### PR TITLE
chore(051): ratify the harness-catch-up spec (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -194,8 +194,8 @@
       }
     ],
     "specId": "051-harness-runs-the-verbs-it-ships",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d256ef9492684b578fb6b93659e8b970cc9ba67e7477acbe7e9dd6fe83828b82"
+  "shardHash": "3da9fe6e4a60db34648017c8fbb381571918bb6f3a2e7501572d252a7759b6fd"
 }

--- a/.derived/spec-registry/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/spec-registry/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -124,10 +124,10 @@
       "6. Resolved decisions"
     ],
     "specPath": "specs/051-harness-runs-the-verbs-it-ships/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Release v0.15.0 shipped two capabilities the harness was written to want and then did not use. Spec 049's `spec-spine verify <id>` retired nothing: all nine harness sites still call `scripts/verify-spec.sh`, so one protocol now has two implementations whose answers are already worded differently, which is the drift 048 1.2 exists to end reappearing inside the repository that wrote it. Spec 050's `--fail-on-unresolved` and `index diagnostics` reached no caller: the spec written because a warning nobody sees is a unit that quietly went unresolved is, in its own dogfood repository, still a warning nobody sees. Underneath both sits a third gap that made them possible: every skill says to run the gate exactly as AGENTS.md lists it, and AGENTS.md's list omits the ownership ratchet CI enforces, so the six skills that inline the step are more correct than the file they defer to. This spec makes the harness run what the tool ships: `/verify` wraps the verb, AGENTS.md names one gate list that a test pins against the skills, this repository turns on 050's gate and reads its diagnostics at session start, the kit's hooks resolve the binary the project declares instead of whatever a bare name finds on PATH, and this repository runs the hooks it ships to adopters.\n",
     "title": "The harness runs the verbs it ships"
   },
-  "shardHash": "95d5088c29b2843850caffa7a6b3938cf3e12a560309563558913ed85906d1ce",
+  "shardHash": "361f37deb9e86cc8e8b09d40cf48f0ccb54915ebaa7f9fe76d3cde724c4f6530",
   "specVersion": "1.1.0"
 }

--- a/specs/051-harness-runs-the-verbs-it-ships/spec.md
+++ b/specs/051-harness-runs-the-verbs-it-ships/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "051-harness-runs-the-verbs-it-ships"
 title: "The harness runs the verbs it ships"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete


### PR DESCRIPTION
## Summary

Flips spec 051 from `status: draft` to `approved` now that it has shipped in #114. This is the ratify half of the repository's file-build-ratify loop; no behavior changes.

Spec 051 made the harness run the verbs the tool had already shipped:

- `/verify` wraps `spec-spine verify` (spec 049) instead of `scripts/verify-spec.sh`, which spec 048 §4 had named as the trigger in advance. The script stays deprecated for adopters pinned below 0.15.0.
- `AGENTS.md` names every gate step CI enforces, with two tests pinning the list against CI and against the skills, from both directions.
- CI runs spec 050's `index check --fail-on-unresolved`, and the init protocol reads `index diagnostics`.
- The kit's hooks resolve `$SPEC_SPINE_BIN`, then the repository's own release build, then `PATH`, and `.claude/settings.json` makes this repository run the hooks it ships to adopters.

Corpus moves to **52/52 approved**.

## Testing

- `compile` / `index` clean, `lint --fail-on-warn` 0/0/0
- `index check --fail-on-unresolved` fresh
- `index coverage --fail-on-untraced` 74/74 specifically claimed
- `couple --base origin/main --head HEAD` 1 path checked, no drift
- `cargo test --workspace --locked` 27 suites, 0 failures
- `registry status-report` reports 52 total, 52 approved