### PR TITLE
feat(056): validate one draft without a temporary repository

### DIFF
--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb417817d22d4ad80ed748f11d8185355730d2b06c41d6775474e9cdc9e3715e"
+  "shardHash": "fa4faa0277ef99f5e3e0636fef10476c30bae4c843a76eb88df725acc228ecca"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -11,7 +11,23 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/couple.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
         "source": "spec-edge"
       },
       {
@@ -20,6 +36,14 @@
       },
       {
         "path": "crates/spec-spine-types/src/verdict.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/version.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/dtos.rs",
         "source": "spec-edge"
       }
     ],
@@ -40,6 +64,45 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-core/src/compile.rs"
           }
         ],
@@ -48,6 +111,19 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
         }
       },
       {
@@ -79,6 +155,32 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-types/src/version.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "docs/design/03-adopter-audit-2026-09.md"
           }
         ],
@@ -94,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c8d18ffd2e8f97fa1ada8011b7f590e066dd5919e96419f58eca97e873621981"
+  "shardHash": "4556e31e139edaf30b8b5b36ff2619f9f283ecb66f850ec17883cecbc5f5d791"
 }

--- a/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
@@ -136,6 +136,6 @@
     "summary": "The coupling gate has always named the specs that own a drifted path, and has never named the mechanism for crossing into their territory. Its resolution footer offers two doors: edit an owning spec, or waive. For an author who has legitimately touched a unit somebody else owns, both are shut. Editing another spec to clear a refusal is the illegitimate edit the corpus rules forbid, and the waiver is a human instrument that no adopter has ever used and that an unattended session is forbidden on every path. The third door, an `extends` edge declared in the author's own spec, is the corpus's actual answer and the gate never mentions it. This spec makes the refusal name it: three doors in author order, and when the diff edits exactly one spec.md, the concrete `extends` block to paste into that file. It also promotes the owner set from prose into an optional `owners` field on the violation, so an orchestrator reading `couple --json` learns the owner as data instead of by regexing English. No committed artifact and no schema version moves.\n",
     "title": "The coupling gate names the crossing"
   },
-  "shardHash": "6d41887e414d87079b35487ba1cfb6629d48ef9806529817cae2ca1686342f6b",
+  "shardHash": "681252329fc036ed34c243f5c75e2f79ca6658630656c4e373482f318072d4cc",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/056-compile-one-spec.json
+++ b/.derived/spec-registry/by-spec/056-compile-one-spec.json
@@ -38,10 +38,58 @@
           "kind": "file",
           "path": "crates/spec-spine-types/src/verdict.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "037-machine-readable-verdicts",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "037-machine-readable-verdicts",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "052-couple-names-the-crossing",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
       }
     ],
     "id": "056-compile-one-spec",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -58,6 +106,7 @@
       "056: Validate one draft without a temporary repository",
       "1. Purpose",
       "2. Territory",
+      "2.1 The version bump reaches four more files",
       "3. Behavior",
       "3.1 `spec-spine compile --spec <id>`",
       "3.2 It reports one spec's violations, and says so",
@@ -72,6 +121,6 @@
     "summary": "Writing a spec means validating it before it lands, and the tool offers no way to do that. `compile` writes the whole shard tree, which an author with an unfinished draft must not do; `compile --check` refuses the whole corpus because the draft has no committed shard, reporting the author's work in progress as staleness. So two adopters wrote down a `mktemp -d` ritual: copy the corpus, copy the draft in, compile there, read the violations, delete the copy. It has a documented gotcha, because a `references` edge into `docs/` does not resolve in a corpus copy that has no `docs/`. This spec adds `compile --spec <id>`: validate one spec against the committed registry, report only that spec's violations, and write nothing.\n",
     "title": "Validate one draft without a temporary repository"
   },
-  "shardHash": "9ad10c9f5c761e516547d4b32b326181a285100094a86889455e0d46a320e606",
+  "shardHash": "485d798d076e8e3449ac206ce93c84778ccc78e2d126336123e495e4fa0213ec",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_compile.rs
+++ b/crates/spec-spine-cli/src/cmd_compile.rs
@@ -37,7 +37,27 @@ use crate::out;
 /// machine-readable verdict from the command that just regenerated the shards
 /// the next gate compares against invites exactly the mid-chain confusion the
 /// non-writing `--check` exists to avoid.
-pub fn run(repo: &Path, check: bool, json: bool) -> Result<u8, Error> {
+pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u8, Error> {
+    // Spec 056 §3.1: `--spec` and `--check` are different questions (is this
+    // well-formed / do the committed shards match), and a combined form would
+    // have to invent an answer for a spec with no shard.
+    if let Some(id) = spec {
+        if check {
+            let err = Error::Config(
+                "compile --spec is incompatible with --check: --spec validates one spec \
+                 against the committed registry, --check compares the whole shard tree \
+                 (spec 056 3.1)"
+                    .to_string(),
+            );
+            if json {
+                crate::emit_error_envelope(verb::COMPILE_SPEC, &err);
+            } else {
+                eprintln!("spec-spine: {err}");
+            }
+            return Ok(err.exit_code());
+        }
+        return run_one_spec(repo, id, json);
+    }
     if json && !check {
         // Written here rather than raised for `main` to render: `json_verb`
         // deliberately maps only `compile --check`, so a caller that asked for
@@ -206,4 +226,49 @@ fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// `compile --spec <id>`: validate one spec, write nothing (spec 056).
+///
+/// Exit `0` when the spec produces no error-tier violation, `1` when it does or
+/// when the id resolves to nothing, `3` for I/O, parse, schema or config
+/// failure. Never `2`: nothing here is a staleness question.
+fn run_one_spec(repo: &Path, id: &str, json: bool) -> Result<u8, Error> {
+    let cfg = load_repo_config(repo)?;
+    let report = spec_spine_core::compile_spec(&cfg, repo, id)?;
+    let code = if report.passed { 0 } else { 1 };
+
+    if json {
+        let value = serde_json::to_value(&report).map_err(|e| Error::Schema(e.to_string()))?;
+        out::verdict(&Verdict::report(verb::COMPILE_SPEC, code, value))?;
+        return Ok(code);
+    }
+
+    for v in &report.violations {
+        // Errors to stderr so they surface in a CI log; warnings and info too,
+        // since the whole output of this verb is its diagnostics.
+        eprintln!("  {} [{}] {}", v.code, report.spec_path, v.message);
+    }
+    if report.passed {
+        outln!(
+            "{}: valid ({} warning(s), nothing written)",
+            report.spec_id,
+            report
+                .violations
+                .iter()
+                .filter(|v| v.severity == Severity::Warning)
+                .count()
+        );
+    } else {
+        eprintln!(
+            "{}: INVALID: {} error(s)",
+            report.spec_id,
+            report
+                .violations
+                .iter()
+                .filter(|v| v.severity == Severity::Error)
+                .count()
+        );
+    }
+    Ok(code)
 }

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -61,10 +61,14 @@ enum Command {
         #[arg(long)]
         check: bool,
         /// Emit the verdict as a JSON envelope on stdout (spec 037). Requires
-        /// `--check`: the writing form mutates `.derived`, and its verdict is
-        /// deliberately not machine-readable (spec 037 4).
+        /// `--check` or `--spec`: the writing form mutates `.derived`, and its
+        /// verdict is deliberately not machine-readable (spec 037 4).
         #[arg(long)]
         json: bool,
+        /// Validate exactly one spec and write nothing (spec 056). Accepts the
+        /// short id (`056`). Incompatible with `--check`.
+        #[arg(long, value_name = "ID")]
+        spec: Option<String>,
     },
     /// Read the effective configuration: every default resolved, and the
     /// built-in bypass floor merged with the adopter's list and attributed.
@@ -194,7 +198,9 @@ fn main() -> ExitCode {
 
     let json_verb = cli.command.json_verb();
     let result = match &cli.command {
-        Command::Compile { check, json } => cmd_compile::run(&repo, *check, *json),
+        Command::Compile { check, json, spec } => {
+            cmd_compile::run(&repo, *check, *json, spec.as_deref())
+        }
         Command::Config { action } => cmd_config::run(&repo, action),
         Command::Registry { query } => cmd_registry::run(&repo, query),
         Command::Index { action } => cmd_index::run(&repo, action.as_ref()),
@@ -306,7 +312,15 @@ impl Command {
             Command::Compile {
                 json: true,
                 check: true,
+                ..
             } => Some(verb::COMPILE_CHECK),
+            // Spec 056: `--spec` is its own verb. A consumer that branched on
+            // `compile.check` must not silently receive a single-spec verdict.
+            Command::Compile {
+                json: true,
+                spec: Some(_),
+                ..
+            } => Some(verb::COMPILE_SPEC),
             Command::Lint { json: true, .. } => Some(verb::LINT),
             Command::Couple { json: true, .. } => Some(verb::COUPLE),
             Command::Verify { json: true, .. } => Some(verb::VERIFY),

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -1770,7 +1770,9 @@ fn verify_json_is_a_verdict_envelope_that_agrees_with_the_exit_code() {
     let (c, v) = json("001-pass");
     assert_eq!(c, 0);
     assert_eq!(v["verb"], "verify");
-    assert_eq!(v["schemaVersion"], "0.2.0");
+    // The constant, not a literal: an additive verb elsewhere is not a change
+    // to this one's envelope (spec 056 bumped it to 0.3.0 for `compile.spec`).
+    assert_eq!(v["schemaVersion"], spec_spine_types::VERDICT_SCHEMA_VERSION);
     assert_eq!(v["ok"], true);
     assert_eq!(v["exitCode"], 0);
     assert_eq!(v["report"]["outcome"], "passed");

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -801,6 +801,9 @@ fn json_envelope_carries_owners_not_prose() {
 
     let text = String::from_utf8_lossy(&out.stdout);
     assert!(!text.contains("Declare an `extends` edge"), "{text}");
-    // §3.4: a payload addition does not move the envelope's version (spec 050 §3.6).
-    assert_eq!(v["schemaVersion"], "0.2.0");
+    // §3.4: a payload addition does not move the envelope's version (spec 050
+    // §3.6). Asserted against the constant rather than a literal, because an
+    // additive verb elsewhere legitimately moves it (spec 056 did) and that is
+    // not a payload addition.
+    assert_eq!(v["schemaVersion"], spec_spine_types::VERDICT_SCHEMA_VERSION);
 }

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde::Serialize;
 use spec_spine_types::{
     Build, Config, Error, Frontmatter, FrontmatterIssue, REGISTRY_SCHEMA_VERSION, Registry,
     RegistrySpecShard, Severity, SpecRecord, Status, ValidationReport, Violation,
@@ -515,6 +516,192 @@ fn build_record(fm: Frontmatter, spec_path: String, body: &str) -> SpecRecord {
         amendment_record: fm.amendment_record,
         origin: fm.origin,
         extra_frontmatter: fm.extra_frontmatter,
+    }
+}
+
+// ===== spec 056: validate one spec, write nothing =====
+
+/// One spec's validation verdict (spec 056 §3.2).
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecCheckReport {
+    /// The resolved full id, so a caller that passed `056` sees what it named.
+    pub spec_id: String,
+    pub spec_path: String,
+    /// This spec's violations: the corpus-independent ones, plus the cross-spec
+    /// ones this spec is party to. Never another spec's.
+    pub violations: Vec<Violation>,
+    /// False iff an error-tier violation is present.
+    pub passed: bool,
+}
+
+/// Validate exactly one spec against the committed registry, writing nothing
+/// (spec 056).
+///
+/// The verb exists because an author with an unfinished draft has had no way to
+/// ask whether it parses. `compile` writes, so asking commits the draft to the
+/// ledger as a side effect of the question; `compile --check` refuses, because a
+/// new draft has no committed shard and the whole run reads as stale. What was
+/// left was a `mktemp -d` ritual two adopters wrote down, whose documented
+/// gotcha (a `references` edge into `docs/` not resolving in a corpus copy that
+/// has no `docs/`) is the tell that a workaround teaching you to disbelieve its
+/// own output is a missing feature with extra steps.
+///
+/// The named spec is read from where it lives, so every path in it resolves the
+/// way it will resolve after it lands. Its siblings come from the **committed**
+/// registry: the author is asking whether the draft fits the corpus as it
+/// stands, and what stands is what was committed.
+pub fn compile_spec(cfg: &Config, repo_root: &Path, id: &str) -> Result<SpecCheckReport, Error> {
+    let specs_dir = repo_root.join(&cfg.layout.specs_dir);
+    let dirname = resolve_spec_dir(&specs_dir, id)?;
+    let spec_md = specs_dir.join(&dirname).join("spec.md");
+    let raw = fs::read_to_string(&spec_md)
+        .map_err(|e| Error::Io(format!("read {}: {e}", spec_md.display())))?;
+    let spec_path = rel_posix(repo_root, &spec_md);
+
+    let mut violations: Vec<Violation> = Vec::new();
+    let fm = match parse_frontmatter_with(&raw, &cfg.frontmatter.extra_known_keys) {
+        Ok(fm) => fm,
+        // The same two skip-and-report arms `compile` uses: a spec whose
+        // frontmatter did not parse has no record to build, and that is the
+        // whole finding.
+        Err(FrontmatterIssue::UnrepresentableDeclared { key, detail }) => {
+            violations.push(error(
+                "V-013",
+                format!(
+                    "declared extra-frontmatter key '{key}' carries an unrepresentable YAML value: {detail}"
+                ),
+                Some(spec_path.clone()),
+            ));
+            return Ok(finish_spec_report(dirname, spec_path, violations));
+        }
+        Err(FrontmatterIssue::Malformed(m)) => {
+            violations.push(error(
+                "V-002",
+                format!("malformed frontmatter: {m}"),
+                Some(spec_path.clone()),
+            ));
+            return Ok(finish_spec_report(dirname, spec_path, violations));
+        }
+    };
+
+    // Siblings as committed. A registry that has never been compiled is an
+    // empty corpus rather than an error: a first spec in a fresh repository is
+    // exactly the case this verb is for.
+    let committed: Vec<SpecRecord> = load_committed_registry(cfg, repo_root)
+        .map(|r| r.specs)
+        .unwrap_or_default();
+
+    let mut fm = fm;
+    let mut all_ids: std::collections::BTreeSet<String> =
+        committed.iter().map(|r| r.id.clone()).collect();
+    all_ids.insert(fm.id.clone());
+    // Short-id resolution (spec 016) before validation sees the references, so
+    // `V-008` / `V-010` judge the resolved value exactly as `compile` does.
+    for dep in &mut fm.depends_on {
+        *dep = resolve_spec_ref(dep, &all_ids);
+    }
+    if let Some(by) = fm.superseded_by.as_mut() {
+        *by = resolve_spec_ref(by, &all_ids);
+    }
+    for item in &mut fm.supersedes {
+        let resolved = resolve_spec_ref(item.spec(), &all_ids);
+        item.set_spec(resolved);
+    }
+
+    validate_spec(cfg, &dirname, &spec_path, &fm, &all_ids, &mut violations);
+
+    let body = split_frontmatter(&raw).map(|(_, b)| b).unwrap_or_default();
+    let record = build_record(fm, spec_path.clone(), &body);
+    let mut records: Vec<SpecRecord> = committed
+        .into_iter()
+        .filter(|r| r.id != record.id)
+        .collect();
+    records.push(record);
+    records.sort_by(|a, b| a.id.cmp(&b.id));
+
+    // The cross-spec codes are not dropped: `V-004` (a duplicate ordinal) and
+    // `V-014` (a cycle) are answerable only against the assembled record set,
+    // and a duplicate ordinal is one of the two mistakes a new draft actually
+    // makes. Only this spec's are kept, and each message already names the
+    // other spec involved, because an author told "duplicate numeric prefix
+    // '056'" without being told who holds it has been given a puzzle.
+    //
+    // `V-008` and `V-010`, the other two cross-spec codes, are NOT recomputed
+    // here: `validate_spec` above already judged them against the same
+    // `all_ids`, and adding them a second time would report one mistake twice.
+    let id = records
+        .iter()
+        .find(|r| r.spec_path == spec_path)
+        .map(|r| r.id.clone())
+        .unwrap_or_else(|| dirname.clone());
+    let mut cross: Vec<Violation> = Vec::new();
+    let id_paths: Vec<(String, String)> = records
+        .iter()
+        .map(|r| (r.id.clone(), r.spec_path.clone()))
+        .collect();
+    detect_duplicates(&id_paths, &mut cross);
+    detect_dependency_cycle(&records, &mut cross);
+    for v in cross {
+        if v.path.as_deref() == Some(spec_path.as_str()) || v.message.contains(&id) {
+            violations.push(v);
+        }
+    }
+
+    Ok(finish_spec_report(dirname, spec_path, violations))
+}
+
+fn finish_spec_report(
+    spec_id: String,
+    spec_path: String,
+    mut violations: Vec<Violation>,
+) -> SpecCheckReport {
+    violations.sort_by(|a, b| a.code.cmp(&b.code));
+    let passed = !violations.iter().any(|v| v.severity == Severity::Error);
+    SpecCheckReport {
+        spec_id,
+        spec_path,
+        violations,
+        passed,
+    }
+}
+
+/// Resolve a spec id, accepting the short form (spec 016): `056` names
+/// `056-compile-one-spec` when exactly one directory carries that ordinal.
+///
+/// [`Error::NotFound`] (exit 1) for none or several. Never exit 2: nothing here
+/// is a staleness question, and reporting a draft as stale is precisely the
+/// wrong answer `compile --check` gives today.
+fn resolve_spec_dir(specs_dir: &Path, id: &str) -> Result<String, Error> {
+    if specs_dir.join(id).join("spec.md").is_file() {
+        return Ok(id.to_string());
+    }
+    let mut matches: Vec<String> = Vec::new();
+    let entries = fs::read_dir(specs_dir).map_err(|e| {
+        Error::Io(format!(
+            "cannot read specs dir {}: {e}",
+            specs_dir.display()
+        ))
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| Error::Io(e.to_string()))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !entry.path().join("spec.md").is_file() {
+            continue;
+        }
+        // The whole leading dash-segment, as spec 016 §3.1 defines it: `109`
+        // resolves `109-foo`, `10` resolves nothing, and a wrong full slug
+        // resolves nothing rather than snapping to a neighbour.
+        if name.split('-').next() == Some(id) {
+            matches.push(name);
+        }
+    }
+    match matches.len() {
+        1 => Ok(matches.remove(0)),
+        0 => Err(Error::NotFound(format!("spec '{id}'"))),
+        n => Err(Error::NotFound(format!(
+            "spec '{id}' is ambiguous ({n} directories carry that ordinal)"
+        ))),
     }
 }
 

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -48,9 +48,9 @@ pub use attest::{
     attestation_hash, spec_attestation_hash, verify_recompute, verify_spec_recompute,
 };
 pub use compile::{
-    CompileOutcome, MAX_UNDECLARED_EXTRA_FRONTMATTER, RegistryShardSet, check_registry_freshness,
-    compare_committed_registry, compile, load_committed_registry, registry_dir,
-    registry_shard_files,
+    CompileOutcome, MAX_UNDECLARED_EXTRA_FRONTMATTER, RegistryShardSet, SpecCheckReport,
+    check_registry_freshness, compare_committed_registry, compile, compile_spec,
+    load_committed_registry, registry_dir, registry_shard_files,
 };
 pub use couple::{
     CoupleReport, DEFAULT_BYPASS_PREFIXES, DiffFile, DiffInput, Waiver, build_superseders, couple,

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -910,3 +910,165 @@ fn registry_freshness_facade_reports_both_verdicts() {
         serde_json::json!({ "fresh": true })
     );
 }
+
+// ── spec 056: validate one spec, write nothing ────────────────────────────
+
+/// Commit the shard tree exactly as `spec-spine compile` does, so `compile_spec`
+/// has a committed registry to assemble the named spec against.
+fn commit_shards(cfg: &Config, root: &Path) {
+    let outcome = compile(cfg, root).unwrap();
+    let dir = spec_spine_core::registry_dir(cfg, root).join("by-spec");
+    let files = spec_spine_core::registry_shard_files(&outcome.shards).unwrap();
+    spec_spine_core::shard::sync_dir(&dir, &files).unwrap();
+}
+
+/// §3.1 + §3.5: it validates a draft that has never compiled, and writes
+/// nothing. Both halves matter: `compile` writes, so asking whether a draft
+/// parses would commit it to the ledger as a side effect of the question.
+#[test]
+fn compile_spec_validates_an_uncommitted_draft_and_writes_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cfg = Config::default();
+    write_spec(root, "001-alpha", "001-alpha", "");
+    commit_shards(&cfg, root);
+
+    // A brand-new draft with no shard of its own.
+    write_spec(
+        root,
+        "002-draft",
+        "002-draft",
+        "depends_on: [\"001-alpha\"]\n",
+    );
+    let before: Vec<String> =
+        fs::read_dir(spec_spine_core::registry_dir(&cfg, root).join("by-spec"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+
+    let report = spec_spine_core::compile_spec(&cfg, root, "002-draft").unwrap();
+    assert!(report.passed, "{:?}", report.violations);
+    assert_eq!(report.spec_id, "002-draft");
+    assert_eq!(report.spec_path, "specs/002-draft/spec.md");
+
+    let after: Vec<String> =
+        fs::read_dir(spec_spine_core::registry_dir(&cfg, root).join("by-spec"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+    assert_eq!(before, after, "no shard was written for the draft");
+}
+
+/// §3.1: the short form resolves, and an id matching none or several is
+/// `NotFound` (exit 1) rather than stale (exit 2).
+#[test]
+fn compile_spec_resolves_the_short_id_and_refuses_an_unknown_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cfg = Config::default();
+    write_spec(root, "056-compile-one-spec", "056-compile-one-spec", "");
+
+    let report = spec_spine_core::compile_spec(&cfg, root, "056").unwrap();
+    assert_eq!(report.spec_id, "056-compile-one-spec", "short id resolves");
+
+    match spec_spine_core::compile_spec(&cfg, root, "999") {
+        Err(spec_spine_types::Error::NotFound(_)) => {}
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    // `05` is not a whole leading segment, so it resolves nothing (spec 016).
+    assert!(spec_spine_core::compile_spec(&cfg, root, "05").is_err());
+}
+
+/// §3.2: local violations are reported, and only the named spec's. A sibling's
+/// problems are the sibling's business.
+#[test]
+fn compile_spec_reports_only_the_named_specs_violations() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cfg = Config::default();
+    // A sibling whose directory does not equal its id (V-001).
+    write_spec(root, "001-wrong-dir", "001-alpha", "");
+    write_spec(root, "002-also-wrong", "002-beta", "");
+    commit_shards(&cfg, root);
+
+    let report = spec_spine_core::compile_spec(&cfg, root, "001-wrong-dir").unwrap();
+    assert!(
+        report.violations.iter().any(|v| v.code == "V-001"),
+        "the named spec's own violation is reported: {:?}",
+        report.violations
+    );
+    assert!(
+        report
+            .violations
+            .iter()
+            .all(|v| v.path.as_deref() == Some("specs/001-wrong-dir/spec.md")),
+        "no sibling's violation leaks in: {:?}",
+        report.violations
+    );
+    assert!(!report.passed, "an error-tier violation fails the spec");
+}
+
+/// §3.2: the cross-spec codes are not silently dropped. A duplicate ordinal is
+/// one of the two mistakes a new draft actually makes, and the message names
+/// the spec that already holds it.
+#[test]
+fn compile_spec_reports_a_duplicate_ordinal_and_names_the_holder() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cfg = Config::default();
+    write_spec(root, "007-first", "007-first", "");
+    commit_shards(&cfg, root);
+
+    // A draft that reuses the ordinal already committed.
+    write_spec(root, "007-second", "007-second", "");
+    let report = spec_spine_core::compile_spec(&cfg, root, "007-second").unwrap();
+    let dup: Vec<&spec_spine_types::Violation> = report
+        .violations
+        .iter()
+        .filter(|v| v.code == "V-004")
+        .collect();
+    assert_eq!(dup.len(), 1, "reported once: {:?}", report.violations);
+    assert!(
+        dup[0].message.contains("007-first"),
+        "names the holder, or the author has a puzzle: {}",
+        dup[0].message
+    );
+}
+
+/// §3.2: a dangling `depends_on` is reported exactly once. `validate_spec` and
+/// the cross-spec recompute both know how to find it, and reporting one mistake
+/// twice would be its own defect.
+#[test]
+fn a_dangling_dependency_is_reported_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cfg = Config::default();
+    write_spec(root, "001-alpha", "001-alpha", "");
+    commit_shards(&cfg, root);
+    write_spec(
+        root,
+        "002-draft",
+        "002-draft",
+        "depends_on: [\"888-nope\"]\n",
+    );
+
+    let report = spec_spine_core::compile_spec(&cfg, root, "002-draft").unwrap();
+    let dangling: Vec<_> = report
+        .violations
+        .iter()
+        .filter(|v| v.code == "V-010")
+        .collect();
+    assert_eq!(dangling.len(), 1, "{:?}", report.violations);
+}
+
+/// §3.1: a first spec in a repository that has never compiled is exactly the
+/// case this verb is for, so an absent committed registry is an empty corpus
+/// rather than an error.
+#[test]
+fn compile_spec_works_before_the_registry_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_spec(root, "001-first", "001-first", "");
+    let report = spec_spine_core::compile_spec(&Config::default(), root, "001-first").unwrap();
+    assert!(report.passed, "{:?}", report.violations);
+}

--- a/crates/spec-spine-types/src/verdict.rs
+++ b/crates/spec-spine-types/src/verdict.rs
@@ -40,6 +40,13 @@ pub mod verb {
     pub const VERIFY_ATTESTATION: &str = "verify-attestation";
     /// `spec-spine verify <id>` (spec 049).
     pub const VERIFY: &str = "verify";
+    /// `spec-spine compile --spec <id>` (spec 056).
+    ///
+    /// Distinct from [`COMPILE_CHECK`] because they answer different questions:
+    /// is this one spec well-formed, versus do the committed shards match the
+    /// corpus. A consumer that branched on `compile.check` must not silently
+    /// receive the other.
+    pub const COMPILE_SPEC: &str = "compile.spec";
 }
 
 /// One adjudicating verb's verdict, as written to stdout under `--json`.

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -56,8 +56,10 @@ pub const SPEC_ATTESTATION_SCHEMA_VERSION: &str = "0.1.0";
 /// token (a consumer's existing branches still match); MAJOR is breaking,
 /// which includes renaming or removing one (they stop matching).
 ///
-/// 0.2.0 added the `verify` verb (spec 049).
-pub const VERDICT_SCHEMA_VERSION: &str = "0.2.0";
+/// 0.2.0 added the `verify` verb (spec 049); 0.3.0 added `compile.spec`
+/// (spec 056). Each is the additive case this doc-comment names, and each
+/// followed the same reasoning rather than reopening it.
+pub const VERDICT_SCHEMA_VERSION: &str = "0.3.0";
 
 /// The `spec-spine.toml` config schema version (optional `config_version` key).
 pub const CONFIG_VERSION: &str = "0.1.0";

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -72,9 +72,10 @@ fn schema_versions_are_pinned() {
     assert_eq!(CONFIG_VERSION, "0.1.0");
     // Spec 037: the verdict envelope, versioned from its first release rather
     // than acquiring a version after the first consumer breaks. Spec 049 took
-    // it to 0.2.0: a new `verb` token is additive, so a consumer's existing
-    // match arms still hold, which is exactly the MINOR rule version.rs states.
-    assert_eq!(VERDICT_SCHEMA_VERSION, "0.2.0");
+    // it to 0.2.0 and spec 056 to 0.3.0: a new `verb` token is additive, so a
+    // consumer's existing match arms still hold, which is exactly the MINOR
+    // rule version.rs states.
+    assert_eq!(VERDICT_SCHEMA_VERSION, "0.3.0");
     // Spec 042: the per-spec attestation, independent of the ledger versions so
     // a consumer pins the evidence shape it verifies without pinning the ledger
     // it was derived from.

--- a/specs/052-couple-names-the-crossing/spec.md
+++ b/specs/052-couple-names-the-crossing/spec.md
@@ -252,7 +252,8 @@ and continues to validate against the unchanged schema. `REGISTRY_SCHEMA_VERSION
 therefore stays at `1.1.0` and the schema files are not edited: they describe
 the artifact, and the artifact gained nothing.
 
-`VERDICT_SCHEMA_VERSION` stays at `0.2.0`. Spec 050 §3.6 settled this: adding a
+`VERDICT_SCHEMA_VERSION` does not move **for this change**. Spec 050 §3.6
+settled this: adding a
 member to one verb's `report` payload is additive and must not move a constant
 that versions the envelope, because a consumer of a different verb cannot
 observe the change. That decision was recorded so that the next spec to add a
@@ -343,7 +344,13 @@ printf 'crates/spec-spine-core/src/index.rs\nspecs/052-couple-names-the-crossing
 printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | python3 -c 'import json,sys; v=json.load(sys.stdin)["report"]["violations"][0]; assert v["code"]=="C-001", v; assert "004-codebase-index" in v["owners"], v'
 ! printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | grep -q 'Declare an'
 # 3.4: a payload addition does not move the envelope version (spec 050 3.6).
-test "$(printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["schemaVersion"])')" = "0.2.0"
+# Asserted as "couple's envelope version is the shared one", not as a literal:
+# the constant is envelope-wide, so a consumer of a different verb cannot
+# observe a payload addition here. A literal would instead pin the corpus's
+# whole verdict version to whatever it was the day this spec landed, and would
+# read a legitimate additive bump elsewhere (spec 056 took it to 0.3.0 by
+# adding `compile.spec`) as a change to this spec's behavior.
+test "$(printf 'crates/spec-spine-core/src/index.rs\n' | target/release/spec-spine couple --paths-from /dev/stdin --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["schemaVersion"])')" = "$(target/release/spec-spine lint --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["schemaVersion"])')"
 # 3.4: every committed registry shard still matches what the corpus compiles to,
 # so no schema file and no schema version had to move.
 target/release/spec-spine compile --check

--- a/specs/056-compile-one-spec/spec.md
+++ b/specs/056-compile-one-spec/spec.md
@@ -4,7 +4,7 @@ title: "Validate one draft without a temporary repository"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -16,6 +16,13 @@ extends:
   - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_compile.rs", nature: additive }
   - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
   - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-types/src/verdict.rs", nature: additive }
+  # The version constant this spec moves, and the three pins that read it (2.1).
+  - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-types/src/version.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/dtos.rs", nature: additive }
+  - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+  - { spec: "052-couple-names-the-crossing", unit: "crates/spec-spine-cli/tests/couple.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
 summary: >
@@ -78,6 +85,31 @@ Spec 001 owns `compile` and defines the `V-` codes and the emission contract. It
 requires that compiling the corpus writes the registry; it says nothing about a
 mode that validates without writing, which spec 031 already established is a
 legitimate second mode of the same verb. This spec adds a third.
+
+### 2.1 The version bump reaches four more files
+
+**Decision, 2026-09-07.** `VERDICT_SCHEMA_VERSION` lives in
+`types/src/version.rs`, not in `verdict.rs`, and three tests plus one draft
+spec pinned its value as a literal. Moving it to `0.3.0` therefore touches
+`version.rs`, `types/tests/dtos.rs`, `cli/tests/cli.rs` and
+`cli/tests/couple.rs`, each declared as an `extends` edge above.
+
+Two of those pins are rewritten to read the constant rather than a literal,
+which is what `cli.rs` already did six lines from the one that did not. A test
+asserting one verb's envelope version should be asserting *that the envelope
+carries the shared version*, since an additive verb elsewhere is not a change to
+the verb under test. The literal made a legitimate bump look like a regression
+in an unrelated spec's acceptance, which is the failure mode this decision
+records so the next additive verb does not rediscover it.
+
+Spec 052's `## Verification` carried the same literal, and was rewritten the
+same way: it now asserts that `couple`'s envelope version equals `lint`'s,
+which is the claim spec 050 §3.6 actually settled (the constant is
+envelope-wide, so a consumer of a different verb cannot observe a payload
+addition). 052 is still `status: draft` and unratified, and the edit corrects
+how it asserts its own requirement rather than changing the requirement: §3.4
+still says a payload addition must not move the constant, and this spec did not
+move it for a payload addition.
 
 ## 3. Behavior
 
@@ -186,16 +218,23 @@ adds.
 
 ## 5. Verification
 
+Every assertion fails against pre-056 code: `--spec` is an unknown argument and
+clap refuses it with exit 2.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test compile --locked
-# The flag exists, resolves the short id, and validates without writing.
-# Until this ships, `--spec` is an unknown argument and clap refuses it.
+# 3.1: the flag exists, resolves the short id, and validates without writing.
 target/release/spec-spine compile --spec 024
 target/release/spec-spine compile --spec 024-index-sharding --json
-# It wrote nothing: the committed shards are untouched.
+# 3.4: the envelope's verb distinguishes it from `compile --check`, and the
+# version moved for the additive token.
+target/release/spec-spine compile --spec 024 --json | python3 -c 'import json,sys; v=json.load(sys.stdin); assert v["verb"]=="compile.spec", v; assert v["schemaVersion"]=="0.3.0", v'
+# 3.5: it wrote nothing. The committed shards are exactly as they were.
 target/release/spec-spine compile --check
-# An unknown id is exit 1 (not found), never exit 2.
+# 3.1: an unknown id is exit 1 (not found), never exit 2.
 target/release/spec-spine compile --spec 999 ; test $? -eq 1
+# 3.1: `--spec` and `--check` are different questions, and the pair is refused.
+target/release/spec-spine compile --spec 024 --check ; test $? -eq 3
 ```


### PR DESCRIPTION
Implements spec 056 (adopter-audit backlog item 8).

## Why

Every spec is wrong at least once before it is right, and an author with an
unfinished draft could not ask the tool about it. `compile` **writes**, so
asking whether a draft parses commits it to the ledger as a side effect of the
question. `compile --check` **refuses**: a new draft has no committed shard, so
the whole run reads as stale, and the output is correct and useless.

What was left was the `mktemp -d` ritual two adopters wrote down. Both
documented the same gotcha, and it is the tell: a `references` edge into `docs/`
does not resolve in a corpus copy that has no `docs/`, so the ritual produces a
violation the real corpus would not and the adopter has to know to ignore it. A
workaround that teaches you which of its own outputs to disbelieve is a missing
feature with extra steps.

## What changed

**`spec-spine compile --spec <id>`** validates one spec and writes nothing. The
named spec is read where it lives — no copy, no temp dir, no synthesized config
— so every path resolves the way it will after it lands. Its siblings come from
the **committed** registry: the author is asking whether the draft fits the
corpus as it stands, and what stands is what was committed. A repository that
has never compiled is an empty corpus rather than an error, since a first spec
is exactly the case this verb is for.

The short id resolves (spec 016 §3.1's whole-leading-segment rule, so `05`
resolves nothing). An unknown or ambiguous id is exit **1**, never exit 2 —
nothing here is a staleness question.

**Cross-spec codes are reported, not dropped.** `V-004` (duplicate ordinal) and
`V-014` (cycle) are recomputed against the assembled record set and kept when
this spec is party to them, with the other spec named. `V-008` and `V-010` are
deliberately *not* recomputed: `validate_spec` already judges them against the
same id set, and my first cut reported a dangling `depends_on` twice. There is
now a test pinning "reported once".

**`--spec` with `--check` is refused** (exit 3, with the reason on stderr).
Different questions, and a combined form would have to invent an answer for a
spec with no shard.

**`VERDICT_SCHEMA_VERSION` → 0.3.0** for the additive `compile.spec` verb,
following the precedent spec 049 set for `verify`.

## One decision recorded in the spec, and one edit to spec 052

**§2.1.** The constant lives in `types/src/version.rs`, not `verdict.rs`, and
three tests plus one spec pinned its value as a *literal*. Two of those pins now
read the constant instead — which is what `cli.rs` already did six lines from
the one that did not. A test asserting one verb's envelope version should assert
that the envelope carries the shared version; an additive verb elsewhere is not
a change to the verb under test.

**Spec 052's `## Verification` carried the same literal**, and I rewrote it:
it now asserts `couple`'s envelope version equals `lint`'s, which is the claim
spec 050 §3.6 actually settled (the constant is envelope-wide, so a consumer of
a different verb cannot observe a payload addition). 052 is still
`status: draft` and unratified, and the edit corrects **how it asserts its own
requirement**, not the requirement: §3.4 still says a payload addition must not
move the constant, and 056 did not move it for a payload addition. Flagging it
because editing another spec is not something I do lightly — say the word and I
will revert it and pin 052 to the literal `0.3.0` instead.

## Verification

Every assertion fails against pre-056 code (`--spec` is an unknown argument).
`spec-spine verify 056` passes, 8 commands. **052, 053, 054 and 055 all still
verify** after the version move — checked, not assumed. Full gate green: 69
shards fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage,
`couple` clean over 12 paths. Workspace tests, clippy `-D warnings`,
`fmt --check` pass. No waiver.