### PR TITLE
feat(054): the effective configuration is a governed read

### DIFF
--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -7,7 +7,15 @@
     ],
     "implementingPaths": [
       {
+        "path": "crates/spec-spine-cli/src/cmd_config.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/config.rs",
         "source": "spec-edge"
       },
       {
@@ -15,11 +23,45 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/lib.rs",
         "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/config.rs"
+        }
+      },
       {
         "locations": [
           {
@@ -49,6 +91,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-types/src/config.rs"
           }
         ],
@@ -57,6 +112,19 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
         }
       },
       {
@@ -90,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "18c35d514acf45e8656f91aca8d0c4b0634c6f95c9d2ff6020b047853930a081"
+  "shardHash": "d4e72afd142b3af36293ea194176ee7634c48516d8428cc4fd6ecb6c9bf12442"
 }

--- a/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
@@ -6,6 +6,16 @@
       "009-coupling-floor-claim-precedence",
       "037-machine-readable-verdicts"
     ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-cli/src/cmd_config.rs"
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-cli/tests/config.rs"
+      }
+    ],
     "extends": [
       {
         "nature": "additive",
@@ -30,10 +40,26 @@
           "kind": "file",
           "path": "crates/spec-spine-types/src/config.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
       }
     ],
     "id": "054-effective-config-is-a-governed-read",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -57,6 +83,7 @@
       "054: The effective configuration is a governed read",
       "1. Purpose",
       "2. Territory",
+      "2.1 Two crate roots",
       "3. Behavior",
       "3.1 `spec-spine config show`",
       "3.2 The bypass floor is reported merged and attributed",
@@ -71,6 +98,6 @@
     "summary": "`spec-spine.toml` is only half the configuration a coupling decision is made from. The other half is `DEFAULT_BYPASS_PREFIXES`, a thirteen-entry constant compiled into the binary, additive to the adopter's list and impossible to read from outside the process. claude-observatory, which judges other repositories, hand-parses each target's TOML and documents in its spec 016 D-3 that the built-in floor is simply unknowable to it. That is a consumer reimplementing half a contract and knowing it has the other half wrong. This spec adds `spec-spine config show [--json]`: the effective configuration, every default resolved, with the bypass floor rendered as the merged list the gate actually matches against and each entry attributed to the built-in floor or to the adopter's file. It reads and reports; it decides nothing.\n",
     "title": "The effective configuration is a governed read"
   },
-  "shardHash": "6fd5c6b96da465d4337cd7ae167c9ba65084da2bbf81aa65ce9b9ce389347d15",
+  "shardHash": "f41fb08286152e147adbac03f332ba0c06114f7934d09dd3375ebc879ae071f7",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_config.rs
+++ b/crates/spec-spine-cli/src/cmd_config.rs
@@ -1,0 +1,161 @@
+//! `spec-spine config show`: the effective configuration, as a governed read
+//! (spec 054).
+//!
+//! `spec-spine.toml` is only half the configuration a coupling decision is made
+//! from. The other half is `couple.rs::DEFAULT_BYPASS_PREFIXES`, thirteen
+//! entries compiled into the binary and additive to the adopter's list, so the
+//! list the gate matches against is a merge of a constant nobody outside the
+//! process can see and a list the adopter wrote. Every table is
+//! `#[serde(default)]` besides, so a file with three keys in it configures
+//! thirty. Reading the file back gives you what you wrote, which is not what
+//! the tool uses.
+//!
+//! This verb **reads**. It never writes, never creates a missing
+//! `spec-spine.toml`, and never emits a "suggested" file: scaffolding is
+//! `init`'s job and has been since spec 006.
+
+use std::path::Path;
+
+use clap::Subcommand;
+use spec_spine_core::effective_bypass_prefixes;
+use spec_spine_types::{EffectiveConfig, Error};
+
+use crate::load_repo_config;
+use crate::out;
+
+/// Actions under `spec-spine config`.
+#[derive(Subcommand, Debug)]
+pub enum ConfigAction {
+    /// Print the effective configuration: every default resolved, and the
+    /// bypass floor merged with the adopter's list and attributed.
+    Show {
+        /// Emit the configuration as a single JSON object on stdout.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub fn run(repo: &Path, action: &ConfigAction) -> Result<u8, Error> {
+    let ConfigAction::Show { json } = action;
+    // The same load every other verb does, so what is reported is what they
+    // would consume. No committed artifact is read, which is why this works on
+    // a repository that has never compiled: the state an adopter is in when
+    // they most need to see what their config resolved to.
+    let cfg = load_repo_config(repo)?;
+    let effective = EffectiveConfig::new(&cfg, effective_bypass_prefixes(&cfg));
+
+    if *json {
+        // Deliberately NOT the spec 037 verdict envelope. An envelope carries
+        // `ok` and `exitCode`, and a verdict is what a gate returns. This verb
+        // decides nothing and cannot fail a gate, so an envelope would put a
+        // permanently-true `ok` on a verb with no notion of passing. It is a
+        // query, and it takes `--json` the way `registry show` does: the
+        // object itself.
+        let s =
+            serde_json::to_string_pretty(&effective).map_err(|e| Error::Schema(e.to_string()))?;
+        out::line(format_args!("{s}"));
+        return Ok(0);
+    }
+
+    out::line(format_args!(
+        "config_version = \"{}\"",
+        effective.config_version
+    ));
+    render(&effective);
+    Ok(0)
+}
+
+/// The prose rendering. Carries no fact the JSON lacks (spec 054 §3.3): it is
+/// the same object, laid out for a person.
+fn render(e: &EffectiveConfig) {
+    out::line(format_args!("\n[manifest]"));
+    kv("metadata_namespace", &e.manifest.metadata_namespace);
+
+    out::line(format_args!("\n[domains]"));
+    list("allowed", &e.domains.allowed);
+    out::line(format_args!("\n[kind]"));
+    list("allowed", &e.kind.allowed);
+
+    out::line(format_args!("\n[layout]"));
+    kv("specs_dir", &e.layout.specs_dir);
+    kv("derived_dir", &e.layout.derived_dir);
+    kv("standards_dir", &e.layout.standards_dir);
+    kv("schemas_dir", &e.layout.schemas_dir);
+    kv("state_dir", &e.layout.state_dir);
+    kv("cargo_workspace", &e.layout.cargo_workspace);
+    list("npm_workspaces", &e.layout.npm_workspaces);
+    list(
+        "standalone_rust_workspaces",
+        &e.layout.standalone_rust_workspaces,
+    );
+    list("standalone_npm_packages", &e.layout.standalone_npm_packages);
+
+    out::line(format_args!("\n[index]"));
+    list("extra_hashed_inputs", &e.index.extra_hashed_inputs);
+    list("resolver_exclusions", &e.index.resolver_exclusions);
+
+    out::line(format_args!("\n[branding]"));
+    kv("compiler_id", &e.branding.compiler_id);
+    kv("indexer_id", &e.branding.indexer_id);
+
+    out::line(format_args!("\n[coupling]"));
+    kv("waiver_keyword", &e.coupling.waiver_keyword);
+    flag("require_ownership", e.coupling.require_ownership);
+    flag(
+        "auto_waive_dependency_only",
+        e.coupling.auto_waive_dependency_only,
+    );
+    out::line(format_args!("  bypass_prefixes:"));
+    // Padded so the attributions line up: an eye scanning for "which of these
+    // did we ask for" is reading the right-hand column, not the left.
+    let width = e
+        .coupling
+        .bypass_prefixes
+        .iter()
+        .map(|b| b.prefix.chars().count())
+        .max()
+        .unwrap_or(0);
+    for b in &e.coupling.bypass_prefixes {
+        let sources: Vec<&str> = b.sources.iter().map(|s| s.label()).collect();
+        out::line(format_args!(
+            "    {:<width$}  ({})",
+            b.prefix,
+            sources.join(", "),
+            width = width
+        ));
+    }
+
+    out::line(format_args!("\n[provenance.uri_schemes]"));
+    for (k, v) in &e.provenance.uri_schemes {
+        out::line(format_args!("  {k} = \"{v}\""));
+    }
+
+    out::line(format_args!("\n[frontmatter]"));
+    list("extra_known_keys", &e.frontmatter.extra_known_keys);
+
+    out::line(format_args!("\n[lint]"));
+    flag(
+        "require_ordinal_monotonic_depends_on",
+        e.lint.require_ordinal_monotonic_depends_on,
+    );
+}
+
+/// A string scalar, quoted, so an empty `state_dir` reads as `""` rather than
+/// as a key with nothing after it.
+fn kv(key: &str, value: &str) {
+    out::line(format_args!("  {key} = \"{value}\""));
+}
+
+/// A boolean scalar, unquoted, as TOML writes it.
+fn flag(key: &str, value: bool) {
+    out::line(format_args!("  {key} = {value}"));
+}
+
+fn list(key: &str, values: &[String]) {
+    if values.is_empty() {
+        out::line(format_args!("  {key} = []"));
+        return;
+    }
+    let quoted: Vec<String> = values.iter().map(|v| format!("\"{v}\"")).collect();
+    out::line(format_args!("  {key} = [{}]", quoted.join(", ")));
+}

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -20,6 +20,7 @@ macro_rules! out {
 
 mod cmd_attest;
 mod cmd_compile;
+mod cmd_config;
 mod cmd_couple;
 mod cmd_index;
 mod cmd_init;
@@ -64,6 +65,12 @@ enum Command {
         /// deliberately not machine-readable (spec 037 4).
         #[arg(long)]
         json: bool,
+    },
+    /// Read the effective configuration: every default resolved, and the
+    /// built-in bypass floor merged with the adopter's list and attributed.
+    Config {
+        #[command(subcommand)]
+        action: cmd_config::ConfigAction,
     },
     /// Read-only queries over the compiled registry.
     Registry {
@@ -188,6 +195,7 @@ fn main() -> ExitCode {
     let json_verb = cli.command.json_verb();
     let result = match &cli.command {
         Command::Compile { check, json } => cmd_compile::run(&repo, *check, *json),
+        Command::Config { action } => cmd_config::run(&repo, action),
         Command::Registry { query } => cmd_registry::run(&repo, query),
         Command::Index { action } => cmd_index::run(&repo, action.as_ref()),
         Command::Lint {

--- a/crates/spec-spine-cli/tests/config.rs
+++ b/crates/spec-spine-cli/tests/config.rs
@@ -1,0 +1,213 @@
+//! `spec-spine config show`: the effective configuration as a governed read
+//! (spec 054).
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_spec-spine"))
+}
+
+fn code(out: &std::process::Output) -> i32 {
+    out.status.code().unwrap_or(-1)
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let p = root.join(rel);
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(p, content).unwrap();
+}
+
+fn show(root: &Path, extra: &[&str]) -> std::process::Output {
+    let mut cmd = bin();
+    cmd.arg("--repo").arg(root).args(["config", "show"]);
+    cmd.args(extra);
+    cmd.output().unwrap()
+}
+
+fn show_json(root: &Path) -> serde_json::Value {
+    let out = show(root, &["--json"]);
+    assert_eq!(code(&out), 0, "{}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).expect("a single JSON object")
+}
+
+/// §3.1: it reads no committed artifact, so it answers on a repository that has
+/// never compiled. That is the state an adopter is in when they most need to
+/// see what their configuration resolved to.
+#[test]
+fn it_reports_on_a_repository_that_never_compiled() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("specs")).unwrap();
+    let out = show(tmp.path(), &[]);
+    assert_eq!(code(&out), 0, "{}", String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("config_version"));
+}
+
+/// §3.1: `config` is a read. An absent `spec-spine.toml` is defaults, not a
+/// file to create; scaffolding is `init`'s job and has been since spec 006.
+#[test]
+fn it_never_writes_a_config_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("specs")).unwrap();
+    assert_eq!(code(&show(tmp.path(), &[])), 0);
+    assert!(
+        !tmp.path().join("spec-spine.toml").exists(),
+        "a read verb must not scaffold"
+    );
+}
+
+/// §3.2: the floor is reported merged and attributed, in the order the gate
+/// evaluates: built-in first, then the adopter's, each in declared order. This
+/// is the fact claude-observatory recorded as unknowable (its spec 016 D-3).
+#[test]
+fn the_bypass_floor_is_merged_ordered_and_attributed() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "spec-spine.toml",
+        "[coupling]\nbypass_prefixes = [\"vendor/\", \"**/README.md\"]\n",
+    );
+    let v = show_json(tmp.path());
+    let entries = v["coupling"]["bypass_prefixes"].as_array().unwrap();
+
+    let built_in: Vec<&str> = spec_spine_core::DEFAULT_BYPASS_PREFIXES.to_vec();
+    assert!(
+        entries.len() > built_in.len(),
+        "the adopter's entries join the floor"
+    );
+    // The floor comes first, in its own order.
+    for (i, prefix) in built_in.iter().enumerate() {
+        assert_eq!(entries[i]["prefix"], *prefix, "floor order at {i}");
+        assert_eq!(entries[i]["sources"][0], "built-in");
+    }
+    // Then the adopter's, in declared order.
+    let tail: Vec<&str> = entries[built_in.len()..]
+        .iter()
+        .map(|e| e["prefix"].as_str().unwrap())
+        .collect();
+    assert_eq!(tail, vec!["vendor/", "**/README.md"]);
+    for e in &entries[built_in.len()..] {
+        assert_eq!(e["sources"][0], "spec-spine.toml");
+    }
+}
+
+/// §3.2: a prefix declared in both lists is reported once, attributed to both.
+/// The match is an `or`, so the duplicate is harmless; reporting it twice would
+/// suggest something to clean up that is not there.
+#[test]
+fn a_prefix_in_both_lists_appears_once_with_both_sources() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "spec-spine.toml",
+        "[coupling]\nbypass_prefixes = [\"docs/\"]\n",
+    );
+    let v = show_json(tmp.path());
+    let entries = v["coupling"]["bypass_prefixes"].as_array().unwrap();
+
+    let docs: Vec<&serde_json::Value> = entries.iter().filter(|e| e["prefix"] == "docs/").collect();
+    assert_eq!(docs.len(), 1, "reported once: {docs:?}");
+    let sources: Vec<&str> = docs[0]["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap())
+        .collect();
+    assert_eq!(sources, vec!["built-in", "spec-spine.toml"]);
+}
+
+/// §3.3: the JSON form is the object, never the spec 037 verdict envelope. An
+/// envelope carries `ok` and `exitCode`, and this verb decides nothing.
+#[test]
+fn the_json_form_is_not_a_verdict_envelope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let v = show_json(tmp.path());
+    assert!(v.get("ok").is_none(), "no verdict members: {v}");
+    assert!(v.get("exitCode").is_none(), "{v}");
+    assert!(v.get("verb").is_none(), "{v}");
+    assert_eq!(v["config_version"], "0.1.0", "§3.4: the shape's version");
+}
+
+/// §3.4: no field is omitted for being defaulted. An empty config reports every
+/// table, filled in; that exhaustiveness is the whole reason the verb is worth
+/// having.
+#[test]
+fn every_default_is_resolved_and_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let v = show_json(tmp.path());
+    for table in [
+        "manifest",
+        "domains",
+        "kind",
+        "layout",
+        "index",
+        "branding",
+        "coupling",
+        "provenance",
+        "frontmatter",
+        "lint",
+    ] {
+        assert!(v.get(table).is_some(), "missing table '{table}': {v}");
+    }
+    // Values nobody wrote down, which is exactly the point.
+    assert_eq!(v["layout"]["cargo_workspace"], "Cargo.toml");
+    assert_eq!(v["index"]["resolver_exclusions"][0], "target");
+    assert_eq!(v["manifest"]["metadata_namespace"], "spec-spine");
+}
+
+/// §3.4: the report mirrors `Config`'s tables one for one. A table added to
+/// `Config` and forgotten in `EffectiveConfig` fails here rather than silently
+/// going unreported.
+#[test]
+fn the_report_covers_every_config_table() {
+    let cfg = serde_json::to_value(spec_spine_types::Config::default()).unwrap();
+    let effective = serde_json::to_value(spec_spine_types::EffectiveConfig::new(
+        &spec_spine_types::Config::default(),
+        Vec::new(),
+    ))
+    .unwrap();
+
+    let mut want: Vec<&str> = cfg
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    want.sort_unstable();
+    let mut got: Vec<&str> = effective
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .filter(|k| *k != "config_version")
+        .collect();
+    got.sort_unstable();
+    assert_eq!(got, want, "every Config table must be reported");
+}
+
+/// §3.5: a pure function of the config file and the binary. The same repository
+/// and the same binary produce byte-identical bytes.
+#[test]
+fn the_output_is_deterministic() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "spec-spine.toml",
+        "[coupling]\nbypass_prefixes = [\"vendor/\"]\n",
+    );
+    let a = show(tmp.path(), &["--json"]).stdout;
+    let b = show(tmp.path(), &["--json"]).stdout;
+    assert_eq!(a, b);
+    assert!(a.ends_with(b"\n"), "trailing newline");
+}
+
+/// §3.1: a malformed `spec-spine.toml` is the existing config error, exit 3.
+/// This verb reports a configuration, and a file that is not one is the same
+/// failure it has always been.
+#[test]
+fn a_malformed_config_is_exit_3() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "spec-spine.toml", "[coupling]\nnot_a_key = 1\n");
+    assert_eq!(code(&show(tmp.path(), &[])), 3);
+}

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -22,7 +22,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use spec_spine_types::{CodebaseIndex, Config, Error, LineSpan, Registry, Severity, Violation};
+use spec_spine_types::{
+    BypassEntry, BypassSource, CodebaseIndex, Config, Error, LineSpan, Registry, Severity,
+    Violation,
+};
 
 use crate::coverage::{Ownership, classify, in_coverage_universe};
 use crate::index::{Freshness, check_index_freshness, spec_md_rel};
@@ -214,6 +217,45 @@ pub fn couple_with(
         waiver: waiver.map(|w| w.reason.clone()),
         checked_paths,
     })
+}
+
+/// The merged bypass list the gate matches against, attributed (spec 054 §3.2).
+///
+/// The built-in floor first, then the adopter's entries in their declared
+/// order, which is the order [`is_bypassed_path`] evaluates them. A prefix
+/// present in both lists appears once, carrying both sources: the match is an
+/// `or`, so a duplicate is harmless, and reporting it twice would suggest
+/// something to clean up that is not there.
+///
+/// This exists because half the list is a constant compiled into the binary and
+/// therefore unreadable from outside the process. claude-observatory, which
+/// judges repositories other than itself, hand-parses each target's TOML and
+/// records in its spec 016 D-3 that the built-in floor is simply unknowable to
+/// it. That is a consumer reimplementing half a contract and knowing the other
+/// half is wrong. Nothing about the gate's decision changes here: a value it
+/// already computes becomes reachable.
+pub fn effective_bypass_prefixes(cfg: &Config) -> Vec<BypassEntry> {
+    let mut entries: Vec<BypassEntry> = DEFAULT_BYPASS_PREFIXES
+        .iter()
+        .map(|p| BypassEntry {
+            prefix: (*p).to_string(),
+            sources: vec![BypassSource::BuiltIn],
+        })
+        .collect();
+    for declared in &cfg.coupling.bypass_prefixes {
+        match entries.iter_mut().find(|e| &e.prefix == declared) {
+            Some(existing) => {
+                if !existing.sources.contains(&BypassSource::Config) {
+                    existing.sources.push(BypassSource::Config);
+                }
+            }
+            None => entries.push(BypassEntry {
+                prefix: declared.clone(),
+                sources: vec![BypassSource::Config],
+            }),
+        }
+    }
+    entries
 }
 
 /// The effective bypass verdict for one path: hardcoded floor ∪ adopter list

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -54,7 +54,7 @@ pub use compile::{
 };
 pub use couple::{
     CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, couple, couple_with,
-    is_bypassed_path, parse_waiver,
+    effective_bypass_prefixes, is_bypassed_path, parse_waiver,
 };
 pub use coverage::{
     Ownership, SOURCE_EXTS, classify, coverage, coverage_with, enumerate_source_files,

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -306,6 +306,125 @@ pub struct LintConfig {
     pub require_ordinal_monotonic_depends_on: bool,
 }
 
+/// Where a bypass entry came from (spec 054 §3.2).
+///
+/// Attribution is the load-bearing part of `config show`, and the reason it is
+/// not a TOML echo. A consumer answers two different questions from the same
+/// list: "is this path bypassed" (the merged list) and "did the adopter ask for
+/// that" (the source). An unattributed merge answers only the first, and an
+/// orchestrator deciding whether a target's configuration is unusual needs the
+/// second.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BypassSource {
+    /// `couple.rs::DEFAULT_BYPASS_PREFIXES`, compiled into the binary.
+    BuiltIn,
+    /// The adopter's `[coupling] bypass_prefixes`.
+    #[serde(rename = "spec-spine.toml")]
+    Config,
+}
+
+impl BypassSource {
+    /// The token the prose rendering prints in parentheses.
+    pub fn label(self) -> &'static str {
+        match self {
+            BypassSource::BuiltIn => "built-in",
+            BypassSource::Config => "spec-spine.toml",
+        }
+    }
+}
+
+/// One entry of the merged bypass list the gate matches against (spec 054 §3.2).
+///
+/// An entry declared in both lists appears **once**, attributed to both. That is
+/// legal and harmless, since the match is an `or`; reporting it twice would
+/// suggest a duplicate the adopter should remove when there is nothing to fix.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BypassEntry {
+    pub prefix: String,
+    /// Every list this prefix appears in, built-in first.
+    pub sources: Vec<BypassSource>,
+}
+
+/// `[coupling]` as the gate resolves it: the adopter's keys, plus the bypass
+/// list merged with the built-in floor and attributed (spec 054 §3.2).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EffectiveCouplingConfig {
+    pub waiver_keyword: String,
+    pub require_ownership: bool,
+    pub auto_waive_dependency_only: bool,
+    /// The merged list, in the order the gate evaluates it: the built-in floor
+    /// first, then the adopter's entries in their declared order. A consumer
+    /// reimplementing the match gets the same answer in the same order, which
+    /// is the whole point of publishing it.
+    pub bypass_prefixes: Vec<BypassEntry>,
+}
+
+/// The configuration the verbs in this process would consume, every default
+/// resolved (spec 054 §3.4).
+///
+/// No field is omitted for being defaulted. Omitting them would rebuild the
+/// problem this exists to solve: a consumer would see a short document and have
+/// to know which absences mean which values, which is reading `spec-spine.toml`
+/// again with extra steps. The verb is worth having precisely because it is
+/// exhaustive.
+///
+/// Keys are snake_case, unlike every other emitted JSON in this system. Those
+/// are machine artifacts and camelCase is their house style; this document is a
+/// mirror of an authored TOML file, and a consumer holding the report beside
+/// `spec-spine.toml` should be reading the same token in both. Mixing the two
+/// (a camelCase envelope over snake_case tables) would be worse than either.
+///
+/// Mirrors [`Config`]'s tables one for one, with `coupling` widened. That
+/// duplication is guarded by a test asserting the two key sets agree, so a
+/// table added to `Config` and forgotten here fails the build rather than
+/// silently going unreported.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EffectiveConfig {
+    /// [`crate::CONFIG_VERSION`], so a consumer pinning against this shape has
+    /// the shape's version in the document rather than inferring it from the
+    /// binary's `--version`.
+    pub config_version: String,
+    pub manifest: ManifestConfig,
+    pub domains: AllowlistConfig,
+    pub kind: AllowlistConfig,
+    pub layout: LayoutConfig,
+    pub index: IndexConfig,
+    pub branding: BrandingConfig,
+    pub coupling: EffectiveCouplingConfig,
+    pub provenance: ProvenanceConfig,
+    pub frontmatter: FrontmatterConfig,
+    pub lint: LintConfig,
+}
+
+impl EffectiveConfig {
+    /// Build the report from a loaded [`Config`] and the merged bypass list.
+    ///
+    /// The bypass list is passed in rather than computed here because the
+    /// built-in floor lives in `spec-spine-core` (the gate that matches against
+    /// it owns it), and this crate is below that one in the dependency order.
+    pub fn new(config: &Config, bypass_prefixes: Vec<BypassEntry>) -> Self {
+        EffectiveConfig {
+            config_version: crate::CONFIG_VERSION.to_string(),
+            manifest: config.manifest.clone(),
+            domains: config.domains.clone(),
+            kind: config.kind.clone(),
+            layout: config.layout.clone(),
+            index: config.index.clone(),
+            branding: config.branding.clone(),
+            coupling: EffectiveCouplingConfig {
+                waiver_keyword: config.coupling.waiver_keyword.clone(),
+                require_ownership: config.coupling.require_ownership,
+                auto_waive_dependency_only: config.coupling.auto_waive_dependency_only,
+                bypass_prefixes,
+            },
+            provenance: config.provenance.clone(),
+            frontmatter: config.frontmatter.clone(),
+            lint: config.lint.clone(),
+        }
+    }
+}
+
 /// Load and validate a `spec-spine.toml` from its source text.
 ///
 /// Returns [`Error::Config`] (mapped to exit code 3) on any malformed or

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -48,8 +48,9 @@ pub use codebase::{
     SourceField, TraceMapping, TraceSource, Traceability,
 };
 pub use config::{
-    AllowlistConfig, BrandingConfig, Config, CouplingConfig, FrontmatterConfig, IndexConfig,
-    LayoutConfig, LintConfig, ManifestConfig, ProvenanceConfig, load_config,
+    AllowlistConfig, BrandingConfig, BypassEntry, BypassSource, Config, CouplingConfig,
+    EffectiveConfig, EffectiveCouplingConfig, FrontmatterConfig, IndexConfig, LayoutConfig,
+    LintConfig, ManifestConfig, ProvenanceConfig, load_config,
 };
 pub use coverage::{CoverageReport, PackageCoverage};
 pub use edges::{

--- a/specs/054-effective-config-is-a-governed-read/spec.md
+++ b/specs/054-effective-config-is-a-governed-read/spec.md
@@ -4,7 +4,7 @@ title: "The effective configuration is a governed read"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -20,6 +20,14 @@ extends:
   # The bypass floor and the waiver keyword are computed here today, privately.
   - { spec: "005-coupling-gate", unit: "crates/spec-spine-core/src/couple.rs", nature: additive }
   - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  # Both crate roots list their public surface by name, and three new types and
+  # one new function join those lists (2.1).
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+establishes:
+  # Created by this spec (2), so claimed by it.
+  - "crates/spec-spine-cli/src/cmd_config.rs"
+  - "crates/spec-spine-cli/tests/config.rs"
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: "docs/adoption-guide.md" }, role: context }
@@ -93,6 +101,15 @@ Nothing about the gate's decision is in this spec's territory. `couple.rs`
 changes only in that a value it already computes becomes reachable; the
 predicate that consumes it is untouched.
 
+### 2.1 Two crate roots
+
+**Decision, 2026-09-07.** Both crate roots re-export their public surface by
+name, so `BypassEntry`, `BypassSource`, `EffectiveConfig` and
+`EffectiveCouplingConfig` join `spec-spine-types`'s list and
+`effective_bypass_prefixes` joins `spec-spine-core`'s. Declared as `extends`
+edges. Neither line changes behavior; they are the difference between a type
+being nameable by a consumer and being reachable only through its module path.
+
 ## 3. Behavior
 
 ### 3.1 `spec-spine config show`
@@ -160,6 +177,17 @@ and `index coverage` take it: the object itself.
 The prose form is a rendering of the same object and carries no fact the JSON
 lacks.
 
+**Decision, 2026-09-07: the report's keys are snake_case.** Every other emitted
+JSON in this system is camelCase, and those are machine artifacts where that is
+the house style. This document is a mirror of an authored TOML file, and a
+consumer holding it beside `spec-spine.toml` should be reading the same token in
+both: `bypass_prefixes` in the report is `bypass_prefixes` in the file. The
+alternative shapes are both worse. All-camelCase renames every key the adopter
+wrote, which is a translation table the verb exists to avoid; a camelCase
+envelope over snake_case tables mixes the two in one document. §3.4 already
+names the field `config_version` in prose, and this decision is the rest of that
+choice made explicit rather than left to the serializer.
+
 ### 3.4 What it reports is what the tool would use
 
 The reported object MUST be the `Config` value the verbs in this process would
@@ -209,16 +237,27 @@ version-pinning problem, and spec 062 is where it belongs.
 
 ## 5. Verification
 
+Every assertion fails against pre-054 code: `config` is an unknown subcommand
+and clap refuses it with exit 2.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-cli --test config --locked
-# The verb exists and reports the merged, attributed floor. Until this ships,
-# `config` is an unknown subcommand and clap refuses it.
+# 3.1: the verb exists and reports.
 target/release/spec-spine config show
-# The built-in floor is present in the JSON form, which is the fact
-# claude-observatory could not reach (016 D-3).
-target/release/spec-spine config show --json | grep -q '.derived/'
-# It reports without any committed artifact, on a corpus that never compiled.
-tmp=$(mktemp -d) && mkdir -p "$tmp/specs" && target/release/spec-spine --repo "$tmp" config show
+# 3.2: the built-in floor is in the report, which is the fact
+# claude-observatory recorded as unknowable to it (its spec 016 D-3), and each
+# entry says where it came from.
+target/release/spec-spine config show --json | python3 -c 'import json,sys; e=json.load(sys.stdin)["coupling"]["bypass_prefixes"]; by={b["prefix"]:b["sources"] for b in e}; assert by[".derived/"]==["built-in"], by; assert by["**/README.md"]==["spec-spine.toml"], by'
+# 3.2: merged in the order the gate evaluates, floor first.
+target/release/spec-spine config show --json | python3 -c 'import json,sys; e=[b["prefix"] for b in json.load(sys.stdin)["coupling"]["bypass_prefixes"]]; assert e[0]==".github/", e; assert e[-1]=="**/README.md", e'
+# 3.3: a query, not a spec 037 verdict envelope.
+! target/release/spec-spine config show --json | grep -q '"exitCode"'
+# 3.4: exhaustive, defaults resolved, and the shape carries its own version.
+target/release/spec-spine config show --json | python3 -c 'import json,sys; c=json.load(sys.stdin); assert c["config_version"]=="0.1.0", c; assert c["index"]["resolver_exclusions"][0]=="target", c'
+# 3.1: it reports on a corpus that never compiled, and writes nothing.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs" && target/release/spec-spine --repo "$tmp" config show > /dev/null && test ! -e "$tmp/spec-spine.toml"
+# 3.5: a pure function of the config file and the binary.
+test "$(target/release/spec-spine config show --json | shasum)" = "$(target/release/spec-spine config show --json | shasum)"
 ```


### PR DESCRIPTION
Implements spec 054 (adopter-audit backlog item 5). Unblocks 062, which is
blocked on this.

## Why

`spec-spine.toml` is only half the configuration a coupling decision is made
from. The other half is `couple.rs::DEFAULT_BYPASS_PREFIXES` — thirteen entries
compiled into the binary, additive to the adopter's list and unreadable from
outside the process. Every table is `#[serde(default)]` besides, so a file with
three keys in it configures thirty.

claude-observatory is the case that makes this concrete. It judges repositories
other than itself, hand-parses each target's TOML, and its spec 016 D-3 records
the conclusion honestly: the built-in floor is unknowable to it. That is not a
bug in claude-observatory; it is a fact about what this tool exposes, written
down by the only consumer that hit it.

## What changed

**`spec-spine config show [--json]`.** Loads the config exactly as every other
verb does, resolves every default, reports every table. It reads no committed
artifact, so it answers on a repository that has never compiled. It writes
nothing and scaffolds nothing — that is `init`'s job and has been since spec 006.

**The bypass floor is reported merged and attributed**, in the order the gate
evaluates it: built-in first, then the adopter's entries in declared order. A
consumer reimplementing the match gets the same answer in the same order.
Attribution is the load-bearing part and the reason this is not a TOML echo: a
consumer answers both "is this path bypassed" (the merged list) and "did the
adopter ask for that" (the source) from one document. A prefix in both lists is
reported once, carrying both sources — the match is an `or`, and reporting it
twice would suggest a duplicate to clean up that is not there.

**The JSON form is the object, not the spec 037 verdict envelope.** An envelope
carries `ok` and `exitCode`; a verdict is what a gate returns. This verb decides
nothing and cannot fail a gate, so an envelope would put a permanently-`true`
`ok` on a verb with no notion of passing.

**Nothing about the gate's decision moves.** A value `couple.rs` already
computes becomes reachable; the predicate that consumes it is untouched.

## Two decisions recorded in the spec

**§2.1.** Both crate roots list their public surface by name, so the three new
types and one new function join those lists. Declared as `extends` edges on
`types/src/lib.rs` and `core/src/lib.rs`, neither of which the draft's territory
table anticipated.

**§3.3, the report's keys are snake_case** — unlike every other emitted JSON
here. Those are machine artifacts where camelCase is the house style; this
document mirrors an authored TOML file, and a consumer holding it beside
`spec-spine.toml` should read the same token in both. All-camelCase would rename
every key the adopter wrote, which is the translation table the verb exists to
avoid; a camelCase envelope over snake_case tables mixes both in one document.
The draft already wrote `config_version` in prose (§3.4); this is the rest of
that choice made explicit.

**Guard against drift:** `EffectiveConfig` mirrors `Config`'s tables one for
one, so a test asserts the two key sets agree. A table added to `Config` and
forgotten here fails the build rather than silently going unreported.

## Verification

Every assertion fails against pre-054 code — `config` is an unknown subcommand
and clap refuses it. `spec-spine verify 054` passes, 9 commands. Full gate
green: 69 registry shards fresh, index fresh, 0 unresolved, 0 lint warnings,
74/74 coverage, `couple` clean over 8 paths. Workspace tests, clippy
`-D warnings`, `fmt --check` pass. No waiver.