### PR TITLE
docs(053-068): file the rest of the adopter-audit backlog as specs

### DIFF
--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -1,0 +1,64 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "003-conformance-lint",
+      "033-dependency-cycle-refusal",
+      "038-registry-plan-ready-set"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "053-depends-on-ordinal-monotonicity",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "18f3df521f179c472145edc9581b1c62eacdfc3d7c7ac2eb34b00d11801558bf"
+}

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -1,0 +1,94 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "005-coupling-gate",
+      "009-coupling-floor-claim-precedence",
+      "037-machine-readable-verdicts"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/adoption-guide.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "054-effective-config-is-a-governed-read",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "18c35d514acf45e8656f91aca8d0c4b0634c6f95c9d2ff6020b047853930a081"
+}

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -1,0 +1,133 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "002-registry-query",
+      "004-codebase-index",
+      "024-index-sharding",
+      "032-ownership-coverage"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_registry.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/query.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/index.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_registry.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "055-the-ledger-answers-what-consumers-rebuild",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "c8d1e2e38c3613208620c32a4e43f8fa9578d5efa6a64b8238e5eff1c5556520"
+}

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -1,0 +1,98 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "001-compile-registry",
+      "031-registry-freshness-check",
+      "037-machine-readable-verdicts"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/verdict.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/verdict.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/verdict.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "056-compile-one-spec",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "c8d18ffd2e8f97fa1ada8011b7f590e066dd5919e96419f58eca97e873621981"
+}

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -1,0 +1,78 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "003-conformance-lint",
+      "004-codebase-index",
+      "023-ledger-seal",
+      "032-ownership-coverage"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lint.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/schema-versioning.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      }
+    ],
+    "specId": "057-claimed-but-unwitnessed",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "ceffd74b3b901d084702768472929745517d690c4fe3b7be2e14a01a689de8cc"
+}

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -1,0 +1,69 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "003-conformance-lint",
+      "022-keypath-section-anchors",
+      "043-governance-document-gaps"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "standards/spec/constitution.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "standards/spec/constitution.md",
+            "span": {
+              "endLine": 73,
+              "startLine": 53
+            }
+          }
+        ],
+        "ownership": true,
+        "sourceField": "refines",
+        "unit": {
+          "anchor": "v-legacy-as-evidence",
+          "file": "standards/spec/constitution.md",
+          "kind": "section"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "058-retroactive-adoption-shape",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "cb781b62b1c54abfa786a7912f84bad8fa6db42ba315d21160fbc2d4ddec6bc1"
+}

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -1,0 +1,115 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "011-index-render-orphans",
+      "032-ownership-coverage",
+      "044-in-progress-is-in-flight"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/render.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/render.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/render.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/render.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/render.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/render.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "059-read-verbs-on-a-code-free-corpus",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "bec655134fc0c876d30906124808b628064c77a1fd9d7f3c9db90ac563326add"
+}

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -1,0 +1,94 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "038-registry-plan-ready-set",
+      "044-in-progress-is-in-flight",
+      "045-absent-implementation-defers-to-status"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_registry.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/query.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/query.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_registry.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/query.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": ".claude/skills/next/SKILL.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": ".claude/skills/next/SKILL.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "060-plan-answers-the-whole-question",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "13397aede68514144cf0b33093a3e49b4bdacaad855169c45717323cb34ccf44"
+}

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -1,0 +1,90 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "006-init-scaffold",
+      "039-declared-state-dir",
+      "043-governance-document-gaps"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/scaffold.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/scaffold.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "spec-spine.toml"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "standards/spec/templates/constitution-template.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "standards/spec/templates/constitution-template.md"
+        }
+      }
+    ],
+    "specId": "061-the-scaffold-ships-what-adopters-wrote",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "d21f43174c54d0cab990dd06b91aa6ce67fc95ba5a9a1ecc33bf259bc6bad48f"
+}

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -1,0 +1,111 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "000-spec-spine-bootstrap",
+      "006-init-scaffold",
+      "054-effective-config-is-a-governed-read"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/scaffold.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/config.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/schema-versioning.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      }
+    ],
+    "specId": "062-a-version-pin-the-cli-can-check",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "7740f26852b266067404b2c6e99482ece576a9a76f55491c4d6c39e3d43108fb"
+}

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -1,0 +1,98 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "029-claude-code-skill-kit",
+      "031-registry-freshness-check",
+      "062-a-version-pin-the-cli-can-check"
+    ],
+    "implementingPaths": [
+      {
+        "path": "AGENTS.md",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/AGENTS.md",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/settings.json",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "AGENTS.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "AGENTS.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/AGENTS.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/AGENTS.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/settings.json"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/settings.json"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "063-a-stale-binary-is-not-a-stale-ledger",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "646affa2dae797dd3b2fca03b1dcaa6ff2a0be99bb1e31089da4e6cd05b78c43"
+}

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -1,0 +1,95 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "020-derived-artifact-merge-driver",
+      "029-claude-code-skill-kit",
+      "024-index-sharding",
+      "051-harness-runs-the-verbs-it-ships"
+    ],
+    "implementingPaths": [
+      {
+        "path": ".githooks/",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/README.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": ".githooks/"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": ".githooks/"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/README.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/README.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": ".github/workflows/ci.yml"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": ".github/workflows/ci.yml"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "064-the-kit-ships-the-composite-gate",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "32faeb2ac4af91359aea61eb7fb7627f537bb141220ee65db1eeec6793dca3bf"
+}

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -1,0 +1,129 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "006-init-scaffold",
+      "029-claude-code-skill-kit",
+      "043-governance-document-gaps",
+      "061-the-scaffold-ships-what-adopters-wrote"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_init.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/init.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/scaffold.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/scaffold.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/README.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_init.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_init.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/init.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/init.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/README.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/README.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/adoption-guide.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "065-init-and-the-kit-are-one-adoption",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "1514224717dd53054d96fd2bd7285e0405ea4bc585ca9d413c91a1ba1d1481a7"
+}

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -1,0 +1,61 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "041-completion-held-to-claims",
+      "043-governance-document-gaps",
+      "044-in-progress-is-in-flight",
+      "045-absent-implementation-defers-to-status"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/scaffold.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "standards/spec/contract.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "standards/spec/contract.md"
+        }
+      }
+    ],
+    "specId": "066-the-contract-records-the-lifecycle-table",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "8a5b701a629bc3d79a5f04276afb8921121ab1d6e94ed41f2bf190263fdff04f"
+}

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -1,0 +1,78 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "009-coupling-floor-claim-precedence",
+      "017-directory-crate-module-units",
+      "037-machine-readable-verdicts",
+      "044-in-progress-is-in-flight"
+    ],
+    "implementingPaths": [
+      {
+        "path": "docs/adoption-guide.md",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/schema-versioning.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "docs/adoption-guide.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/schema-versioning.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "README.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "README.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "067-the-docs-name-what-adopters-derived",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "ec41757efa1f67f96d5529d9853e61b0e9edae6116b2eac096ac71cb0494b155"
+}

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -1,0 +1,77 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "029-claude-code-skill-kit",
+      "047-harness-rules-name-the-legitimate-edits",
+      "048-kit-ships-the-governed-loop-skills"
+    ],
+    "implementingPaths": [
+      {
+        "path": "kit/.claude/rules/",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/README.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "kit/.claude/rules/"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/.claude/rules/"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/README.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "kit/README.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": ".claude/rules/governed-artifact-reads.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": ".claude/rules/governed-artifact-reads.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/03-adopter-audit-2026-09.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "specId": "068-a-path-scoped-rule-example",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "8e37459dc44c7f96e9005f71553ba1a7ebd1d3e8544791e15e3af2d831f7b911"
+}

--- a/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -1,0 +1,60 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "003-conformance-lint",
+      "033-dependency-cycle-refusal",
+      "038-registry-plan-ready-set"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      }
+    ],
+    "id": "053-depends-on-ordinal-monotonicity",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "053: A dependency points backward, and the corpus can say so",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 One new opt-in knob",
+      "3.2 `L-007`",
+      "3.3 The ordinal is the leading digits, and absence is not a violation",
+      "3.4 It is a lint, not a validation",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/053-depends-on-ordinal-monotonicity/spec.md",
+    "status": "draft",
+    "summary": "Three adopters independently wrote the same ninety-line `scripts/spec-dag.sh` to assert one thing the tool does not: that a `depends_on` entry names a lower ordinal than the spec declaring it. Spec 033 already ships the harder half of that graph check, refusing a cycle at compile time, and ordinal monotonicity is the cheap total order that makes a cycle impossible by construction rather than detectable after the fact. This spec adds `L-007`, an opt-in conformance lint gated on a new `[lint] require_ordinal_monotonic_depends_on` knob, defaulting off so no existing corpus changes verdict. It is deliberately a lint and not a `V-` code: a forward dependency is a corpus convention an adopter may reasonably not hold, not a structural defect that makes the registry unreadable.\n",
+    "title": "A dependency points backward, and the corpus can say so"
+  },
+  "shardHash": "dc6f84f9028f81773820fa2c13e547b4e927a68e13e6bd6e9bf80f86a377bffe",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
@@ -1,0 +1,76 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "005-coupling-gate",
+      "009-coupling-floor-claim-precedence",
+      "037-machine-readable-verdicts"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      }
+    ],
+    "id": "054-effective-config-is-a-governed-read",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "054: The effective configuration is a governed read",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `spec-spine config show`",
+      "3.2 The bypass floor is reported merged and attributed",
+      "3.3 The report is data first",
+      "3.4 What it reports is what the tool would use",
+      "3.5 Determinism",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/054-effective-config-is-a-governed-read/spec.md",
+    "status": "draft",
+    "summary": "`spec-spine.toml` is only half the configuration a coupling decision is made from. The other half is `DEFAULT_BYPASS_PREFIXES`, a thirteen-entry constant compiled into the binary, additive to the adopter's list and impossible to read from outside the process. claude-observatory, which judges other repositories, hand-parses each target's TOML and documents in its spec 016 D-3 that the built-in floor is simply unknowable to it. That is a consumer reimplementing half a contract and knowing it has the other half wrong. This spec adds `spec-spine config show [--json]`: the effective configuration, every default resolved, with the bypass floor rendered as the merged list the gate actually matches against and each entry attributed to the built-in floor or to the adopter's file. It reads and reports; it decides nothing.\n",
+    "title": "The effective configuration is a governed read"
+  },
+  "shardHash": "6fd5c6b96da465d4337cd7ae167c9ba65084da2bbf81aa65ce9b9ce389347d15",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -1,0 +1,93 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "002-registry-query",
+      "004-codebase-index",
+      "024-index-sharding",
+      "032-ownership-coverage"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      }
+    ],
+    "id": "055-the-ledger-answers-what-consumers-rebuild",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "055: The ledger answers what consumers rebuild by hand",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `spec-spine index owner <path>`",
+      "3.2 The owner query is the gate's own function",
+      "3.3 `contentHash` on `registry show --json`",
+      "3.4 What the hash means, said once",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/055-the-ledger-answers-what-consumers-rebuild/spec.md",
+    "status": "draft",
+    "summary": "Two facts the ledger computes and then keeps to itself, each of which an adopter has reimplemented. Ownership of a path is resolved inside `couple.rs::owners_for_path`, a private function, so a consumer that wants to know which spec governs a file rebuilds a path-to-spec map from raw edges and gets the subtree, supersession and comment-header rules wrong. A spec's content hash is written into every registry shard as `shardHash` and is absent from every read verb, so claude-observatory reimplemented `hash.rs` normalization in TypeScript in order to pin against it. This spec adds `spec-spine index owner <path>` and puts `contentHash` on `registry show --json`'s output object. Neither touches a committed artifact, a DTO, or a schema version: both facts already exist and are merely unreachable.\n",
+    "title": "The ledger answers what consumers rebuild by hand"
+  },
+  "shardHash": "def73526768c35799310982d6277dc30a027156632612a63ce2e46ca665c7968",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/056-compile-one-spec.json
+++ b/.derived/spec-registry/by-spec/056-compile-one-spec.json
@@ -1,0 +1,77 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "001-compile-registry",
+      "031-registry-freshness-check",
+      "037-machine-readable-verdicts"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "037-machine-readable-verdicts",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/verdict.rs"
+        }
+      }
+    ],
+    "id": "056-compile-one-spec",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "056: Validate one draft without a temporary repository",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `spec-spine compile --spec <id>`",
+      "3.2 It reports one spec's violations, and says so",
+      "3.3 It resolves against the real repository",
+      "3.4 The verdict envelope",
+      "3.5 Writing is still `compile`",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/056-compile-one-spec/spec.md",
+    "status": "draft",
+    "summary": "Writing a spec means validating it before it lands, and the tool offers no way to do that. `compile` writes the whole shard tree, which an author with an unfinished draft must not do; `compile --check` refuses the whole corpus because the draft has no committed shard, reporting the author's work in progress as staleness. So two adopters wrote down a `mktemp -d` ritual: copy the corpus, copy the draft in, compile there, read the violations, delete the copy. It has a documented gotcha, because a `references` edge into `docs/` does not resolve in a corpus copy that has no `docs/`. This spec adds `compile --spec <id>`: validate one spec against the committed registry, report only that spec's violations, and write nothing.\n",
+    "title": "Validate one draft without a temporary repository"
+  },
+  "shardHash": "9ad10c9f5c761e516547d4b32b326181a285100094a86889455e0d46a320e606",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
@@ -1,0 +1,68 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "003-conformance-lint",
+      "004-codebase-index",
+      "023-ledger-seal",
+      "032-ownership-coverage"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      }
+    ],
+    "id": "057-claimed-but-unwitnessed",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "057: A claim no hash witnesses",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 One predicate, in the indexer",
+      "3.2 `L-008`",
+      "3.3 `index check` reports the count",
+      "3.4 Nothing is folded into a hash",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/057-claimed-but-unwitnessed/spec.md",
+    "status": "draft",
+    "summary": "A `file` unit carries no span, and only span-backing source files are folded into a per-spec index shard hash. So a spec can claim a file, `index check` can report fresh, `index coverage` can report it claimed, and the file's contents can be rewritten from end to end with no gate noticing. This is not hypothetical in this repository: `AGENTS.md` is claimed by three specs, and appending a line to it leaves both `index check` and `compile --check` reporting fresh. Twenty-four claimed paths here are in that state, and spec 023 signs an attestation over a ledger that never hashed any of them. This spec adds `L-008`, a warning naming each claimed path that contributes to no content hash, and one line of `index check` output reporting the count. It does not fold claimed files into the hash: that would change what staleness means, and the honest first move is to say how large the gap is.\n",
+    "title": "A claim no hash witnesses"
+  },
+  "shardHash": "08c21103beb8d54e8352e3045fada0e04283d972a1847504466c38043d8099a5",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
@@ -1,0 +1,62 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "003-conformance-lint",
+      "022-keypath-section-anchors",
+      "043-governance-document-gaps"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      }
+    ],
+    "id": "058-retroactive-adoption-shape",
+    "implementation": "pending",
+    "kind": "governance",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "refines": [
+      {
+        "aspect": "defects-heading-anchor",
+        "unit": {
+          "anchor": "v-legacy-as-evidence",
+          "file": "standards/spec/constitution.md",
+          "kind": "section"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "058: The defects heading has one spelling",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The heading is an anchor",
+      "3.2 `L-009`",
+      "3.3 `origin.retroactive` does not imply the heading",
+      "3.4 Nothing else moves",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/058-retroactive-adoption-shape/spec.md",
+    "status": "draft",
+    "summary": "Constitution V requires code adopted from outside the corpus to be specced as found, with the behavior the adopting spec would not have chosen recorded under a `## Known defects` heading. It does not say what counts as that heading, and the first consumer to check mechanically got it wrong: claude-observatory's `defects.ts` matches the string `## Known defects` exactly and therefore rejects the numbered headings of the very specs it cites as precedent. This spec settles the spelling as an anchor rather than a string: any heading whose computed slug is or ends with `known-defects`, at any level, under the same slug rule the indexer already uses for section units. It adds `L-009`, an info-tier lint for a near-miss spelling, and it declines to lint `origin.retroactive` into implying the heading, because spec 043 established that the two are orthogonal.\n",
+    "title": "The defects heading has one spelling"
+  },
+  "shardHash": "f54b6024e52f358c72f50ca37e4b0c7af95fab14e92ffe74dd291ac0724ca17d",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -1,0 +1,84 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "011-index-render-orphans",
+      "032-ownership-coverage",
+      "044-in-progress-is-in-flight"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "011-index-render-orphans",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/render.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "032-ownership-coverage",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/coverage.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "032-ownership-coverage",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/coverage.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "011-index-render-orphans",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/render.rs"
+        }
+      }
+    ],
+    "id": "059-read-verbs-on-a-code-free-corpus",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "059: Two read verbs that mislead a specify-first corpus",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `orphans` partitions by the in-flight predicate",
+      "3.2 An empty coverage universe is a refusal, not a pass",
+      "3.3 The message says which of two things happened",
+      "3.4 Nothing committed moves",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/059-read-verbs-on-a-code-free-corpus/spec.md",
+    "status": "draft",
+    "summary": "Three of the four governed repositories are specify-first: the whole corpus is ratified before a line of code exists, and specs live at approved plus pending for months. Two read verbs give that corpus an answer that is technically correct and practically a lie. `index orphans` reports sixty-four of hqgit's sixty-eight specs, because an orphan is a spec claiming nothing that resolves, and a spec whose code is not written yet claims nothing that resolves; the list is the corpus, so it says nothing. `index coverage --fail-on-untraced` on a tree with no discovered package enumerates zero source files, computes zero untraced, and exits 0 from inside a CI step named \"the whole-tree ownership assertion\". This spec makes the first partition by the in-flight predicate the index already computes, and makes the second refuse an empty universe instead of passing it.\n",
+    "title": "Two read verbs that mislead a specify-first corpus"
+  },
+  "shardHash": "ce36a159081cd934bca75a6873a7e9d24f4c5379edf167c01c0a001a05ef3ec4",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
@@ -1,0 +1,75 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "038-registry-plan-ready-set",
+      "044-in-progress-is-in-flight",
+      "045-absent-implementation-defers-to-status"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "038-registry-plan-ready-set",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "038-registry-plan-ready-set",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/query.rs"
+        }
+      }
+    ],
+    "id": "060-plan-answers-the-whole-question",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": ".claude/skills/next/SKILL.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "060: The plan answers the whole question, and names one pick",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The prose form renders what the structure holds",
+      "3.2 `--next`",
+      "3.3 The JSON shape gains titles and nothing else",
+      "3.4 It still answers what is claimed, not what is done",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/060-plan-answers-the-whole-question/spec.md",
+    "status": "draft",
+    "summary": "`registry plan` prints spec ids and a count. Every consumer needs more than that, so every consumer adds it back: adopters kept about forty lines of Python to join the ready ids against titles and to explain why each blocked spec is blocked, and the corpus's own `/next` skill has to make a second call to turn an id into something a human can read. The data is all there. `Plan` already carries each blocked spec's blockers with the state of each, and the registry it was computed from carries every title. This spec makes the prose form render what the structure already holds, and adds `--next`, the single pick that the one-spec-per-session loop actually asks for. The JSON shape gains title fields and is otherwise unchanged.\n",
+    "title": "The plan answers the whole question, and names one pick"
+  },
+  "shardHash": "1a4a4b5efbe945e20b11c573a24d41c7f163b7545cbe87a443cfb4f18af3ec77",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -1,0 +1,74 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "006-init-scaffold",
+      "039-declared-state-dir",
+      "043-governance-document-gaps"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      }
+    ],
+    "id": "061-the-scaffold-ships-what-adopters-wrote",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "standards/spec/templates/constitution-template.md"
+        }
+      },
+      {
+        "role": "exemplar",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "061: The scaffold ships what every adopter wrote by hand",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The scaffold writes a `.gitignore`",
+      "3.2 The scaffolded config shows every knob",
+      "3.3 The real constitution template",
+      "3.4 Purity and determinism",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/061-the-scaffold-ships-what-adopters-wrote/spec.md",
+    "status": "draft",
+    "summary": "Four scaffold defects the audit measured, all in one generator. `init` writes no `.gitignore`, so every adopter independently learns that `.derived/**/build-meta.json` carries a wall clock and dirties the tree, and spec 039's `state_dir` has the same missing half: the live failure it fixed was a permanently dirty tree, not a classification. The scaffolded `spec-spine.toml` emits five knobs; adopters needed thirteen, and aicortex annotated each of its own with the diagnostic code that knob drives, which is the template to copy. And `CONSTITUTION_TEMPLATE` in `scaffold.rs` is still the two-bullet stub spec 043 complained about, while the real thirty-four-line document sits in `standards/spec/templates/constitution-template.md`: adopters get the stub, and two of them deleted it. This spec fixes all four in `scaffold_init`, which stays a pure function of `Config` performing no IO.\n",
+    "title": "The scaffold ships what every adopter wrote by hand"
+  },
+  "shardHash": "cadd616f1667e25d5019eb0c0788446b347e8ddf34cb847a44e624c8a80f119d",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -1,0 +1,84 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "000-spec-spine-bootstrap",
+      "006-init-scaffold",
+      "054-effective-config-is-a-governed-read"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/config.rs"
+        }
+      }
+    ],
+    "id": "062-a-version-pin-the-cli-can-check",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "062: A version pin the CLI can check",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `[meta] required_version`",
+      "3.2 Every verb checks it",
+      "3.3 An old binary refuses too, for the wrong reason",
+      "3.4 The scaffold writes it, commented out",
+      "3.5 It does not check the schema versions",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/062-a-version-pin-the-cli-can-check/spec.md",
+    "status": "draft",
+    "summary": "A repository is governed by whichever spec-spine binary happens to be on the path, and nothing anywhere says which one it should be. rahi states 0.11.0 in three files that must agree by hand. All four governed repositories are two to four releases behind the fixes their own experience motivated, and rahi cannot see spec 044, which was written for rahi's exact state, because it is pinned below it. This spec adds `[meta] required_version`, a semver requirement the CLI checks on every run, refusing with a message that names both the requirement and the running version. The schema versions already tell a loader whether it can read an artifact; this tells an operator whether they are running the tool the corpus was governed by, which is a different question and currently has no answer at all.\n",
+    "title": "A version pin the CLI can check"
+  },
+  "shardHash": "4bcd1a42d21a8914fbebaefa44a437ffb32b31aed4d2eb944d896544181f476a",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/spec-registry/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -1,0 +1,76 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "029-claude-code-skill-kit",
+      "031-registry-freshness-check",
+      "062-a-version-pin-the-cli-can-check"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/settings.json"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/AGENTS.md"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "AGENTS.md"
+        }
+      }
+    ],
+    "id": "063-a-stale-binary-is-not-a-stale-ledger",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "063: A stale binary is not a stale ledger",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 A usage error is exit 3",
+      "3.2 The transitional answer is the version, not the stderr",
+      "3.3 The kit's hook stops asserting staleness",
+      "3.4 Nothing else moves",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/063-a-stale-binary-is-not-a-stale-ledger/spec.md",
+    "status": "draft",
+    "summary": "`spec-spine compile --check` exits 2 when the committed registry is stale. A binary predating `--check` rejects the unknown flag and clap exits 2 as well. Two unrelated conditions, one code, distinguishable only by matching English on stderr, and two adopters plus the kit plus this repository's own AGENTS.md carry that matching ritual. This spec maps every command-line usage error to exit 3, so a new binary can never report a usage failure as staleness, and replaces the stderr ritual with the precondition that actually settles it: ask the binary its version first, which every binary ever released answers. The ritual's real defect was that it made the caller parse prose to recover a fact the process had already destroyed by choosing the wrong exit code.\n",
+    "title": "A stale binary is not a stale ledger"
+  },
+  "shardHash": "8df732e954b1024f3086a0c05bdeaf448de99c7a3bdc3a5ba039931dae4bde43",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -1,0 +1,76 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "020-derived-artifact-merge-driver",
+      "029-claude-code-skill-kit",
+      "024-index-sharding",
+      "051-harness-runs-the-verbs-it-ships"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/README.md"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "020-derived-artifact-merge-driver",
+        "unit": {
+          "kind": "file",
+          "path": ".githooks/"
+        }
+      }
+    ],
+    "id": "064-the-kit-ships-the-composite-gate",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "exemplar",
+        "unit": {
+          "kind": "file",
+          "path": ".github/workflows/ci.yml"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "064: The kit ships the composite gate and the merge driver",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `kit/Makefile`",
+      "3.2 `kit/govern.yml`",
+      "3.3 The merge driver moves into the kit",
+      "3.4 This repository runs what the kit ships",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/064-the-kit-ships-the-composite-gate/spec.md",
+    "status": "draft",
+    "summary": "The kit ships a session harness and no build. Every adopter therefore wrote the same two things by hand. First a composite gate: a Makefile whose language targets are guarded on a manifest probe so the whole thing is green on a code-free tree, and a CI workflow carrying the `has_cargo` job-output pattern that three adopters each rediscovered after GitHub rejected `hashFiles` in a job-level `if`. Second, nothing at all for the committed shard trees: rahi runs one spec per PR with committed shards and has no merge driver, and the kit's README never says the words. This spec ships `kit/Makefile`, `kit/govern.yml`, `kit/.githooks/` and the `.gitattributes` stanza, and holds them to the rule spec 046 and 051 established for everything else in the kit: what the kit ships, this repository runs.\n",
+    "title": "The kit ships the composite gate and the merge driver"
+  },
+  "shardHash": "90d5e4ae936a6398c7adb707365e218cc1f6c35128d7655ae2bccf8bf109667e",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/spec-registry/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -1,0 +1,93 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "006-init-scaffold",
+      "029-claude-code-skill-kit",
+      "043-governance-document-gaps",
+      "061-the-scaffold-ships-what-adopters-wrote"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_init.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/init.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/README.md"
+        }
+      }
+    ],
+    "id": "065-init-and-the-kit-are-one-adoption",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "065: Init and the kit are one adoption",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 Plain `init` writes an `AGENTS.md`",
+      "3.2 `init --with-kit`",
+      "3.3 It refuses to clobber",
+      "3.4 The scaffolded repository is immediately governed",
+      "3.5 The README says how it is installed",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/065-init-and-the-kit-are-one-adoption/spec.md",
+    "status": "draft",
+    "summary": "Adoption is two halves that nothing joins. `spec-spine init` writes a corpus, a constitution, a contract, templates and three agent rules. `kit/` adds the session protocol, the hooks, the agents and fifteen skills. The scaffold does not mention the kit, the kit is not installable by any verb, and `AGENTS.md`, which every skill in the kit reads first and which the three rewriting adopters each wrote from nothing, is written by neither. Spec 043 named this gap G5 and did not close it. This spec adds `spec-spine init --with-kit`, emitting the kit's files through the same `Scaffold` data path as everything else, and makes plain `init` write an `AGENTS.md` naming the governed loop, because a repository with rules and no protocol is the configuration three adopters had to repair by hand.\n",
+    "title": "Init and the kit are one adoption"
+  },
+  "shardHash": "22be5fa11babd5218c8b9b4b6aa9a49d91a28f20c9934c8647be77440dd31a4a",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -1,0 +1,61 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "041-completion-held-to-claims",
+      "043-governance-document-gaps",
+      "044-in-progress-is-in-flight",
+      "045-absent-implementation-defers-to-status"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      }
+    ],
+    "id": "066-the-contract-records-the-lifecycle-table",
+    "implementation": "pending",
+    "kind": "governance",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "standards/spec/contract.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "066: The contract records the lifecycle table and the extra keys",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 Lifecycle as scheduling",
+      "3.2 Extra keys",
+      "3.3 The scaffold ships both",
+      "3.4 The lifecycle table is a summary, not a fifth authority",
+      "3.5 Nothing mechanical changes",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/066-the-contract-records-the-lifecycle-table/spec.md",
+    "status": "draft",
+    "summary": "`status` and `implementation` are the two keys every adopter reasons about daily, and the contract mentions `status` once, in a list of required frontmatter, and `implementation` not at all. The mechanical consequences are spread across four specs: 041 makes a `complete` claim checkable, 044 defines the in-flight window, 045 says an absent key takes its answer from `status`, and 038 reads both to build the ready set. Every specify-first adopter wrote the resulting table into its own contract by hand, and hqgit had to invent a section called \"Lifecycle as scheduling\" because ours has none. This spec adds that section and an \"Extra keys\" section telling adopters to document their `extra_known_keys`, and claims both as section units of the contract.\n",
+    "title": "The contract records the lifecycle table and the extra keys"
+  },
+  "shardHash": "06cc9520f7bf654da7bbd25aa4b731a1c4d18e4d841c4e053968cae53ff16f1d",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -1,0 +1,60 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "009-coupling-floor-claim-precedence",
+      "017-directory-crate-module-units",
+      "037-machine-readable-verdicts",
+      "044-in-progress-is-in-flight"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "docs/adoption-guide.md"
+      },
+      {
+        "kind": "file",
+        "path": "docs/schema-versioning.md"
+      }
+    ],
+    "id": "067-the-docs-name-what-adopters-derived",
+    "implementation": "pending",
+    "kind": "documentation",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "README.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "067: The docs name what adopters derived by experiment",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `docs/specify-first.md`",
+      "3.2 The two interactions, in the adoption guide",
+      "3.3 The 037 migration note",
+      "3.4 Nothing mechanical changes",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/067-the-docs-name-what-adopters-derived/spec.md",
+    "status": "draft",
+    "summary": "Three documentation gaps the audit measured, each with a named victim. There is no page for specify-first adoption, which is how three of the four governed repositories work, so each of them independently derived the guarded Makefile, the CI manifest probe, `implementation: n-a` for record specs, and the fact that two hundred and forty-eight W-001 warnings is the defined state rather than a backlog. Two interactions are documented nowhere and were found by experiment: a path can be on the coupling bypass floor and simultaneously a hashed input, and a trailing-slash directory unit in `establishes` satisfies ownership recursively. And spec 037 changed `attest`'s stdout, which claude-observatory regexes in two places, with no migration note. This spec writes the page and the three paragraphs.\n",
+    "title": "The docs name what adopters derived by experiment"
+  },
+  "shardHash": "6bf220acf5cfc366794f24e7d33252507e82469fe8ae2f779977a7d1aee9a40d",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
@@ -1,0 +1,68 @@
+{
+  "record": {
+    "created": "2026-09-07",
+    "dependsOn": [
+      "029-claude-code-skill-kit",
+      "047-harness-rules-name-the-legitimate-edits",
+      "048-kit-ships-the-governed-loop-skills"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/.claude/rules/"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "029-claude-code-skill-kit",
+        "unit": {
+          "kind": "file",
+          "path": "kit/README.md"
+        }
+      }
+    ],
+    "id": "068-a-path-scoped-rule-example",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/03-adopter-audit-2026-09.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": ".claude/rules/governed-artifact-reads.md"
+        }
+      }
+    ],
+    "risk": "low",
+    "sectionHeadings": [
+      "068: A path-scoped rule the kit actually ships",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 One path-scoped rule",
+      "3.2 The unconditional rule stays",
+      "3.3 The README describes when to scope",
+      "3.4 It is exercised here",
+      "3.5 Nothing mechanical changes",
+      "4. Out of scope",
+      "5. Verification"
+    ],
+    "specPath": "specs/068-a-path-scoped-rule-example/spec.md",
+    "status": "draft",
+    "summary": "The kit's three rules are unconditional: every one loads in every session regardless of what the session touches. Claude Code supports `paths:` frontmatter that loads a rule only when a matching file is touched, and the kit's README lists that pattern under \"intentionally excluded\" while hqgit carries three good ones, including per-file scoping. The exclusion was a judgement made before any adopter had tried it, and an adopter has now tried it and kept it. This spec ships one path-scoped rule, scoped to the derived artifact tree, whose content is the one instruction that is only ever relevant when someone has a compiled artifact open: do not hand-edit it. One rule, as a worked example of the mechanism, with the README's exclusion replaced by a description of when to reach for it.\n",
+    "title": "A path-scoped rule the kit actually ships"
+  },
+  "shardHash": "a7f600605c6e7ca06a8ac74f89cbf1012a934423dab03650920bfeb5274da247",
+  "specVersion": "1.1.0"
+}

--- a/docs/design/03-adopter-audit-2026-09.md
+++ b/docs/design/03-adopter-audit-2026-09.md
@@ -260,3 +260,55 @@ the audit. None of these is spec-spine's to fix.
   why: the best worked corpus of cross-territory edits in the family.
 - **Skill frontmatter with `allowed-tools`** scoped per command
   (`Bash(spec-spine:*)`, `Bash(git diff:*)`), which the kit's skills lack.
+
+## 7. Where each backlog item was filed
+
+Added 2026-09-07, when the remainder of both backlogs was filed as drafts.
+Grouping is by coherent claim, not one spec per item: several items were one
+mistake in one function and are argued together.
+
+| §3 (tool) | Filed as |
+|---|---|
+| 1. `spec-spine verify <id>` | 049-verify-declared-acceptance |
+| 2. Surface index diagnostics in a gate | 050-index-diagnostics-reach-a-gate |
+| 3. `couple` names the owning spec and points at `extends` | 052-couple-names-the-crossing |
+| 4. Ordinal-monotonic `depends_on` | 053-depends-on-ordinal-monotonicity |
+| 5. A governed read for effective coupling config | 054-effective-config-is-a-governed-read |
+| 6. Owner-of-path query | 055-the-ledger-answers-what-consumers-rebuild |
+| 7. Per-spec content hash on `registry show --json` | 055-the-ledger-answers-what-consumers-rebuild |
+| 8. `compile --spec <id>` | 056-compile-one-spec |
+| 9. Lint a claimed `file` unit outside every hashed input | 057-claimed-but-unwitnessed |
+| 10. Lint the retroactive-adoption shape | 058-retroactive-adoption-shape |
+| 11. `index orphans` under the in-flight predicate | 059-read-verbs-on-a-code-free-corpus |
+| 12. `--fail-on-untraced` on a package-less tree | 059-read-verbs-on-a-code-free-corpus |
+| 13. Richer `registry plan` output | 060-plan-answers-the-whole-question |
+| 14. `registry plan --next` | 060-plan-answers-the-whole-question |
+| 15. `build-meta.json` and the working tree | 061-the-scaffold-ships-what-adopters-wrote |
+| 16. A version pin the CLI can check | 062-a-version-pin-the-cli-can-check |
+| 17. The stale-binary exit-2 ambiguity | 063-a-stale-binary-is-not-a-stale-ledger |
+
+| §4 (kit and scaffold) | Filed as |
+|---|---|
+| 1. Ship the `.derived/` merge driver in `kit/` | 064-the-kit-ships-the-composite-gate |
+| 2. Ship a `Makefile` and a `govern.yml` | 064-the-kit-ships-the-composite-gate |
+| 3. `spec-spine init --with-kit` | 065-init-and-the-kit-are-one-adoption |
+| 4. A specify-first adoption page | 067-the-docs-name-what-adopters-derived |
+| 5. `CONSTITUTION_TEMPLATE` is still the stub | 061-the-scaffold-ships-what-adopters-wrote |
+| 6. The scaffolded `spec-spine.toml` hides every knob | 061-the-scaffold-ships-what-adopters-wrote |
+| 7. Contract additions | 066-the-contract-records-the-lifecycle-table |
+| 8. Document two interactions found by experiment | 067-the-docs-name-what-adopters-derived |
+| 9. Skills for the governed loop | 048-kit-ships-the-governed-loop-skills |
+| 10. A path-scoped rule example | 068-a-path-scoped-rule-example |
+| 11. State that the waiver is a human instrument | 047-harness-rules-name-the-legitimate-edits |
+| 12. Dogfood the hooks | 046-kit-hooks-read-never-write |
+| 13. Migration note for 037 | 067-the-docs-name-what-adopters-derived |
+| 14. `state_dir` needs its `.gitignore` half | 061-the-scaffold-ships-what-adopters-wrote |
+
+§5 (adopter-side follow-ups) is unchanged and remains each repository's own
+work. Nothing in it is spec-spine's to fix.
+
+One finding surfaced while filing, and is recorded here because it belongs to no
+backlog item. Spec 057's premise was verified rather than assumed: `AGENTS.md`
+is claimed by three specs, and appending a line to it leaves both
+`spec-spine index check` and `spec-spine compile --check` reporting fresh.
+Twenty-four claimed paths in this repository are in that state.

--- a/specs/053-depends-on-ordinal-monotonicity/spec.md
+++ b/specs/053-depends-on-ordinal-monotonicity/spec.md
@@ -1,0 +1,230 @@
+---
+id: "053-depends-on-ordinal-monotonicity"
+title: "A dependency points backward, and the corpus can say so"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "003-conformance-lint"
+  - "033-dependency-cycle-refusal"
+  - "038-registry-plan-ready-set"
+extends:
+  # The conformance lint gains one opt-in code. Spec 003 owns the lint module
+  # and its severity tiers; it says nothing about which conventions are
+  # checkable, so a new code is surface added rather than behavior changed.
+  # 003's spec.md is not edited (spec 040).
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
+  # One new opt-in table in the config model.
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+summary: >
+  Three adopters independently wrote the same ninety-line `scripts/spec-dag.sh`
+  to assert one thing the tool does not: that a `depends_on` entry names a lower
+  ordinal than the spec declaring it. Spec 033 already ships the harder half of
+  that graph check, refusing a cycle at compile time, and ordinal monotonicity
+  is the cheap total order that makes a cycle impossible by construction rather
+  than detectable after the fact. This spec adds `L-007`, an opt-in conformance
+  lint gated on a new `[lint] require_ordinal_monotonic_depends_on` knob,
+  defaulting off so no existing corpus changes verdict. It is deliberately a
+  lint and not a `V-` code: a forward dependency is a corpus convention an
+  adopter may reasonably not hold, not a structural defect that makes the
+  registry unreadable.
+---
+
+# 053: A dependency points backward, and the corpus can say so
+
+## 1. Purpose
+
+`depends_on` is the scheduling edge. `registry plan` (spec 038) reads it to
+partition the corpus into what can be worked on now and what is blocked, and
+spec 033 refuses a cycle in it at compile time, because a cyclic scheduling
+graph has no answer and a walk over it does not terminate.
+
+What the tool has never checked is direction. Nothing stops
+`012-index-hash-slices` from declaring `depends_on: ["044-in-progress-is-in-flight"]`,
+and nothing about that entry is structurally wrong: the target resolves, the
+graph stays acyclic, `plan` reports 012 as blocked and moves on.
+
+It is still almost always a mistake, and three adopters thought so independently.
+hqgit, aicortex and rahi each carry the same ninety-line `scripts/spec-dag.sh`,
+and each wrote it for this one assertion. That is the audit's ordinary signal
+for a missing feature: not one adopter with an unusual need, but three arriving
+at the same script without talking to each other.
+
+The reason a forward dependency is a mistake is that ordinals encode filing
+order. A spec filed later was written knowing the corpus that existed when it
+was filed; a spec filed earlier was not. An edge from earlier to later says the
+earlier spec's schedule depends on work whose shape was unknown when it was
+written, which is either a renumbering nobody finished, a copied frontmatter
+block, or a genuine inversion the author should turn into the other edge. Every
+one of those is worth a line of output.
+
+Ordinal monotonicity is also strictly stronger than the property spec 033
+defends. A graph whose every edge decreases a total order cannot contain a
+cycle, so a corpus that holds this convention gets acyclicity as a theorem
+rather than as a detection. 033 stays exactly as it is: it is the check for
+corpora that do not hold this convention, and it is the reason this one can be
+opt-in without leaving anybody unprotected.
+
+This is item 4 of the adopter audit's ranked backlog for the tool.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-types/src/config.rs` | 000 | a new `[lint]` table with one boolean |
+| `crates/spec-spine-core/src/lint.rs` | 003 | the `L-007` check |
+
+The corpus has no dedicated lint test file today: `L-006`'s acceptance lives in
+`tests/coverage.rs` and the scaffold's in `tests/scaffold.rs`. The implementing
+change creates `crates/spec-spine-core/tests/lint.rs` and claims it there, which
+is one of the two always-legitimate mid-build edits
+(`.claude/rules/adversarial-prompt-refusal.md`): a file you created is added to
+the spec you are implementing, in the same change.
+
+Spec 003 owns the lint and defines its severity tiers (error always, warning
+under `--fail-on-warn`, info under `--fail-on-info`). It enumerates the codes
+that existed when it was written and states no closed set, so adding a code is
+additive surface. Spec 033 owns the cycle refusal and is untouched: this spec
+adds a second, independent, opt-in check over the same edge and changes nothing
+about the first.
+
+## 3. Behavior
+
+### 3.1 One new opt-in knob
+
+`Config` MUST gain a `[lint]` table carrying a single boolean,
+`require_ordinal_monotonic_depends_on`, defaulting to `false`.
+
+The table is new rather than a field on an existing one because there is no
+existing home that is not a lie. `[frontmatter]` is the authored grammar's
+configuration and this is not a grammar rule; `[coupling]` is the PR-time gate
+and this never runs there. A `[lint]` table names what the knob actually gates,
+and it is where a future opt-in conformance convention belongs, so the next one
+does not have to relitigate this.
+
+Every table in `Config` carries `#[serde(default, deny_unknown_fields)]`, so a
+`spec-spine.toml` written before this spec parses unchanged and reads the
+default. `CONFIG_VERSION` does not move: it versions the config schema, and an
+added optional table with a default is the additive case that a version exists
+to make safe rather than to record.
+
+Defaulting off is not timidity. The convention is real but not universal: a
+corpus that files by domain rather than by date, or one that renumbered once and
+lives with the result, holds a coherent position this lint would spam. The
+adopters who want it asked for it by writing a script; a knob is how they stop
+maintaining that script, and it is not a verdict on anybody who did not.
+
+### 3.2 `L-007`
+
+When the knob is on, `lint` MUST emit one `L-007` diagnostic, at **error**
+severity, for each `depends_on` entry whose ordinal is greater than or equal to
+the ordinal of the spec declaring it:
+
+```
+L-007  spec '012-index-hash-slices' depends_on '044-in-progress-is-in-flight',
+       which is not a lower ordinal (044 >= 012): a dependency points backward
+       in filing order
+```
+
+Error tier, so the knob alone decides whether the corpus is held to this. A
+warning tier would have meant two knobs (this one and `--fail-on-warn`) for one
+decision, and an adopter who turned this on turned it on to be refused. It
+matches `L-006`, the other check whose whole purpose is to refuse.
+
+The diagnostic's `path` MUST be the declaring spec's `spec_path`, as every other
+`L-` code sets it, so an editor jumping to the diagnostic lands on the file that
+has to change.
+
+When the knob is off, `L-007` MUST NOT be emitted at all. Not emitted at info
+tier, not emitted and filtered: a corpus that has not opted in sees byte-identical
+lint output before and after this spec.
+
+### 3.3 The ordinal is the leading digits, and absence is not a violation
+
+A spec's ordinal is the leading decimal digit run of its `id`, parsed as an
+integer. `053-foo` yields 53. `007-bar` yields 7, and compares equal to a
+hypothetical `7-bar`: the comparison is numeric, not lexical, so a corpus that
+outgrows three digits and files `1001-foo` orders correctly rather than sorting
+`1001` below `999`.
+
+An id with **no** leading digit run has no ordinal. Both the declaring spec and
+the target are checked, and if either lacks an ordinal, `L-007` MUST NOT fire for
+that pair. Silence is correct here and a diagnostic would not be. The corpus does
+not require numeric ids: `V-001` requires only that the directory equal the id,
+and `V-004`'s duplicate-prefix check reads the first three characters whatever
+they are. A corpus with `auth-login` and `auth-logout` is well-formed, and
+telling it that `auth-login` has no ordinal is telling it that it does not hold a
+convention it never claimed. If such a corpus turns this knob on, it gets silence,
+which is the honest answer to "are these edges monotonic" when the order is
+undefined.
+
+Equality is a violation, not a pass. Two specs cannot share an ordinal (`V-004`
+refuses it), so an entry whose ordinal equals the declaring spec's is a spec
+depending on itself, which `L-007` catches as a side effect and which is worth
+catching however it arrives.
+
+### 3.4 It is a lint, not a validation
+
+`L-007` MUST NOT become a `V-` code and MUST NOT fail `compile`.
+
+The `V-` codes are structural: a duplicate id, a dangling `superseded_by`, a
+`depends_on` cycle. Each of them describes a registry that cannot be read
+correctly, and each fires unconditionally because no adopter can coherently
+opt out of being readable. A forward dependency is none of that. The registry
+compiles, the shard is valid, `plan` gives a correct answer, and the only thing
+wrong is a convention the corpus may or may not hold. That is the definition of
+the lint's job, and spec 003 drew the line in exactly this place.
+
+`compile --check` therefore stays byte-identical, no shard changes, and no
+schema version moves.
+
+## 4. Out of scope
+
+**Turning it on in this repository.** The knob ships off, and whether this corpus
+holds the convention is a separate decision from whether the tool can check it.
+This corpus does appear to hold it today, but "appears to" is what a verification
+step is for, not what a spec asserts on its own authority.
+
+**Fixing a violation.** The lint names the edge; a person decides whether the
+answer is a renumbering, a deleted entry, or an inverted edge. A tool that
+rewrote frontmatter to satisfy its own lint would be repairing the tree it is
+meant to judge, which is the error spec 046 found in the kit's hooks.
+
+**Ordering any other edge.** `extends`, `refines`, `amends`, `supersedes` and
+`constrains` all legitimately point in either direction: an amendment names an
+older spec, and a `constrains` edge on a reserved unit may well name a newer one.
+Only `depends_on` carries scheduling semantics, and only scheduling has a reason
+to respect filing order.
+
+**Replacing spec 033.** The cycle refusal stays unconditional and unchanged. It
+is what protects a corpus that has not opted in, and it is the reason this check
+can be opt-in at all.
+
+**The `&id[..3]` slicing in `detect_duplicates`.** `V-004` reads the first three
+characters of an id by byte index, which is not guaranteed to be a character
+boundary for a non-ASCII id and would panic rather than diagnose. This spec's
+ordinal parser is character-safe by construction, so it does not inherit the
+defect, but it also does not fix it: that is a panic-on-user-input defect in
+spec 001's territory and it deserves its own spec rather than a drive-by patch
+inside a lint change.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test lint --locked
+# The knob exists and parses. `[lint]` is an unknown table to a pre-053 Config,
+# whose every table is `deny_unknown_fields`, so this is a hard config error
+# (exit 3) until this spec ships.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs" \
+  && printf '[lint]\nrequire_ordinal_monotonic_depends_on = true\n' > "$tmp/spec-spine.toml" \
+  && target/release/spec-spine --repo "$tmp" lint
+# The corpus this repository actually holds still lints clean.
+target/release/spec-spine lint --fail-on-warn
+```

--- a/specs/054-effective-config-is-a-governed-read/spec.md
+++ b/specs/054-effective-config-is-a-governed-read/spec.md
@@ -1,0 +1,224 @@
+---
+id: "054-effective-config-is-a-governed-read"
+title: "The effective configuration is a governed read"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "005-coupling-gate"
+  - "009-coupling-floor-claim-precedence"
+  - "037-machine-readable-verdicts"
+extends:
+  # A new `config show` verb. Spec 002 owns the read-only query surface and its
+  # `--json` shape; it scopes itself to the compiled registry and says nothing
+  # about reading configuration, so this is a sibling verb rather than a change
+  # to what 002 requires. 002's spec.md is not edited (spec 040).
+  - { spec: "002-registry-query", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  # The bypass floor and the waiver keyword are computed here today, privately.
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "docs/adoption-guide.md" }, role: context }
+summary: >
+  `spec-spine.toml` is only half the configuration a coupling decision is made
+  from. The other half is `DEFAULT_BYPASS_PREFIXES`, a thirteen-entry constant
+  compiled into the binary, additive to the adopter's list and impossible to
+  read from outside the process. claude-observatory, which judges other
+  repositories, hand-parses each target's TOML and documents in its spec 016
+  D-3 that the built-in floor is simply unknowable to it. That is a consumer
+  reimplementing half a contract and knowing it has the other half wrong. This
+  spec adds `spec-spine config show [--json]`: the effective configuration,
+  every default resolved, with the bypass floor rendered as the merged list the
+  gate actually matches against and each entry attributed to the built-in floor
+  or to the adopter's file. It reads and reports; it decides nothing.
+---
+
+# 054: The effective configuration is a governed read
+
+## 1. Purpose
+
+Every read in this system is meant to go through a typed consumer. The
+constitution's principle II says machine truth is read only through the
+`spec-spine` binary or the `spec-spine-core` library, and
+`.claude/rules/governed-artifact-reads.md` says the same to every agent working
+in an adopting repository. The reason is always the same: a hand-rolled parser
+encodes today's assumptions and then goes quietly wrong when the contract moves.
+
+Configuration is the one input that has no such consumer. `spec-spine.toml` is
+authored TOML, and an adopter reading it back gets exactly what they wrote,
+which is not what the tool uses. Two things are missing from the file:
+
+**Defaults.** Every table is `#[serde(default)]`, so the absent keys are the
+common case. `index.resolver_exclusions` is six directory names nobody wrote
+down. `layout.cargo_workspace` is `Cargo.toml`. A file with three keys in it
+configures thirty.
+
+**The built-in bypass floor.** `couple.rs::DEFAULT_BYPASS_PREFIXES` is thirteen
+entries compiled into the binary: `.github/`, `docs/`, `README.md`,
+`CHANGELOG.md`, `LICENSE`, `CODEOWNERS`, `.gitignore`, `.gitattributes`,
+`standards/spec/constitution.md`, `.derived/`, and three lockfile globs. The
+adopter's `coupling.bypass_prefixes` is **additive** to it and cannot remove an
+entry. So the list the gate matches against is a merge of a constant nobody
+outside the process can see and a list the adopter wrote, and only the second
+half is in the file.
+
+claude-observatory is the case that makes this concrete. It is an orchestrator:
+it judges repositories other than itself, so it must reason about a target's
+coupling configuration without being that target. It hand-parses the target's
+TOML, and its spec 016 D-3 records the conclusion honestly: the built-in floor
+is unknowable to it. It is not a bug in claude-observatory. It is a fact about
+what the tool exposes, written down by the only consumer that hit it.
+
+The answer is the one the corpus already gives everywhere else: a verb. This is
+item 5 of the adopter audit's ranked backlog for the tool.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-cli/src/main.rs` | 002 | the `config` subcommand |
+| `crates/spec-spine-core/src/couple.rs` | 005 | the floor becomes readable as data |
+| `crates/spec-spine-types/src/config.rs` | 000 | the effective-config DTO |
+
+A new `crates/spec-spine-cli/src/cmd_config.rs` and its acceptance test are
+created by the implementing change and claimed there, per
+`.claude/rules/adversarial-prompt-refusal.md`: adding a file you created to the
+spec you are implementing is one of the two always-legitimate mid-build edits.
+
+Nothing about the gate's decision is in this spec's territory. `couple.rs`
+changes only in that a value it already computes becomes reachable; the
+predicate that consumes it is untouched.
+
+## 3. Behavior
+
+### 3.1 `spec-spine config show`
+
+A new subcommand, `config`, with one action, `show`, taking `--json`.
+
+It loads the repository's configuration exactly as every other verb does, fills
+in every default, and prints it. It reads no committed artifact, so it works on
+a repository that has never compiled, which is the state an adopter is in when
+they most need to see what their config resolved to.
+
+Exit `0` on success. A malformed `spec-spine.toml` is the existing
+`Error::Config`, exit `3`, unchanged: this verb reports a configuration, and a
+file that is not a configuration is the same failure it has always been.
+
+`config` is a **read**. It MUST NOT write, MUST NOT create a missing
+`spec-spine.toml`, and MUST NOT emit a "suggested" file. Scaffolding is
+`init`'s job and has been since spec 006.
+
+### 3.2 The bypass floor is reported merged and attributed
+
+The report's coupling section MUST carry the bypass floor as the merged, ordered
+list the gate matches against, with each entry attributed to its source:
+
+```
+coupling:
+  waiver_keyword: "Spec-Drift-Waiver:"
+  require_ownership: true
+  auto_waive_dependency_only: true
+  bypass_prefixes:
+    .github/                          (built-in)
+    docs/                             (built-in)
+    ...
+    **/README.md                      (spec-spine.toml)
+```
+
+Attribution is the load-bearing part and the reason this is not just a TOML
+echo. A consumer needs to answer two different questions: "is this path
+bypassed" (the merged list) and "did the adopter ask for that" (the source). An
+unattributed merge answers only the first, and an orchestrator deciding whether
+a target's configuration is unusual needs the second.
+
+The order MUST be the order the gate evaluates: built-in floor first, then the
+adopter's entries, each in its declared order. A consumer reimplementing the
+match against this list gets the same answer as the gate, in the same order,
+and that is the whole point of publishing it.
+
+An entry appearing in both lists MUST be reported once, attributed to both. It
+is legal and harmless (the match is an `or`), and reporting it twice would
+suggest a duplicate the adopter should remove when there is nothing to fix.
+
+### 3.3 The report is data first
+
+`--json` MUST emit the effective configuration as a single JSON object, sorted
+keys, pretty-printed, LF, trailing newline, exactly as every other emitted JSON
+in this system.
+
+It MUST NOT be the spec 037 verdict envelope. Spec 037 versions verdicts, and a
+verdict is what a **gate** returns: `ok`, `exitCode`, and a report of what was
+decided. `config show` decides nothing and cannot fail a gate, so wrapping it in
+an envelope would put a permanently-`true` `ok` field on a verb that has no
+notion of passing. It is a query, and it takes `--json` the way `registry show`
+and `index coverage` take it: the object itself.
+
+The prose form is a rendering of the same object and carries no fact the JSON
+lacks.
+
+### 3.4 What it reports is what the tool would use
+
+The reported object MUST be the `Config` value the verbs in this process would
+consume, with defaults resolved and no field omitted for being defaulted.
+
+Omitting defaulted fields would rebuild the exact problem this verb exists to
+solve: a consumer would see a short document and have to know which absences
+mean which values, which is reading `spec-spine.toml` again with extra steps.
+The verb is worth having precisely because it is exhaustive.
+
+It MUST include `config_version`, reporting `CONFIG_VERSION`, so a consumer
+pinning against this shape has the shape's version in the document rather than
+having to infer it from the binary's `--version`.
+
+### 3.5 Determinism
+
+The output is a pure function of `(config file contents, binary version)`. No
+clock, no environment, no filesystem walk beyond reading the config file that
+every verb already reads. The same repository and the same binary produce
+byte-identical bytes.
+
+## 4. Out of scope
+
+**`couple --explain-bypass`.** The audit offered it as the alternative shape:
+given a diff, say which paths the gate bypassed and why. It is a good verb and
+it answers a different question, about a specific run rather than about the
+configuration. Making the configuration readable first is the smaller change and
+the one the blocked consumer actually needs; per-path explanation can be built
+on it later without redoing anything here.
+
+**Changing the floor, or making it removable.** The built-in list stays exactly
+as it is, and adopter entries stay additive. Spec 009 settled the interaction
+between the floor and an explicit claim, and this spec neither reopens it nor
+depends on how it was settled. This verb makes the floor visible; it does not
+make it negotiable.
+
+**A `config check` or config lint.** Validating that an adopter's configuration
+is sensible (a `bypass_prefixes` entry matching nothing, a `resolver_exclusions`
+directory that does not exist) is a real idea and a different one. `show`
+reports; it does not judge.
+
+**Reading another repository's configuration without its binary.** `--repo`
+already points every verb at another tree, so an orchestrator with the CLI can
+read any target it can see. What it cannot do is read a target governed by a
+*different version* of spec-spine and learn that version's floor. That is a
+version-pinning problem, and spec 062 is where it belongs.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-cli --test config --locked
+# The verb exists and reports the merged, attributed floor. Until this ships,
+# `config` is an unknown subcommand and clap refuses it.
+target/release/spec-spine config show
+# The built-in floor is present in the JSON form, which is the fact
+# claude-observatory could not reach (016 D-3).
+target/release/spec-spine config show --json | grep -q '.derived/'
+# It reports without any committed artifact, on a corpus that never compiled.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs" && target/release/spec-spine --repo "$tmp" config show
+```

--- a/specs/055-the-ledger-answers-what-consumers-rebuild/spec.md
+++ b/specs/055-the-ledger-answers-what-consumers-rebuild/spec.md
@@ -1,0 +1,233 @@
+---
+id: "055-the-ledger-answers-what-consumers-rebuild"
+title: "The ledger answers what consumers rebuild by hand"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "002-registry-query"
+  - "004-codebase-index"
+  - "024-index-sharding"
+  - "032-ownership-coverage"
+extends:
+  # `index owner <path>`: the resolution the gate does privately, as a verb.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/tests/index.rs", nature: additive }
+  # `registry show --json` gains the shard's content hash as an output field.
+  - { spec: "002-registry-query", unit: "crates/spec-spine-cli/src/cmd_registry.rs", nature: additive }
+  - { spec: "002-registry-query", unit: "crates/spec-spine-core/src/query.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+summary: >
+  Two facts the ledger computes and then keeps to itself, each of which an
+  adopter has reimplemented. Ownership of a path is resolved inside
+  `couple.rs::owners_for_path`, a private function, so a consumer that wants to
+  know which spec governs a file rebuilds a path-to-spec map from raw edges and
+  gets the subtree, supersession and comment-header rules wrong. A spec's
+  content hash is written into every registry shard as `shardHash` and is
+  absent from every read verb, so claude-observatory reimplemented `hash.rs`
+  normalization in TypeScript in order to pin against it. This spec adds
+  `spec-spine index owner <path>` and puts `contentHash` on `registry show
+  --json`'s output object. Neither touches a committed artifact, a DTO, or a
+  schema version: both facts already exist and are merely unreachable.
+---
+
+# 055: The ledger answers what consumers rebuild by hand
+
+## 1. Purpose
+
+The authority ledger's whole promise is that "who owns this" and "has this
+changed" are answerable mechanically. It keeps that promise to itself and not
+to its consumers. Two questions, both already computed, neither reachable.
+
+**Which spec owns this path?** The coupling gate answers it on every run.
+`couple.rs::owners_for_path` walks the index's resolved units and implementing
+paths, applies `claim_matches` (an exact match or a directory-prefix match for a
+subtree unit), transfers authority transitively across `supersedes`, filters by
+hunk overlap for span-bearing units, and adds amends-awareness for a `spec.md`
+path. That is five separate rules, four of which a naive consumer will not
+guess, and the function is private. So consumers rebuild it: the audit found
+them reconstructing path-to-spec maps from raw edges, which gets bare-string
+file units right and everything else wrong.
+
+**What is this spec's content hash?** Every registry shard carries `shardHash`,
+SHA-256 over that spec's `spec.md` under the corpus's normalization rules (BOM
+stripped, CRLF and CR to LF, hashed as `<path>\0<bytes>`). No read verb reports
+it. `registry show --json` returns the record and not the shard. So
+claude-observatory, which wants to pin a spec's text so it can detect that the
+contract moved under it, reimplemented `hash.rs`'s normalization in TypeScript.
+That is a second implementation of the determinism claim, maintained by someone
+who does not own it, which will be wrong the first time the normalization gains
+a case.
+
+Both are the same failure. A fact is computed, used internally, and discarded at
+the boundary, so the consumer computes it again, worse. These are items 6 and 7
+of the adopter audit's ranked backlog for the tool, and they belong in one
+change because they are one mistake.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/couple.rs` | 005 | `owners_for_path` becomes reachable |
+| `crates/spec-spine-core/src/index.rs` | 004 | the public owner query |
+| `crates/spec-spine-cli/src/cmd_index.rs` | 004 | the `owner` action |
+| `crates/spec-spine-core/tests/index.rs` | 004 | its acceptance |
+| `crates/spec-spine-core/src/query.rs` | 002 | `show` can carry the shard hash |
+| `crates/spec-spine-cli/src/cmd_registry.rs` | 002 | reporting it |
+
+Specs 002, 004 and 005 each keep everything they require. Nothing here changes a
+resolution rule, a hash input, or a gate decision: two existing computations
+become readable.
+
+## 3. Behavior
+
+### 3.1 `spec-spine index owner <path>`
+
+A new read action beside `orphans`, `diagnostics` and `coverage`, taking
+`--json`.
+
+It reports, for one repo-relative path, the specs that own it and how:
+
+```
+crates/spec-spine-core/src/couple.rs
+  005-coupling-gate      unit        crates/spec-spine-core/src/couple.rs
+  052-couple-names-the-crossing  extends     crates/spec-spine-core/src/couple.rs
+  001-compile-registry   floor       crates/spec-spine-cli (package manifest)
+```
+
+Three linkage kinds, because a consumer's next decision depends on which one it
+is. A **unit** owner claimed the path in an ownership-bearing edge. A **floor**
+owner owns it only through a package's `[package.metadata.<ns>].spec`, which
+counts for `C-001` and counts as debt for coverage (spec 032). A **header**
+owner is a `// Spec:` comment in the file itself. Collapsing these into a flat
+list of spec ids would reproduce exactly the ambiguity spec 032 was written to
+remove.
+
+It MUST live under `index`, not under `registry`, and the reason is not
+cosmetic. The registry is the spec-as-source view: it holds units as authored,
+including symbol ids and section anchors that name no path at all. Resolving a
+unit to a set of files is the indexer's job and its output is the index. A
+`registry owner <path>` verb would either have to resolve (making the registry
+query depend on the index, which inverts the two views) or answer only for bare
+file units, which is the wrong answer stated confidently. The audit offered
+`registry owner`; the corpus's own layering says `index owner`.
+
+**Freshness.** Like `coverage`, it MUST refuse a stale committed index with
+`Error::Stale` (exit 2) rather than answer from a ledger that no longer
+describes the tree. An owner answer read off a stale index is the one kind of
+wrong answer this verb must never give, because its caller is deciding what to
+edit.
+
+**No owner is not an error.** A path nothing owns exits `0` with an empty result
+(`[]` under `--json`, a single explanatory line otherwise). It is a true and
+common answer, especially on a specify-first corpus, and `NotFound` is reserved
+for a thing that was asked for by name and does not exist. The path need not
+exist on disk: asking who *would* own a file before creating it is a legitimate
+question and the honest answer is computed the same way.
+
+### 3.2 The owner query is the gate's own function
+
+`owners_for_path`'s rules MUST NOT be reimplemented. The public query MUST call
+the same code the gate calls, so an answer from `index owner` and a `C-001`
+decision cannot disagree.
+
+That is the entire value of the verb. A second implementation that agreed today
+and drifted next quarter would be worse than no verb, because a consumer would
+have stopped rebuilding the map by hand and started trusting an answer nobody
+tests against the gate.
+
+Two of the gate's inputs are absent outside a diff and MUST be handled
+explicitly rather than faked:
+
+- **Hunk overlap.** The gate filters span-bearing owners by whether the change
+  touched their lines. With no diff there are no hunks, and the query MUST use
+  the whole-file interpretation the gate already defines for empty hunks
+  (`--paths-from` mode uses it today). Every owner whose span is in the file is
+  reported, which is the right answer to "who owns this file".
+- **Amends-awareness.** The gate widens the owner set for a `<specs_dir>/<id>/spec.md`
+  path, and only when the base set is non-empty (the strict-expansion guard).
+  The query MUST apply the same rule under the same guard, so asking about a
+  `spec.md` path returns what the gate would use.
+
+Supersession transfer applies unchanged: a successor inherits its predecessor's
+authority, additively, and both are reported.
+
+### 3.3 `contentHash` on `registry show --json`
+
+`registry show --json` MUST gain a `contentHash` field carrying the value the
+spec's committed registry shard records as `shardHash`. The prose form MUST
+print it as one additional line.
+
+This is additive at the output boundary and nowhere else:
+
+- **`SpecRecord` does not change.** The field is added to what `show` prints,
+  not to the record type. Adding it to `SpecRecord` would put it in every
+  committed shard, whose schema is `additionalProperties: false`, which means a
+  schema-file edit and a `REGISTRY_SCHEMA_VERSION` bump for a value the shard
+  already carries one line above the record.
+- **No committed artifact changes.** Every shard is byte-identical and
+  `compile --check` stays fresh.
+- **No schema version moves.** Not `REGISTRY_SCHEMA_VERSION`, which versions the
+  artifact, and not `VERDICT_SCHEMA_VERSION`, which versions gate envelopes that
+  this verb does not emit.
+
+The hash is read from the committed shard, never recomputed. `registry` is the
+read-side view of what was committed, and a `show` that recomputed from
+`spec.md` would report a hash the ledger does not hold, silently repairing a
+staleness that `compile --check` exists to reveal.
+
+### 3.4 What the hash means, said once
+
+`contentHash` is SHA-256 over that spec's `spec.md` alone: the registry's only
+hashed input, unchanged since before sharding. It is deliberately **not** the
+index's per-spec shard hash, which additionally folds span-backing source files
+and the global-inputs scalar.
+
+A consumer pinning "has this spec's text changed" wants the registry value. A
+consumer asking "has anything this spec depends on changed" wants the index
+value and a different question. The prose form MUST say which one it is
+reporting in the same breath as reporting it, because the two are the same shape
+and a consumer that confuses them gets a pin that fires on unrelated edits.
+
+## 4. Out of scope
+
+**`index coverage --by-path --json`.** The audit's alternative shape. Coverage
+answers a whole-tree question with a classification per file; `owner` answers a
+single path with its linkage detail. Bolting a per-path projection onto coverage
+would give the second answer in the first answer's vocabulary, which is
+`Specific` / `FloorOnly` / `Unowned` and cannot name a spec.
+
+**A reverse query (paths owned by a spec).** `index render` already projects it
+per spec, and a dedicated verb is a different design with a different output
+shape. Not needed by any evidence the audit collected.
+
+**Changing any ownership rule.** Subtree matching, supersession transfer,
+comment headers, the floor, the strict-expansion guard: all exactly as specs
+004, 005, 009, 019 and 032 left them. This spec makes a decision readable; it
+does not revisit it.
+
+**The index's per-spec shard hash as a read verb.** A real gap and a different
+one, tangled with what is and is not a hashed input, which spec 057 is about.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test index --locked
+cargo test -p spec-spine-core --test query --locked
+# The owner verb exists and agrees with the gate about a file the gate refuses.
+# Until this ships, `owner` is an unknown action and clap refuses it.
+target/release/spec-spine index owner crates/spec-spine-core/src/couple.rs | grep -q '005-coupling-gate'
+# A path nothing owns is an empty answer, not an error.
+target/release/spec-spine index owner no/such/path.rs
+# The registry reports the hash the committed shard holds, without recomputing.
+target/release/spec-spine registry show 024-index-sharding --json | grep -q contentHash
+target/release/spec-spine compile --check
+```

--- a/specs/056-compile-one-spec/spec.md
+++ b/specs/056-compile-one-spec/spec.md
@@ -1,0 +1,201 @@
+---
+id: "056-compile-one-spec"
+title: "Validate one draft without a temporary repository"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "001-compile-registry"
+  - "031-registry-freshness-check"
+  - "037-machine-readable-verdicts"
+extends:
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_compile.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+  - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-types/src/verdict.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+summary: >
+  Writing a spec means validating it before it lands, and the tool offers no
+  way to do that. `compile` writes the whole shard tree, which an author with an
+  unfinished draft must not do; `compile --check` refuses the whole corpus
+  because the draft has no committed shard, reporting the author's work in
+  progress as staleness. So two adopters wrote down a `mktemp -d` ritual:
+  copy the corpus, copy the draft in, compile there, read the violations, delete
+  the copy. It has a documented gotcha, because a `references` edge into `docs/`
+  does not resolve in a corpus copy that has no `docs/`. This spec adds
+  `compile --spec <id>`: validate one spec against the committed registry,
+  report only that spec's violations, and write nothing.
+---
+
+# 056: Validate one draft without a temporary repository
+
+## 1. Purpose
+
+The corpus is authored one spec at a time, and every spec is wrong at least
+once before it is right: a `depends_on` naming an id that does not exist, a
+`domain` outside the allowlist, a malformed edge, a directory that does not
+equal the id. Those are `V-` codes, and `compile` reports every one of them.
+
+An author with an unfinished draft cannot run it.
+
+`compile` **writes**. It emits the shard tree, so running it to see whether a
+draft parses commits that draft to the ledger as a side effect of asking a
+question. In a repository whose shards are committed, that dirties the tree with
+an artifact for a spec that may not survive the next edit. It is the same
+mistake spec 031 was written about and spec 046 found in three of the kit's
+hooks: writing while reading hides what the committed copy said.
+
+`compile --check` **refuses**. It compares the corpus to the committed shards,
+and a new draft has no committed shard, so the whole run is stale. The output is
+correct and useless: it reports the author's own unfinished work as drift, mixed
+in with nothing else, and gives no line about whether the draft is well-formed.
+
+What is left is the ritual two adopters wrote down: `mktemp -d`, copy
+`spec-spine.toml` and the corpus, copy the draft in, `compile` there, read the
+violations, delete the directory. Both documented the same gotcha, and it is
+instructive: a `references` edge pointing into `docs/` does not resolve in a
+copy that has no `docs/`, so the ritual produces a violation the real corpus
+would not, and the adopter has to know to ignore it. A workaround that teaches
+you which of its own outputs to disbelieve is a missing feature with extra
+steps.
+
+This is item 8 of the adopter audit's ranked backlog for the tool.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/compile.rs` | 001 | single-spec validation |
+| `crates/spec-spine-cli/src/cmd_compile.rs` | 001 | the `--spec` flag |
+| `crates/spec-spine-core/tests/compile.rs` | 001 | its acceptance |
+| `crates/spec-spine-types/src/verdict.rs` | 037 | the verdict's report payload |
+
+Spec 001 owns `compile` and defines the `V-` codes and the emission contract. It
+requires that compiling the corpus writes the registry; it says nothing about a
+mode that validates without writing, which spec 031 already established is a
+legitimate second mode of the same verb. This spec adds a third.
+
+## 3. Behavior
+
+### 3.1 `spec-spine compile --spec <id>`
+
+`compile` MUST accept `--spec <id>`, which validates exactly one spec and writes
+nothing.
+
+`<id>` accepts the short form (spec 016): `056` resolves to `056-compile-one-spec`
+when exactly one directory carries that ordinal. An id matching none or several
+is `Error::NotFound`, exit `1`, as everywhere else the short form is accepted.
+
+The spec need not have a committed shard. That is the entire point: the verb
+exists for a draft that has never compiled.
+
+Exit codes follow the existing contract exactly. `0` when the spec produces no
+error-tier violation, `1` when it does, `3` for I/O, parse, schema or config
+failure. It MUST NOT exit `2`: nothing here is a staleness question, and
+reporting a draft as stale is precisely the wrong answer `compile --check` gives
+today.
+
+`--spec` is incompatible with `--check` and MUST be refused as a usage error if
+both are given. They are different questions (is this well-formed / do the
+committed shards match) and a combined form would have to invent an answer for a
+spec with no shard.
+
+### 3.2 It reports one spec's violations, and says so
+
+The report MUST contain the violations attributable to the named spec and no
+others.
+
+Spec 001's structure already draws this line and this verb reuses it rather than
+inventing a filter. `CROSS_SPEC_CODES` (`V-003`, `V-004`, `V-008`, `V-010`,
+`V-014`) are the codes whose verdict depends on the whole corpus, which is why
+they are recomputed on read instead of stored per shard. Everything else is
+local to one spec and is exactly what `--spec` reports.
+
+The cross-spec codes are **not** silently dropped. They are evaluated with the
+named spec assembled against the committed registry, and reported, because they
+are the codes an author is most likely to trip: a `depends_on` naming a spec
+that does not exist (`V-010`) and a duplicate ordinal (`V-004`) are the two
+mistakes a new draft actually makes. Assembling against the committed registry
+rather than against a recompile of the corpus is what makes this fast and what
+keeps it honest: the author is asking whether their draft fits the corpus as it
+stands, and the corpus as it stands is what was committed.
+
+When a cross-spec code fires, the message MUST name the other spec involved, as
+it does today. An author told "duplicate numeric prefix '056'" without being
+told which spec already holds it has been given a puzzle.
+
+### 3.3 It resolves against the real repository
+
+Validation MUST read the real `spec-spine.toml` and the real corpus root. No
+copy, no temporary directory, no synthesized configuration.
+
+This is what kills the `references`-into-`docs/` gotcha rather than documenting
+it. The draft is validated where it lives, so every path in it resolves the way
+it will resolve after it lands, and a violation reported here is a violation
+that would be reported there.
+
+### 3.4 The verdict envelope
+
+`--spec` MUST accept `--json` and emit the spec 037 verdict envelope, with a
+`verb` token distinguishing it from `compile --check`.
+
+`compile --check` already carries one, and the flag's contract is that it
+changes what is written and never what is decided: every exit code is identical
+with and without it.
+
+`VERDICT_SCHEMA_VERSION` moves from `0.2.0` to `0.3.0`: a MINOR bump, because
+adding a `verb` token is the additive case that constant's documentation names.
+Spec 049 set the precedent when `verify` was added, and the reasoning has not
+changed: a consumer's existing branches still match, and a consumer that
+switches exhaustively on `verb` learns about the new one from the version.
+
+No registry shard changes and `REGISTRY_SCHEMA_VERSION` does not move. This verb
+writes nothing.
+
+### 3.5 Writing is still `compile`
+
+`--spec` MUST NOT write a shard, not even the named spec's.
+
+A per-spec write would be a genuinely useful verb and a different one, and
+offering it here would put an author one flag away from committing a shard for a
+draft they were only checking. The gate chain stays `compile` (write all) then
+`index` then `lint` then `couple`, and `--spec` sits outside it as a read, next
+to `--check`.
+
+## 4. Out of scope
+
+**Linting one spec.** `lint --spec <id>` is the obvious sibling and is not in
+this change. The `L-` codes are conventions, most are corpus-wide by nature, and
+the audit's evidence is about `V-` codes on an unlanded draft. A single-spec
+lint can be added later without redoing anything here.
+
+**Validating a file outside the corpus.** `compile --spec` names a spec by id,
+which means a directory under `specs_dir`. Validating a `spec.md` sitting
+somewhere else would need a second resolution story and answers no question an
+adopter has asked.
+
+**Making `compile --check` tolerant of new drafts.** Its job is to report whether
+the committed shards match the corpus, and an uncommitted draft genuinely means
+they do not. Teaching it to ignore that would break the freshness contract spec
+031 exists to hold, in order to work around the absence of the verb this spec
+adds.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test compile --locked
+# The flag exists, resolves the short id, and validates without writing.
+# Until this ships, `--spec` is an unknown argument and clap refuses it.
+target/release/spec-spine compile --spec 024
+target/release/spec-spine compile --spec 024-index-sharding --json
+# It wrote nothing: the committed shards are untouched.
+target/release/spec-spine compile --check
+# An unknown id is exit 1 (not found), never exit 2.
+target/release/spec-spine compile --spec 999 ; test $? -eq 1
+```

--- a/specs/057-claimed-but-unwitnessed/spec.md
+++ b/specs/057-claimed-but-unwitnessed/spec.md
@@ -1,0 +1,247 @@
+---
+id: "057-claimed-but-unwitnessed"
+title: "A claim no hash witnesses"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "003-conformance-lint"
+  - "004-codebase-index"
+  - "023-ledger-seal"
+  - "032-ownership-coverage"
+extends:
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "docs/schema-versioning.md" }, role: context }
+summary: >
+  A `file` unit carries no span, and only span-backing source files are folded
+  into a per-spec index shard hash. So a spec can claim a file, `index check`
+  can report fresh, `index coverage` can report it claimed, and the file's
+  contents can be rewritten from end to end with no gate noticing. This is not
+  hypothetical in this repository: `AGENTS.md` is claimed by three specs, and
+  appending a line to it leaves both `index check` and `compile --check`
+  reporting fresh. Twenty-four claimed paths here are in that state, and spec
+  023 signs an attestation over a ledger that never hashed any of them. This
+  spec adds `L-008`, a warning naming each claimed path that contributes to no
+  content hash, and one line of `index check` output reporting the count. It
+  does not fold claimed files into the hash: that would change what staleness
+  means, and the honest first move is to say how large the gap is.
+---
+
+# 057: A claim no hash witnesses
+
+## 1. Purpose
+
+The determinism claim is the centre of this system, and the sentence people read
+it as is stronger than the sentence it makes.
+
+What is actually hashed, per spec shard, is three things: that spec's `spec.md`,
+the source files backing its resolved `section` / `symbol` / `module` spans, and
+a global scalar over `spec-spine.toml` plus `index.extra_hashed_inputs`. A
+per-package shard hashes its manifest's governance projection and the same
+scalar. Nothing else.
+
+`file`, `directory` and `crate` units carry no span. `span_files_for_mapping`
+says so in as many words, and it is correct to: those units have no line range
+to shift. The consequence is what nobody wrote down. **A file claimed by a bare
+`file` unit contributes nothing to any hash**, unless it happens to be a
+manifest or to fall inside an `extra_hashed_inputs` glob.
+
+This is measurable here, not inferred. `AGENTS.md` is claimed by specs 029, 047
+and 051. Appending a line to it and re-running both freshness gates:
+
+```
+$ printf '\n<!-- probe -->\n' >> AGENTS.md
+$ spec-spine index check
+index is fresh
+$ spec-spine compile --check
+spec-registry is fresh: 53 shard(s) match the corpus
+```
+
+Twenty-eight paths outside `crates/` and `npm/` are claimed in this corpus.
+Four of them fall under `standards/**` or `.github/workflows/**` and are
+therefore hashed. The other twenty-four are not: every `.claude/` rule, agent
+and skill, both `.githooks/` scripts, `install.sh`, `docs/releasing.md`,
+`scripts/verify-spec.sh`, `py/scripts/generate_wheels.py`, and the entire `kit/`
+tree that specs 029, 046, 048 and 051 exist to govern.
+
+Three separate things read as safe and are not:
+
+- **The Stop and PostToolUse hooks** run `index check` after an edit to
+  `AGENTS.md`, `CLAUDE.md`, `.claude/rules/*.md` and `.claude/skills/*/*.md`.
+  Every one of those paths is unhashed, so the check is a formality on exactly
+  the paths the hook lists.
+- **`index coverage`** reports a claimed file as claimed, which is true and is
+  about ownership, not about witnessing. A reader takes the two together and
+  concludes the file is governed and pinned. Only the first half holds.
+- **Spec 023's attestation** signs a reproducible corpus seal built from the
+  ledger. For these twenty-four paths, the seal attests to a claim and to
+  nothing about the content claimed.
+
+hqgit found the same thing from the other end: its spec 001 claims four scripts
+no glob covers, and they can be rewritten with `index check` still reporting
+fresh. That is item 9 of the adopter audit's ranked backlog.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/lint.rs` | 003 | the `L-008` check |
+| `crates/spec-spine-core/src/index.rs` | 004 | the witnessed-input predicate |
+
+The implementing change creates `crates/spec-spine-core/tests/lint.rs` if spec
+053 has not already, and claims it in whichever spec creates it.
+
+No hash input changes. No committed artifact changes. `INDEX_SCHEMA_VERSION`
+does not move.
+
+## 3. Behavior
+
+### 3.1 One predicate, in the indexer
+
+`index.rs` MUST expose a predicate answering, for a repo-relative path, whether
+that path contributes to any content hash the index computes. It is true when
+the path is a spec's `spec.md`, a discovered package's manifest,
+`spec-spine.toml`, matched by an `index.extra_hashed_inputs` glob, or a
+span-backing file of some resolved unit.
+
+It MUST be derived from the same code that builds the hashes, not restated
+beside it. A second list of what is hashed would be wrong the first time the
+first list changes, and this whole spec exists because a reader's model of the
+hash inputs was wrong.
+
+A path under `layout.state_dir` is never witnessed, by construction (spec 039
+excludes state from every content hash). It is also never claimable: `L-006`
+already refuses a unit claimed inside the state root at error tier. So the two
+checks cannot both fire on one path, and `L-008` MUST defer: if `L-006` fires,
+`L-008` MUST NOT, because "you claimed the ungoverned directory" is the whole
+diagnosis and adding "and it is not hashed" is noise on a path that must move.
+
+### 3.2 `L-008`
+
+`lint` MUST emit one `L-008` diagnostic, at **warning** severity, for each
+ownership-bearing claimed path that the predicate reports as unwitnessed:
+
+```
+L-008  spec '051-harness-runs-the-verbs-it-ships' claims 'AGENTS.md', which is
+       in no content hash: its contents can change without staling any shard.
+       Add a covering glob to [index] extra_hashed_inputs, or claim a section
+       or symbol unit, whose span is hashed.
+```
+
+**Warning, not error.** An unwitnessed claim is a real gap and a legitimate
+state. A spec may deliberately claim a file whose content it does not want
+staling the ledger, and on a specify-first corpus a spec routinely claims files
+that do not exist yet, which are unwitnessed for a reason that will resolve
+itself. Error tier would refuse a corpus for a condition many corpora hold on
+purpose. Warning tier means `lint --fail-on-warn` refuses it, which is what this
+repository runs in CI, and which is the decision this corpus should make
+deliberately rather than inherit.
+
+The message MUST name both remedies, because they are genuinely different
+choices and the right one depends on the file. A glob in `extra_hashed_inputs`
+folds the file into the **global** scalar, which restamps every shard when it
+changes: correct for a small set of governance files, wrong for a large tree of
+source. A `section` or `symbol` unit is hashed through its span and stales only
+the claiming spec's shard: correct for source, and unavailable for a file with
+no parseable sections.
+
+A path that does not exist on disk MUST NOT produce `L-008`. It is already
+diagnosed: an unresolved unit is `W-001` or `W-002` (spec 025), and telling a
+specify-first corpus that a file it has not written yet is also not hashed would
+put a second warning on every pending claim in the corpus. `L-008` is about
+files that exist and are claimed and are invisible to the ledger.
+
+### 3.3 `index check` reports the count
+
+`index check` MUST report the number of claimed-but-unwitnessed paths on one
+line, beside the unresolved-unit counts spec 050 added:
+
+```
+index is fresh
+  unresolved: 0 (W-001: 0, W-002: 0)
+  unwitnessed claims: 24
+```
+
+Reporting only. `index check` MUST NOT change its exit code for this, with or
+without `--fail-on-unresolved`. The gate half is the lint's, at warning tier,
+and putting a second refusal on `check` would make one flag mean two conditions.
+
+The line exists because `index check` is where a person reads the word "fresh",
+and "fresh" is the word this spec is qualifying. A count there is the smallest
+honest correction to what the reader is being told.
+
+Under `--json`, the count joins the existing `IndexCheckReport` payload as an
+additive field. `VERDICT_SCHEMA_VERSION` does not move: spec 050 §3.6 settled
+that adding a member to one verb's report payload is additive and must not move
+the constant that versions the envelope, and this spec follows that decision
+rather than reopening it.
+
+### 3.4 Nothing is folded into a hash
+
+The alternative the audit offered, folding claimed `file` units into the shard
+hash, is **not** taken, and the reason is worth recording rather than leaving to
+inference.
+
+It would change what staleness means. Today a shard is stale when the spec's
+text, its spans, or the global inputs changed: an edit to a claimed source file
+does not stale the index, because drift between code and spec is the coupling
+gate's question, asked at PR time against a diff. Folding claimed files in would
+make every source edit stale the index, so every code change would require
+regenerating and committing shards, and `index check` would start refusing for a
+condition `couple` already refuses better.
+
+It would also cost the property spec 024 was written for. A claimed file shared
+between two specs would stale both shards, so two PRs touching different specs
+would write the same files again, which is the conflict sharding removed.
+
+Naming the gap is the change that is clearly right. Closing it by folding is a
+change to the staleness contract that deserves its own spec, its own argument,
+and a corpus that already knows how big the gap is. This spec produces that
+number.
+
+## 4. Out of scope
+
+**Deciding this repository's twenty-four.** The lint reports them; which get a
+glob, which get a narrower unit, and which are deliberately unwitnessed is a
+sequence of judgements about specific files, and none of them is a mechanical
+consequence of this spec. `lint --fail-on-warn` runs in CI here, so the
+implementing change must resolve the corpus to green, and the resolution it
+picks is a decision recorded in this spec at that time, not predetermined now.
+
+**Folding claimed files into the hash.** §3.4.
+
+**Extending the seal.** Spec 023's attestation covers what the ledger hashes.
+Making it cover more is a change to the seal's input set and belongs with the
+folding decision, not ahead of it.
+
+**Unresolved units.** `W-001` and `W-002` (specs 025, 050) diagnose a claim that
+resolves to nothing. `L-008` diagnoses a claim that resolves to something no
+hash covers. Different conditions, and §3.2 keeps them from firing on the same
+path.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test lint --locked
+# `index check` reports the count. Until this ships, the line is absent.
+target/release/spec-spine index check | grep -q 'unwitnessed claims'
+# A synthetic corpus claiming an existing file that no hash covers produces
+# L-008. This is the condition 3.2 defines, isolated from this repository's
+# own remedies.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" \
+  && printf 'claimed\n' > "$tmp/thing.sh" \
+  && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "thing.sh"\n---\n\n# x\n' > "$tmp/specs/001-x/spec.md" \
+  && target/release/spec-spine --repo "$tmp" lint | grep -q 'L-008'
+# This corpus is green at the tier CI gates on, which means the twenty-four
+# unwitnessed claims named in 1 were each resolved or deliberately covered by
+# the implementing change.
+target/release/spec-spine lint --fail-on-warn
+```

--- a/specs/058-retroactive-adoption-shape/spec.md
+++ b/specs/058-retroactive-adoption-shape/spec.md
@@ -1,0 +1,209 @@
+---
+id: "058-retroactive-adoption-shape"
+title: "The defects heading has one spelling"
+status: draft
+kind: "governance"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "003-conformance-lint"
+  - "022-keypath-section-anchors"
+  - "043-governance-document-gaps"
+extends:
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
+refines:
+  # 043 refined this principle with the aspect `adopted-code-as-evidence`,
+  # adding the heading. This spec refines a different aspect of the same
+  # section: what counts as that heading. Not `amends` (its targets are spec
+  # ids and the constitution is not a spec) and not `co_authority` (the two
+  # aspects are separable, not shared), per the amendment clause 043 wrote.
+  - { aspect: "defects-heading-anchor", unit: { kind: section, file: "standards/spec/constitution.md", anchor: "v-legacy-as-evidence" } }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+summary: >
+  Constitution V requires code adopted from outside the corpus to be specced as
+  found, with the behavior the adopting spec would not have chosen recorded
+  under a `## Known defects` heading. It does not say what counts as that
+  heading, and the first consumer to check mechanically got it wrong:
+  claude-observatory's `defects.ts` matches the string `## Known defects`
+  exactly and therefore rejects the numbered headings of the very specs it cites
+  as precedent. This spec settles the spelling as an anchor rather than a
+  string: any heading whose computed slug is or ends with `known-defects`, at
+  any level, under the same slug rule the indexer already uses for section
+  units. It adds `L-009`, an info-tier lint for a near-miss spelling, and it
+  declines to lint `origin.retroactive` into implying the heading, because spec
+  043 established that the two are orthogonal.
+---
+
+# 058: The defects heading has one spelling
+
+## 1. Purpose
+
+Constitution V gained its operational half in spec 043:
+
+> Code adopted from outside the corpus is specced **as found**. The adopting
+> spec describes the behavior that exists, and records the behavior it would not
+> have chosen under a `## Known defects` heading, with the defect named.
+
+That sentence closes a real dilemma. Without the heading, a spec adopting
+foreign code must either describe it accurately, thereby ratifying its defects
+as the specified behavior, or describe the intended behavior and ship a spec its
+own coupling gate will contradict. The heading is the seam between "this is the
+contract" and "this is what is there".
+
+It is a load-bearing convention that no code has ever checked, and the first
+consumer to check it got it wrong. claude-observatory's `defects.ts` matches the
+literal string `## Known defects`. The specs it names as precedent write the
+heading with a section number, `## 5. Known defects`, so the checker rejects its
+own citations. That is not carelessness. It is what happens when a governance
+document specifies a heading by quoting it, and a consumer has to guess whether
+the quote is the exact form or an example.
+
+The corpus already knows how to answer this, and has since spec 022. Section
+units name a heading by its **anchor**, the slug the indexer computes:
+alphanumerics lowercased, every other run collapsed to a single dash, ends
+trimmed. `## Known defects` and `## Known Defects` and `### known defects` all
+slug to `known-defects`. `## 5. Known defects` slugs to `5-known-defects`.
+Specifying the heading as an anchor rather than a string makes the question
+mechanical, and makes it the same question the section-unit resolver already
+answers.
+
+This is item 10 of the adopter audit's ranked backlog for the tool.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/lint.rs` | 003 | the `L-009` check |
+| `standards/spec/constitution.md` §V | 043, refined here | the spelling, stated |
+
+The constitution edit is a `refines` claim, with the named aspect
+`defects-heading-anchor`, on the same section spec 043 refined under the aspect
+`adopted-code-as-evidence`. It is not an `amends` edge: `amends` resolves to
+spec ids and the constitution is not a spec. That is the mechanism spec 043
+itself defined, and this spec is its second use. The file is on the coupling gate's built-in bypass
+floor, so the claim is a ledger fact rather than a `C-001` refusal, exactly as
+043 §3 describes.
+
+## 3. Behavior
+
+### 3.1 The heading is an anchor
+
+A defects section is any heading in a `spec.md` whose computed anchor is
+`known-defects` or ends with `-known-defects`.
+
+The slug rule is the existing one in `sections.rs`, unchanged and not
+reimplemented. That gives, for free:
+
+- case insensitivity (`Known Defects`, `KNOWN DEFECTS`),
+- any heading level (`##`, `###`),
+- section numbering (`## 5. Known defects` slugs to `5-known-defects`, which
+  ends with the anchor),
+- punctuation tolerance (`## Known defects:` trims to `known-defects`).
+
+And it excludes the things it should: `## Known defect` (singular) slugs to
+`known-defect`, `## Defects` slugs to `defects`, and `## Known defects and open
+questions` slugs to `known-defects-and-open-questions`, which does not end with
+the anchor. The last is the interesting one and the rule is deliberate: a
+heading that continues past the anchor is a section about something wider, and
+a consumer extracting defects from it would extract the open questions too.
+
+**Suffix, not prefix or substring.** A prefix rule would accept the
+open-questions case. A substring rule would accept both that and
+`## Why known defects matter`. The suffix rule accepts exactly the numbering and
+prefixing that real specs use, which is the case that broke `defects.ts`.
+
+The constitution's §V MUST state this, in one sentence, where it currently
+quotes the heading. Quoting a heading and meaning an anchor is the defect; a
+governance document that names the rule cannot be misread into a string match.
+
+### 3.2 `L-009`
+
+`lint` MUST emit one `L-009` diagnostic, at **info** severity, for each heading
+in a `spec.md` whose anchor is a near miss for the defects anchor: it contains
+`defect` and is not itself a defects anchor under §3.1.
+
+```
+L-009  spec '031-registry-freshness-check' has heading '## Known defect'
+       (anchor 'known-defect'), which is not the defects anchor: a consumer
+       looking for 'known-defects' will not find this section
+```
+
+**Info tier.** It is a spelling nudge on a section that is otherwise valid
+prose, and info is the tier this corpus reserves for exactly that (`L-005`, the
+stub check). It surfaces under `--fail-on-info`, which no gate here runs, so a
+corpus is told without being refused.
+
+The check reads `section_headings`, which `SpecRecord` already carries and
+`compile` already populates. No new parsing, no new field, no new IO.
+
+### 3.3 `origin.retroactive` does not imply the heading
+
+There is deliberately **no** lint requiring a spec with `origin.retroactive: true`
+to carry a defects section.
+
+The audit's item 10 proposed one, and spec 043 already answered it in the
+sentence that added the heading to the constitution: `origin.retroactive: true`
+says *when* the authority began; `## Known defects` says *what* the adopting spec
+makes of what it found. The two are orthogonal, and 043 wrote that down as a
+conclusion, not as a hedge.
+
+The counterexample is in this corpus. `specs/000-spec-spine-bootstrap` declares
+`origin.retroactive: true` and has no defects section, and it is right not to:
+it claims authority over a corpus convention that predates the graph, not over
+foreign code with behavior it would not have chosen. A lint implementing the
+audit's proposal would fire on the tier-1 bootstrap spec, which is both wrong
+and unfixable, since spec 000's `unamendable` anchors are non-overridable.
+
+Nothing in the frontmatter distinguishes "adopted foreign code" from "authority
+that predates the graph", and inventing a key to carry that distinction would be
+adding grammar to make a lint possible rather than because an author needs to
+say it. So the corpus checks the spelling of the heading, which is mechanical,
+and leaves the judgement of when one is owed to the constitution, which is where
+judgement belongs.
+
+### 3.4 Nothing else moves
+
+No committed artifact changes, and no schema version moves. `compile --check`
+stays fresh, `L-009` is info tier so `lint --fail-on-warn` is unaffected, and
+the constitution is a hashed input under `standards/**`, so editing it restamps
+the global scalar and therefore every shard. The implementing change regenerates
+and commits them, as any edit under `standards/` requires.
+
+## 4. Out of scope
+
+**Requiring a defects section anywhere.** No spec is refused for lacking one.
+Constitution V says when one is owed and that is a judgement a person makes about
+code they adopted.
+
+**Checking what is inside the section.** "With the defect named" is prose the
+author writes and no lint can evaluate.
+
+**A machine-readable defects list.** Extracting the section's contents into the
+registry as structured data is a real idea, and it is the one that would let a
+consumer stop reading markdown. It needs a grammar for a defect entry and a
+schema version, and it should be designed after the heading has one spelling,
+not at the same time.
+
+**Fixing claude-observatory's `defects.ts`.** An adopter-side follow-up, recorded
+in the audit's §5. This spec gives it the rule to implement.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test lint --locked
+# The constitution states the anchor rule rather than quoting a heading.
+grep -q 'known-defects' standards/spec/constitution.md
+# A near-miss heading is reported at info tier, and only under --fail-on-info.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" \
+  && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n\n## Known defect\n\nprose\n' > "$tmp/specs/001-x/spec.md" \
+  && target/release/spec-spine --repo "$tmp" lint | grep -q 'L-009'
+# The corpus stays green at the tier CI gates on, and the shards were committed.
+target/release/spec-spine lint --fail-on-warn
+target/release/spec-spine compile --check
+target/release/spec-spine index check
+```

--- a/specs/059-read-verbs-on-a-code-free-corpus/spec.md
+++ b/specs/059-read-verbs-on-a-code-free-corpus/spec.md
@@ -1,0 +1,217 @@
+---
+id: "059-read-verbs-on-a-code-free-corpus"
+title: "Two read verbs that mislead a specify-first corpus"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "011-index-render-orphans"
+  - "032-ownership-coverage"
+  - "044-in-progress-is-in-flight"
+extends:
+  - { spec: "011-index-render-orphans", unit: "crates/spec-spine-core/src/render.rs", nature: additive }
+  - { spec: "032-ownership-coverage", unit: "crates/spec-spine-core/src/coverage.rs", nature: additive }
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  - { spec: "032-ownership-coverage", unit: "crates/spec-spine-core/tests/coverage.rs", nature: additive }
+  - { spec: "011-index-render-orphans", unit: "crates/spec-spine-core/tests/render.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+summary: >
+  Three of the four governed repositories are specify-first: the whole corpus is
+  ratified before a line of code exists, and specs live at approved plus pending
+  for months. Two read verbs give that corpus an answer that is technically
+  correct and practically a lie. `index orphans` reports sixty-four of hqgit's
+  sixty-eight specs, because an orphan is a spec claiming nothing that resolves,
+  and a spec whose code is not written yet claims nothing that resolves; the
+  list is the corpus, so it says nothing. `index coverage --fail-on-untraced`
+  on a tree with no discovered package enumerates zero source files, computes
+  zero untraced, and exits 0 from inside a CI step named "the whole-tree
+  ownership assertion". This spec makes the first partition by the in-flight
+  predicate the index already computes, and makes the second refuse an empty
+  universe instead of passing it.
+---
+
+# 059: Two read verbs that mislead a specify-first corpus
+
+## 1. Purpose
+
+Specify-first is not an edge case. Three of the four repositories the audit
+examined work that way: hqgit (68 specs, no code), aicortex (29 specs, no code)
+and rahi (22 specs, one wave built). Specs 041 and 044 were written for exactly
+this mode. It is the mode a new adopter is in on their first day, and it is the
+mode two read verbs handle badly.
+
+**`index orphans` reports the corpus.** An orphan is a spec whose
+`implementing_paths` is empty: it claims nothing that resolves to a file. On a
+corpus where the code is not written yet, that describes every spec that has not
+been built, which on hqgit is sixty-four of sixty-eight. The output is correct
+and carries no information, because a list that is nearly the whole corpus
+cannot distinguish the case it exists to find: a spec that claims territory
+which will never resolve, because the code moved or the claim was wrong.
+
+**`index coverage --fail-on-untraced` passes an empty tree.** The coverage
+universe is package-scoped: `enumerate_source_files` walks the discovered
+packages, and a repository with no `Cargo.toml` and no `package.json` discovers
+none. So `source_files` is 0, `untraced_files()` is 0, `is_fully_claimed()` is
+true, and the verb exits 0. An adopter who has wired this into CI under a step
+named for the whole-tree ownership assertion has a green check asserting
+nothing, and it stays green on the day they add their first source file outside
+a package.
+
+The second is the more dangerous of the two, because it fails open. The first
+merely wastes a verb. Both come from the same root: a predicate that means one
+thing on a built corpus and something else on a corpus that has not been built,
+with no way for the reader to tell which they are looking at.
+
+These are items 11 and 12 of the adopter audit's ranked backlog for the tool.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/render.rs` | 011 | `orphans` partitions |
+| `crates/spec-spine-core/tests/render.rs` | 011 | its acceptance |
+| `crates/spec-spine-core/src/coverage.rs` | 032 | the empty-universe case |
+| `crates/spec-spine-core/tests/coverage.rs` | 032 | its acceptance |
+| `crates/spec-spine-cli/src/cmd_index.rs` | 004 | both renderings |
+
+Neither spec 011 nor spec 032 is edited. 011 requires `orphans` to report the
+id-sorted `orphanedSpecs` list, and it still does; this spec adds a partition
+over that same list. 032 requires `--fail-on-untraced` to exit 1 unless every
+source file has a specific owner, and it still does; this spec adds a refusal
+for the case where "every source file" is vacuous.
+
+## 3. Behavior
+
+### 3.1 `orphans` partitions by the in-flight predicate
+
+`index orphans` MUST report two groups rather than one flat list:
+
+```
+orphaned (claims nothing that resolves, and is not in flight):
+  019-structured-partial-supersedes
+
+in flight (claims nothing that resolves yet; draft or pending):
+  061-something-not-built-yet
+  062-also-not-built-yet
+```
+
+The predicate is the one `index.rs` already computes and spec 044 defined:
+in flight is `implementation: complete` being absent and either `status: draft`
+or `implementation` in `{pending, in-progress}`. It is the same predicate that
+decides whether an unresolved unit is a blocking error or a `W-001` warning, and
+using it here means the two verbs cannot disagree about which specs are under
+way.
+
+The first group is the finding. A spec that is neither draft nor pending nor
+in-progress, that claims nothing resolving, is a spec whose author said the work
+is done or does not apply while the ledger says nothing of theirs exists. That
+is the condition `orphans` was built to surface, and on hqgit it is four specs
+rather than sixty-four.
+
+The second group is the corpus's normal state and MUST be reported, not
+filtered. Suppressing it would replace a useless answer with an incomplete one,
+and a scheduler wanting "what has no code yet" would lose the verb that answers
+it. Two named groups let a reader take either.
+
+Under `--json`, the flat array becomes an object with the two arrays as named
+members. This is a **breaking** shape change for a consumer parsing the array
+directly, and it is the right call: the flat array's meaning is the thing this
+spec is fixing, so preserving it would preserve the defect under a compatibility
+argument. `INDEX_SCHEMA_VERSION` does not move (no committed artifact changes)
+and no verdict envelope is involved (`orphans` emits none); the change is to one
+read verb's `--json` output and MUST be called out in the release notes as such.
+
+Ordering inside each group stays id-sorted, as spec 011 §3.3 requires.
+
+### 3.2 An empty coverage universe is a refusal, not a pass
+
+`index coverage --fail-on-untraced` MUST exit `1` when the coverage universe is
+empty, with a message naming the reason:
+
+```
+coverage: no source files under any discovered package.
+--fail-on-untraced asserts that every source file has a specific owning spec,
+and there are none to assert about. Nothing was verified.
+```
+
+The flag is an assertion, and an assertion over an empty set is vacuously true,
+which is the mathematically correct answer and the operationally wrong one. A
+person wiring `--fail-on-untraced` into CI is asserting that the tree is fully
+owned. If the tool cannot see the tree, the honest report is that the assertion
+did not run, and a CI step that did not run its check should not be green.
+
+Without `--fail-on-untraced`, `coverage` MUST still exit `0` on an empty
+universe and report the fact plainly. The report is a read verb, and "no source
+files under any discovered package" is a true and useful thing for it to say to
+a specify-first corpus. Only the assertion refuses.
+
+An empty universe with packages discovered but no source files in them is the
+same refusal for the same reason. What matters is that the denominator is zero,
+not why.
+
+### 3.3 The message says which of two things happened
+
+The refusal MUST distinguish, in its text, no discovered packages from
+discovered packages containing no source files. They have different fixes:
+the first is usually `layout.standalone_rust_workspaces` or
+`standalone_npm_packages` not naming a package that exists, and the second is
+usually `index.resolver_exclusions` pruning too much.
+
+A refusal that names the condition without naming the likely cause makes the
+reader search for both. The audit found adopters deriving this class of thing by
+experiment, and this is the cheapest place to stop that.
+
+### 3.4 Nothing committed moves
+
+No shard changes, `INDEX_SCHEMA_VERSION` and `VERDICT_SCHEMA_VERSION` stay
+where they are, and `compile --check` stays fresh. Both changes are to read
+verbs' output and to one exit code in a case that previously could not fail.
+
+This repository's CI runs `index coverage --fail-on-untraced` and has four
+discovered packages with seventy-four source files, so §3.2's refusal is
+unreachable here and the step's behavior is unchanged.
+
+## 4. Out of scope
+
+**Widening the coverage universe beyond packages.** hqgit's four claimed scripts
+live outside every package and are therefore invisible to coverage as well as
+unhashed. That is a real gap, it is the same gap spec 057 measures from the hash
+side, and widening the universe changes what every coverage number in every
+adopting repository means. It needs its own spec and its own migration note.
+
+**Changing what an orphan is.** A spec claiming nothing that resolves is the
+definition spec 011 gave and this spec keeps it. Only the presentation
+partitions.
+
+**A `--fail-on-orphans` gate.** `orphans` stays a read verb. With the partition
+in place a gate becomes conceivable for the first time, since the first group is
+finally a small set, but adding a refusal is a separate decision from making the
+report meaningful.
+
+**Reporting in-flight specs anywhere else.** `registry plan` already answers
+"what can be worked on" from the scheduling side. This spec makes `orphans`
+honest, not a second scheduler.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test render --locked
+cargo test -p spec-spine-core --test coverage --locked
+# `orphans` partitions. Until this ships, the output is one flat list.
+target/release/spec-spine index orphans --json | grep -q 'inFlight'
+# An empty coverage universe refuses the assertion instead of passing it.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" \
+  && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n' > "$tmp/specs/001-x/spec.md" \
+  && target/release/spec-spine --repo "$tmp" compile >/dev/null \
+  && target/release/spec-spine --repo "$tmp" index >/dev/null \
+  && target/release/spec-spine --repo "$tmp" index coverage \
+  && ! target/release/spec-spine --repo "$tmp" index coverage --fail-on-untraced
+# This repository's own coverage assertion is unaffected.
+target/release/spec-spine index coverage --fail-on-untraced
+```

--- a/specs/060-plan-answers-the-whole-question/spec.md
+++ b/specs/060-plan-answers-the-whole-question/spec.md
@@ -1,0 +1,210 @@
+---
+id: "060-plan-answers-the-whole-question"
+title: "The plan answers the whole question, and names one pick"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "038-registry-plan-ready-set"
+  - "044-in-progress-is-in-flight"
+  - "045-absent-implementation-defers-to-status"
+extends:
+  - { spec: "038-registry-plan-ready-set", unit: "crates/spec-spine-core/src/query.rs", nature: additive }
+  - { spec: "002-registry-query", unit: "crates/spec-spine-cli/src/cmd_registry.rs", nature: additive }
+  - { spec: "038-registry-plan-ready-set", unit: "crates/spec-spine-core/tests/query.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: ".claude/skills/next/SKILL.md" }, role: context }
+summary: >
+  `registry plan` prints spec ids and a count. Every consumer needs more than
+  that, so every consumer adds it back: adopters kept about forty lines of
+  Python to join the ready ids against titles and to explain why each blocked
+  spec is blocked, and the corpus's own `/next` skill has to make a second call
+  to turn an id into something a human can read. The data is all there. `Plan`
+  already carries each blocked spec's blockers with the state of each, and the
+  registry it was computed from carries every title. This spec makes the prose
+  form render what the structure already holds, and adds `--next`, the single
+  pick that the one-spec-per-session loop actually asks for. The JSON shape
+  gains title fields and is otherwise unchanged.
+---
+
+# 060: The plan answers the whole question, and names one pick
+
+## 1. Purpose
+
+Spec 038 built `registry plan` to answer the scheduling question, and it
+answers it correctly. `Plan` carries a topologically ordered `ready` list and a
+`blocked` list where each entry names its blockers and each blocker carries the
+state that makes it a blocker. The ordering of both is contractual. The cycle
+case is refused rather than truncated. As a data structure it is complete.
+
+Then the CLI prints this:
+
+```
+052-couple-names-the-crossing
+ready: 1, blocked: 0
+```
+
+Ids and a count. The blocked list, which is the half a person reads when the
+ready set is empty, is rendered as a number. The titles, which are in the same
+registry the plan was computed from, are absent. So consumers add them back:
+the audit found roughly forty lines of Python doing the join in adopting repos,
+and this repository's own `/next` skill has to issue a second `registry` call to
+turn an id into a line a human can act on.
+
+There is also a shape mismatch. The corpus's working rule is one session, one
+spec: `.claude/rules/orchestrator-rules.md` says so, `AGENTS.md` says so, and
+every driven session begins by picking exactly one. `plan` returns a list, so
+every caller takes the first element and re-derives which "first" means the
+right one. That derivation is contractual (topological, ties by ascending id)
+and it is written down in `query.rs`, which is not where a caller looks.
+
+These are items 13 and 14 of the adopter audit's ranked backlog for the tool,
+and they are one change: the second is the smallest useful projection of the
+first.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/query.rs` | 038 | titles on the plan, `--next` selection |
+| `crates/spec-spine-core/tests/query.rs` | 038 | acceptance |
+| `crates/spec-spine-cli/src/cmd_registry.rs` | 002 | the rendering and the flag |
+
+Spec 038 defines what the ready and blocked sets contain and the order of both.
+Nothing here changes either. It says nothing about the prose rendering, which is
+the surface this spec adds to.
+
+## 3. Behavior
+
+### 3.1 The prose form renders what the structure holds
+
+`registry plan` MUST render both sets with titles, and MUST render each blocked
+spec's blockers with the state of each:
+
+```
+ready (1):
+  052  The coupling gate names the crossing
+
+blocked (2):
+  061  A version pin the CLI can check
+       blocked by 054 (draft)
+  062  The stale binary is not a stale ledger
+       blocked by 054 (draft), 061 (pending)
+
+53 specs: 1 ready, 2 blocked, 50 not schedulable
+```
+
+Three facts the current output does not carry, each already in hand:
+
+- **Titles.** Joined from the same registry `plan` was computed from. No second
+  load, no second call.
+- **Why each blocked spec is blocked.** `BlockedSpec.blocked_by` is a list of
+  `Blocker { id, state }` and the state is the reason. Printing the count and
+  discarding the reasons is discarding the part a reader needs.
+- **The remainder.** `plan` excludes specs the corpus has moved past
+  (`superseded`, `retired`) or that someone has already answered "no" for
+  (`complete`, `n-a`, `deferred`). Today those specs vanish silently, so the two
+  numbers do not add up to the corpus and a reader cannot tell whether the
+  missing ones were excluded or lost. One "not schedulable" figure closes it.
+
+The ordering contract is untouched: `ready` stays topological with ties by
+ascending id, `blocked` stays ascending by id, and each entry's blockers stay in
+that spec's authored `depends_on` order. Spec 038 §3.2 requires the report to be
+a pure function of the corpus, and adding titles from that same corpus keeps it
+one.
+
+`(nothing ready)` stays exactly as it is when `ready` is empty. It is the line a
+finished corpus prints and it already carries its own count.
+
+### 3.2 `--next`
+
+`registry plan --next` MUST print exactly one spec: the first element of
+`ready`.
+
+```
+052  The coupling gate names the crossing
+```
+
+With `--json`, the single spec object rather than an array, so a consumer does
+not index into a one-element list to reach the thing it asked for.
+
+An empty ready set exits `0` and prints `(nothing ready)`. It is a true answer
+to "what should I work on", not a failure, and a driven session that treats
+"nothing to do" as an error will stop for the wrong reason. `Error::NotFound`
+would be wrong here: nothing was asked for by name.
+
+`--next` MUST be a projection of `plan` and MUST NOT reimplement selection. The
+first element of the topological order is already the defined pick; this flag
+names it so that callers stop re-deriving what "first" means. If the ordering
+contract ever changes, it changes in one place and `--next` follows.
+
+`--next` and the full listing are mutually exclusive by nature, and passing
+`--next` simply prints the one line. There is no interaction with a status
+filter, because `plan` takes none.
+
+### 3.3 The JSON shape gains titles and nothing else
+
+`plan --json` MUST gain a `title` on each ready entry and on each blocked entry.
+
+Ready entries are bare id strings today, so this is a **breaking** shape change
+for that array: strings become objects. Blocked entries are already objects and
+gain a field additively.
+
+Making `ready` an array of objects is the right call rather than adding a
+parallel `readyTitles` array. Two arrays that must be zipped by position is the
+shape that generates the exact join code this spec exists to delete, and the
+asymmetry with `blocked` (objects on one side, strings on the other) is already
+a thing consumers work around.
+
+`plan` emits no verdict envelope and writes no artifact, so
+`VERDICT_SCHEMA_VERSION` and `REGISTRY_SCHEMA_VERSION` are both untouched. The
+change is to one read verb's `--json` output and MUST be called out in the
+release notes as breaking for that verb.
+
+### 3.4 It still answers what is claimed, not what is done
+
+`query.rs` records the reason `plan` is the right input to scheduling and the
+wrong input to acceptance: `implementation` is self-declared, no gate verifies
+that a spec marked `complete` has any code, and a scheduler that reads a claim
+must stay a different mechanism from an adjudicator that verifies one.
+
+Nothing here changes that, and `--next` MUST NOT be read as an instruction. It
+is the corpus's answer to "what is schedulable first", which is a claim about
+claims. `spec-spine verify <id>` (spec 049) is the verb that checks whether the
+work was done, and it deliberately runs after a merge rather than inside this
+one.
+
+## 4. Out of scope
+
+**Choosing differently.** `--next` returns the first element of the existing
+order. Priority fields, effort estimates, or a weighting over `depends_on` fan-out
+are a scheduler, and a scheduler is not the ledger's job.
+
+**Filtering the plan.** No `--status`, no `--domain`. `plan` partitions the whole
+corpus by schedulability, and a filter on top of that partition would produce a
+ready set that is not the ready set.
+
+**Reporting the excluded specs individually.** The "not schedulable" figure is a
+count. Which specs those are, and why each was excluded, is `registry list` plus
+`status-report`, and duplicating them inside `plan` would make the verb's output
+the corpus.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test query --locked
+# The prose form carries titles and the not-schedulable remainder.
+target/release/spec-spine registry plan | grep -q 'not schedulable'
+# --next prints one spec. Until this ships, it is an unknown argument.
+target/release/spec-spine registry plan --next
+# The ready array carries titles, so no consumer needs a second call.
+target/release/spec-spine registry plan --json | grep -q '"title"'
+# The ledger is untouched by a read verb.
+target/release/spec-spine compile --check
+```

--- a/specs/061-the-scaffold-ships-what-adopters-wrote/spec.md
+++ b/specs/061-the-scaffold-ships-what-adopters-wrote/spec.md
@@ -1,0 +1,227 @@
+---
+id: "061-the-scaffold-ships-what-adopters-wrote"
+title: "The scaffold ships what every adopter wrote by hand"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "006-init-scaffold"
+  - "039-declared-state-dir"
+  - "043-governance-document-gaps"
+extends:
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/tests/scaffold.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "standards/spec/templates/constitution-template.md" }, role: context }
+  - { unit: { kind: file, path: "spec-spine.toml" }, role: exemplar }
+summary: >
+  Four scaffold defects the audit measured, all in one generator. `init` writes
+  no `.gitignore`, so every adopter independently learns that
+  `.derived/**/build-meta.json` carries a wall clock and dirties the tree, and
+  spec 039's `state_dir` has the same missing half: the live failure it fixed
+  was a permanently dirty tree, not a classification. The scaffolded
+  `spec-spine.toml` emits five knobs; adopters needed thirteen, and aicortex
+  annotated each of its own with the diagnostic code that knob drives, which is
+  the template to copy. And `CONSTITUTION_TEMPLATE` in `scaffold.rs` is still
+  the two-bullet stub spec 043 complained about, while the real thirty-four-line
+  document sits in `standards/spec/templates/constitution-template.md`: adopters
+  get the stub, and two of them deleted it. This spec fixes all four in
+  `scaffold_init`, which stays a pure function of `Config` performing no IO.
+---
+
+# 061: The scaffold ships what every adopter wrote by hand
+
+## 1. Purpose
+
+`spec-spine init` is the first thing an adopter runs and the last thing anyone
+looks at afterwards. The audit looked at what four adopters had to add to it,
+and found the same four additions.
+
+**No `.gitignore`.** The scaffold writes nine files and none of them is one.
+`.derived/**/build-meta.json` is the single non-deterministic artifact in the
+system: it carries `builtAt`, it is excluded from every determinism and golden
+check, and it is regenerated on every run. Every adopter discovers by
+experiment that it must be gitignored, because until it is, the working tree is
+dirty after every compile. The tool knows the path: it is `derived_dir` plus a
+filename the tool itself chose.
+
+Spec 039's `state_dir` has the identical missing half. 039 declared a root that
+no content hash reaches, so a tool writing its own state cannot stale the
+ledger. The failure it was written for was a **permanently dirty tree**, and a
+declared-but-untracked-and-unignored state root is still permanently dirty. The
+classification landed; the `.gitignore` line did not.
+
+**Five knobs out of thirteen.** `config_toml` emits `[manifest]`, `[domains]`,
+`[kind]`, `[layout]` (three of its ten keys) and `[coupling]` (two of its five).
+Absent entirely: `index.extra_hashed_inputs`, `index.resolver_exclusions`,
+`index.slices`, `layout.state_dir`, `layout.schemas_dir`,
+`layout.standalone_rust_workspaces`, `layout.standalone_npm_packages`,
+`coupling.require_ownership`, `coupling.auto_waive_dependency_only`,
+`frontmatter.extra_known_keys`, `provenance.uri_schemes` and `[branding]`. Every
+one of those is a knob an adopter reached for, and the scaffolded file gives no
+hint any of them exists. aicortex's own config annotates each knob with the
+diagnostic code it drives, which is the presentation worth copying: a knob whose
+comment says which refusal it changes is a knob an adopter can reason about.
+
+**The constitution stub.** Spec 043 §1.4 complained about it and did not fix it.
+`CONSTITUTION_TEMPLATE` is still seven lines: a title, two sentences, and two
+`<principle>` placeholders. The real template, thirty-four lines with the tier
+statement, the normative hierarchy and the amendment clause, lives at
+`standards/spec/templates/constitution-template.md` and is not what `init`
+writes. Two adopters deleted the stub rather than fill it in.
+
+These are item 15 of the audit's tool backlog and items 5, 6 and 14 of its kit
+and scaffold backlog. They are one change because they are one function.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/scaffold.rs` | 006 | a tenth file, a fuller config, the real template |
+| `crates/spec-spine-core/tests/scaffold.rs` | 006 | acceptance for each |
+
+Spec 006 owns the scaffold and requires that `init` return files as data
+(`Scaffold`) which the CLI writes, and that the generator be pure. Both hold
+after this change: one more `ScaffoldFile` in the vector, two constants
+rewritten. 006's `spec.md` is not edited.
+
+## 3. Behavior
+
+### 3.1 The scaffold writes a `.gitignore`
+
+`scaffold_init` MUST emit a tenth file, `.gitignore`, containing at minimum the
+two lines the tool's own behavior requires:
+
+```
+# spec-spine writes wall-clock metadata here; it is the one non-deterministic
+# artifact and is excluded from every determinism and golden check.
+<derived_dir>/**/build-meta.json
+```
+
+and, when `layout.state_dir` is non-empty, the state root.
+
+Both paths are computed from `Config`, so a non-default `derived_dir` or
+`state_dir` scaffolds coherently, exactly as `config_toml` is already
+config-aware.
+
+**It does not ignore the shard trees.** Whether `.derived/spec-registry/` and
+`.derived/codebase-index/` are committed is the adopter's decision, and both
+answers are legitimate: this repository commits them and gates on their
+freshness, and an adopter who does not want that regenerates in CI instead. The
+scaffold MUST NOT decide it, and the emitted file MUST carry a comment saying
+so, naming both options. Ignoring them by default would silently opt every new
+adopter out of the freshness gate that is one of the system's two central
+mechanisms.
+
+`ScaffoldFile.overwrite` stays `false` for it, like every other scaffolded file,
+so `init` in a repository that already has a `.gitignore` does not clobber it.
+`init --force` behaves for this file exactly as it does for the other nine.
+Merging into an existing `.gitignore` is deliberately not attempted: a
+three-way merge of an adopter's ignore file is a different feature, and getting
+it subtly wrong would be worse than a clear "this file already exists".
+
+### 3.2 The scaffolded config shows every knob
+
+`config_toml` MUST emit every table and every key of `Config`, with each key set
+to its actual default, and each accompanied by a one-line comment saying what it
+does and, where one exists, which diagnostic code it drives:
+
+```toml
+[coupling]
+# The PR-body waiver keyword (the reason follows the colon). A waiver is a
+# human instrument: it needs explicit human approval, and an agent never
+# writes one on its own authority.
+waiver_keyword = "Spec-Drift-Waiver:"
+# Adopter entries are ADDITIVE to the built-in floor and cannot remove one.
+# `spec-spine config show` prints the merged list the gate matches against.
+bypass_prefixes = []
+# C-002: refuse a changed source file that no spec specifically claims.
+# Off by default: a corpus adopts this once its coverage debt is retired.
+require_ownership = false
+```
+
+Commented-out versus emitted is the one judgement here, and the rule is: a key
+whose default is the right starting value is **emitted** at that value, and a
+key that only makes sense once the adopter has something to put in it
+(`extra_known_keys`, `slices`, `standalone_*`, `provenance.uri_schemes`) is
+emitted **commented out** with a one-line example. An adopter should be able to
+uncomment rather than invent syntax, and should not be handed a file full of
+empty tables that look like they mean something.
+
+The emitted file MUST still parse to a `Config` equal to `Config::default()`
+modulo the values the CLI substitutes from the invoked configuration, and the
+scaffold test MUST assert that. A documented config that has drifted from the
+defaults it documents is worse than none, and this is the check that keeps the
+comments honest as `Config` grows.
+
+### 3.3 The real constitution template
+
+`CONSTITUTION_TEMPLATE` MUST be replaced with the content of
+`standards/spec/templates/constitution-template.md`, the thirty-four-line
+document with the tier statement, the normative hierarchy, the amendment clause
+spec 043 made writable, and the seam saying which principles are the adopter's
+own.
+
+Spec 043 §3.4 already updated `CONSTITUTION`, the scaffolded constitution
+itself, for exactly these things. The **template** was left behind, which is why
+this defect survived a spec that diagnosed it. The two constants now say the
+same thing in the two registers they are for, and the scaffold test MUST assert
+that the emitted template states an amendment mechanism, mirroring the
+assertion 043 added for the constitution.
+
+The template stays a template: placeholders where an adopter's own principles
+go, not this corpus's five principles copied into every repository.
+
+### 3.4 Purity and determinism
+
+`scaffold_init` stays a pure function of `Config` and performs no IO.
+
+In particular, §3.3 MUST NOT read
+`standards/spec/templates/constitution-template.md` from disk. The library is
+self-contained by construction, as the embedded JSON Schemas are: the content
+becomes a `const` in `scaffold.rs`. A test MUST assert the constant and the
+checked-in template agree, so the two cannot drift, which is the same shape as
+the conformance test that pins DTOs against the embedded schemas.
+
+The scaffolded corpus MUST still compile and lint clean, which
+`tests/scaffold.rs` already asserts and which the new `.gitignore` and the
+fuller config must not break.
+
+## 4. Out of scope
+
+**Writing `AGENTS.md` or shipping the kit.** `init --with-kit` is spec 065.
+This spec fixes the files `init` already writes.
+
+**A `Makefile` or a CI workflow.** Spec 064.
+
+**Merging into an existing `.gitignore`.** §3.1.
+
+**Deciding whether adopters commit their shard trees.** §3.1. The scaffold
+presents both options and takes neither.
+
+**Adding knobs.** Every key emitted is one `Config` already has. Making the
+scaffold honest about the current surface is separable from growing it.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test scaffold --locked
+# `init` writes a .gitignore covering the one non-deterministic artifact.
+tmp=$(mktemp -d) && target/release/spec-spine --repo "$tmp" init >/dev/null \
+  && grep -q 'build-meta.json' "$tmp/.gitignore"
+# The scaffolded config names the knobs an adopter reaches for.
+grep -q 'require_ownership' "$tmp/spec-spine.toml"
+grep -q 'resolver_exclusions' "$tmp/spec-spine.toml"
+# The scaffolded constitution template is the real one, not the two-bullet stub.
+grep -q 'Amendment' "$tmp/standards/spec/templates/constitution-template.md"
+# The scaffolded corpus still compiles and lints clean, and running the tool in
+# it leaves a tree the adopter's git would call clean.
+target/release/spec-spine --repo "$tmp" compile >/dev/null
+target/release/spec-spine --repo "$tmp" lint --fail-on-warn
+```

--- a/specs/062-a-version-pin-the-cli-can-check/spec.md
+++ b/specs/062-a-version-pin-the-cli-can-check/spec.md
@@ -1,0 +1,223 @@
+---
+id: "062-a-version-pin-the-cli-can-check"
+title: "A version pin the CLI can check"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "000-spec-spine-bootstrap"
+  - "006-init-scaffold"
+  - "054-effective-config-is-a-governed-read"
+extends:
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/config.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "docs/schema-versioning.md" }, role: context }
+summary: >
+  A repository is governed by whichever spec-spine binary happens to be on the
+  path, and nothing anywhere says which one it should be. rahi states 0.11.0 in
+  three files that must agree by hand. All four governed repositories are two to
+  four releases behind the fixes their own experience motivated, and rahi cannot
+  see spec 044, which was written for rahi's exact state, because it is pinned
+  below it. This spec adds `[meta] required_version`, a semver requirement the
+  CLI checks on every run, refusing with a message that names both the
+  requirement and the running version. The schema versions already tell a loader
+  whether it can read an artifact; this tells an operator whether they are
+  running the tool the corpus was governed by, which is a different question and
+  currently has no answer at all.
+---
+
+# 062: A version pin the CLI can check
+
+## 1. Purpose
+
+Everything in this system is versioned except the thing doing the work.
+
+`REGISTRY_SCHEMA_VERSION`, `INDEX_SCHEMA_VERSION`, `VERDICT_SCHEMA_VERSION`,
+`SPEC_ATTESTATION_SCHEMA_VERSION` and `CONFIG_VERSION` are compile-time
+constants, asserted against embedded schemas so a DTO drift fails the build, and
+`docs/schema-versioning.md` explains how a loader reacts to an unknown MAJOR.
+That machinery answers "can this reader read this artifact". It does not answer
+"is this the tool this repository is governed by", and nothing does.
+
+The consequences the audit measured:
+
+- **rahi states `0.11.0` in three files that must agree by hand**, none of which
+  the tool reads. Nothing detects a fourth place that disagrees.
+- **All four repositories run two to four releases behind** the fixes their own
+  experience motivated. Not by decision: nothing told them.
+- **rahi cannot see spec 044.** 044 was written for rahi's exact `approved` plus
+  `in-progress` state, by an audit of rahi, and rahi is pinned below the release
+  that ships it. The corpus that motivated a fix cannot get the fix, and nothing
+  in either repository says so.
+- **A pin is not just about features.** The built-in bypass floor is a constant
+  compiled into the binary. Two versions can judge the same diff differently,
+  and spec 054 makes the floor readable but cannot make an old binary's floor
+  match a new one's.
+
+The distinction worth stating plainly: a schema version protects a **reader**
+from an artifact it cannot parse. A version pin protects an **operator** from
+running a different tool than their repository was governed by. The second is
+the one CI needs and the one this spec adds.
+
+This is item 16 of the adopter audit's ranked backlog for the tool.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-types/src/config.rs` | 000 | the `[meta]` table and the check |
+| `crates/spec-spine-types/tests/config.rs` | 000 | its acceptance |
+| `crates/spec-spine-cli/src/main.rs` | 001 | enforcement, and the verbs exempt from it |
+| `crates/spec-spine-core/src/scaffold.rs` | 006 | the scaffolded key |
+
+## 3. Behavior
+
+### 3.1 `[meta] required_version`
+
+`Config` MUST gain a `[meta]` table with one optional key, `required_version`,
+holding a semver **requirement** string (`"0.15.0"`, `">=0.15, <0.16"`,
+`"^0.15"`). Absent means unpinned, which is every existing repository, and the
+default.
+
+A requirement rather than an exact version, because both intentions are
+legitimate. An adopter reproducing a byte-identical ledger pins exactly. An
+adopter who wants fixes but not a MAJOR writes a range. A single exact string
+would force the first on everybody and produce a pin that is bumped without
+being thought about.
+
+The key is a **config** key rather than a `.spec-spine-version` sidecar. One
+file already governs the repository, `spec-spine config show` (spec 054) reports
+it with everything else, and a sidecar would be a second configuration surface
+with its own discovery rules for one scalar.
+
+`CONFIG_VERSION` does not move. An added optional table with a default is the
+additive case that constant exists to make safe.
+
+### 3.2 Every verb checks it
+
+When `required_version` is present and the running binary's version does not
+satisfy it, the CLI MUST refuse before doing any work:
+
+```
+spec-spine: this repository requires spec-spine >=0.15, <0.16
+            (spec-spine.toml [meta] required_version); running 0.11.0.
+            Install the required version, or change the pin deliberately.
+```
+
+Exit `3`. It is a configuration the tool cannot honour, which is what `3` means,
+and it is emphatically not `1` (nothing was validated), not `2` (nothing is
+stale), and not `0`.
+
+The refusal MUST name three things: the requirement, the running version, and
+that the pin lives in `spec-spine.toml`. An operator seeing only "version
+mismatch" has to go find all three.
+
+**Exempt verbs.** `--version` and `--help` MUST NOT be refused. They are how an
+operator finds out what they are running, and refusing them would make the
+diagnostic unavailable at exactly the moment it is needed. `init` MUST NOT be
+refused either: it scaffolds a repository that does not have a configuration
+yet, and in a repository that does, `init` is the verb an operator reaches for
+when things are wrong.
+
+Every other verb, including every read, is refused. A read from a mismatched
+binary is the quiet failure this spec exists to prevent: `registry plan` from an
+old binary answers a question about a corpus it may misunderstand, and answers
+it confidently.
+
+### 3.3 An old binary refuses too, for the wrong reason
+
+`Config` carries `deny_unknown_fields` on every table, so a binary released
+before this spec rejects `[meta]` as an unknown field and exits `3`:
+
+```
+config error: TOML parse error at line 1, column 2
+unknown field `meta`, expected one of `manifest`, `domains`, ...
+```
+
+This is worth stating rather than discovering. The pin is enforced even by
+binaries that predate it, which is the property that makes it usable at all: an
+adopter adding the key today is protected from every older binary immediately,
+not only from future ones. The message is poor, naming a parse error rather than
+a version mismatch, and it cannot be improved: the binary producing it was built
+before the key existed.
+
+`docs/schema-versioning.md` MUST record this, because an operator who hits it
+will otherwise read "unknown field `meta`" as a corrupt config rather than as an
+out-of-date binary.
+
+### 3.4 The scaffold writes it, commented out
+
+`config_toml` MUST emit the key commented out, with the running version as the
+example:
+
+```toml
+[meta]
+# Pin the spec-spine version this repository is governed by. Uncomment to
+# refuse a binary that does not satisfy it. A pin is not only about features:
+# the coupling gate's built-in bypass floor is compiled into the binary, so two
+# versions can judge the same diff differently.
+# required_version = "0.15.0"
+```
+
+Commented out is the right default for the same reason the key is optional: a
+scaffold that pinned a new repository to the version that happened to scaffold
+it would create the exact stale-pin problem this spec is about, on day one, by
+accident. Spec 061 §3.2 sets the rule this follows: a key that only makes sense
+once the adopter has decided something is emitted commented out with an example.
+
+### 3.5 It does not check the schema versions
+
+`required_version` constrains the **binary**. It says nothing about
+`REGISTRY_SCHEMA_VERSION` or `INDEX_SCHEMA_VERSION`, which the committed shards
+carry and the loaders already enforce by rejecting an unknown MAJOR.
+
+The two are deliberately separate axes and `docs/schema-versioning.md` already
+says so about package version and schema version. A repository can pin a binary
+without pinning a schema (the ordinary case) or find its shards rejected by a
+binary that satisfies its pin (a MAJOR bump within a permissive range, which is
+the pin being too loose, and the loader is right to refuse).
+
+## 4. Out of scope
+
+**Bumping any adopter's pin.** The audit's §5 records that as each repository's
+own follow-up. This spec gives them a place to write it down.
+
+**Installing or fetching the required version.** The refusal names what is
+needed; it does not download anything. A tool that installed itself on a version
+mismatch would be doing the largest possible thing in response to a config
+mismatch.
+
+**Warning on a satisfied-but-old pin.** "You are on 0.15.0 and 0.18.0 exists" is
+a network question, and every verb in this system is a pure function of local
+inputs. That property is worth more than the notification.
+
+**Pinning per verb.** One binary, one pin.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-types --test config --locked
+# A satisfiable pin is silent. Until this ships, `[meta]` is an unknown table
+# and every one of these exits 3.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs" \
+  && printf '[meta]\nrequired_version = ">=0.1"\n' > "$tmp/spec-spine.toml" \
+  && target/release/spec-spine --repo "$tmp" lint
+# An unsatisfiable pin refuses, and the refusal names the requirement.
+printf '[meta]\nrequired_version = "=0.0.1"\n' > "$tmp/spec-spine.toml"
+target/release/spec-spine --repo "$tmp" lint 2>&1 | grep -q '0.0.1'
+! target/release/spec-spine --repo "$tmp" lint 2>/dev/null
+# --version stays available under an unsatisfiable pin: it is the diagnostic.
+target/release/spec-spine --repo "$tmp" --version
+# The scaffold writes the key, commented out.
+tmp2=$(mktemp -d) && target/release/spec-spine --repo "$tmp2" init >/dev/null \
+  && grep -q 'required_version' "$tmp2/spec-spine.toml"
+```

--- a/specs/063-a-stale-binary-is-not-a-stale-ledger/spec.md
+++ b/specs/063-a-stale-binary-is-not-a-stale-ledger/spec.md
@@ -1,0 +1,197 @@
+---
+id: "063-a-stale-binary-is-not-a-stale-ledger"
+title: "A stale binary is not a stale ledger"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "029-claude-code-skill-kit"
+  - "031-registry-freshness-check"
+  - "062-a-version-pin-the-cli-can-check"
+extends:
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "029-claude-code-skill-kit", unit: "kit/settings.json", nature: additive }
+  - { spec: "029-claude-code-skill-kit", unit: "kit/AGENTS.md", nature: additive }
+  - { spec: "029-claude-code-skill-kit", unit: "AGENTS.md", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+summary: >
+  `spec-spine compile --check` exits 2 when the committed registry is stale. A
+  binary predating `--check` rejects the unknown flag and clap exits 2 as well.
+  Two unrelated conditions, one code, distinguishable only by matching English
+  on stderr, and two adopters plus the kit plus this repository's own AGENTS.md
+  carry that matching ritual. This spec maps every command-line usage error to
+  exit 3, so a new binary can never report a usage failure as staleness, and
+  replaces the stderr ritual with the precondition that actually settles it: ask
+  the binary its version first, which every binary ever released answers. The
+  ritual's real defect was that it made the caller parse prose to recover a fact
+  the process had already destroyed by choosing the wrong exit code.
+---
+
+# 063: A stale binary is not a stale ledger
+
+## 1. Purpose
+
+The exit codes are a stable contract, mapped in exactly one place: `0` ok, `1`
+validation failure or not found or drift, `2` stale, `3` I/O or parse or schema
+or config. Every verb honours it, and `Error::exit_code()` is the single
+mapping.
+
+Clap is not in that mapping. `Cli::parse()` handles its own errors, and clap's
+default for a usage error is exit **2**. So:
+
+```
+$ spec-spine compile --check      # binary predating spec 031
+error: unexpected argument '--check' found
+$ echo $?
+2
+```
+
+which is the code `2` means stale. Two unrelated conditions, one number.
+
+The cost is written down in four places. This repository's own `AGENTS.md`
+carries the disambiguation under a heading called **Stale binary**: "the two
+separate only by stderr: a rejection says `error: unexpected argument
+'--check'`, while a real report names shards". `kit/AGENTS.md` carries it for
+every adopter. Two adopters carry their own copy. The kit's `SessionStart` hook
+maps exit 2 to "STALE, run spec-spine compile and commit the shards", which is
+the wrong instruction when the real problem is an old binary, and which the hook
+cannot detect because it looked at the code.
+
+That ritual is not a workaround for a hard problem. It is a caller parsing
+English to recover a fact the process had in hand and destroyed by choosing the
+wrong number.
+
+This is item 17 of the adopter audit's ranked backlog for the tool, and it is
+last on that list for a reason: it is the smallest of them. It is also the one
+that has been silently teaching every reader of `AGENTS.md` that exit codes in
+this system are not quite trustworthy.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-cli/src/main.rs` | 001 | usage errors map to 3 |
+| `AGENTS.md` | 029 | the ritual becomes a version precondition |
+| `kit/AGENTS.md` | 029 | the same, for adopters |
+| `kit/settings.json` | 029 | the hook stops reporting 2 as staleness |
+
+Spec 001 owns the CLI and its exit-code mapping. It requires that the codes mean
+what the table says; mapping a case that currently violates the table into the
+table is holding 001 to its own contract, not changing it.
+
+## 3. Behavior
+
+### 3.1 A usage error is exit 3
+
+`main` MUST use `Cli::try_parse()` and map a clap error to the exit code the
+contract gives it:
+
+- `DisplayHelp`, `DisplayVersion` and the help-on-no-subcommand kinds keep exit
+  `0` and keep writing to stdout. They are successful requests for information.
+- Every other clap error exits **3**, writing clap's message to stderr
+  unchanged.
+
+`3` is the right cell rather than a new code. It already means "the tool could
+not proceed for a reason that is not the corpus": I/O, parse, schema, config. An
+unparseable command line is the invocation's parse failure, and it belongs with
+the others. Adding a fourth code would extend a contract that four repositories
+and two package shims document, in order to distinguish a case none of them
+needs distinguished from `3`.
+
+After this, exit `2` from any verb means staleness and nothing else. That is the
+whole point, and it is a property callers can rely on going forward.
+
+### 3.2 The transitional answer is the version, not the stderr
+
+Changing the code fixes new binaries. It cannot fix the case that causes the
+problem, because the binary that reports the wrong code is by definition the old
+one. Any correct procedure for a caller that may be talking to an old binary
+must therefore not depend on the new behavior at all.
+
+`AGENTS.md` and `kit/AGENTS.md` MUST replace the stderr-matching ritual with the
+precondition that settles it:
+
+> Ask `spec-spine --version` before believing any exit code. Every binary ever
+> released answers it, and it exits 0. If the version predates the flag you are
+> about to pass, rebuild or reinstall; do not interpret the exit code of a flag
+> the binary does not have.
+
+This is strictly better than matching stderr. It is one call, it works against
+every version including ones that predate every flag, and it fails in the
+direction of asking rather than guessing. The stderr text it replaces is clap's,
+which this project does not control and which changes between clap releases: the
+ritual was pinned to a dependency's message format.
+
+Spec 062's `[meta] required_version` is the automated form of the same
+precondition, and where a repository sets it, the check happens on every run and
+the manual step is unnecessary. This spec's documentation change MUST say so and
+point at it, so an adopter reads the manual procedure as the fallback it is.
+
+### 3.3 The kit's hook stops asserting staleness
+
+`kit/settings.json`'s `SessionStart` hook maps `compile --check`'s exit `2` to
+"STALE, run spec-spine compile and commit the shards".
+
+It MUST first establish that the binary understands the flag, and report an
+out-of-date binary as an out-of-date binary:
+
+```
+[session-freshness] spec registry: spec-spine 0.11.0 predates `compile --check`,
+                    rebuild or reinstall (see /setup)
+```
+
+The hook already resolves a binary through `spec_spine_bin` and already
+branches on the exit code, so this is one more branch in a function that exists.
+It remains read-only, which spec 046 requires of every kit hook and which
+nothing here relaxes.
+
+This is the concrete harm being fixed. A session that starts by being told its
+committed shards are stale, when they are not, will regenerate and commit
+artifacts that were already correct, on the authority of a diagnosis the tool
+got wrong.
+
+### 3.4 Nothing else moves
+
+No verb's exit code changes for any corpus condition. `compile --check` still
+exits `2` for a stale registry and `1` for a corpus that fails validation.
+`index check` is unchanged. No committed artifact changes and no schema version
+moves: `VERDICT_SCHEMA_VERSION` in particular does not, because a usage error
+never reaches the verdict path (there is no verb yet to name).
+
+## 4. Out of scope
+
+**A distinct code for usage errors.** §3.1.
+
+**Auditing every other clap-handled path.** `try_parse` covers argument parsing.
+Errors clap raises later, from value parsing inside a subcommand, follow the same
+mapping because they are the same error type.
+
+**Making an old binary behave.** Impossible by construction, which is why §3.2
+is a precondition rather than a fix.
+
+**Enforcing the version pin.** Spec 062. This spec makes the codes honest; 062
+makes the mismatch impossible to reach.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-cli --test cli --locked
+# An unknown flag is exit 3, not exit 2. Until this ships, clap exits 2 and the
+# second assertion fails.
+target/release/spec-spine compile --no-such-flag 2>/dev/null ; test $? -eq 3
+target/release/spec-spine no-such-verb 2>/dev/null ; test $? -eq 3
+# --help and --version stay exit 0.
+target/release/spec-spine --help >/dev/null
+target/release/spec-spine --version >/dev/null
+# Exit 2 still means stale, and only that.
+target/release/spec-spine compile --check
+# The stderr-matching ritual is gone from both harness documents.
+! grep -q 'unexpected argument' AGENTS.md
+! grep -q 'unexpected argument' kit/AGENTS.md
+```

--- a/specs/064-the-kit-ships-the-composite-gate/spec.md
+++ b/specs/064-the-kit-ships-the-composite-gate/spec.md
@@ -1,0 +1,211 @@
+---
+id: "064-the-kit-ships-the-composite-gate"
+title: "The kit ships the composite gate and the merge driver"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "020-derived-artifact-merge-driver"
+  - "029-claude-code-skill-kit"
+  - "024-index-sharding"
+  - "051-harness-runs-the-verbs-it-ships"
+extends:
+  - { spec: "029-claude-code-skill-kit", unit: "kit/", nature: additive }
+  - { spec: "029-claude-code-skill-kit", unit: "kit/README.md", nature: additive }
+  - { spec: "020-derived-artifact-merge-driver", unit: ".githooks/", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: ".github/workflows/ci.yml" }, role: exemplar }
+summary: >
+  The kit ships a session harness and no build. Every adopter therefore wrote
+  the same two things by hand. First a composite gate: a Makefile whose language
+  targets are guarded on a manifest probe so the whole thing is green on a
+  code-free tree, and a CI workflow carrying the `has_cargo` job-output pattern
+  that three adopters each rediscovered after GitHub rejected `hashFiles` in a
+  job-level `if`. Second, nothing at all for the committed shard trees: rahi
+  runs one spec per PR with committed shards and has no merge driver, and the
+  kit's README never says the words. This spec ships `kit/Makefile`,
+  `kit/govern.yml`, `kit/.githooks/` and the `.gitattributes` stanza, and holds
+  them to the rule spec 046 and 051 established for everything else in the kit:
+  what the kit ships, this repository runs.
+---
+
+# 064: The kit ships the composite gate and the merge driver
+
+## 1. Purpose
+
+`kit/` is a session harness: rules, agents, skills, hooks, an `AGENTS.md`. It
+tells an agent how to work in a governed repository. It says nothing about how
+that repository is built or how its artifacts are merged, and adopters found out
+that those are not optional.
+
+**The composite gate.** Every adopter reinvented it, and each hit the same two
+problems. A gate that runs `cargo test` fails on a corpus with no Rust, which is
+the state three of the four repositories are in, so each guarded its language
+targets on a manifest probe. And each then discovered that GitHub rejects
+`hashFiles` in a job-level `if`, so each arrived at the same workaround: a
+probe job emitting `has_cargo` as a job output that later jobs condition on.
+hqgit hit it, then rahi, then aicortex. Three repositories paying the same
+half-day for the same undocumented platform behavior is the audit's clearest
+signal of a missing artifact.
+
+**The merge driver.** Spec 020 built one and spec 024 narrowed the case it is
+for: since sharding, two PRs touching different specs write disjoint files, and
+the driver remains for the rare same-shard conflict. It lives in `.githooks/`
+with a `.gitattributes` stanza and a per-clone enable script. None of it is in
+`kit/`, and `kit/README.md` never uses the words "merge driver". rahi runs one
+spec per PR with committed shards, which is precisely the workflow the driver
+exists for, and has none of it.
+
+The rule this repository has already adopted twice applies here. Spec 046 found
+three kit hooks that wrote when they should read, and the reason they shipped
+that way was that this repository had no `.claude/settings.json` and never
+exercised them. Spec 051 made the harness run the verbs it ships. A kit
+`Makefile` this repository does not use would be a third instance of the same
+mistake, so this spec does not ship one unexercised.
+
+These are items 1 and 2 of the adopter audit's ranked backlog for the kit.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `kit/` | 029 | four new files under it |
+| `kit/README.md` | 029 | the composite gate and the driver, documented |
+| `.githooks/` | 020 | the scripts become the kit's source |
+
+The implementing change creates `kit/Makefile`, `kit/govern.yml`,
+`kit/.githooks/` and `kit/.gitattributes-stanza`, and claims them in this spec,
+which is one of the two always-legitimate mid-build edits. A new
+`crates/spec-spine-core/tests/kit_gate.rs` is created and claimed the same way.
+
+## 3. Behavior
+
+### 3.1 `kit/Makefile`
+
+The kit MUST ship a `Makefile` with the composite targets every adopter wrote:
+
+- `gate`: the governed loop in order, `compile --check`, `index check`,
+  `lint --fail-on-warn`, `couple`. Read-only throughout, because a gate that
+  writes repairs what it is meant to judge (spec 046).
+- `refresh`: the writing half, `compile` then `index`, for the session that has
+  edited a spec and can commit the result.
+- `test`, `build`, `fmt`, `clippy`: language targets, each **guarded on a
+  manifest probe** so they are no-ops on a tree that has no such manifest.
+- `verify SPEC=<id>`: `spec-spine verify <id>` (spec 049).
+
+Two variables, both overridable, both with the defaults the adopters converged
+on: `SPEC_SPINE ?= spec-spine` and `BASE ?= origin/main`. The first is what lets
+a repository that builds its own binary point at it, which spec 051 established
+is the correct resolution order for a self-governing repository.
+
+The guard MUST be a file probe (`test -f Cargo.toml`), not a command probe. A
+tree with `cargo` installed and no `Cargo.toml` is the specify-first case, and
+probing for the tool answers the wrong question.
+
+### 3.2 `kit/govern.yml`
+
+The kit MUST ship a CI workflow carrying the `has_cargo` job-output pattern:
+
+```yaml
+jobs:
+  probe:
+    outputs:
+      has_cargo: ${{ steps.p.outputs.has_cargo }}
+    steps:
+      - id: p
+        run: test -f Cargo.toml && echo "has_cargo=true" >> "$GITHUB_OUTPUT" || echo "has_cargo=false" >> "$GITHUB_OUTPUT"
+  build:
+    needs: probe
+    if: needs.probe.outputs.has_cargo == 'true'
+```
+
+with a comment stating why: **GitHub rejects `hashFiles` in a job-level `if`**,
+so the probe must be a job whose output later jobs condition on. That sentence
+is the artifact. Three adopters spent time rediscovering it, and a workflow that
+carries the pattern without the reason will be "simplified" back into the broken
+form by the next person who reads it.
+
+The workflow MUST write the PR body to a file under `$RUNNER_TEMP` and pass it
+with `--pr-body`, which is how a body containing a waiver line reaches the gate
+without shell quoting hazards. It MUST run `couple` only on `pull_request`, since
+the gate compares a base to a head.
+
+### 3.3 The merge driver moves into the kit
+
+`kit/.githooks/` MUST carry the driver and the enable script, and the kit MUST
+carry the `.gitattributes` stanza registering it on the shard globs.
+
+The kit's copy is the **source**, and this repository's `.githooks/` is
+generated from it or asserted equal to it. One direction, tested, because two
+hand-maintained copies of a shell script that regenerates committed artifacts is
+how they diverge silently.
+
+`kit/README.md` MUST say "merge driver", say that it is opt-in per clone, say
+that sharding (spec 024) already removes the common conflict so the driver is for
+the same-shard case, and say that it never replaces the `index check` staleness
+gate. rahi's situation is the test of this text: an adopter running one spec per
+PR with committed shards should be able to read the README and know whether they
+need it.
+
+### 3.4 This repository runs what the kit ships
+
+`tests/kit_gate.rs` MUST assert, at compile time against the checked-in files,
+that:
+
+- every `spec-spine` invocation in `kit/Makefile` and `kit/govern.yml` is a verb
+  this binary has, and every gate-path invocation is read-only, which is the
+  same assertion `tests/kit_hooks.rs` makes for the hooks (spec 046);
+- `kit/.githooks/` and this repository's `.githooks/` agree;
+- the gate chain in `kit/Makefile` is the chain `AGENTS.md` lists, in order,
+  which is the assertion spec 051 established for the skills.
+
+And this repository MUST adopt `kit/Makefile` itself, as the entry point its own
+CI and its own skills call. That is the point of the test and the lesson of
+specs 046 and 051: the kit's artifacts are exercised here or they ship broken.
+
+The existing `.github/workflows/ci.yml` keeps its structure. It is a
+self-governing repository's workflow with a determinism matrix and release
+concerns that a generic `govern.yml` should not carry; what changes is that its
+gate steps call the Makefile targets rather than open-coding the same commands,
+so the chain has one definition.
+
+## 4. Out of scope
+
+**Replacing `ci.yml`.** §3.4. `govern.yml` is the adopter's starting point, not
+this repository's workflow.
+
+**A non-GitHub CI template.** The `has_cargo` finding is GitHub-specific and so
+is the artifact. An adopter on other CI takes the Makefile, which is portable,
+and writes their own invocation.
+
+**Enabling the merge driver anywhere.** It stays opt-in per clone, exactly as
+spec 020 left it. Shipping it in the kit makes it available; it does not
+register it.
+
+**Language targets beyond Rust and npm.** The manifest probes cover what the
+indexer discovers. A Python or Go target would be guessing at a toolchain the
+tool does not model.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test kit_gate --locked
+# The kit ships all four artifacts.
+test -f kit/Makefile
+test -f kit/govern.yml
+test -d kit/.githooks
+# The workflow carries the finding, not just the pattern.
+grep -q 'hashFiles' kit/govern.yml
+# The README names the merge driver, which it never did before.
+grep -q 'merge driver' kit/README.md
+# This repository runs the gate it ships, read-only, and the tree stays clean.
+make -f kit/Makefile gate BASE=HEAD~1
+target/release/spec-spine compile --check
+target/release/spec-spine index check
+```

--- a/specs/065-init-and-the-kit-are-one-adoption/spec.md
+++ b/specs/065-init-and-the-kit-are-one-adoption/spec.md
@@ -1,0 +1,201 @@
+---
+id: "065-init-and-the-kit-are-one-adoption"
+title: "Init and the kit are one adoption"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "006-init-scaffold"
+  - "029-claude-code-skill-kit"
+  - "043-governance-document-gaps"
+  - "061-the-scaffold-ships-what-adopters-wrote"
+extends:
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-cli/src/cmd_init.rs", nature: additive }
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/tests/scaffold.rs", nature: additive }
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-cli/tests/init.rs", nature: additive }
+  - { spec: "029-claude-code-skill-kit", unit: "kit/README.md", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "docs/adoption-guide.md" }, role: context }
+summary: >
+  Adoption is two halves that nothing joins. `spec-spine init` writes a corpus,
+  a constitution, a contract, templates and three agent rules. `kit/` adds the
+  session protocol, the hooks, the agents and fifteen skills. The scaffold does
+  not mention the kit, the kit is not installable by any verb, and `AGENTS.md`,
+  which every skill in the kit reads first and which the three rewriting
+  adopters each wrote from nothing, is written by neither. Spec 043 named this
+  gap G5 and did not close it. This spec adds `spec-spine init --with-kit`,
+  emitting the kit's files through the same `Scaffold` data path as everything
+  else, and makes plain `init` write an `AGENTS.md` naming the governed loop,
+  because a repository with rules and no protocol is the configuration three
+  adopters had to repair by hand.
+---
+
+# 065: Init and the kit are one adoption
+
+## 1. Purpose
+
+Ask what a new adopter has to do, and the answer is a sequence nobody wrote
+down.
+
+`spec-spine init` gives them a corpus, `standards/`, a bootstrap spec, and three
+`.claude/rules/` files. That is a governed repository with no instructions for
+working in it.
+
+`kit/` gives them the instructions: `AGENTS.md` with the New Sessions protocol
+and the Working the backlog protocol, `settings.json` with four hooks, four
+agents, fifteen skills. It is a directory in this repository's git tree. There
+is no verb that installs it. An adopter copies it, or does not know it exists.
+
+Nothing connects the two. `init`'s output never mentions the kit. The kit's
+README assumes a corpus that `init` produced but cannot produce one. And
+`AGENTS.md`, which is the cross-agent authority every skill reads first and the
+file the AAIF standard defines, is written by neither half: three adopters each
+wrote one from nothing, and each wrote a "Working the backlog" section, which is
+why spec 047 had to add that section to the kit after the fact.
+
+Spec 043 named this G5 and did not close it. The audit lists it as item 3 of the
+kit backlog. It is the difference between a tool that scaffolds a corpus and a
+tool that scaffolds an adoption.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/scaffold.rs` | 006 | the kit files as scaffold data |
+| `crates/spec-spine-cli/src/cmd_init.rs` | 006 | the `--with-kit` flag |
+| `crates/spec-spine-core/tests/scaffold.rs` | 006 | acceptance |
+| `crates/spec-spine-cli/tests/init.rs` | 006 | end-to-end acceptance |
+| `kit/README.md` | 029 | says how it is installed |
+
+Spec 006 owns the scaffold and requires that `init` return files as data which
+the CLI writes. That contract is what makes this change small: the kit becomes
+more entries in the same `Vec<ScaffoldFile>`, written by the same code, with the
+same `overwrite: false` semantics.
+
+## 3. Behavior
+
+### 3.1 Plain `init` writes an `AGENTS.md`
+
+`scaffold_init` MUST emit `AGENTS.md`, unconditionally, whether or not
+`--with-kit` is given.
+
+It is not a kit extra. It is the cross-agent authority that every governed
+repository needs and that this repository, the kit, and all four adopters treat
+as the first file an agent reads. A scaffold that writes three `.claude/rules/`
+files and no protocol has written the constraints without the procedure.
+
+The scaffolded `AGENTS.md` MUST contain:
+
+- **New Sessions**, the init protocol, with the parallel reads named as the
+  `spec-spine` verbs they are, `compile --check` and `index check` and not their
+  writing forms, and with the freshness verdicts spelled out per exit code;
+- **Working the backlog**, the pick-branch-implement-gate-verify-ship-stop
+  sequence spec 047 added to the kit;
+- **The gate chain**, in order, once, as the definition every skill refers to;
+- **the ask-the-version precondition** from spec 063.
+
+Config-aware, as everything in the scaffold is: the specs directory, the derived
+directory and the binary invocation come from `Config` so a non-default layout
+scaffolds coherently.
+
+### 3.2 `init --with-kit`
+
+`init` MUST accept `--with-kit`, adding the kit's files to the same `Scaffold`:
+`.claude/settings.json`, `.claude/agents/*`, `.claude/skills/*/SKILL.md`,
+`.mcp.json`, and, when spec 064 has landed, `Makefile` and the
+`.github/workflows/govern.yml` starting point.
+
+They are emitted at the adopter's own paths, not under a `kit/` directory. The
+`kit/` prefix is this repository's storage location for the templates; an
+adopter's `.claude/skills/build/SKILL.md` is where the file has to be to work.
+
+The three `.claude/rules/` files that plain `init` already writes are **not**
+duplicated. They are the same three files the kit carries, which spec 047 kept
+in sync across the scaffold constants, the kit copy, and this repository's copy.
+
+**Purity holds.** `scaffold_init` stays a pure function of `Config` performing
+no IO, so the kit's contents are embedded as `const`s exactly as the JSON
+Schemas and the constitution template are. A test MUST assert that the embedded
+constants and the checked-in `kit/` tree agree, so a change to one cannot
+silently diverge from the other. That is the same shape as the conformance test
+pinning DTOs against embedded schemas, and it is what keeps `kit/` the editable
+source rather than a copy nobody remembers to update.
+
+### 3.3 It refuses to clobber
+
+Every kit file keeps `overwrite: false`, like every other scaffolded file. An
+adopter running `--with-kit` in a repository that already has
+`.claude/skills/build/SKILL.md` is told the file exists, not silently
+overwritten. `--force` behaves for these files exactly as it does for the other
+ten.
+
+This is the case that matters most for `AGENTS.md`. An adopter who has written
+their own is the common case in a repository that has been worked in, and
+overwriting a cross-agent authority document would destroy project-specific
+protocol that no backup makes obvious.
+
+### 3.4 The scaffolded repository is immediately governed
+
+After `init --with-kit`, the repository MUST satisfy its own gate:
+`compile`, `index`, `lint --fail-on-warn` all clean, exactly as
+`tests/scaffold.rs` already asserts for the plain scaffold.
+
+The end-to-end test MUST scaffold with `--with-kit` into a temporary directory
+and run the whole chain, because the kit adds hooks and skills that reference
+verbs and paths, and a scaffold that produces a repository failing its own gate
+on the first run is worse than no scaffold.
+
+### 3.5 The README says how it is installed
+
+`kit/README.md` MUST state that `spec-spine init --with-kit` installs it, that
+`kit/` is the source of those templates, and what the difference is between
+plain `init` and `--with-kit`, in one short section near the top.
+
+The README today describes the kit's contents to a reader who has already found
+the directory. The one thing it cannot currently tell them is how to get it.
+
+## 4. Out of scope
+
+**Updating an installed kit.** `--with-kit` installs; it does not diff, merge or
+migrate an adopter's edited skills against a newer kit. That is a real need with
+a real design (a three-way merge against the version they installed) and it
+requires recording which version they installed, which nothing does yet.
+
+**Making the kit's contents adopter-specific.** The skills ship as written. Spec
+048 settled where project-specific material goes: `AGENTS.md`, not the skill
+files.
+
+**A `spec-spine kit` verb.** `init --with-kit` covers install. A verb family for
+listing, diffing or updating kit files is the update story above.
+
+**The Makefile and workflow themselves.** Spec 064.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test scaffold --locked
+cargo test -p spec-spine-cli --test init --locked
+# Plain init writes an AGENTS.md with the protocol, and no kit.
+tmp=$(mktemp -d) && target/release/spec-spine --repo "$tmp" init >/dev/null \
+  && grep -q 'New Sessions' "$tmp/AGENTS.md" \
+  && grep -q 'Working the backlog' "$tmp/AGENTS.md" \
+  && test ! -d "$tmp/.claude/skills"
+# --with-kit installs the kit at the adopter's own paths.
+tmp2=$(mktemp -d) && target/release/spec-spine --repo "$tmp2" init --with-kit >/dev/null \
+  && test -f "$tmp2/.claude/skills/build/SKILL.md" \
+  && test -f "$tmp2/.claude/settings.json" \
+  && test ! -d "$tmp2/kit"
+# The scaffolded repository satisfies its own gate on the first run.
+target/release/spec-spine --repo "$tmp2" compile >/dev/null
+target/release/spec-spine --repo "$tmp2" index >/dev/null
+target/release/spec-spine --repo "$tmp2" lint --fail-on-warn
+# The README says how the kit is installed.
+grep -q 'init --with-kit' kit/README.md
+```

--- a/specs/066-the-contract-records-the-lifecycle-table/spec.md
+++ b/specs/066-the-contract-records-the-lifecycle-table/spec.md
@@ -1,0 +1,205 @@
+---
+id: "066-the-contract-records-the-lifecycle-table"
+title: "The contract records the lifecycle table and the extra keys"
+status: draft
+kind: "governance"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "041-completion-held-to-claims"
+  - "043-governance-document-gaps"
+  - "044-in-progress-is-in-flight"
+  - "045-absent-implementation-defers-to-status"
+extends:
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "standards/spec/contract.md" }, role: context }
+summary: >
+  `status` and `implementation` are the two keys every adopter reasons about
+  daily, and the contract mentions `status` once, in a list of required
+  frontmatter, and `implementation` not at all. The mechanical consequences are
+  spread across four specs: 041 makes a `complete` claim checkable, 044 defines
+  the in-flight window, 045 says an absent key takes its answer from `status`,
+  and 038 reads both to build the ready set. Every specify-first adopter wrote
+  the resulting table into its own contract by hand, and hqgit had to invent a
+  section called "Lifecycle as scheduling" because ours has none. This spec adds
+  that section and an "Extra keys" section telling adopters to document their
+  `extra_known_keys`, and claims both as section units of the contract.
+---
+
+# 066: The contract records the lifecycle table and the extra keys
+
+## 1. Purpose
+
+`standards/spec/contract.md` is the one-page operational summary an adopter
+reads to learn what a spec is. It covers inputs, outputs, required frontmatter,
+the eight edges, amendment authoring, amending the constitution, authority
+units, the gate chain and determinism. It is a good page.
+
+It says nothing about the lifecycle.
+
+`status` appears once, inside the required-frontmatter list, as four permitted
+values. `implementation` does not appear at all. Those two keys are what every
+adopter reasons about every day, and their meaning is now mechanical and spread
+across four specs:
+
+- **041** holds a `complete` claim to its claims: a spec asserting completion
+  whose units do not resolve is an error, not a warning.
+- **044** defines the in-flight window (`draft`, or `pending` / `in-progress`,
+  and not `complete`) and makes an unresolved unit inside it a `W-001` warning
+  rather than a refusal.
+- **045** settles the absent key: it takes its answer from `status`, reading as
+  `pending` on a draft and as settled on anything ratified.
+- **038** reads both to partition the corpus into ready and blocked.
+
+Four specs, one table, and the table exists nowhere. So adopters wrote it.
+Every specify-first repository the audit examined has a `status` by
+`implementation` severity table in its own contract, and hqgit went further,
+adding a section titled **Lifecycle as scheduling** stating that `approved` plus
+`pending` is a work order, that `draft` is never schedulable, and that
+`complete` and `n-a` count as shipped. Spec 043 quoted that section and said the
+reason it exists is that ours does not.
+
+The second, smaller gap is `frontmatter.extra_known_keys`. It is how an adopter
+adds a key of their own without tripping the unknown-key diagnostic, and the
+contract never mentions it, so the audit found adopters either not knowing it
+exists or using it without recording what their keys mean. A key declared in
+config and documented nowhere is a private convention that the next person on
+the project has to reverse-engineer from a TOML list.
+
+This is item 7 of the adopter audit's ranked backlog for the kit and the
+scaffold.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `standards/spec/contract.md` §Lifecycle as scheduling | this spec | new section |
+| `standards/spec/contract.md` §Extra keys | this spec | new section |
+| `crates/spec-spine-core/src/scaffold.rs` | 006 | the scaffolded `CONTRACT` |
+
+Both contract sections are `establishes`, not `refines`: they are text that does
+not exist, added to a tier-3 document, which is the ordinary ownership
+vocabulary spec 043 §3 describes for a governance file. The contract is on the
+coupling gate's built-in bypass floor as part of `standards/`, so these are
+ledger facts rather than gate-enforced ones.
+
+Nothing in specs 038, 041, 044 or 045 is edited. This spec states in one place
+what those four decided; it decides nothing itself, and where this text and one
+of those specs disagree, the spec governs.
+
+## 3. Behavior
+
+### 3.1 Lifecycle as scheduling
+
+The contract MUST gain a section, anchored `lifecycle-as-scheduling`, stating
+the two keys, their values, and the joint table:
+
+| `status` | `implementation` | schedulable | unresolved unit is |
+|---|---|---|---|
+| `draft` | absent, `pending`, `in-progress` | yes | `W-001` warning |
+| `approved` | `pending`, `in-progress` | yes | `W-001` warning |
+| `approved` | absent | no (settled, spec 045) | error |
+| any | `complete` | no | error (spec 041) |
+| any | `n-a`, `deferred` | no | takes its answer from `status` |
+| `superseded`, `retired` | any | no | takes its answer from `status` |
+
+and the three sentences that make it usable:
+
+- **`approved` plus `pending` is a work order.** It is the state a specify-first
+  corpus lives in for months, and it is the state `registry plan` offers.
+- **`draft` is never a claim about code.** A draft's unresolved units are
+  expected, which is why they warn instead of refusing.
+- **An absent `implementation` is not a third value.** It defers to `status`,
+  which is what keeps a bootstrap spec that owns no code from being offered as
+  ready forever (spec 045), and which is why `n-a` exists for a record spec that
+  is ratified and owns nothing.
+
+The section MUST name the spec behind each row, so a reader who needs the full
+argument knows where it is and so this page stays a summary rather than becoming
+a fifth authority.
+
+### 3.2 Extra keys
+
+The contract MUST gain a section, anchored `extra-keys`, stating that
+`frontmatter.extra_known_keys` declares adopter-specific frontmatter keys, that
+a declared key's value is preserved verbatim into the registry (spec 013), and
+that an adopter who declares keys **should document what they mean**, in their
+own constitution or contract, because the config lists the names and nothing
+records the semantics.
+
+Short, three or four sentences. The point is discoverability: the key exists,
+here is what it does, write down what yours mean.
+
+### 3.3 The scaffold ships both
+
+`scaffold.rs`'s `CONTRACT` constant MUST gain both sections, so a new adopter
+gets them rather than writing them.
+
+This is the pattern spec 043 §3.4 established when it added the amendment
+mechanism to the scaffolded `CONSTITUTION` and one line to `CONTRACT`. The
+scaffolded copy is terser than this repository's own, as it already is: an
+adopter needs the table and the three sentences, not the citations to specs they
+do not have.
+
+The generator stays a pure function of `Config` with no IO, and the scaffolded
+corpus MUST still compile and lint clean.
+
+### 3.4 The lifecycle table is a summary, not a fifth authority
+
+The contract's own preamble already says it: the bootstrap spec and the
+constitution are authoritative, and where this summary is terser, they govern.
+The new section MUST carry the same disclaimer inline, because a table is
+exactly the shape of thing a reader will treat as the definition.
+
+The risk is concrete. If 045's rule for an absent key were ever revised, a table
+in a summary document would be the last place anyone looked, and a stale table is
+worse than no table because it is confidently wrong. Naming the owning spec per
+row is the mitigation and it is why §3.1 requires it.
+
+### 3.5 Nothing mechanical changes
+
+No code path reads the contract. No committed artifact changes shape, no schema
+version moves, and no lint or gate behaves differently.
+
+`standards/**` is a hashed input, so editing the contract restamps the global
+scalar and therefore every index shard. The implementing change regenerates and
+commits them, as any edit under `standards/` requires.
+
+## 4. Out of scope
+
+**Changing any lifecycle rule.** §2. This spec is a transcription with
+citations.
+
+**A fifth `implementation` value.** The five are `pending`, `in-progress`,
+`complete`, `n-a`, `deferred`, and nothing here proposes a sixth.
+
+**Enforcing that adopters document their extra keys.** §3.2 says they should.
+A lint for it would be a lint on prose.
+
+**Restructuring the contract.** Two sections added in the register of the rest
+of the page.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test scaffold --locked
+# Both sections exist and are claimable as section units, which is what the
+# frontmatter of this spec asserts.
+target/release/spec-spine index render | grep -q '066-the-contract-records-the-lifecycle-table'
+grep -q 'Lifecycle as scheduling' standards/spec/contract.md
+grep -q 'Extra keys' standards/spec/contract.md
+# The scaffolded contract carries them too.
+tmp=$(mktemp -d) && target/release/spec-spine --repo "$tmp" init >/dev/null \
+  && grep -q 'Lifecycle as scheduling' "$tmp/standards/spec/contract.md" \
+  && grep -q 'extra_known_keys' "$tmp/standards/spec/contract.md"
+# This spec's own units resolve, so it is not an orphan, and the shards were
+# regenerated after editing a hashed input under standards/.
+target/release/spec-spine compile --check
+target/release/spec-spine index check --fail-on-unresolved
+```

--- a/specs/067-the-docs-name-what-adopters-derived/spec.md
+++ b/specs/067-the-docs-name-what-adopters-derived/spec.md
@@ -1,0 +1,203 @@
+---
+id: "067-the-docs-name-what-adopters-derived"
+title: "The docs name what adopters derived by experiment"
+status: draft
+kind: "documentation"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "009-coupling-floor-claim-precedence"
+  - "017-directory-crate-module-units"
+  - "037-machine-readable-verdicts"
+  - "044-in-progress-is-in-flight"
+establishes:
+  # Both files exist and no spec claimed them. This spec takes authority over
+  # the two documents it edits; `docs/specify-first.md` is claimed by the
+  # implementing change that creates it.
+  - "docs/adoption-guide.md"
+  - "docs/schema-versioning.md"
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: "README.md" }, role: context }
+summary: >
+  Three documentation gaps the audit measured, each with a named victim. There
+  is no page for specify-first adoption, which is how three of the four governed
+  repositories work, so each of them independently derived the guarded Makefile,
+  the CI manifest probe, `implementation: n-a` for record specs, and the fact
+  that two hundred and forty-eight W-001 warnings is the defined state rather
+  than a backlog. Two interactions are documented nowhere and were found by
+  experiment: a path can be on the coupling bypass floor and simultaneously a
+  hashed input, and a trailing-slash directory unit in `establishes` satisfies
+  ownership recursively. And spec 037 changed `attest`'s stdout, which
+  claude-observatory regexes in two places, with no migration note. This spec
+  writes the page and the three paragraphs.
+---
+
+# 067: The docs name what adopters derived by experiment
+
+## 1. Purpose
+
+The audit's question was what adopters had to work out for themselves. Three
+answers are documentation, and each has a name attached.
+
+**Specify-first has no page.** Three of the four governed repositories ratify
+the entire corpus before a line of code exists, and live at `approved` plus
+`pending` for months. Specs 041 and 044 were built for that mode. No document
+mentions it. So each adopter independently derived the same four things: a
+Makefile whose language targets are guarded on a manifest probe so the composite
+gate is green on a code-free tree; the CI job-output probe, because GitHub
+rejects `hashFiles` in a job-level `if`; `implementation: n-a` as the convention
+for a record spec that owns nothing; and the fact that aicortex's two hundred
+and forty-eight `W-001` warnings are the defined state of a corpus that has not
+been built, not a backlog to burn down. Four rediscoveries, three times each.
+
+**Two interactions were found by experiment.** Both are consequences of designs
+that are individually documented and jointly surprising:
+
+- *A path can be on the coupling bypass floor and simultaneously a hashed
+  input.* `docs/` is on `DEFAULT_BYPASS_PREFIXES`, so editing a doc raises no
+  `C-001`. `standards/**` is in the default `extra_hashed_inputs`, so editing a
+  standards file restamps the global scalar and stales every index shard. An
+  adopter reasonably assumes bypassed means invisible, and then watches a
+  documentation edit stale sixty shards.
+- *A trailing-slash directory unit in `establishes` satisfies ownership
+  recursively.* `- "src/thing/"` claims the subtree, so every file under it is
+  specifically claimed for coverage and for `C-002`. This is the cheapest way to
+  retire coverage debt and it is documented only in spec 017's own text.
+
+**Spec 037 has no migration note.** It made every verdict verb emit a canonical
+JSON envelope, and in doing so changed what `attest` writes to stdout.
+claude-observatory regexes `attestationHash:` out of that stdout in two places.
+Nothing told it to stop.
+
+These are items 4, 8 and 13 of the adopter audit's ranked backlog for the kit
+and the scaffold.
+
+## 2. Territory
+
+This spec claims no code and no committed artifact. It owns prose in `docs/`,
+which is on the coupling gate's built-in bypass floor, so the claims here are
+ledger facts rather than gate-enforced ones.
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `docs/adoption-guide.md` | this spec | the two interactions |
+| `docs/schema-versioning.md` | this spec | the 037 migration note |
+| `docs/specify-first.md` | this spec, from the build | new page |
+
+Neither of the two existing documents was claimed by any spec, so this one takes
+authority over them rather than extending somebody. The new page is created by
+the implementing change and claimed there, which is one of the two
+always-legitimate mid-build edits. `docs/` is not a hashed input in this repository's
+configuration (only `standards/**` and `.github/workflows/**` are), so these
+edits stale nothing.
+
+## 3. Behavior
+
+### 3.1 `docs/specify-first.md`
+
+A new page MUST describe the mode three of four adopters work in, covering:
+
+- **What specify-first means**: the corpus is ratified before the code exists,
+  and `approved` plus `pending` is the steady state, not a transitional one.
+- **The lifecycle table**, by reference to the contract section spec 066 adds
+  rather than as a second copy. Two tables that must agree by hand is the defect
+  this page would otherwise create.
+- **`implementation: n-a` for record specs**: a spec that owns no code is not
+  pending forever, and the scaffolded bootstrap spec already carries `n-a` for
+  exactly this reason (spec 045).
+- **Why the warnings are fine**: `W-001` counts on an unbuilt corpus are the
+  defined state, `index check` is right to call the ledger fresh, and
+  `--fail-on-unresolved` is the flag for a corpus that has moved past this stage.
+  aicortex's 248 is the worked example.
+- **The guarded composite gate**: pointing at `kit/Makefile` and `kit/govern.yml`
+  (spec 064) rather than restating them, and naming the `hashFiles` finding once
+  so a reader who is not using the kit still gets it.
+- **What to do first**: the honest sequence for a repository with no code, which
+  is `compile`, `index`, `lint`, and specifically not `couple` until there is a
+  base and a head to compare.
+
+It MUST be linked from `README.md`'s documentation table and from
+`docs/adoption-guide.md`, because a page nobody links is a page nobody finds,
+and the adopters who needed it were reading both.
+
+### 3.2 The two interactions, in the adoption guide
+
+`docs/adoption-guide.md` MUST gain a short section, anchored
+`bypass-and-hashing-are-independent`, stating that the coupling bypass floor and
+the content-hash input set are **independent axes**, that a path can be on both,
+neither, or either, and giving `docs/` (bypassed, not hashed here) and
+`standards/**` (bypassed, hashed) as the two worked examples.
+
+The sentence that closes it: bypassed means the coupling gate will not refuse a
+change to it; hashed means a change to it stales shards. Neither implies the
+other, and the two mechanisms answer different questions.
+
+It MUST also gain a section, anchored `directory-units-claim-recursively`,
+stating that a trailing slash makes a `file` unit a subtree claim, that every
+file under it counts as specifically claimed for `index coverage` and for
+`C-002`, and that this is the intended instrument for retiring coverage debt
+across a directory rather than enumerating files.
+
+Both are short. They are things a reader needs to have been told once.
+
+### 3.3 The 037 migration note
+
+`docs/schema-versioning.md` MUST gain a migration note for spec 037 saying, in
+its own words: if you regex a field out of a verdict verb's stdout, stop, and
+parse the `--json` envelope instead.
+
+It MUST name `attest` and `attestationHash` specifically, because that is the
+case that broke and a general note would not have told claude-observatory that
+its two call sites were the ones affected.
+
+It MUST state the guarantee that makes migration safe: `--json` changes what is
+written and never what is decided, so every exit code is identical with and
+without it. A consumer switching to the envelope is not changing its control
+flow, only its parsing.
+
+### 3.4 Nothing mechanical changes
+
+No code, no committed artifact, no schema version. This spec's whole output is
+prose, and its `## Verification` block can only assert that the prose exists and
+that the corpus is unchanged by it. That is a weaker acceptance than a code
+spec's and it is stated plainly rather than dressed up: a documentation spec is
+verified by a reader, and the mechanical check is that the files are there and
+the ledger did not move.
+
+## 4. Out of scope
+
+**Writing the Makefile or the workflow.** Spec 064. This page points at them.
+
+**A second lifecycle table.** §3.1. The contract holds it (spec 066).
+
+**Restructuring the documentation set.** One new page, two sections and one
+note, each in an existing document's register.
+
+**Fixing claude-observatory's two call sites.** An adopter-side follow-up, in
+the audit's §5. This spec gives it the note to act on.
+
+**A general migration-notes convention.** One note for one change that broke a
+known consumer. A standing "Migration" section per schema bump is a good idea
+and a separate one.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+# The page exists and is linked from the places its readers were already in.
+test -f docs/specify-first.md
+grep -q 'specify-first' README.md
+grep -q 'specify-first' docs/adoption-guide.md
+# The two interactions are written down.
+grep -q 'bypass' docs/adoption-guide.md
+grep -q 'trailing slash' docs/adoption-guide.md
+# The 037 migration note names the field that broke a real consumer.
+grep -q 'attestationHash' docs/schema-versioning.md
+# Prose only: the ledger did not move.
+target/release/spec-spine compile --check
+target/release/spec-spine index check
+```

--- a/specs/068-a-path-scoped-rule-example/spec.md
+++ b/specs/068-a-path-scoped-rule-example/spec.md
@@ -1,0 +1,192 @@
+---
+id: "068-a-path-scoped-rule-example"
+title: "A path-scoped rule the kit actually ships"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "029-claude-code-skill-kit"
+  - "047-harness-rules-name-the-legitimate-edits"
+  - "048-kit-ships-the-governed-loop-skills"
+extends:
+  - { spec: "029-claude-code-skill-kit", unit: "kit/.claude/rules/", nature: additive }
+  - { spec: "029-claude-code-skill-kit", unit: "kit/README.md", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
+  - { unit: { kind: file, path: ".claude/rules/governed-artifact-reads.md" }, role: context }
+summary: >
+  The kit's three rules are unconditional: every one loads in every session
+  regardless of what the session touches. Claude Code supports `paths:`
+  frontmatter that loads a rule only when a matching file is touched, and the
+  kit's README lists that pattern under "intentionally excluded" while hqgit
+  carries three good ones, including per-file scoping. The exclusion was a
+  judgement made before any adopter had tried it, and an adopter has now tried
+  it and kept it. This spec ships one path-scoped rule, scoped to the derived
+  artifact tree, whose content is the one instruction that is only ever relevant
+  when someone has a compiled artifact open: do not hand-edit it. One rule, as
+  a worked example of the mechanism, with the README's exclusion replaced by a
+  description of when to reach for it.
+---
+
+# 068: A path-scoped rule the kit actually ships
+
+## 1. Purpose
+
+`kit/.claude/rules/` holds three files: `orchestrator-rules`,
+`governed-artifact-reads`, `adversarial-prompt-refusal`. All three load in every
+session, always, because that is the only mode the kit uses.
+
+Claude Code supports another. A rule file with `paths:` frontmatter loads only
+when the session touches a matching file. The kit's README lists that pattern
+under **intentionally excluded**, which was a defensible call when the kit was
+first assembled and nobody had used one. It is no longer the state of the
+evidence: hqgit carries three path-scoped rules, including one scoped to a
+single file, and kept them.
+
+The cost of the omission is not that adopters cannot write one. It is that the
+kit teaches, by example, that rules are unconditional, and the README actively
+says the alternative was excluded rather than saying when to use it. An adopter
+reading both concludes the mechanism is discouraged.
+
+There is also a fit. Unconditional rules are the right shape for the three the
+kit ships, which are about how to work at all. The rule that does not fit that
+shape is the one about compiled artifacts: "do not hand-edit a derived artifact,
+and do not parse one with `jq`" is advice that matters only when somebody has a
+derived artifact open, and it currently loads in every session about anything.
+That is a small waste of context and, more to the point, it is the worked
+example sitting in the kit already.
+
+This is item 10 of the adopter audit's ranked backlog for the kit.
+
+## 2. Territory
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `kit/.claude/rules/` | 029 | one new rule file |
+| `kit/README.md` | 029 | the exclusion becomes guidance |
+
+The new rule file is created by the implementing change and claimed there. The
+three existing rules are **not** edited: spec 047 tuned their wording across the
+scaffold constants, the kit copy and this repository's copy, and reopening them
+here would put a fourth hand on text three specs have settled.
+
+## 3. Behavior
+
+### 3.1 One path-scoped rule
+
+The kit MUST ship exactly one rule file carrying `paths:` frontmatter, scoped to
+the derived artifact tree:
+
+```markdown
+---
+paths:
+  - ".derived/**"
+---
+
+# Derived artifacts are compiler output
+...
+```
+
+Its content is the artifact-specific half of what
+`governed-artifact-reads.md` says: a derived artifact is compiler output,
+hand-editing one is a workflow violation, reading one with `jq` or `sed` is
+equally forbidden, and the way to read it is a `spec-spine` subcommand. Parsing
+the **output** of a subcommand is a typed read and is allowed, which is the
+clarification spec 047 added and which is the sentence adopters most needed.
+
+The `paths` glob MUST be derived from `layout.derived_dir` when the kit is
+installed through `init --with-kit` (spec 065), the same way every other
+scaffolded file is config-aware. A repository with a non-default derived
+directory gets a rule that matches it.
+
+**One, not three.** The value here is the worked example and the fit; a kit that
+shipped a directory of conditional rules would be making adopters read scoping
+decisions that are theirs to make. hqgit has three because hqgit has three
+domains that want them.
+
+### 3.2 The unconditional rule stays
+
+`kit/.claude/rules/governed-artifact-reads.md` MUST remain unconditional and
+MUST keep its full content.
+
+This is the part worth getting right. The path-scoped rule is not a replacement
+and MUST NOT be described as one. A rule that loads only when `.derived/**` is
+touched cannot prevent the mistake it is about, because the mistake is reaching
+for `jq` **instead of** the subcommand, and an agent that reaches for `jq` may
+never touch a path the glob matches. The unconditional rule is what prevents
+that. The scoped rule is what reinforces it at the moment somebody has the file
+open.
+
+Saying this in the rule file itself is required, not optional. A reader
+comparing the two files will otherwise conclude one is redundant, and the
+redundant-looking one is the one that does the work.
+
+### 3.3 The README describes when to scope
+
+`kit/README.md` MUST replace the "intentionally excluded" entry for `paths:`
+frontmatter with a short description of when a scoped rule is right:
+
+- **unconditional** when the rule is about how to work at all: the loop, the
+  refusals, the standing constraints;
+- **scoped** when the rule is only actionable while a particular kind of file is
+  open, and when loading it always would spend context on a case most sessions
+  never reach;
+- and the caveat from §3.2: a scoped rule cannot prevent a mistake whose whole
+  shape is not touching the path.
+
+It MUST name the shipped rule as the example and MUST note that hqgit's
+three, including a per-file scoping, are the field evidence.
+
+### 3.4 It is exercised here
+
+Spec 046 found three kit hooks that wrote when they should read, and the reason
+was that this repository had no `.claude/settings.json` and never ran them. Spec
+051 made the harness run the verbs it ships.
+
+So this repository MUST carry the same path-scoped rule under its own
+`.claude/rules/`, and `tests/kit_skills.rs` (or its successor) MUST assert that
+the kit's copy and this repository's copy agree, as it already does for the
+unconditional three. A rule shipped to adopters and never loaded here is the
+third instance of a mistake this corpus has now made twice.
+
+### 3.5 Nothing mechanical changes
+
+No code path reads a rule file. No committed artifact changes shape and no
+schema version moves. `kit/` and `.claude/rules/` are claimed territory, so the
+new files are claimed and the index gains their paths; the implementing change
+regenerates and commits the shards.
+
+## 4. Out of scope
+
+**Rewriting the three unconditional rules.** §2. Specs 047 and 048 settled them.
+
+**Splitting `governed-artifact-reads.md`.** §3.2. It keeps its full content and
+the scoped rule reinforces rather than replaces it.
+
+**A rules taxonomy.** One example and three sentences of guidance. A general
+framework for when to scope a rule is a document nobody asked for.
+
+**Path-scoped agents or skills.** The `paths:` mechanism is a rule feature and
+this spec uses it as one.
+
+## 5. Verification
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+cargo test -p spec-spine-core --test kit_skills --locked
+# The kit ships exactly one path-scoped rule, and it is scoped to .derived.
+test "$(grep -rl '^paths:' kit/.claude/rules/ | wc -l | tr -d ' ')" = "1"
+grep -rq '.derived' kit/.claude/rules/
+# The unconditional rule kept its full content, including the 047 clarification.
+grep -q 'typed read' kit/.claude/rules/governed-artifact-reads.md
+# The README describes when to scope instead of excluding the pattern.
+grep -q 'paths:' kit/README.md
+! grep -q 'intentionally excluded.*paths' kit/README.md
+# This repository loads what it ships, and the shards were regenerated.
+test "$(grep -rl '^paths:' .claude/rules/ | wc -l | tr -d ' ')" = "1"
+target/release/spec-spine index check
+```


### PR DESCRIPTION
The 2026-09 adopter audit (`docs/design/03-adopter-audit-2026-09.md`) left two
ranked backlogs, 31 items between them. Six are already specced: tool items 1-3
as specs 049, 050 and 052; kit items 9, 11 and 12 as 048, 047 and 046.

This files **the remaining 25 items as 16 draft specs**, grouped by coherent
claim rather than one spec per item. Several of them are one mistake in one
function and are argued together: items 6 and 7 are both facts the ledger
computes and discards at the boundary; 11 and 12 are both read verbs that
mislead a corpus with no code yet; 15 and kit 5, 6, 14 are all `scaffold.rs`.

`docs/design/03-adopter-audit-2026-09.md` gains a §7 mapping every backlog item
to the spec it was filed as, so the backlog stays navigable.

## Tool backlog, items 4-17

| Spec | Claim |
|---|---|
| 053 | opt-in ordinal-monotonic `depends_on`: a new `[lint]` table, `L-007` |
| 054 | `config show`: the effective config, with the built-in bypass floor merged and attributed |
| 055 | `index owner <path>`, and `contentHash` on `registry show --json` |
| 056 | `compile --spec <id>`: validate a draft without the `mktemp -d` ritual |
| 057 | `L-008`: a claim no hash witnesses |
| 058 | the defects heading has one spelling, as an anchor and not a string |
| 059 | `orphans` partitions by the in-flight predicate; an empty coverage universe refuses `--fail-on-untraced` |
| 060 | `registry plan` renders titles, blockers and the remainder; `--next` |
| 061 | the scaffold writes a `.gitignore`, every knob, and the real constitution template |
| 062 | `[meta] required_version`, a version pin the CLI can check |
| 063 | usage errors exit 3, so exit 2 means stale and only that |

## Kit and scaffold backlog, items 1-8, 10, 13, 14

| Spec | Claim |
|---|---|
| 064 | the kit ships the composite gate (`Makefile`, `govern.yml`) and the merge driver |
| 065 | `init --with-kit`, and plain `init` writes an `AGENTS.md` |
| 066 | the contract records the lifecycle table and the extra keys |
| 067 | the specify-first page, two interactions found by experiment, the 037 migration note |
| 068 | one path-scoped rule, as a worked example |

## Three things worth a reviewer's attention

**A verified finding, not an assumed one.** Spec 057's premise was probed
before it was written: `AGENTS.md` is claimed by specs 029, 047 and 051, and
appending a line to it leaves both `index check` and `compile --check`
reporting fresh. Only span-backing files are folded into a spec's shard hash,
and a `file` unit carries no span. Twenty-four claimed paths in this repository
are in that state, including every `.claude/` rule and skill and the whole
`kit/` tree. 057 names the gap and deliberately does **not** close it by
folding claimed files into the hash, because that would change what staleness
means; the argument is in its §3.4.

**Every `## Verification` block was probed to fail against today's code.**
A block that passes on unbuilt code asserts nothing, which is the lesson spec
052's own block taught. All 16 were run before being written down.

**Two audit items were filed differently from how the audit proposed them,
with the reasoning in the spec.** The audit asked for `registry owner <path>`;
055 puts it under `index` instead, because resolving a unit to a path is the
indexer's job and a registry query that resolved would invert the two views.
The audit asked for a lint making `origin.retroactive: true` imply a defects
section; 058 declines, because spec 043 established that the two are orthogonal
and such a lint would fire on the tier-1 bootstrap spec, unfixably.

## Gate

Green on the filing commit. 69 registry shards fresh, index fresh, 0 unresolved
units, 0 lint warnings, 74/74 coverage, `couple` clean over 16 paths.

No draft claims a path that does not resolve today, which is what keeps the
corpus at zero unresolved units under CI's `index check --fail-on-unresolved`.
Files each draft will create are claimed by the change that creates them, per
`.claude/rules/adversarial-prompt-refusal.md`.

## What is not in this PR

Implementation. These are 16 drafts; approval is a human flip and each build is
its own change. Corpus is now 69 specs: 52 approved, 17 draft.

This deliberately sets aside "one session, one spec" from
`.claude/rules/orchestrator-rules.md`, on explicit instruction to file the whole
backlog in one pass.