### PR TITLE
feat(052): the coupling gate names the crossing

### DIFF
--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -11,11 +11,27 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-cli/src/cmd_verify.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-cli/tests/couple.rs",
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/query.rs",
         "source": "spec-edge"
       },
       {
@@ -24,6 +40,14 @@
       },
       {
         "path": "crates/spec-spine-types/src/registry.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/verdict.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/dtos.rs",
         "source": "spec-edge"
       }
     ],
@@ -44,6 +68,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-cli/src/cmd_verify.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_verify.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-cli/tests/couple.rs"
           }
         ],
@@ -57,6 +94,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-core/src/couple.rs"
           }
         ],
@@ -65,6 +115,32 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
         }
       },
       {
@@ -91,6 +167,32 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-types/src/registry.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/verdict.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/verdict.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
         }
       },
       {
@@ -124,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d0188da558c6e1852689b759448634b8edbbc28b6bf56718ccdbc8aec42be146"
+  "shardHash": "bb417817d22d4ad80ed748f11d8185355730d2b06c41d6775474e9cdc9e3715e"
 }

--- a/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
@@ -46,10 +46,58 @@
           "kind": "file",
           "path": "crates/spec-spine-types/src/registry.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "037-machine-readable-verdicts",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/verdict.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "049-verify-declared-acceptance",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_verify.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
       }
     ],
     "id": "052-couple-names-the-crossing",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -73,6 +121,7 @@
       "052: The coupling gate names the crossing",
       "1. Purpose",
       "2. Territory",
+      "2.1 Six more files the field's shape forces",
       "3. Behavior",
       "3.1 `C-001` carries its owners as data",
       "3.2 The footer names three doors",
@@ -87,6 +136,6 @@
     "summary": "The coupling gate has always named the specs that own a drifted path, and has never named the mechanism for crossing into their territory. Its resolution footer offers two doors: edit an owning spec, or waive. For an author who has legitimately touched a unit somebody else owns, both are shut. Editing another spec to clear a refusal is the illegitimate edit the corpus rules forbid, and the waiver is a human instrument that no adopter has ever used and that an unattended session is forbidden on every path. The third door, an `extends` edge declared in the author's own spec, is the corpus's actual answer and the gate never mentions it. This spec makes the refusal name it: three doors in author order, and when the diff edits exactly one spec.md, the concrete `extends` block to paste into that file. It also promotes the owner set from prose into an optional `owners` field on the violation, so an orchestrator reading `couple --json` learns the owner as data instead of by regexing English. No committed artifact and no schema version moves.\n",
     "title": "The coupling gate names the crossing"
   },
-  "shardHash": "488b1c328e5cabb0543d5c5ecd03294df29b6dafd3bc5232fa9d7b4e928d9aa8",
+  "shardHash": "6d41887e414d87079b35487ba1cfb6629d48ef9806529817cae2ca1686342f6b",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_couple.rs
+++ b/crates/spec-spine-cli/src/cmd_couple.rs
@@ -13,11 +13,12 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use spec_spine_core::couple::spec_id_for_spec_md_path;
 use spec_spine_core::{
-    DiffFile, DiffInput, FileContents, couple, dependency_only_waiver, is_bypassed_path,
-    load_committed_index, parse_waiver,
+    CoupleReport, DiffFile, DiffInput, FileContents, couple, dependency_only_waiver,
+    is_bypassed_path, load_committed_index, parse_waiver,
 };
-use spec_spine_types::{Config, Error, LineSpan, Verdict, verdict::verb};
+use spec_spine_types::{Config, Error, LineSpan, Verdict, Violation, verdict::verb};
 
 use crate::load_repo_config;
 use crate::out;
@@ -84,17 +85,7 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
         for v in &report.violations {
             eprintln!("  {} {}", v.code, v.message);
         }
-        if unclaimed == 0 {
-            eprintln!(
-                "\nResolve by editing an owning spec's spec.md, or add a '{}' line to the PR body.",
-                cfg.coupling.waiver_keyword
-            );
-        } else {
-            eprintln!(
-                "\nResolve by editing an owning spec's spec.md (C-001), claiming the path in a spec's owning edge (C-002), or add a '{}' line to the PR body.",
-                cfg.coupling.waiver_keyword
-            );
-        }
+        eprint!("{}", resolution_footer(&cfg, &report, &diff));
     } else if let Some(reason) = &report.waiver {
         outln!(
             "spec-spine couple: {} violation(s) {}, reason: {reason}",
@@ -112,6 +103,135 @@ pub fn run(repo: &Path, args: &CoupleArgs) -> Result<u8, Error> {
     }
 
     Ok(report.exit_code())
+}
+
+/// The resolution footer a blocking report ends with (spec 052 §3.2, §3.3).
+///
+/// A pure function of `(config, report, diff)`: no input is read and nothing is
+/// written, so the same three arguments always produce the same bytes.
+///
+/// The gate has always named the specs that own a drifted path and never named
+/// the mechanism for crossing into their territory. Of the two doors it used to
+/// offer, both are shut for the case that produces most `C-001` refusals: an
+/// author building their own spec who reached into a file another spec owns.
+/// Editing the other spec is the illegitimate mid-build edit
+/// `.claude/rules/adversarial-prompt-refusal.md` forbids, and the waiver is a
+/// human instrument an unattended session may not grant itself. The third door,
+/// an `extends` edge in the author's own spec, is the corpus's actual answer,
+/// and this is where the gate finally says so.
+fn resolution_footer(cfg: &Config, report: &CoupleReport, diff: &DiffInput) -> String {
+    let drift: Vec<&Violation> = report
+        .violations
+        .iter()
+        .filter(|v| v.code == "C-001")
+        .collect();
+    let unclaimed = report.violations.len() - drift.len();
+    let keyword = &cfg.coupling.waiver_keyword;
+
+    // No `C-001`: the report is `C-002` only, and renders exactly the footer it
+    // rendered before this spec (§3.2). Claiming a path is a different act from
+    // crossing into somebody's territory, and the three doors do not apply.
+    if drift.is_empty() {
+        return format!(
+            "\nResolve by editing an owning spec's spec.md (C-001), claiming the path in a spec's owning edge (C-002), or add a '{keyword}' line to the PR body.\n"
+        );
+    }
+
+    let mut f = String::from("\nResolve, in the order an author should consider them");
+    if unclaimed > 0 {
+        f.push_str(" (1-3 answer C-001; 4 answers C-002)");
+    }
+    f.push_str(":\n\n");
+
+    f.push_str(
+        "  1. Edit the owning spec's spec.md. The right door when the spec that owns\n\
+         \x20    the path is the one you are authoring.\n\n",
+    );
+
+    f.push_str(
+        "  2. Declare an `extends` edge in your OWN spec, naming the owning spec\n\
+         \x20    and the unit you touched. That makes your spec a legitimate owner of\n\
+         \x20    the unit, so the gate clears on the next run. It amends nobody and\n\
+         \x20    needs no waiver.\n\n",
+    );
+    f.push_str(&extends_guidance(cfg, &drift, diff));
+
+    f.push_str(&format!(
+        "  3. Add a '{keyword} <reason>' line to the PR body. A waiver is a\n\
+         \x20    human instrument: it needs explicit human approval, and is not a\n\
+         \x20    flag an unattended session sets for itself.\n"
+    ));
+
+    if unclaimed > 0 {
+        f.push_str(
+            "\n  4. For the unclaimed path(s) above, claim the path in a spec's owning\n\
+             \x20    edge.\n",
+        );
+    }
+    f
+}
+
+/// Door two's body: the concrete `extends` block when the diff makes it
+/// concrete, else the shape to fill in (spec 052 §3.3).
+///
+/// The specific form triggers on **exactly one** edited `spec.md`, and needs no
+/// further test: clearance is "any one owner's spec.md is in the diff", so a
+/// single edited spec that owned a violating path would already have cleared it.
+/// Every `C-001` reaching this footer is therefore a path that spec does not
+/// own, which is exactly the crossing case. Zero or two-or-more edited specs
+/// fall back to the generic form: an amendment pair is a legitimate shape and
+/// the gate has no basis for guessing which of the two should declare the edge.
+fn extends_guidance(cfg: &Config, drift: &[&Violation], diff: &DiffInput) -> String {
+    let specs_dir = cfg.layout.specs_dir.as_str();
+    let edited: Vec<&str> = diff
+        .files
+        .iter()
+        .filter_map(|f| spec_id_for_spec_md_path(specs_dir, &f.path))
+        .collect();
+
+    let Some(id) = edited.first().filter(|_| edited.len() == 1) else {
+        return concat!(
+            "     In your spec's frontmatter:\n\n",
+            "       extends:\n",
+            "         - { spec: \"<owning-spec-id>\", unit: \"<path>\", nature: additive }\n\n",
+        )
+        .to_string();
+    };
+
+    let mut s = format!(
+        "     spec {id} is the only spec.md edited in this diff, and owns none of\n\
+         \x20    the paths above. Cross into the owning territory by declaring, in\n\
+         \x20    {}:\n\n\
+         \x20      extends:\n",
+        spec_md_rel(specs_dir, id)
+    );
+    // One item per violating path, in the report's existing sorted-by-path
+    // order. Three values are defaults rather than verdicts: the first owner in
+    // sorted order (clearing needs only one), the file-shorthand unit, and
+    // `nature: additive`. The note below says so, because a gate that presented
+    // a guess as the answer would be worse than one that stayed silent.
+    for v in drift {
+        let (Some(path), Some(owner)) = (v.path.as_deref(), v.owners.first()) else {
+            continue;
+        };
+        s.push_str(&format!(
+            "         - {{ spec: \"{owner}\", unit: \"{path}\", nature: additive }}\n"
+        ));
+    }
+    s.push_str(
+        "\n     A suggestion, not an instruction, and not the only correct form:\n\
+         \x20    where a path has several owners any one of them clears it, a narrower\n\
+         \x20    section or symbol unit is available if you want the claim tighter,\n\
+         \x20    and `nature` is a free-text hint (`superseding` describes a crossing\n\
+         \x20    that replaces behavior rather than adding to it). If you did not mean\n\
+         \x20    to touch the path, revert the touch and declare nothing.\n\n",
+    );
+    s
+}
+
+/// `<specs_dir>/<id>/spec.md`, matching the core gate's own `spec_md_rel`.
+fn spec_md_rel(specs_dir: &str, id: &str) -> String {
+    format!("{}/{id}/spec.md", specs_dir.trim_end_matches('/'))
 }
 
 /// Build the [`DiffInput`]: either from `--paths-from` (whole-file fallback, no

--- a/crates/spec-spine-cli/src/cmd_verify.rs
+++ b/crates/spec-spine-cli/src/cmd_verify.rs
@@ -60,16 +60,18 @@ pub fn run(repo: &Path, id: &str, json: bool, plan_only: bool) -> Result<u8, Err
         .unwrap_or_default();
     if stack.contains(&plan.spec_id) {
         stack.push(plan.spec_id.clone());
-        return Err(Error::Validation(vec![Violation {
-            code: RE_ENTRY_CODE.to_string(),
-            severity: Severity::Error,
-            message: format!(
-                "verification re-entered itself: {}. A `## Verification` command \
-                 that runs `verify` on its own spec recurses without bound.",
-                stack.join(" -> ")
-            ),
-            path: Some(format!("{}/{}/spec.md", cfg.layout.specs_dir, plan.spec_id)),
-        }]));
+        return Err(Error::Validation(vec![
+            Violation::new(
+                RE_ENTRY_CODE,
+                Severity::Error,
+                format!(
+                    "verification re-entered itself: {}. A `## Verification` command \
+                     that runs `verify` on its own spec recurses without bound.",
+                    stack.join(" -> ")
+                ),
+            )
+            .at(format!("{}/{}/spec.md", cfg.layout.specs_dir, plan.spec_id)),
+        ]));
     }
     stack.push(plan.spec_id.clone());
     let child_stack = stack.join(",");

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -642,3 +642,165 @@ fn ratchet_refuses_new_unowned_source_and_allows_its_deletion() {
         .unwrap();
     assert_eq!(code(&full), 0, "{}", String::from_utf8_lossy(&full.stderr));
 }
+
+// ── spec 052: the refusal names the crossing ──────────────────────────────
+
+/// [`setup`] plus a second spec that owns a *different* file, so a diff can
+/// edit exactly one `spec.md` that owns none of the violating paths: the
+/// crossing case §3.3 is about.
+fn setup_two_specs(root: &Path) {
+    setup(root);
+    write(root, "crate-a/src/other.rs", "pub fn other() {}\n");
+    write(
+        root,
+        "specs/002-b/spec.md",
+        "---\nid: \"002-b\"\ntitle: \"B\"\nstatus: approved\ncreated: \"2026-09-07\"\n\
+         summary: \"s\"\nestablishes:\n  - \"crate-a/src/other.rs\"\n---\n# 002-b\n## body\n",
+    );
+}
+
+/// §3.2: a `C-001` report names three doors, and door two is the one that was
+/// missing. The corpus's answer to "I legitimately touched somebody else's
+/// unit" has always been an `extends` edge in the author's own spec; the gate
+/// never said so, and claude-observatory spent four sessions proving the wall.
+#[test]
+fn footer_names_three_doors_including_extends() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup(tmp.path());
+    refresh(tmp.path());
+
+    let out = couple_paths(tmp.path(), &["crate-a/src/lib.rs"], &[]);
+    assert_eq!(code(&out), 1);
+    let e = String::from_utf8_lossy(&out.stderr);
+
+    assert!(e.contains("  1. Edit the owning spec's spec.md"), "{e}");
+    assert!(e.contains("  2. Declare an `extends` edge"), "{e}");
+    assert!(e.contains("  3. Add a 'Spec-Drift-Waiver:"), "{e}");
+    // Door two's two load-bearing facts, without which an author still reads
+    // the edge as a change to somebody else's spec.
+    assert!(e.contains("amends nobody and\n     needs no waiver"), "{e}");
+    // And the waiver is named as the human instrument it is, not as a flag.
+    assert!(e.contains("needs explicit human approval"), "{e}");
+    // Pasteable YAML, not prose: the syntax is the part adopters got wrong.
+    assert!(e.contains("extends:"), "{e}");
+    assert!(e.contains("nature: additive"), "{e}");
+}
+
+/// §3.3: exactly one edited `spec.md` ⇒ the footer names it and emits the
+/// concrete block, with the violating path and its owner filled in.
+#[test]
+fn one_edited_spec_gets_a_concrete_extends_block() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_two_specs(tmp.path());
+    refresh(tmp.path());
+
+    // 002-b is edited; it owns `other.rs`, not `lib.rs`, so `lib.rs` drifts.
+    let out = couple_paths(
+        tmp.path(),
+        &["crate-a/src/lib.rs", "specs/002-b/spec.md"],
+        &[],
+    );
+    assert_eq!(code(&out), 1, "{}", String::from_utf8_lossy(&out.stderr));
+    let e = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        e.contains("spec 002-b is the only spec.md edited in this diff"),
+        "{e}"
+    );
+    assert!(e.contains("specs/002-b/spec.md"), "{e}");
+    assert!(
+        e.contains("- { spec: \"001-a\", unit: \"crate-a/src/lib.rs\", nature: additive }"),
+        "the block is filled in, not a template: {e}"
+    );
+    // §3.3: a suggestion, never an instruction, and never a claim that
+    // `additive` is a judgement the gate reached about the author's intent.
+    assert!(e.contains("A suggestion, not an instruction"), "{e}");
+    assert!(e.contains("revert the touch and declare nothing"), "{e}");
+}
+
+/// §3.3: zero or two-or-more edited `spec.md` paths fall back to the generic
+/// form. Two edited specs is a legitimate shape (an amendment pair) and the
+/// gate has no basis for guessing which one should declare the edge.
+#[test]
+fn two_edited_specs_fall_back_to_the_generic_form() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_two_specs(tmp.path());
+    refresh(tmp.path());
+
+    // A third spec that owns nothing here, so neither edited spec clears
+    // `lib.rs` and two spec.md paths are in the diff.
+    write(
+        tmp.path(),
+        "specs/003-c/spec.md",
+        "---\nid: \"003-c\"\ntitle: \"C\"\nstatus: approved\ncreated: \"2026-09-07\"\n\
+         summary: \"s\"\nreferences:\n  - { unit: { kind: file, path: \"README.md\" }, role: context }\n\
+         ---\n# 003-c\n## body\n",
+    );
+    write(tmp.path(), "README.md", "# r\n");
+    refresh(tmp.path());
+
+    let out = couple_paths(
+        tmp.path(),
+        &[
+            "crate-a/src/lib.rs",
+            "specs/002-b/spec.md",
+            "specs/003-c/spec.md",
+        ],
+        &[],
+    );
+    assert_eq!(code(&out), 1, "{}", String::from_utf8_lossy(&out.stderr));
+    let e = String::from_utf8_lossy(&out.stderr);
+
+    assert!(!e.contains("is the only spec.md edited"), "{e}");
+    assert!(e.contains("<owning-spec-id>"), "generic shape: {e}");
+}
+
+/// §3.2: a report carrying only `C-002` renders the footer it rendered before
+/// this spec. Claiming an unowned path is a different act from crossing into
+/// somebody else's territory, and the three doors do not describe it.
+#[test]
+fn c002_only_footer_is_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_ratchet(root);
+    refresh(root);
+
+    write(root, "crate-a/src/extra.rs", "pub fn extra() {}\n");
+    refresh(root);
+    let out = couple_paths(root, &["crate-a/src/extra.rs"], &[]);
+    assert_eq!(code(&out), 1, "{}", String::from_utf8_lossy(&out.stderr));
+    let e = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        e.contains(
+            "Resolve by editing an owning spec's spec.md (C-001), claiming the path \
+             in a spec's owning edge (C-002), or add a 'Spec-Drift-Waiver:' line to \
+             the PR body."
+        ),
+        "{e}"
+    );
+    assert!(!e.contains("  1. Edit the owning spec"), "{e}");
+}
+
+/// §3.5: the envelope carries `owners` as data and no guidance prose. Guidance
+/// in the envelope would be a third representation of the same list, stale
+/// against the prose and useless to the machine that already has the list.
+#[test]
+fn json_envelope_carries_owners_not_prose() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup(tmp.path());
+    refresh(tmp.path());
+
+    let out = couple_paths(tmp.path(), &["crate-a/src/lib.rs"], &["--json"]);
+    assert_eq!(code(&out), 1);
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("verdict envelope is JSON");
+    let violation = &v["report"]["violations"][0];
+    assert_eq!(violation["code"], "C-001");
+    assert_eq!(violation["owners"][0], "001-a");
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(!text.contains("Declare an `extends` edge"), "{text}");
+    // §3.4: a payload addition does not move the envelope's version (spec 050 §3.6).
+    assert_eq!(v["schemaVersion"], "0.2.0");
+}

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -754,21 +754,11 @@ fn resolve_spec_ref(short: &str, all_ids: &std::collections::BTreeSet<String>) -
 // --- small helpers ---
 
 fn error(code: &str, message: String, path: Option<String>) -> Violation {
-    Violation {
-        code: code.to_string(),
-        severity: Severity::Error,
-        message,
-        path,
-    }
+    Violation::new(code, Severity::Error, message).at_opt(path)
 }
 
 fn warning(code: &str, message: String, path: Option<String>) -> Violation {
-    Violation {
-        code: code.to_string(),
-        severity: Severity::Warning,
-        message,
-        path,
-    }
+    Violation::new(code, Severity::Warning, message).at_opt(path)
 }
 
 /// Repo-relative POSIX path of `file` under `repo_root` (forward slashes).

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -171,12 +171,11 @@ pub fn couple_with(
                 )),
             };
             if let Some(message) = message {
-                violations.push(Violation {
-                    code: "C-002".to_string(),
-                    severity: Severity::Error,
-                    message,
-                    path: Some(path.clone()),
-                });
+                // No `owners` (spec 052 §3.1): `C-002` fires precisely when no
+                // spec specifically claims the path, so there is no owner to
+                // name. The floor specs the message reports are why the path is
+                // debt, not who owns it.
+                violations.push(Violation::new("C-002", Severity::Error, message).at(path.clone()));
                 continue;
             }
         }
@@ -189,16 +188,23 @@ pub fn couple_with(
             continue; // primary-owner heuristic: any one owner's spec.md cleared it
         }
 
+        // Spec 052 §3.1: the owner set is carried as data as well as rendered
+        // into the message. `owners` is the sole non-prose copy, in the same
+        // sorted order the sentence names, so a consumer of the spec 037
+        // envelope reads it instead of regexing English. `owners` came from a
+        // `BTreeSet`, so the order is the message's by construction.
         let names: Vec<String> = owners.iter().cloned().collect();
-        violations.push(Violation {
-            code: "C-001".to_string(),
-            severity: Severity::Error,
-            message: format!(
+        let mut v = Violation::new(
+            "C-001",
+            Severity::Error,
+            format!(
                 "'{path}' changed without an authoring edit to any owning spec ({})",
                 names.join(", ")
             ),
-            path: Some(path.clone()),
-        });
+        )
+        .at(path.clone());
+        v.owners = names;
+        violations.push(v);
     }
 
     violations.sort_by(|a, b| a.path.cmp(&b.path));
@@ -438,7 +444,11 @@ fn is_bypass<S: AsRef<str>>(path: &str, prefixes: &[S]) -> bool {
 /// `layout.specs_dir` rather than a literal `specs/` (spec 036). The prefix and
 /// the separator are stripped in two steps on purpose: a single
 /// `strip_prefix("specs")` would accept `specsX/005-x/spec.md`.
-fn spec_id_for_spec_md_path<'p>(specs_dir: &str, path: &'p str) -> Option<&'p str> {
+///
+/// Public since spec 052: the CLI's resolution footer asks the same question of
+/// the diff (is exactly one spec.md edited, and whose?) and must ask it with the
+/// gate's own answer rather than a second, drifting copy of the path grammar.
+pub fn spec_id_for_spec_md_path<'p>(specs_dir: &str, path: &'p str) -> Option<&'p str> {
     let rest = path
         .strip_prefix(specs_dir.trim_end_matches('/'))?
         .strip_prefix('/')?;

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -194,28 +194,13 @@ fn unit_path(unit: &Unit) -> Option<String> {
 }
 
 fn error(code: &str, message: String, path: Option<String>) -> Violation {
-    Violation {
-        code: code.to_string(),
-        severity: Severity::Error,
-        message,
-        path,
-    }
+    Violation::new(code, Severity::Error, message).at_opt(path)
 }
 
 fn warn(code: &str, message: String, path: Option<String>) -> Violation {
-    Violation {
-        code: code.to_string(),
-        severity: Severity::Warning,
-        message,
-        path,
-    }
+    Violation::new(code, Severity::Warning, message).at_opt(path)
 }
 
 fn info(code: &str, message: String, path: Option<String>) -> Violation {
-    Violation {
-        code: code.to_string(),
-        severity: Severity::Info,
-        message,
-        path,
-    }
+    Violation::new(code, Severity::Info, message).at_opt(path)
 }

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -265,15 +265,14 @@ pub fn plan(registry: &Registry) -> Result<Plan, Error> {
         registry.specs.iter().map(|s| (s.id.as_str(), s)).collect();
 
     if let Some(cycle) = find_cycle(&by_id) {
-        return Err(Error::Validation(vec![Violation {
-            code: "V-014".to_string(),
-            severity: Severity::Error,
-            message: format!(
+        return Err(Error::Validation(vec![Violation::new(
+            "V-014",
+            Severity::Error,
+            format!(
                 "depends_on cycle refuses scheduling: {}",
                 cycle.join(" -> ")
             ),
-            path: None,
-        }]));
+        )]));
     }
 
     let mut ready: Vec<&str> = Vec::new();

--- a/crates/spec-spine-core/tests/couple.rs
+++ b/crates/spec-spine-core/tests/couple.rs
@@ -1284,3 +1284,110 @@ fn the_ownership_ratchet_does_not_reach_into_the_state_root() {
     assert!(declared.violations.is_empty(), "{:?}", declared.violations);
     assert_eq!(declared.checked_paths, 0);
 }
+
+// ── spec 052: the owner set is carried as data, not only as prose ─────────
+
+/// §3.1: every `C-001` carries `owners`, holding exactly the owner set its
+/// message names, in the same sorted order. Before this spec the gate computed
+/// that set and then destroyed it by formatting it into English, so an
+/// orchestrator reading the spec 037 envelope had to regex a sentence back into
+/// a list.
+#[test]
+fn c001_carries_its_owners_as_data() {
+    let index = index_from(json!([
+        {
+            "specId": "004-codebase-index",
+            "implementingPaths": [],
+            "resolvedUnits": [{
+                "unit": { "kind": "file", "path": "src/index.rs" },
+                "sourceField": "establishes",
+                "ownership": true,
+                "locations": [{ "file": "src/index.rs" }]
+            }]
+        },
+        {
+            "specId": "001-compile-registry",
+            "implementingPaths": [],
+            "resolvedUnits": [{
+                "unit": { "kind": "file", "path": "src/index.rs" },
+                "sourceField": "co_authority",
+                "ownership": true,
+                "locations": [{ "file": "src/index.rs" }]
+            }]
+        }
+    ]));
+
+    let report = run(
+        &index,
+        &empty_registry(),
+        &diff(vec![file("src/index.rs", &[LineSpan::new(5, 8)])]),
+    );
+    let v = &report.violations[0];
+    assert_eq!(v.code, "C-001");
+    assert_eq!(
+        v.owners,
+        vec![
+            "001-compile-registry".to_string(),
+            "004-codebase-index".to_string()
+        ],
+        "owners are the message's set, sorted"
+    );
+    // The prose and the data cannot disagree: the field is the same list the
+    // sentence renders, in the same order.
+    assert!(
+        v.message
+            .contains("001-compile-registry, 004-codebase-index"),
+        "{}",
+        v.message
+    );
+}
+
+/// §3.1: `C-002` deliberately keeps an empty `owners`. It fires precisely when
+/// no spec specifically claims the path, so there is no owner to name; the
+/// floor specs its message reports are why the path is debt, not who owns it.
+#[test]
+fn c002_carries_no_owners() {
+    let index = index_with_packages(
+        json!([{ "name": "a", "path": ".", "kind": "rust-lib", "specId": "001-a" }]),
+        json!([{
+            "specId": "001-a",
+            "implementingPaths": [],
+            "resolvedUnits": []
+        }]),
+    );
+    let report = run_with(
+        &ratchet_config(),
+        &index,
+        &diff(vec![file("src/orphan.rs", &[])]),
+        None,
+    );
+    let v = &report.violations[0];
+    assert_eq!(v.code, "C-002");
+    assert!(
+        v.owners.is_empty(),
+        "no owner exists to name: {:?}",
+        v.owners
+    );
+}
+
+/// §3.4: an empty `owners` is omitted from serialization, so every producer
+/// other than `C-001` emits exactly the JSON it emitted before the field
+/// existed. This is why no schema file and no schema version had to move.
+#[test]
+fn empty_owners_is_omitted_from_json() {
+    let index = index_with_packages(
+        json!([{ "name": "a", "path": ".", "kind": "rust-lib", "specId": "001-a" }]),
+        json!([{ "specId": "001-a", "implementingPaths": [], "resolvedUnits": [] }]),
+    );
+    let report = run_with(
+        &ratchet_config(),
+        &index,
+        &diff(vec![file("src/orphan.rs", &[])]),
+        None,
+    );
+    let json = serde_json::to_string(&report).unwrap();
+    assert!(
+        !json.contains("\"owners\""),
+        "an owner-less violation must serialize as it always did: {json}"
+    );
+}

--- a/crates/spec-spine-types/src/registry.rs
+++ b/crates/spec-spine-types/src/registry.rs
@@ -185,6 +185,43 @@ pub struct Violation {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// The spec ids that own `path`, sorted, for the codes where "owner" is a
+    /// fact the producer computed (spec 052: `C-001` alone). Empty everywhere
+    /// else, and omitted from serialization when empty, so every other
+    /// producer's JSON is byte-identical to what it emitted before this field
+    /// existed. It carries as data the owner set `message` renders into
+    /// English, so a consumer of the spec 037 `--json` envelope reads the
+    /// owners instead of regexing a sentence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owners: Vec<String>,
+}
+
+impl Violation {
+    /// A violation carrying no owner set: every code except `C-001`.
+    ///
+    /// The owner-less shape is the overwhelming majority, so it gets the
+    /// constructor and `C-001` names `owners` explicitly at its one site.
+    pub fn new(code: impl Into<String>, severity: Severity, message: impl Into<String>) -> Self {
+        Violation {
+            code: code.into(),
+            severity,
+            message: message.into(),
+            path: None,
+            owners: Vec::new(),
+        }
+    }
+
+    /// Attach the path this violation is about.
+    pub fn at(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Attach the path this violation is about, when there may not be one.
+    pub fn at_opt(mut self, path: Option<String>) -> Self {
+        self.path = path;
+        self
+    }
 }
 
 /// The registry's validation summary. `passed` is false iff any `error`-tier

--- a/crates/spec-spine-types/src/verdict.rs
+++ b/crates/spec-spine-types/src/verdict.rs
@@ -221,12 +221,9 @@ mod tests {
         use crate::registry::Severity;
         let v = Verdict::failure(
             verb::COMPILE_CHECK,
-            &Error::Validation(vec![Violation {
-                code: "V-001".to_string(),
-                severity: Severity::Error,
-                message: "boom".to_string(),
-                path: Some("specs/001-a/spec.md".to_string()),
-            }]),
+            &Error::Validation(vec![
+                Violation::new("V-001", Severity::Error, "boom").at("specs/001-a/spec.md"),
+            ]),
         );
         let e = v.error.as_ref().unwrap();
         assert_eq!(e.kind, "validation");

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -51,20 +51,12 @@ fn registry_round_trips_camelcase() {
 
 #[test]
 fn validation_passed_follows_error_tier() {
-    let warn = ValidationReport::from_violations(vec![Violation {
-        code: "L-001".into(),
-        severity: Severity::Warning,
-        message: "w".into(),
-        path: None,
-    }]);
+    let warn =
+        ValidationReport::from_violations(vec![Violation::new("L-001", Severity::Warning, "w")]);
     assert!(warn.passed, "warnings alone do not fail validation");
 
-    let err = ValidationReport::from_violations(vec![Violation {
-        code: "V-001".into(),
-        severity: Severity::Error,
-        message: "e".into(),
-        path: None,
-    }]);
+    let err =
+        ValidationReport::from_violations(vec![Violation::new("V-001", Severity::Error, "e")]);
     assert!(!err.passed, "any error-tier violation fails validation");
 }
 

--- a/specs/052-couple-names-the-crossing/spec.md
+++ b/specs/052-couple-names-the-crossing/spec.md
@@ -4,7 +4,7 @@ title: "The coupling gate names the crossing"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -24,6 +24,17 @@ extends:
   # alone. Registry emission is byte-identical (3.4), so no schema file and no
   # schema version moves.
   - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/registry.rs", nature: additive }
+  # Adding a field to a struct whose fields are public forces every struct
+  # literal in the workspace to name it (2.1). These six carry a `Violation`
+  # literal and nothing else; each is rewritten to the constructor and asserts
+  # nothing new. Named individually rather than waived, because a crossing the
+  # ledger records is the whole point of the door this spec is adding.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  - { spec: "002-registry-query", unit: "crates/spec-spine-core/src/query.rs", nature: additive }
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
+  - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-types/src/verdict.rs", nature: additive }
+  - { spec: "049-verify-declared-acceptance", unit: "crates/spec-spine-cli/src/cmd_verify.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/dtos.rs", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: ".claude/rules/adversarial-prompt-refusal.md" }, role: context }
@@ -109,6 +120,24 @@ Spec 005 §3.5 states that an owned path with no owner edit is a `C-001`
 violation. It states nothing about the message text, the footer, or the fields a
 violation carries, so every change below adds surface rather than changing what
 005 requires. No `amends` edge is declared and 005's `spec.md` is not edited.
+
+### 2.1 Six more files the field's shape forces
+
+**Decision, 2026-09-07.** The table above was written as though `Violation`
+could gain a field without anything else moving. It cannot: the struct's fields
+are public and every construction site is a struct literal, so Rust requires
+each one to name the new field. Six further files carry such a literal
+(`core/src/compile.rs`, `core/src/query.rs`, `core/src/lint.rs`,
+`types/src/verdict.rs`, `cli/src/cmd_verify.rs`, `types/tests/dtos.rs`).
+
+They are declared as `extends` edges in this spec's own frontmatter rather than
+waived. That is the door §3.2 is about, and a spec that printed the
+instruction while taking the other exit would not be worth reading. The edits
+themselves assert nothing: each literal becomes `Violation::new(..).at(..)`, a
+constructor added alongside the field precisely so a future field costs one
+file instead of ten. `Violation::new` produces the owner-less shape, which is
+every code except `C-001`, so a site that is not thinking about owners cannot
+accidentally claim one.
 
 ## 3. Behavior
 
@@ -270,24 +299,52 @@ and does not pre-empt the design.
 refused, and putting them in an `owners` field would make the field mean two
 different things depending on the code.
 
-**Guidance for the `--paths-from` mode.** It carries no diff and no spec.md
-edits, so 3.3's specific form never triggers there and the generic footer
-applies. That is correct rather than a limitation: without a diff there is no
-"the spec you are authoring" to name.
+**Guidance for the `--paths-from` mode.** Nothing is special-cased for it.
+
+**Decision, 2026-09-07.** This paragraph originally asserted that
+`--paths-from` "carries no diff and no spec.md edits, so 3.3's specific form
+never triggers there". The first half is a description of how CI uses the flag,
+not a property of it: the mode builds a `DiffInput` like any other, and a list
+that happens to name a `spec.md` satisfies §3.3's condition exactly as a git
+diff would. §3.3 states its rule over "the diff", so the specific form triggers
+in both modes, and suppressing it in one would be a mode special-case no
+requirement asks for. It would also be backwards: the sentence's stated reason
+was that there is no "spec you are authoring" to name, which is precisely
+untrue when the list names one.
 
 **Per-payload schema versioning.** Spec 050 §3.6 declined to open that axis and
 this spec does not reopen it.
 
 ## 5. Verification
 
+Every assertion below fails against the code as it stood before this spec: the
+strings did not exist and `owners` was not a field. The `--paths-from` inputs
+name `crates/spec-spine-core/src/index.rs`, which this repository's own corpus
+owns (spec 004 among others) and which spec 052 does not claim, so the gate
+refuses it and renders the footer under test. Reading the refusal through
+`grep` is deliberate: the exit code of a refusal is 1, and it is the rendered
+text that is the subject here.
+
 ```verify:cli
-# Self-contained: the commands below invoke the release binary.
+# Self-contained: the assertions below run the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test couple --locked
 cargo test -p spec-spine-cli --test couple --locked
-# The envelope version did not move for a payload addition (3.4, spec 050 3.6).
-test "$(target/release/spec-spine couple --base HEAD~1 --head HEAD --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["schemaVersion"])')" = "0.2.0"
-# Every committed registry shard still validates against the unchanged schema,
-# and is byte-identical to what the corpus compiles to (3.4).
+# 3.2: three doors, and door two names the mechanism and its two properties.
+printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin 2>&1 | grep -q '2. Declare an `extends` edge'
+printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin 2>&1 | grep -q 'amends nobody'
+printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin 2>&1 | grep -q 'needs explicit human approval'
+# 3.3: exactly one spec.md in the change set makes the block concrete.
+printf 'crates/spec-spine-core/src/index.rs\nspecs/052-couple-names-the-crossing/spec.md\n' | target/release/spec-spine couple --paths-from /dev/stdin 2>&1 | grep -q 'spec 052-couple-names-the-crossing is the only spec.md edited'
+printf 'crates/spec-spine-core/src/index.rs\nspecs/052-couple-names-the-crossing/spec.md\n' | target/release/spec-spine couple --paths-from /dev/stdin 2>&1 | grep -q 'unit: "crates/spec-spine-core/src/index.rs", nature: additive'
+# 3.3: two edited spec.md paths fall back to the generic form.
+printf 'crates/spec-spine-core/src/index.rs\nspecs/052-couple-names-the-crossing/spec.md\nspecs/005-coupling-gate/spec.md\n' | target/release/spec-spine couple --paths-from /dev/stdin 2>&1 | grep -q '<owning-spec-id>'
+# 3.1 + 3.5: the envelope carries the owner set as data, and no guidance prose.
+printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | python3 -c 'import json,sys; v=json.load(sys.stdin)["report"]["violations"][0]; assert v["code"]=="C-001", v; assert "004-codebase-index" in v["owners"], v'
+! printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | grep -q 'Declare an'
+# 3.4: a payload addition does not move the envelope version (spec 050 3.6).
+test "$(printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["schemaVersion"])')" = "0.2.0"
+# 3.4: every committed registry shard still matches what the corpus compiles to,
+# so no schema file and no schema version had to move.
 target/release/spec-spine compile --check
 ```


### PR DESCRIPTION
Implements spec 052 (adopter-audit backlog item 3). The gate has always named
the specs that own a drifted path and never named the mechanism for crossing
into their territory.

## What changed

**The footer names three doors** (§3.2), in the order an author should consider
them: edit the owning spec, declare an `extends` edge in your own spec, or ask
a human for a waiver. Door two is the one that was missing, and it is rendered
as pasteable YAML rather than described in prose, because the syntax is the
part the audit found adopters getting wrong. Its two load-bearing properties
are stated: it amends nobody, and it needs no waiver.

**The block is concrete when the diff makes it concrete** (§3.3). With exactly
one edited `spec.md`, the footer names that spec and fills in one `extends`
item per violating path, with the owner the gate already computed. With zero or
two-or-more, it falls back to the generic shape: an amendment pair is a
legitimate diff and the gate has no basis for guessing which spec should
declare the edge. The block is offered as a suggestion and says so, twice: the
gate cannot distinguish a deliberate crossing from an accidental touch, and an
author who did not mean to touch the path is told to revert it and declare
nothing.

**`C-001` carries its owners as data** (§3.1, §3.5). `Violation` gains an
optional `owners`, populated on `C-001` alone with exactly the set its message
renders into English. An orchestrator reading `couple --json` now reads a list
instead of regexing a sentence. `C-002` keeps an empty list by construction: it
fires precisely when no spec claims the path.

**Nothing committed moves** (§3.4). `owners` is omitted when empty and registry
violations never carry owners, so every shard is byte-identical, the schemas
are untouched, and `REGISTRY_SCHEMA_VERSION` / `VERDICT_SCHEMA_VERSION` stay
where they were (following spec 050 §3.6 rather than reopening it).

## Two decisions recorded in the spec, both yours to overturn

**§2.1, the territory grew from five files to eleven.** The spec was written as
though `Violation` could gain a field without anything else moving. It cannot:
the struct's fields are public and every construction site is a struct literal,
so Rust requires each to name the new field. Six further files carry one. They
are declared as `extends` edges in 052's own frontmatter rather than waived,
which is the door this spec exists to advertise; a spec that printed the
instruction while taking the other exit would not be worth reading. A
`Violation::new` constructor was added alongside the field so the next one
costs one file instead of ten.

**§4, the `--paths-from` premise was wrong.** The draft asserted that the mode
"carries no diff and no spec.md edits, so 3.3's specific form never triggers
there". That describes how CI uses the flag, not a property of it: the mode
builds a `DiffInput` like any other, and §3.3 states its rule over "the diff".
The specific form therefore triggers in both modes. Suppressing it in one would
be a special-case no requirement asks for, and backwards besides: the stated
reason was that there is no "spec you are authoring" to name, which is untrue
exactly when the list names one.

## Verification

The `## Verification` block was rewritten before the build, and every assertion
in it fails against pre-052 code. Checked empirically rather than assumed: the
0.15.0 binary on `PATH` renders the old two-door footer for the same input and
emits no `owners` key.

`spec-spine verify 052` passes, 13 commands. Full gate green on this commit:
69 registry shards fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74
coverage, `couple` clean over 12 paths. Workspace tests, clippy `-D warnings`
and `fmt --check` all pass. No waiver.