### PR TITLE
feat(055): the ledger answers what consumers rebuild by hand

### DIFF
--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -24,11 +24,19 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/query.rs",
         "source": "spec-edge"
       },
       {
         "path": "crates/spec-spine-core/tests/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/query.rs",
         "source": "spec-edge"
       }
     ],
@@ -88,6 +96,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-core/src/query.rs"
           }
         ],
@@ -114,6 +135,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/tests/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/query.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "docs/design/03-adopter-audit-2026-09.md"
           }
         ],
@@ -129,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c8d1e2e38c3613208620c32a4e43f8fa9578d5efa6a64b8238e5eff1c5556520"
+  "shardHash": "e15c356b314afed0abeceab336017754f69641d45b6af5d54d035731194ffb6d"
 }

--- a/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -55,10 +55,26 @@
           "kind": "file",
           "path": "crates/spec-spine-core/src/query.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/query.rs"
+        }
       }
     ],
     "id": "055-the-ledger-answers-what-consumers-rebuild",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -88,6 +104,6 @@
     "summary": "Two facts the ledger computes and then keeps to itself, each of which an adopter has reimplemented. Ownership of a path is resolved inside `couple.rs::owners_for_path`, a private function, so a consumer that wants to know which spec governs a file rebuilds a path-to-spec map from raw edges and gets the subtree, supersession and comment-header rules wrong. A spec's content hash is written into every registry shard as `shardHash` and is absent from every read verb, so claude-observatory reimplemented `hash.rs` normalization in TypeScript in order to pin against it. This spec adds `spec-spine index owner <path>` and puts `contentHash` on `registry show --json`'s output object. Neither touches a committed artifact, a DTO, or a schema version: both facts already exist and are merely unreachable.\n",
     "title": "The ledger answers what consumers rebuild by hand"
   },
-  "shardHash": "def73526768c35799310982d6277dc30a027156632612a63ce2e46ca665c7968",
+  "shardHash": "f7fc386bd2a03618429387dd3068303680eff123631d5f051743482d0f06c0a7",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -54,6 +54,18 @@ pub enum IndexAction {
         #[arg(long)]
         json: bool,
     },
+    /// Report which specs own one path, and how (spec 055).
+    ///
+    /// Calls the coupling gate's own owner derivation, so this answer and a
+    /// `C-001` decision cannot disagree. The path need not exist on disk:
+    /// asking who *would* own a file before creating it is a legitimate
+    /// question, computed the same way.
+    Owner {
+        /// A repo-relative POSIX path.
+        path: String,
+        #[arg(long)]
+        json: bool,
+    },
     /// Report which source files no spec specifically claims (spec 032).
     Coverage {
         #[arg(long)]
@@ -98,6 +110,40 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 for d in &diags {
                     let at = d.path.as_deref().unwrap_or("-");
                     outln!("  {} [{}] [{}] {}", d.code, d.spec_id, at, d.message);
+                }
+            }
+            Ok(0)
+        }
+        Some(IndexAction::Owner { path, json }) => {
+            // Freshness-guarded inside `owner`: an owner answer read off a
+            // stale ledger is the one wrong answer this verb must never give,
+            // because its caller is deciding what to edit.
+            let report = spec_spine_core::owner(&cfg, repo, path)?;
+            if *json {
+                let s = serde_json::to_string_pretty(&report)
+                    .map_err(|e| Error::Schema(e.to_string()))?;
+                outln!("{s}");
+            } else {
+                outln!("{}", report.path);
+                if report.owners.is_empty() {
+                    // A true and common answer on a specify-first corpus, and
+                    // not a `NotFound`: nothing was asked for by name.
+                    outln!("  (no spec owns this path)");
+                }
+                let width = report
+                    .owners
+                    .iter()
+                    .map(|o| o.spec_id.chars().count())
+                    .max()
+                    .unwrap_or(0);
+                for o in &report.owners {
+                    outln!(
+                        "  {:<width$}  {:<9}  {}",
+                        o.spec_id,
+                        owner_kind_label(o.kind),
+                        o.claim,
+                        width = width
+                    );
                 }
             }
             Ok(0)
@@ -340,4 +386,14 @@ fn write_slices(
         + "\n";
     fs::write(&path, json).map_err(|e| Error::Io(format!("write {}: {e}", path.display())))?;
     Ok(())
+}
+
+/// The token the prose form prints for a linkage kind (spec 055 §3.1).
+fn owner_kind_label(kind: spec_spine_core::OwnerKind) -> &'static str {
+    match kind {
+        spec_spine_core::OwnerKind::Unit => "unit",
+        spec_spine_core::OwnerKind::Floor => "floor",
+        spec_spine_core::OwnerKind::Header => "header",
+        spec_spine_core::OwnerKind::Inherited => "inherited",
+    }
 }

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 use clap::Subcommand;
 use spec_spine_core::{
-    ListFilter, Plan, list, list_ids, load_committed_registry, plan, relationships, show,
-    status_report,
+    ListFilter, Plan, list, list_ids, load_committed_registry, plan, relationships,
+    shard_content_hash, show, status_report,
 };
 use spec_spine_types::{Error, Status};
 
@@ -94,8 +94,19 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
         }
         RegistryQuery::Show { id, json } => {
             let spec = show(&registry, id)?;
+            // Spec 055 §3.3: the hash the committed shard records, read and
+            // never recomputed. Added at the output boundary and nowhere else:
+            // putting it on `SpecRecord` would write it into every shard, whose
+            // schema is `additionalProperties: false`, for a value the shard
+            // already carries one line above the record.
+            let content_hash = shard_content_hash(&cfg, repo, &spec.id)?;
             if *json {
-                print_json(spec)?;
+                let mut value =
+                    serde_json::to_value(spec).map_err(|e| Error::Schema(e.to_string()))?;
+                if let (Some(obj), Some(h)) = (value.as_object_mut(), content_hash.as_ref()) {
+                    obj.insert("contentHash".to_string(), serde_json::json!(h));
+                }
+                print_json(&value)?;
             } else {
                 outln!("id:      {}", spec.id);
                 outln!("title:   {}", spec.title);
@@ -103,6 +114,13 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 outln!("created: {}", spec.created);
                 outln!("path:    {}", spec.spec_path);
                 outln!("summary: {}", spec.summary.trim());
+                if let Some(h) = &content_hash {
+                    // §3.4: say which hash this is in the same breath as
+                    // reporting it. The registry's and the index's per-spec
+                    // hashes are the same shape, and a consumer that confuses
+                    // them gets a pin that fires on unrelated edits.
+                    outln!("contentHash: {h}  (sha256 of this spec.md)");
+                }
             }
         }
         RegistryQuery::StatusReport { json, nonzero_only } => {

--- a/crates/spec-spine-core/src/couple.rs
+++ b/crates/spec-spine-core/src/couple.rs
@@ -321,7 +321,16 @@ pub fn parse_waiver(cfg: &Config, body: &str) -> Option<Waiver> {
 /// The legitimate owners of a changed `(path, hunks)`. Unions span-aware
 /// resolved-unit ownership with whole-file `implementingPaths`, applies
 /// supersedes transfer, then amends-awareness under the FR-005 strict guard.
-fn owners_for_path(
+///
+/// Public since spec 055: `index owner <path>` reports what the gate would
+/// decide, and it must call this rather than reimplement it. A second
+/// implementation that agreed today and drifted next quarter would be worse
+/// than no verb at all, because a consumer would have stopped rebuilding the
+/// map by hand and started trusting an answer nobody tests against the gate.
+/// Pass empty `hunks` for the whole-file interpretation the gate already
+/// defines (`--paths-from` mode uses it today), which is the right reading of
+/// "who owns this file" when there is no diff.
+pub fn owners_for_path(
     specs_dir: &str,
     path: &str,
     hunks: &[LineSpan],
@@ -402,13 +411,16 @@ fn any_owner_in_diff(
 
 /// Direct `predecessor → {superseders}` map from the registry's `supersedes`.
 ///
+/// Public since spec 055, so a caller can assemble the same input
+/// [`owners_for_path`] is given inside the gate.
+///
 /// Only **full** supersession contributes a whole-spec authority transfer (spec
 /// 019). A **partial** item transfers authority over a single unit only: that
 /// is threaded through the index instead, as a `SourceField::Supersedes`
 /// resolved unit owned by the superseder, so it is already an owner of that
 /// unit's paths via `owners_for_path` step 1 and must NOT also inherit the
 /// predecessor's entire surface here.
-fn build_superseders(registry: &Registry) -> BTreeMap<String, BTreeSet<String>> {
+pub fn build_superseders(registry: &Registry) -> BTreeMap<String, BTreeSet<String>> {
     let mut map: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for spec in &registry.specs {
         for item in &spec.supersedes {

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -10,11 +10,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use spec_spine_types::{
-    CodebaseIndex, Diagnostic, Diagnostics, Error, INDEX_SCHEMA_VERSION, Implementation,
+    CodebaseIndex, Config, Diagnostic, Diagnostics, Error, INDEX_SCHEMA_VERSION, Implementation,
     ImplementingPath, IndexBuild, IndexPackageShard, IndexSpecShard, LayoutConfig, PackageKind,
-    PackageRecord, ResolvedLocation, ResolvedUnit, SourceField, TraceMapping, TraceSource,
-    Traceability, Unit, parse_frontmatter_with,
+    PackageRecord, Registry, ResolvedLocation, ResolvedUnit, SourceField, TraceMapping,
+    TraceSource, Traceability, Unit, parse_frontmatter_with,
 };
 
 use crate::coverage::SOURCE_EXTS;
@@ -1222,4 +1223,204 @@ fn status_str(status: spec_spine_types::Status) -> String {
         Retired => "retired",
     }
     .to_string()
+}
+
+// ===== spec 055: who owns this path =====
+
+/// How a spec comes to own a path.
+///
+/// The kinds are separate because a consumer's next decision depends on which
+/// one it is: a `Unit` owner claimed the path deliberately, a `Floor` owner has
+/// it only through a package manifest (which counts for `C-001` and counts as
+/// debt for coverage, spec 032), and a `Header` owner is named by the file
+/// itself. Collapsing them into a flat list of spec ids would reproduce exactly
+/// the ambiguity spec 032 was written to remove.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OwnerKind {
+    /// An ownership-bearing resolved unit claim covers the path.
+    Unit,
+    /// Only a package's `[package.metadata.<ns>].spec` covers it.
+    Floor,
+    /// A `// Spec:` comment header in the file names this spec.
+    Header,
+    /// The gate counts this spec an owner without a direct claim: it supersedes
+    /// one that has a claim, or it amends the spec whose `spec.md` this is.
+    Inherited,
+}
+
+/// One spec's link to a path, with the claim that produced it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnerLink {
+    pub spec_id: String,
+    pub kind: OwnerKind,
+    /// The claim itself: the unit's location, the package directory, the file,
+    /// or, for `Inherited`, the relation that conferred the authority.
+    pub claim: String,
+}
+
+/// Who owns one path (spec 055 §3.1).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnerReport {
+    pub path: String,
+    /// Sorted by spec id, then by kind. Empty when nothing owns the path, which
+    /// is a true and common answer rather than an error.
+    pub owners: Vec<OwnerLink>,
+}
+
+/// Freshness-guarded owner query: refuses a stale committed index (exit 2).
+///
+/// An owner answer read off a stale ledger is the one kind of wrong answer this
+/// verb must never give, because its caller is deciding what to edit.
+pub fn owner(cfg: &Config, repo_root: &Path, path: &str) -> Result<OwnerReport, Error> {
+    match check_index_freshness(cfg, repo_root)? {
+        Freshness::Stale { expected, actual } => return Err(Error::Stale { expected, actual }),
+        Freshness::Fresh => {}
+    }
+    let registry = crate::compile::load_committed_registry(cfg, repo_root)?;
+    let index = load_committed_index(cfg, repo_root)?;
+    Ok(owner_with(cfg, &registry, &index, path))
+}
+
+/// Pure owner query over already-loaded artifacts.
+///
+/// The id set is [`crate::couple::owners_for_path`]'s, verbatim, so this verb
+/// and a `C-001` decision cannot disagree. Only the attribution is computed
+/// here, and it is computed with the predicates [`crate::coverage::classify`]
+/// already uses, so the report and the ratchet cannot disagree either.
+pub fn owner_with(
+    cfg: &Config,
+    registry: &Registry,
+    index: &CodebaseIndex,
+    path: &str,
+) -> OwnerReport {
+    let specs_dir = cfg.layout.specs_dir.as_str();
+    let superseders = crate::couple::build_superseders(registry);
+    // Empty hunks: the whole-file interpretation the gate already defines. With
+    // no diff there are no hunks, and every owner whose span is in the file is
+    // the right answer to "who owns this file".
+    let ids = crate::couple::owners_for_path(specs_dir, path, &[], index, &superseders);
+
+    let mut owners: Vec<OwnerLink> = Vec::new();
+    for id in &ids {
+        let before = owners.len();
+        for m in index
+            .traceability
+            .mappings
+            .iter()
+            .filter(|m| &m.spec_id == id)
+        {
+            for ru in m.resolved_units.iter().filter(|ru| ru.ownership) {
+                for loc in ru.locations.iter().filter(|l| claim_covers(&l.file, path)) {
+                    owners.push(OwnerLink {
+                        spec_id: id.clone(),
+                        kind: OwnerKind::Unit,
+                        claim: format!("{} ({})", loc.file, source_field_name(ru.source_field)),
+                    });
+                }
+            }
+            // A header claims exactly the file it sits in, never a subtree.
+            // `Multiple` on a file path means a header agreed with another
+            // source, which is how `classify` reads it too.
+            for ip in m.implementing_paths.iter().filter(|ip| ip.path == path) {
+                if matches!(
+                    ip.source,
+                    TraceSource::CommentHeader | TraceSource::Multiple
+                ) {
+                    owners.push(OwnerLink {
+                        spec_id: id.clone(),
+                        kind: OwnerKind::Header,
+                        claim: format!("{path} (// Spec: header)"),
+                    });
+                }
+            }
+        }
+        for p in index
+            .packages
+            .iter()
+            .filter(|p| p.spec_ref.as_deref() == Some(id.as_str()))
+            .filter(|p| package_covers(&p.path, path))
+        {
+            owners.push(OwnerLink {
+                spec_id: id.clone(),
+                kind: OwnerKind::Floor,
+                claim: format!("{} (package manifest)", p.path),
+            });
+        }
+        if owners.len() == before {
+            // In the gate's set with no direct claim: supersession transfer, or
+            // the amends widening on a `spec.md` path. Both are rules the gate
+            // applies and this verb reports rather than hides.
+            owners.push(OwnerLink {
+                spec_id: id.clone(),
+                kind: OwnerKind::Inherited,
+                claim: inherited_reason(specs_dir, path, id, index, &superseders),
+            });
+        }
+    }
+    owners.sort_by(|a, b| (&a.spec_id, a.kind, &a.claim).cmp(&(&b.spec_id, b.kind, &b.claim)));
+    owners.dedup();
+    OwnerReport {
+        path: path.to_string(),
+        owners,
+    }
+}
+
+/// Why a spec holds authority it never claimed directly.
+fn inherited_reason(
+    specs_dir: &str,
+    path: &str,
+    id: &str,
+    index: &CodebaseIndex,
+    superseders: &std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
+) -> String {
+    let predecessors: Vec<&str> = superseders
+        .iter()
+        .filter(|(_, succs)| succs.contains(id))
+        .map(|(pred, _)| pred.as_str())
+        .collect();
+    if !predecessors.is_empty() {
+        return format!("supersedes {}", predecessors.join(", "));
+    }
+    if let Some(amended) = crate::couple::spec_id_for_spec_md_path(specs_dir, path) {
+        if index
+            .traceability
+            .mappings
+            .iter()
+            .any(|m| m.spec_id == id && m.amends.iter().any(|a| a == amended))
+        {
+            return format!("amends {amended}");
+        }
+        return format!("amendment record of {amended}");
+    }
+    "inherited".to_string()
+}
+
+/// Exact match, or a directory-prefix match for a subtree claim: the same
+/// reading [`crate::couple`] applies, spelled here so the report cannot drift
+/// from it in the trailing-slash case.
+fn claim_covers(claim: &str, path: &str) -> bool {
+    claim == path
+        || (claim.ends_with('/') && path.starts_with(claim))
+        || path.starts_with(&format!("{claim}/"))
+}
+
+/// A package directory contains the path (`.` is the whole repository).
+fn package_covers(pkg: &str, path: &str) -> bool {
+    pkg == "." || pkg.is_empty() || path.starts_with(&format!("{}/", pkg.trim_end_matches('/')))
+}
+
+fn source_field_name(f: SourceField) -> &'static str {
+    match f {
+        SourceField::Establishes => "establishes",
+        SourceField::Extends => "extends",
+        SourceField::Refines => "refines",
+        SourceField::Supersedes => "supersedes",
+        SourceField::Amends => "amends",
+        SourceField::CoAuthority => "co_authority",
+        SourceField::Constrains => "constrains",
+        SourceField::References => "references",
+    }
 }

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -53,8 +53,8 @@ pub use compile::{
     registry_shard_files,
 };
 pub use couple::{
-    CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, couple, couple_with,
-    effective_bypass_prefixes, is_bypassed_path, parse_waiver,
+    CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, build_superseders, couple,
+    couple_with, effective_bypass_prefixes, is_bypassed_path, owners_for_path, parse_waiver,
 };
 pub use coverage::{
     Ownership, SOURCE_EXTS, classify, coverage, coverage_with, enumerate_source_files,
@@ -70,13 +70,15 @@ pub use diagnostics::{
     committed_diagnostics, count as count_diagnostics,
 };
 pub use index::{
-    Freshness, IndexOutcome, IndexShardSet, authorities, check_index_freshness,
-    check_slice_freshness, index, index_dir, index_shard_files, load_committed_index, slices_path,
+    Freshness, IndexOutcome, IndexShardSet, OwnerKind, OwnerLink, OwnerReport, authorities,
+    check_index_freshness, check_slice_freshness, index, index_dir, index_shard_files,
+    load_committed_index, owner, owner_with, slices_path,
 };
 pub use lint::{LintReport, lint};
 pub use query::{
     BlockedSpec, Blocker, ListFilter, Plan, RelationshipView, StatusReport, StatusReportNonzero,
-    list, list_ids, load_index, load_registry, plan, relationships, show, status_report,
+    list, list_ids, load_index, load_registry, plan, relationships, shard_content_hash, show,
+    status_report,
 };
 pub use render::{orphans, render_markdown};
 pub use scaffold::{Scaffold, ScaffoldFile, scaffold_init};

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -5,11 +5,12 @@
 //! `load_registry`.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use serde::Serialize;
 use spec_spine_types::{
-    CodebaseIndex, Error, INDEX_SCHEMA_VERSION, Implementation, REGISTRY_SCHEMA_VERSION, Registry,
-    Severity, SpecRecord, Status, Violation, parse_semver,
+    CodebaseIndex, Config, Error, INDEX_SCHEMA_VERSION, Implementation, REGISTRY_SCHEMA_VERSION,
+    Registry, RegistrySpecShard, Severity, SpecRecord, Status, Violation, parse_semver,
 };
 
 /// Parse `registry.json` bytes into a typed [`Registry`], rejecting an unknown
@@ -20,6 +21,41 @@ pub fn load_registry(bytes: &[u8]) -> Result<Registry, Error> {
         .map_err(|e| Error::Parse(format!("invalid registry.json: {e}")))?;
     reject_unknown_major("registry", &registry.spec_version, REGISTRY_SCHEMA_VERSION)?;
     Ok(registry)
+}
+
+/// The content hash the committed registry shard records for one spec (spec
+/// 055 §3.3): SHA-256 over that spec's `spec.md` under the corpus's
+/// normalization, which is the registry's only hashed input.
+///
+/// **Read, never recomputed.** `registry` is the read-side view of what was
+/// committed, and a `show` that hashed `spec.md` afresh would report a value
+/// the ledger does not hold, silently repairing a staleness that
+/// `compile --check` exists to reveal.
+///
+/// `None` when no shard exists for the id, so a caller that already resolved
+/// the record can report the rest of it rather than failing.
+///
+/// It is deliberately **not** the index's per-spec shard hash, which
+/// additionally folds span-backing source files and the global-inputs scalar. A
+/// consumer pinning "has this spec's text changed" wants this one; a consumer
+/// asking "has anything this spec depends on changed" wants the other and a
+/// different question.
+pub fn shard_content_hash(
+    cfg: &Config,
+    repo_root: &Path,
+    spec_id: &str,
+) -> Result<Option<String>, Error> {
+    let path = crate::compile::registry_dir(cfg, repo_root)
+        .join("by-spec")
+        .join(format!("{spec_id}.json"));
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(Error::Io(format!("read {}: {e}", path.display()))),
+    };
+    let shard: RegistrySpecShard = serde_json::from_slice(&bytes)
+        .map_err(|e| Error::Parse(format!("invalid registry shard {spec_id}: {e}")))?;
+    Ok(Some(shard.shard_hash))
 }
 
 /// Parse `index.json` bytes into a typed [`CodebaseIndex`], rejecting an unknown

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -1044,3 +1044,178 @@ fn in_progress_leniency_reports_rather_than_ignores() {
         reported.diagnostics.warnings
     );
 }
+
+// ── spec 055: who owns this path ──────────────────────────────────────────
+
+/// A repo where 001 owns a file by unit, 002 owns the crate by manifest floor,
+/// and a third file carries a `// Spec:` header naming 003.
+fn owner_fixture(root: &Path) {
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        root,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n\
+         [package.metadata.spec-spine]\nspec = \"002-floor\"\n",
+    );
+    write(root, "crate-a/src/claimed.rs", "pub fn a() {}\n");
+    write(root, "crate-a/src/plain.rs", "pub fn b() {}\n");
+    write(
+        root,
+        "crate-a/src/headed.rs",
+        "// Spec: specs/003-header/spec.md\npub fn c() {}\n",
+    );
+    write(
+        root,
+        "specs/001-unit/spec.md",
+        &spec("001-unit", "establishes:\n  - \"crate-a/src/claimed.rs\"\n"),
+    );
+    write(root, "specs/002-floor/spec.md", &spec("002-floor", ""));
+    write(root, "specs/003-header/spec.md", &spec("003-header", ""));
+}
+
+fn owners_of(root: &Path, path: &str) -> spec_spine_core::OwnerReport {
+    let cfg = Config::default();
+    let registry = spec_spine_core::compile(&cfg, root).unwrap().registry;
+    let index = spec_spine_core::index(&cfg, root).unwrap().index;
+    spec_spine_core::owner_with(&cfg, &registry, &index, path)
+}
+
+/// §3.1: the three linkage kinds are reported separately, because a consumer's
+/// next decision depends on which one it is. A unit claim is deliberate; a
+/// floor is a blanket that counts as debt for coverage (spec 032).
+#[test]
+fn owner_separates_unit_floor_and_header_linkage() {
+    let tmp = tempfile::tempdir().unwrap();
+    owner_fixture(tmp.path());
+
+    let claimed = owners_of(tmp.path(), "crate-a/src/claimed.rs");
+    let unit = claimed
+        .owners
+        .iter()
+        .find(|o| o.spec_id == "001-unit")
+        .expect("the unit owner: {claimed:?}");
+    assert_eq!(unit.kind, spec_spine_core::OwnerKind::Unit);
+    assert!(unit.claim.contains("establishes"), "{}", unit.claim);
+    // The floor owner is reported too, and as a floor.
+    let floor = claimed
+        .owners
+        .iter()
+        .find(|o| o.spec_id == "002-floor")
+        .expect("the floor owner");
+    assert_eq!(floor.kind, spec_spine_core::OwnerKind::Floor);
+
+    // A file only the floor covers reports exactly that, and nothing stronger.
+    let plain = owners_of(tmp.path(), "crate-a/src/plain.rs");
+    assert_eq!(plain.owners.len(), 1, "{plain:?}");
+    assert_eq!(plain.owners[0].spec_id, "002-floor");
+    assert_eq!(plain.owners[0].kind, spec_spine_core::OwnerKind::Floor);
+
+    // And a `// Spec:` header is its own kind: the file naming its own spec.
+    let headed = owners_of(tmp.path(), "crate-a/src/headed.rs");
+    assert!(
+        headed
+            .owners
+            .iter()
+            .any(|o| o.spec_id == "003-header" && o.kind == spec_spine_core::OwnerKind::Header),
+        "{headed:?}"
+    );
+}
+
+/// §3.1: a path nothing owns exits with an empty result, not an error. It is a
+/// true and common answer on a specify-first corpus, and the path need not
+/// exist: asking who *would* own a file before creating it is legitimate.
+#[test]
+fn owner_of_an_unowned_or_absent_path_is_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    owner_fixture(tmp.path());
+    assert!(
+        owners_of(tmp.path(), "outside/nothing.rs")
+            .owners
+            .is_empty(),
+        "unowned"
+    );
+    assert!(
+        owners_of(tmp.path(), "outside/does-not-exist-yet.rs")
+            .owners
+            .is_empty(),
+        "a path that does not exist on disk is answered, not refused"
+    );
+}
+
+/// §3.2: the answer is the gate's own, not a second implementation. Whatever
+/// `owners_for_path` returns for the whole-file reading is exactly the id set
+/// reported, so `index owner` and a `C-001` decision cannot disagree.
+#[test]
+fn owner_reports_exactly_the_gates_id_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    owner_fixture(tmp.path());
+    let cfg = Config::default();
+    let registry = spec_spine_core::compile(&cfg, tmp.path()).unwrap().registry;
+    let index = spec_spine_core::index(&cfg, tmp.path()).unwrap().index;
+
+    for path in [
+        "crate-a/src/claimed.rs",
+        "crate-a/src/plain.rs",
+        "crate-a/src/headed.rs",
+        "outside/nothing.rs",
+    ] {
+        let gate = spec_spine_core::owners_for_path(
+            "specs",
+            path,
+            &[],
+            &index,
+            &spec_spine_core::build_superseders(&registry),
+        );
+        let mut reported: Vec<String> = spec_spine_core::owner_with(&cfg, &registry, &index, path)
+            .owners
+            .into_iter()
+            .map(|o| o.spec_id)
+            .collect();
+        reported.dedup();
+        let expected: Vec<String> = gate.into_iter().collect();
+        assert_eq!(reported, expected, "id sets must agree for {path}");
+    }
+}
+
+/// §3.2: supersession transfer applies unchanged, and the successor is reported
+/// with the relation that conferred the authority rather than as a claim it
+/// never made.
+#[test]
+fn a_superseding_spec_is_reported_as_inherited() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        r,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "crate-a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        r,
+        "specs/001-old/spec.md",
+        &spec("001-old", "establishes:\n  - \"crate-a/src/lib.rs\"\n"),
+    );
+    write(
+        r,
+        "specs/002-new/spec.md",
+        &spec("002-new", "supersedes:\n  - \"001-old\"\n"),
+    );
+
+    let report = owners_of(r, "crate-a/src/lib.rs");
+    let new = report
+        .owners
+        .iter()
+        .find(|o| o.spec_id == "002-new")
+        .expect("the successor inherits: {report:?}");
+    assert_eq!(new.kind, spec_spine_core::OwnerKind::Inherited);
+    assert!(new.claim.contains("supersedes 001-old"), "{}", new.claim);
+    // Additive: the predecessor keeps its claim.
+    assert!(
+        report
+            .owners
+            .iter()
+            .any(|o| o.spec_id == "001-old" && o.kind == spec_spine_core::OwnerKind::Unit),
+        "{report:?}"
+    );
+}

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -665,3 +665,52 @@ fn plan_blocked_by_follows_authored_depends_on_order() {
         "authored order is preserved, not re-sorted by id"
     );
 }
+
+// ── spec 055: the shard's content hash is readable ────────────────────────
+
+/// §3.3: the hash is read from the committed shard, never recomputed. A `show`
+/// that hashed `spec.md` afresh would report a value the ledger does not hold,
+/// silently repairing a staleness that `compile --check` exists to reveal.
+#[test]
+fn shard_content_hash_is_read_from_the_committed_shard() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_spec(root, "001-alpha", "");
+    let cfg = Config::default();
+
+    // Nothing committed yet: absent, not an error.
+    assert_eq!(
+        spec_spine_core::shard_content_hash(&cfg, root, "001-alpha").unwrap(),
+        None
+    );
+
+    // Commit the shard tree exactly as the CLI does.
+    let outcome = compile(&cfg, root).unwrap();
+    let dir = spec_spine_core::registry_dir(&cfg, root).join("by-spec");
+    let files = spec_spine_core::registry_shard_files(&outcome.shards).unwrap();
+    spec_spine_core::shard::sync_dir(&dir, &files).unwrap();
+
+    let committed = spec_spine_core::shard_content_hash(&cfg, root, "001-alpha")
+        .unwrap()
+        .expect("a committed shard has a hash");
+    assert_eq!(committed.len(), 64, "sha256 hex: {committed}");
+    assert_eq!(
+        committed, outcome.shards.spec_shards[0].shard_hash,
+        "the value the shard records, verbatim"
+    );
+
+    // Edit the spec without recompiling: the reported hash does NOT move. That
+    // is the property that makes it a pin rather than a recomputation.
+    write_spec(root, "001-alpha", "kind: \"tooling\"\n");
+    assert_eq!(
+        spec_spine_core::shard_content_hash(&cfg, root, "001-alpha").unwrap(),
+        Some(committed),
+        "a read verb reports the ledger, not the tree"
+    );
+
+    // A spec with no shard is absent rather than an error.
+    assert_eq!(
+        spec_spine_core::shard_content_hash(&cfg, root, "999-nope").unwrap(),
+        None
+    );
+}

--- a/specs/055-the-ledger-answers-what-consumers-rebuild/spec.md
+++ b/specs/055-the-ledger-answers-what-consumers-rebuild/spec.md
@@ -4,7 +4,7 @@ title: "The ledger answers what consumers rebuild by hand"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -21,6 +21,11 @@ extends:
   # `registry show --json` gains the shard's content hash as an output field.
   - { spec: "002-registry-query", unit: "crates/spec-spine-cli/src/cmd_registry.rs", nature: additive }
   - { spec: "002-registry-query", unit: "crates/spec-spine-core/src/query.rs", nature: additive }
+  # Six new names join the crate root's re-export list, and two functions the
+  # gate kept private become public there.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  # The shard-hash read's acceptance sits beside the other `query` tests.
+  - { spec: "002-registry-query", unit: "crates/spec-spine-core/tests/query.rs", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
 summary: >
@@ -158,6 +163,16 @@ explicitly rather than faked:
 Supersession transfer applies unchanged: a successor inherits its predecessor's
 authority, additively, and both are reported.
 
+**Decision, 2026-09-07: a fourth linkage kind, `inherited`.** §3.1 names three,
+which are the three ways a spec makes a claim. Supersession transfer and the
+amends widening make a spec an owner *without* a claim, and this section
+requires both to be reported. Reporting them as `unit` would attribute a claim
+that was never written, and dropping them would make the reported id set
+disagree with the gate's, which is the one thing §3.2 forbids. So they carry
+`inherited`, and the claim column names the relation that conferred the
+authority (`supersedes 019-…`, `amends 026-…`) rather than a path. The three
+claim kinds keep their meanings exactly.
+
 ### 3.3 `contentHash` on `registry show --json`
 
 `registry show --json` MUST gain a `contentHash` field carrying the value the
@@ -217,17 +232,30 @@ one, tangled with what is and is not a hashed input, which spec 057 is about.
 
 ## 5. Verification
 
+`index owner` and `contentHash` both fail against pre-055 code: `owner` is an
+unknown action clap refuses, and `show`'s object has no such field.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test index --locked
 cargo test -p spec-spine-core --test query --locked
-# The owner verb exists and agrees with the gate about a file the gate refuses.
-# Until this ships, `owner` is an unknown action and clap refuses it.
-target/release/spec-spine index owner crates/spec-spine-core/src/couple.rs | grep -q '005-coupling-gate'
-# A path nothing owns is an empty answer, not an error.
-target/release/spec-spine index owner no/such/path.rs
-# The registry reports the hash the committed shard holds, without recomputing.
-target/release/spec-spine registry show 024-index-sharding --json | grep -q contentHash
+# 3.1: the verb reports the owners, and separates how each one owns.
+target/release/spec-spine index owner crates/spec-spine-core/src/couple.rs --json | python3 -c 'import json,sys; o=json.load(sys.stdin)["owners"]; k={x["specId"]:x["kind"] for x in o}; assert k["005-coupling-gate"]=="unit", k; assert k["001-compile-registry"]=="floor", k'
+# 3.2: the id set is the gate's own. `couple` refuses this path naming exactly
+# the specs `owner` reports, so the two cannot disagree.
+test "$(target/release/spec-spine index owner crates/spec-spine-core/src/couple.rs --json | python3 -c 'import json,sys; print(",".join(sorted({o["specId"] for o in json.load(sys.stdin)["owners"]})))')" = "$(printf 'crates/spec-spine-core/src/couple.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | python3 -c 'import json,sys; print(",".join(sorted(json.load(sys.stdin)["report"]["violations"][0]["owners"])))')"
+# 3.1: a path nothing owns is an empty answer, not an error, and the path need
+# not exist on disk.
+target/release/spec-spine index owner no/such/path.rs --json | python3 -c 'import json,sys; assert json.load(sys.stdin)["owners"]==[]'
+# 3.3: `show` reports the hash the committed shard holds.
+target/release/spec-spine registry show 024-index-sharding --json | python3 -c 'import json,sys; h=json.load(sys.stdin)["contentHash"]; assert len(h)==64, h'
+# 3.3: that it is the shard's value and not a recomputation is asserted by
+# `shard_content_hash_is_read_from_the_committed_shard` in the query tests
+# above, which edits a spec.md without recompiling and watches the reported
+# hash stay put. It is asserted there rather than here because reading the
+# shard to compare against it is exactly the ad-hoc parse
+# `.claude/rules/governed-artifact-reads.md` forbids.
+# 3.3: nothing committed moves.
 target/release/spec-spine compile --check
 ```


### PR DESCRIPTION
Implements spec 055 (adopter-audit backlog items 6 and 7). They land together
because they are one mistake: a fact is computed, used internally, and discarded
at the boundary, so the consumer computes it again, worse.

## `spec-spine index owner <path>`

`couple.rs::owners_for_path` answers "which spec owns this" on every gate run,
applying five rules a naive consumer will not guess — subtree matching,
supersession transfer, hunk overlap, amends-awareness under the strict-expansion
guard, and the manifest floor — and it is private. The audit found consumers
rebuilding path-to-spec maps from raw edges, which gets bare file units right
and everything else wrong.

The verb reports each owner's **linkage kind**, because the consumer's next
decision depends on it: a `unit` owner claimed the path deliberately, a `floor`
owner holds it only through a package manifest (which counts for `C-001` and
counts as debt for coverage, spec 032), a `header` owner is named by a
`// Spec:` comment in the file itself.

It **calls the gate's derivation** rather than reimplementing it, and a test
asserts the two id sets are equal for every path in a fixture. A second
implementation that agreed today and drifted next quarter would be worse than no
verb at all.

It lives under `index`, not `registry`, and that is not cosmetic: the registry
holds units as authored, including symbol ids and section anchors that name no
path. Resolving a unit to files is the indexer's job. A `registry owner` would
either have to resolve — inverting the two views — or answer only for bare file
units, which is the wrong answer stated confidently. The audit offered
`registry owner`; the corpus's own layering says `index owner`.

Freshness-guarded (exit 2 on a stale index): an owner answer off a stale ledger
is the one wrong answer this verb must never give, because its caller is
deciding what to edit. A path nothing owns is an empty answer at exit 0, and the
path need not exist on disk — asking who *would* own a file is legitimate.

## `contentHash` on `registry show`

Every registry shard carries `shardHash`, and no read verb reported it, so
claude-observatory reimplemented `hash.rs`'s normalization in TypeScript to pin
against it. `show` now reports it, **read from the committed shard and never
recomputed**: a `show` that hashed `spec.md` afresh would report a value the
ledger does not hold, silently repairing a staleness `compile --check` exists to
reveal. A test edits a spec without recompiling and watches the reported hash
stay put.

Added at `show`'s output boundary, not to `SpecRecord` — that would write it
into every shard (whose schema is `additionalProperties: false`) for a value the
shard already carries one line above the record. No committed artifact changes;
no schema version moves.

## One decision recorded in the spec

**§3.2, a fourth linkage kind: `inherited`.** The draft named three, which are
the three ways a spec makes a *claim*. Supersession transfer and the amends
widening make a spec an owner **without** a claim, and §3.2 requires both to be
reported. Reporting them as `unit` would attribute a claim nobody wrote;
dropping them would make the reported id set disagree with the gate's, which is
the one thing §3.2 forbids. They carry `inherited`, and the claim column names
the relation (`supersedes 001-old`) rather than a path.

## A note on the verification block

My first draft asserted "read, not recomputed" by `python3`-parsing
`.derived/spec-registry/by-spec/024-index-sharding.json` — exactly the ad-hoc
parse `.claude/rules/governed-artifact-reads.md` forbids. Replaced with the
typed test, which asserts the stronger property anyway. A `diff <(…) <(…)` line
also went: CI's `sh` is `dash`, which has no process substitution.

`spec-spine verify 055` passes, 8 commands. Full gate green: 69 shards fresh,
index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple` clean over
9 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass. No waiver.