### PR TITLE
feat(053): a dependency points backward, and the corpus can say so

### DIFF
--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -11,11 +11,32 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/tests/lint.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/lib.rs",
         "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
       {
         "locations": [
           {
@@ -45,6 +66,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-types/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "docs/design/03-adopter-audit-2026-09.md"
           }
         ],
@@ -60,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "18f3df521f179c472145edc9581b1c62eacdfc3d7c7ac2eb34b00d11801558bf"
+  "shardHash": "0c7c17f1f92737453aba45d95379fafaef82569a733193a459f5a21af2f54c24"
 }

--- a/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -6,6 +6,12 @@
       "033-dependency-cycle-refusal",
       "038-registry-plan-ready-set"
     ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/tests/lint.rs"
+      }
+    ],
     "extends": [
       {
         "nature": "additive",
@@ -22,10 +28,18 @@
           "kind": "file",
           "path": "crates/spec-spine-types/src/config.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
       }
     ],
     "id": "053-depends-on-ordinal-monotonicity",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -42,6 +56,7 @@
       "053: A dependency points backward, and the corpus can say so",
       "1. Purpose",
       "2. Territory",
+      "2.1 One line in the crate root",
       "3. Behavior",
       "3.1 One new opt-in knob",
       "3.2 `L-007`",
@@ -55,6 +70,6 @@
     "summary": "Three adopters independently wrote the same ninety-line `scripts/spec-dag.sh` to assert one thing the tool does not: that a `depends_on` entry names a lower ordinal than the spec declaring it. Spec 033 already ships the harder half of that graph check, refusing a cycle at compile time, and ordinal monotonicity is the cheap total order that makes a cycle impossible by construction rather than detectable after the fact. This spec adds `L-007`, an opt-in conformance lint gated on a new `[lint] require_ordinal_monotonic_depends_on` knob, defaulting off so no existing corpus changes verdict. It is deliberately a lint and not a `V-` code: a forward dependency is a corpus convention an adopter may reasonably not hold, not a structural defect that makes the registry unreadable.\n",
     "title": "A dependency points backward, and the corpus can say so"
   },
-  "shardHash": "dc6f84f9028f81773820fa2c13e547b4e927a68e13e6bd6e9bf80f86a377bffe",
+  "shardHash": "e3a14fac12e75cea1cbd364992f4307fe54007fe915404a84a653f88ee9671ec",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -94,6 +94,34 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
             }
         }
 
+        // L-007: a `depends_on` entry that does not point backward in filing
+        // order (spec 053 §3.2). Opt-in: when the knob is off nothing is
+        // emitted at all, not emitted-and-filtered, so a corpus that has not
+        // opted in sees byte-identical output before and after spec 053.
+        //
+        // Error tier, matching `L-006`: the knob alone decides whether the
+        // corpus is held to this, and an adopter who turned it on turned it on
+        // to be refused. A warning would have meant two knobs (this one and
+        // `--fail-on-warn`) for one decision.
+        if cfg.lint.require_ordinal_monotonic_depends_on {
+            for target in &spec.depends_on {
+                if let Some((mine, theirs)) = ordinal_pair(&spec.id, target) {
+                    if theirs >= mine {
+                        violations.push(error(
+                            "L-007",
+                            format!(
+                                "spec '{}' depends_on '{target}', which is not a lower \
+                                 ordinal ({theirs:03} >= {mine:03}): a dependency points \
+                                 backward in filing order",
+                                spec.id
+                            ),
+                            at(),
+                        ));
+                    }
+                }
+            }
+        }
+
         // L-005: stub (no body sections).
         if spec.section_headings.is_empty() {
             violations.push(info(
@@ -105,6 +133,29 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
     }
 
     Ok(LintReport { violations })
+}
+
+/// Both ids' ordinals, or `None` when either lacks one (spec 053 §3.3).
+///
+/// Silence is the honest answer when the order is undefined. The corpus does
+/// not require numeric ids: `V-001` requires only that the directory equal the
+/// id, so `auth-login` is well-formed, and telling such a corpus that its ids
+/// have no ordinal would be telling it that it does not hold a convention it
+/// never claimed.
+fn ordinal_pair(declaring: &str, target: &str) -> Option<(u64, u64)> {
+    Some((ordinal(declaring)?, ordinal(target)?))
+}
+
+/// The leading decimal digit run of an id, as an integer.
+///
+/// Numeric rather than lexical, so a corpus that outgrows three digits and
+/// files `1001-foo` orders above `999-bar` instead of below it. Iterating
+/// `char`s rather than slicing bytes keeps this safe on a non-ASCII id, which
+/// is the defect `detect_duplicates` carries and which spec 053 §4 declines to
+/// fix from inside a lint change.
+fn ordinal(id: &str) -> Option<u64> {
+    let digits: String = id.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
 }
 
 fn has_ownership_edge(spec: &SpecRecord) -> bool {

--- a/crates/spec-spine-core/tests/lint.rs
+++ b/crates/spec-spine-core/tests/lint.rs
@@ -1,0 +1,211 @@
+//! Spec 053: `L-007`, the opt-in ordinal-monotonicity check on `depends_on`.
+//!
+//! The corpus had no dedicated lint test file before this spec: `L-006`'s
+//! acceptance lives in `tests/coverage.rs` and the scaffold's in
+//! `tests/scaffold.rs`. This is that file, and spec 053 claims it.
+
+use std::fs;
+use std::path::Path;
+
+use spec_spine_types::{Config, Severity, load_config};
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let p = root.join(rel);
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(p, content).unwrap();
+}
+
+/// A minimal well-formed spec. `establishes` keeps `L-001` quiet so the
+/// assertions below read against `L-007` alone.
+fn spec(id: &str, depends_on: &[&str]) -> String {
+    let deps = if depends_on.is_empty() {
+        String::new()
+    } else {
+        let items: String = depends_on
+            .iter()
+            .map(|d| format!("  - \"{d}\"\n"))
+            .collect();
+        format!("depends_on:\n{items}")
+    };
+    format!(
+        "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-07\"\n\
+         summary: \"s\"\nestablishes:\n  - \"src/{id}.rs\"\n{deps}---\n# {id}\n## body\n"
+    )
+}
+
+/// The knob on, everything else default.
+fn opted_in() -> Config {
+    load_config("[lint]\nrequire_ordinal_monotonic_depends_on = true\n").unwrap()
+}
+
+fn l007(cfg: &Config, root: &Path) -> Vec<spec_spine_types::Violation> {
+    spec_spine_core::lint(cfg, root)
+        .unwrap()
+        .violations
+        .into_iter()
+        .filter(|v| v.code == "L-007")
+        .collect()
+}
+
+/// A corpus with one forward edge (`012 -> 044`) and one backward one
+/// (`044 -> 012` would be a cycle, so `044 -> 001`).
+fn forward_corpus(root: &Path) {
+    write(root, "specs/001-base/spec.md", &spec("001-base", &[]));
+    write(
+        root,
+        "specs/012-early/spec.md",
+        &spec("012-early", &["044-late"]),
+    );
+    write(
+        root,
+        "specs/044-late/spec.md",
+        &spec("044-late", &["001-base"]),
+    );
+}
+
+/// §3.1: the knob defaults off, and off means *not emitted*, not
+/// emitted-and-filtered. A corpus that has not opted in sees byte-identical
+/// lint output before and after this spec.
+#[test]
+fn the_knob_defaults_off_and_off_emits_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    forward_corpus(tmp.path());
+    assert!(
+        Config::default()
+            .lint
+            .require_ordinal_monotonic_depends_on
+            .eq(&false),
+        "the knob defaults off"
+    );
+    assert!(
+        l007(&Config::default(), tmp.path()).is_empty(),
+        "a corpus that did not opt in is not told about its edges"
+    );
+}
+
+/// §3.2: with the knob on, a forward edge is one error-tier `L-007` naming
+/// both ids, and the backward edge in the same corpus is silent.
+#[test]
+fn a_forward_dependency_is_an_error_and_a_backward_one_is_silent() {
+    let tmp = tempfile::tempdir().unwrap();
+    forward_corpus(tmp.path());
+    let found = l007(&opted_in(), tmp.path());
+
+    assert_eq!(found.len(), 1, "only the forward edge fires: {found:?}");
+    let v = &found[0];
+    assert_eq!(v.severity, Severity::Error, "the knob alone decides");
+    assert!(v.message.contains("012-early"), "{}", v.message);
+    assert!(v.message.contains("044-late"), "{}", v.message);
+    assert!(
+        v.message.contains("points backward in filing order"),
+        "{}",
+        v.message
+    );
+    // §3.2: the path is the *declaring* spec, so an editor jumping to the
+    // diagnostic lands on the file that has to change.
+    assert_eq!(v.path.as_deref(), Some("specs/012-early/spec.md"));
+}
+
+/// §3.3: equality is a violation, not a pass. Two specs cannot share an
+/// ordinal (`V-004` refuses it), so an entry whose ordinal equals the
+/// declaring spec's is a spec depending on itself.
+#[test]
+fn a_self_dependency_is_caught_by_the_equality_arm() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "specs/007-self/spec.md",
+        &spec("007-self", &["007-self"]),
+    );
+    let found = l007(&opted_in(), tmp.path());
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(
+        found[0].message.contains("007 >= 007"),
+        "{}",
+        found[0].message
+    );
+}
+
+/// §3.3: an id with no leading digit run has no ordinal, and silence is the
+/// honest answer when the order is undefined. Checked in both positions: the
+/// declaring spec and the target.
+#[test]
+fn an_id_without_an_ordinal_is_silence_in_either_position() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "specs/auth-login/spec.md", &spec("auth-login", &[]));
+    // Declaring spec has no ordinal.
+    write(
+        r,
+        "specs/auth-logout/spec.md",
+        &spec("auth-logout", &["auth-login"]),
+    );
+    // Target has no ordinal, declaring spec does.
+    write(
+        r,
+        "specs/003-numbered/spec.md",
+        &spec("003-numbered", &["auth-login"]),
+    );
+    assert!(
+        l007(&opted_in(), r).is_empty(),
+        "a corpus that never claimed the convention is not held to it"
+    );
+}
+
+/// §3.3: the comparison is numeric, not lexical, so a corpus that outgrows
+/// three digits orders `1001` above `999` instead of below it.
+#[test]
+fn the_comparison_is_numeric_not_lexical() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "specs/999-nine/spec.md", &spec("999-nine", &[]));
+    // 1001 -> 999 decreases numerically; lexically "1001" < "999" would have
+    // called this forward and fired.
+    write(
+        r,
+        "specs/1001-thousand/spec.md",
+        &spec("1001-thousand", &["999-nine"]),
+    );
+    assert!(
+        l007(&opted_in(), r).is_empty(),
+        "1001 -> 999 points backward"
+    );
+
+    // And the genuine inversion still fires.
+    let tmp2 = tempfile::tempdir().unwrap();
+    let r2 = tmp2.path();
+    write(
+        r2,
+        "specs/1001-thousand/spec.md",
+        &spec("1001-thousand", &[]),
+    );
+    write(
+        r2,
+        "specs/999-nine/spec.md",
+        &spec("999-nine", &["1001-thousand"]),
+    );
+    assert_eq!(l007(&opted_in(), r2).len(), 1);
+}
+
+/// §3.4: `L-007` is a lint and never a `V-` code. The corpus above compiles,
+/// its shard is valid, and `compile` reports no violation of its own.
+#[test]
+fn a_forward_dependency_does_not_fail_compile() {
+    let tmp = tempfile::tempdir().unwrap();
+    forward_corpus(tmp.path());
+    let outcome = spec_spine_core::compile(&opted_in(), tmp.path()).unwrap();
+    assert!(
+        outcome.registry.validation.passed,
+        "a convention the corpus may not hold is not a structural defect: {:?}",
+        outcome.registry.validation.violations
+    );
+    assert!(
+        !outcome
+            .registry
+            .validation
+            .violations
+            .iter()
+            .any(|v| v.code == "L-007"),
+        "the lint's code never appears in compile's report"
+    );
+}

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub coupling: CouplingConfig,
     pub provenance: ProvenanceConfig,
     pub frontmatter: FrontmatterConfig,
+    pub lint: LintConfig,
 }
 
 /// `[manifest]`: how a manifest links a compilation unit back to its spec.
@@ -282,6 +283,27 @@ pub struct FrontmatterConfig {
     /// Keys an adopter recognizes (suppresses the lint's unknown-key warning);
     /// they still overflow into `extra_frontmatter`.
     pub extra_known_keys: Vec<String>,
+}
+
+/// `[lint]`: opt-in conformance conventions (spec 053).
+///
+/// A table of its own rather than a field on an existing one, because no
+/// existing home is honest: `[frontmatter]` configures the authored grammar and
+/// this is not a grammar rule, and `[coupling]` is the PR-time gate, where this
+/// never runs. The table names what the knob gates, and it is where the next
+/// opt-in convention belongs, so that one does not have to relitigate this.
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LintConfig {
+    /// Emit `L-007` for a `depends_on` entry that does not name a lower
+    /// ordinal than the spec declaring it (spec 053 §3.2).
+    ///
+    /// Off by default. The convention is real but not universal: a corpus that
+    /// files by domain, or one that renumbered once and lives with the result,
+    /// holds a coherent position this lint would spam. Adopters who want it
+    /// asked for it by each writing the same script; the knob is how they stop
+    /// maintaining it, not a verdict on anybody who did not.
+    pub require_ordinal_monotonic_depends_on: bool,
 }
 
 /// Load and validate a `spec-spine.toml` from its source text.

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -49,7 +49,7 @@ pub use codebase::{
 };
 pub use config::{
     AllowlistConfig, BrandingConfig, Config, CouplingConfig, FrontmatterConfig, IndexConfig,
-    LayoutConfig, ManifestConfig, ProvenanceConfig, load_config,
+    LayoutConfig, LintConfig, ManifestConfig, ProvenanceConfig, load_config,
 };
 pub use coverage::{CoverageReport, PackageCoverage};
 pub use edges::{

--- a/specs/053-depends-on-ordinal-monotonicity/spec.md
+++ b/specs/053-depends-on-ordinal-monotonicity/spec.md
@@ -4,7 +4,7 @@ title: "A dependency points backward, and the corpus can say so"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -19,6 +19,14 @@ extends:
   - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
   # One new opt-in table in the config model.
   - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  # `LintConfig` joins the crate root's re-export beside every sibling table
+  # (2.1). One line, and the only reason it is a crossing at all is that the
+  # re-export list lives in the crate root rather than in `config.rs`.
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+establishes:
+  # Created by this spec (2), so claimed by it: the corpus had no dedicated
+  # lint test file, and `L-007`'s acceptance is the reason to open one.
+  - "crates/spec-spine-core/tests/lint.rs"
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
 summary: >
@@ -92,6 +100,15 @@ that existed when it was written and states no closed set, so adding a code is
 additive surface. Spec 033 owns the cycle refusal and is untouched: this spec
 adds a second, independent, opt-in check over the same edge and changes nothing
 about the first.
+
+### 2.1 One line in the crate root
+
+**Decision, 2026-09-07.** `crates/spec-spine-types/src/lib.rs` re-exports every
+`Config` table by name, and `LintConfig` joins that list. The table would be
+reachable without it (`config` is a `pub mod`), so this is not a correctness
+need; it is that a new public table absent from the list every sibling appears
+in is a wart a reader trips on. Declared as an `extends` edge rather than left
+undone or waived.
 
 ## 3. Behavior
 
@@ -185,10 +202,12 @@ schema version moves.
 
 ## 4. Out of scope
 
-**Turning it on in this repository.** The knob ships off, and whether this corpus
-holds the convention is a separate decision from whether the tool can check it.
-This corpus does appear to hold it today, but "appears to" is what a verification
-step is for, not what a spec asserts on its own authority.
+**Turning it on in this repository.** The knob ships off in `spec-spine.toml`,
+and whether this corpus holds the convention is a separate decision from whether
+the tool can check it. Whether it *does* hold it is not a matter of opinion, so
+§5 asks rather than asserting: it runs the corpus through the lint with the knob
+on, from a scratch root that symlinks `specs/`, leaving the repository's own
+configuration untouched. As of this spec the answer is zero diagnostics.
 
 **Fixing a violation.** The lint names the edge; a person decides whether the
 answer is a renumbering, a deleted entry, or an inverted edge. A tool that
@@ -215,16 +234,25 @@ inside a lint change.
 
 ## 5. Verification
 
+The first three commands fail against pre-053 code: the test target does not
+exist, and `[lint]` is an unknown table to a `Config` whose every table is
+`deny_unknown_fields`, which is a hard config error (exit 3) rather than a
+silently ignored key.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test lint --locked
-# The knob exists and parses. `[lint]` is an unknown table to a pre-053 Config,
-# whose every table is `deny_unknown_fields`, so this is a hard config error
-# (exit 3) until this spec ships.
-tmp=$(mktemp -d) && mkdir -p "$tmp/specs" \
-  && printf '[lint]\nrequire_ordinal_monotonic_depends_on = true\n' > "$tmp/spec-spine.toml" \
-  && target/release/spec-spine --repo "$tmp" lint
-# The corpus this repository actually holds still lints clean.
+# 3.1: the knob exists and parses.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs" && printf '[lint]\nrequire_ordinal_monotonic_depends_on = true\n' > "$tmp/spec-spine.toml" && target/release/spec-spine --repo "$tmp" lint
+# 3.1: and a config written before this spec still parses, reading the default.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs" && printf '[layout]\nspecs_dir = "specs"\n' > "$tmp/spec-spine.toml" && target/release/spec-spine --repo "$tmp" lint
+# 4: this corpus is asked, not assumed. A scratch root symlinks `specs/` so the
+# repository's own `spec-spine.toml` is neither read nor written; the knob is on
+# only inside the scratch root. Zero diagnostics means the convention holds.
+tmp=$(mktemp -d) && ln -s "$PWD/specs" "$tmp/specs" && printf '[lint]\nrequire_ordinal_monotonic_depends_on = true\n' > "$tmp/spec-spine.toml" && target/release/spec-spine --repo "$tmp" lint | grep -q '^lint: 0 error'
+# 3.4: a lint is not a validation. The committed shards are byte-identical and
+# the corpus this repository ships still lints clean with the knob off.
+target/release/spec-spine compile --check
 target/release/spec-spine lint --fail-on-warn
 ```


### PR DESCRIPTION
Implements spec 053 (adopter-audit backlog item 4). Three adopters — hqgit,
aicortex and rahi — independently carry the same ninety-line
`scripts/spec-dag.sh`, each written for one assertion the tool does not make.

## What changed

**`L-007`**, at error tier, for each `depends_on` entry whose ordinal is not
lower than the declaring spec's. Behind a new `[lint]` table carrying
`require_ordinal_monotonic_depends_on`, defaulting **off**. Off means *not
emitted*, not emitted-and-filtered: a corpus that has not opted in sees
byte-identical lint output before and after this spec.

Error tier rather than warning because the knob alone should decide. A warning
would have meant two knobs (this one and `--fail-on-warn`) for one decision,
and an adopter who turns this on turns it on to be refused. It matches `L-006`,
the other check whose whole purpose is to refuse.

**The ordinal is the leading digit run, compared numerically**, so a corpus that
outgrows three digits orders `1001` above `999` instead of below it. An id with
no digit run has no ordinal, and fires nothing in either position — the corpus
does not require numeric ids (`V-001` requires only that the directory equal the
id), and telling a corpus of `auth-login` / `auth-logout` that its ids have no
ordinal is telling it that it does not hold a convention it never claimed.
Equality is a violation, which catches a self-dependency as a side effect.

**A new `[lint]` table** rather than a field on an existing one. `[frontmatter]`
configures the authored grammar and this is not a grammar rule; `[coupling]` is
the PR-time gate, where this never runs. `CONFIG_VERSION` does not move: an
added optional table with a default is the additive case a version exists to
make safe.

**It is a lint, not a validation.** The registry compiles, the shard is valid,
`plan` answers correctly, and the only thing wrong is a convention the corpus
may or may not hold. Spec 033's cycle refusal is untouched and stays
unconditional — it protects corpora that have not opted in, and it is the reason
this check can be opt-in at all. Monotonicity is strictly stronger than
acyclicity, so a corpus that holds this convention gets 033's property as a
theorem rather than as a detection.

## One decision recorded in the spec

**§2.1.** `LintConfig` joins the crate root's re-export beside every sibling
`Config` table. Not a correctness need (`config` is a `pub mod`, so the type is
reachable either way) but a new public table missing from the list every sibling
appears in is a wart. Declared as an `extends` edge on
`crates/spec-spine-types/src/lib.rs` rather than left undone or waived.

## Verification

The block's first three commands fail against pre-053 code: the test target does
not exist, and `[lint]` is an unknown table to a `Config` whose every table is
`deny_unknown_fields`, so it is a hard config error (exit 3) rather than a
silently ignored key.

The draft's §4 said this corpus "does appear to hold" the convention, and noted
that "appears to" is what a verification step is for. It now *is* one: §5 runs
this corpus through the lint with the knob on, from a scratch root that
symlinks `specs/`, leaving `spec-spine.toml` neither read nor written. The
answer is zero diagnostics. The knob still ships off.

`spec-spine verify 053` passes, 7 commands. Full gate green: 69 registry shards
fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple`
clean over 5 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass.
No waiver.