### PR TITLE
feat(057): a claim no hash witnesses

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8006cb8037ca63977ae2b3751a3b162cada7bd4016e04a23592134cdcb359a87"
+  "shardHash": "5596e7c75410b774e2708d008a2270ad056a26025c1b6ebe5e6d20192ff7fca8"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "522740fe406f781ff5168a23c2c915c7dee41d42ed0510c48768b5959be2fd82"
+  "shardHash": "548b2607e2e3b3e7139b62921e8ec0b3ed9c834d918c464970e633279ad985f5"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "19d049ae3ee3696b57ba057196640d27dfd3255e1453ca1ea4a6224b76a35fc8"
+  "shardHash": "29ab3d293b278a73a95ea7d41832f671a129a5bb267670fec399174a63246496"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "94624da8ff32267563d1be3ff0fe19c7746c8caec1741636d5ae22ec975bedef"
+  "shardHash": "9a35da0c66ed9835e21fda2a2416085ac27f4824b4fe538d937eff64a3f56348"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "acc0a3ae7a54ea0972bc6d8fa48a095fc9e810f8635c0f23ffa63ea66201c4e7"
+  "shardHash": "1a6b9e431fdefc7764ffd2f5a9a8a97614f804ce83e02649e9169cde3978692a"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8da9f1c500c61d138073f1df22c87599962be7d884d857c85f4f05dc419ad3d4"
+  "shardHash": "3f2566e27985855600eb679272984a1aeae1917c4e0e1e1b5b8a0a33b9b2dca9"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "54be2356dce69ca45c056d1b6da37985e71178ceb6545a5708dbd830d574abfa"
+  "shardHash": "56fb2913482180bde53873c24ba15d470dc8c83ac8ec61ff740c3f95d766c6ec"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d5e516fad73c1276cd12eb2090dd3592159d61b3611393c7992a8ccc39328b06"
+  "shardHash": "9c2ae21ae126eed6f780140f765afcbc8ed644e18144faacf51d707576b8a233"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "18a72a8132458954b3792b1491a33a7614e826b409a674bc362d8978a0f8b86b"
+  "shardHash": "5e2950e7ab2a1869f2edcfddaf17069eba9d1b3b4489c0249dbaa3a20fc743bb"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1cd4e2b9cd3ec8b06ff2cc76ff4261233f3bcb11b72631dc2046d96fb59bdf56"
+  "shardHash": "e2df408b2726b030b94d41d35d08b71a97a89a08b9ee450c8f8530b907bf7de7"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "92756568427234bdc4d1d921b1c28e045cab0506c5a95d0640482fc09919d67d"
+  "shardHash": "73a59818566e288ab861566c429ad750aed326f9999af10ccb525858d6236fe6"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "96fa7f0e2b3701ec2599aa536746caf41b4f298c89197432cc1bb65b2145b216"
+  "shardHash": "89da9ffbebeb95090ad6128b8ec300602d12090fe6358d7f0f2eee09fd117a54"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "afa4f154e107ac8a41cab90bd248ddc4f2ccd93acd86be3773c9d3e0c9b05af5"
+  "shardHash": "4908b1616e2f7ebea1f32c3f99974759e85ba25b11f0bc74ecbc2ef5c46dc58d"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05e1fd3a3affc61c33e11e08358821e0905b83746df2415606226e2763b5cf3f"
+  "shardHash": "12b075800188f0bb293d02298c36bf5032025a036ee8b2aa6eabf411ba8a14f5"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5c9547caab057931f16e744a3e5a6e703fb34ec26c4151fddff9ac82b4d217d0"
+  "shardHash": "476c63aa449d9ce72ff8d74b00d9bad2c7f1a4c85cf378a8d683357396e4e7c1"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6233d74a1a4d9c1e2cf94f4275d9f0d0df7d30a36030325ae7e587252a6c3abd"
+  "shardHash": "6b8c75ef9be5324343dc35b2a06c23be6986f91ddda3bfc9f63bb40eaee45973"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cafbdfa7407e989ce67f9698a1c9f27b4abc37b891beaae59279771ada813e38"
+  "shardHash": "3c9ee89e99570d54bb43ae644794f7ea96b7a3d51b7bf3626ea1571fc83c47f9"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e98a18025b89fc8fb231a252bed3ceb638e6d3113f7d50e55f333d1d0ca9a46"
+  "shardHash": "93ab9c287e80e2b36167b21e7ded04d5ca0260d50c8c4b33d10b8535ded2a350"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b1b250483c3a89ad848d287572564b23cd034adcf12a80cccf599982249a1b60"
+  "shardHash": "4e0a6c6be9de3ae79167ad485ebff9c9e3698f3cad4bbfdef65a5921ca03b684"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cf03d4c444bb4e6e91a0b905c685fbcab332261d6677a9d7b202ecda9f177eb2"
+  "shardHash": "95f9172004465f0d75ebb80a04a7d39fe8ee921cf8ddf155de2f5c3deba86f3d"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a6a9c195030d0b06d06b6ea134dc1a30a0d22c1cf66abb9128159cc5065aad31"
+  "shardHash": "eb63a95746dea1af1aa78e448965c0405ee3847848425915948546aa6bf3dd30"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b0c290447e1e953922740ea8a19982a3170f188d94c5f6738a478544b1d1197"
+  "shardHash": "aff6e5775a01dc66c8736afa8597395fd91157b87373d751cdb46dc690d45803"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80f9e9a78f8f07eaff2ba193c525d361e71c599e1801af647890bcdcaddc28a8"
+  "shardHash": "88c16f476906a0bd9fa0d8e5952923e1cf76db7c7408f280e6fff92d2c4075b6"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c27f5d31ad7c0030291293be4bf8c978f8bc5919e7f8b7ab00bfda78c6b06183"
+  "shardHash": "20ff4a3d239c84830acb2613c5aff89d88f043dfcf86969a6e72d8984d1cd48c"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9aa95c3ef0eaf9252183faa0a885b1e8ad7d6188d1bfe44fd34ff2b9675713b6"
+  "shardHash": "aa836146d5b15e361f6cb8efcff96eeccdb60ea1baaf925952709f7ed8b92f93"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "92997ae9a0047b13513828bdcefa348bbcbb0f82271028d69d66d00636af1db7"
+  "shardHash": "a4fba097f9b27c9ace40ce51c9af39140510e43db7e9cbe06734f2789c848d09"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e1bff65d84c6cd97f80483f6fccd2980a41806bcfaff381267f788c02b5e119"
+  "shardHash": "b4dfb49cf8425eb8dd82925b3cd35c234cdf8c79bf6f3615cb464820ab6543d4"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5a6611e97a72eb3cba5a4013023427035c34b47a9fd416145c11c91a3b92df7c"
+  "shardHash": "8df1a869d3291b000e0ad7ca38b1d35c07afd8d13e50ead7581f250602c7d143"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a6b0ce1eddb06bb9235e9d478c427f696ec8ab0d68900fcbda66d10977e7d146"
+  "shardHash": "04bcca73b652307b25885ce30cb57267a4d92c1348799033db0ef3e3be54d27d"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a1b0c67f20bab3dd8485f0f687b20bfcd9741fb94a181ce56ec74a74d2f85370"
+  "shardHash": "a04b8e97035eeb22cf54a0b1e87ce82ae253774543f87c0ff1bf106052b8fedd"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6a3c2d9f819f07bd58a3276412a1ed116894892cacc336faebefacbbadafd61f"
+  "shardHash": "d35870329d1c47d0e02f1072983f534d0165d5985fd282a61d3d46b758ed0b37"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "60f60fab5e74355a0a629815caff7d94f2b39d8b33521f3311321312561d6546"
+  "shardHash": "c27b34fa73fedcb9777f5e583a25f0fcc04560534af1df96fb5f0e138a74175c"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb753855856d241cd0b11d56e9b2cbef493697e7d88cc91a48bd0551151c417f"
+  "shardHash": "f5637e19cf65ec7d8e9f3cfd3f913871fc1877f237514639c92a28ff3b3dfd2b"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4ab68de86e873b5a5f9b8de433a381bab573b7385de71a08ef11c86e56098714"
+  "shardHash": "5166331f01d22216913c2794fd9ab9a0a802c2b11e6a468e135303347a5c7f4c"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4ce683ee112298a1fc196a4f73e9f4244c75b5a8d242cc2899ffc8df469d7c75"
+  "shardHash": "5e140b29c367fad58fa35feb71888634700946fc076bde39ccb2c59adc5f5f44"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c5475ac1b64d77232bf6d6feb6c6f7881e67b3751408bd21330fc614cb998a2b"
+  "shardHash": "76eecd6432df4b14101e7027c5dfd6703d3da8f58278e868a45b2c237c0b9b8a"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d91dbdc0a0cba26c550a06117d1d20a90f76df69423ab47bef68c99e04d4df2b"
+  "shardHash": "c04924a720fb3c9676257f2dd2a19207f49072ac752a0d919c14d73c1078c47b"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "00445e9c59f15d637a4b137e9fdd59a7ac1044e1fb732580d88f254ddb6d20ab"
+  "shardHash": "89fecd93af86e2e247a8e531e5aa1cba244d3575f4451e5c91d0c6c88d10951d"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b3d025686460d2e6096571c291e7011e5633028f025eccbd84bf3ca1b0474cd5"
+  "shardHash": "9a10df8ce720e5ba25541b7d92015d8dc847db00dc98de1823c5ecf5e32a07b7"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4baf9edf3ffe4c07a779e33a87b9d9ee454351f1176a09a23894e13f4bb7fbce"
+  "shardHash": "8e81883fcdfbd677e4fcf3f103e6362745913bc905c5ae0bfab3321d08b68f80"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6456f2ca363cc328b511b7df0e0bc99867cbb34b891340fe9a2cc54262707b31"
+  "shardHash": "d796a79c15122240581eaecef2368337450cdac98428c1019696ca3961442f8f"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d91ea69a7f2f30eda7b36e016fe142c2eb3c0aef309527275d3bbf389910776f"
+  "shardHash": "1d4478850e9dba0c2953d2828e6ecdc9194f0dd3de9fd830da1daf5f5b09d95f"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fd19117bb017791f4528e27ccec25be8c6b5e1f21cc91c7666c7210b1a779ebd"
+  "shardHash": "012f6c8bc39203405a0e82806336fac7f341160649cc3ca74dd27d53e04e2292"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dbc362e8e3733c22bdc4949578aa5278ac922f1fd50eebd76232c2f1bdeef53e"
+  "shardHash": "be52237a694fdb9c9f25439f002ea2deefb0d1da59486f7be0d868848b0c1c52"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "62c8af12a8da7f2f448cf221099c8fcbd512ee1caf08b3efefc12abdc940efe8"
+  "shardHash": "e04f389123d9609ebe81bb05e4236d4bee6673b57d0dfaa2466a42c1e9d6d542"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f364af53cbd0a4265490e3fab28954bec2194be8c600764a900e850eaa3daf83"
+  "shardHash": "36dbb9f4196d3808e2403cc140691b6409704a98bb80aa9f6f6b8d38c1e4c5ec"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ec96a86939a9211c1cb37f2b8ac8a85a27c72b245814179e86b74f6cf8659263"
+  "shardHash": "db3a5f8873579f3ec1bf476ab49fe2222ba59e4fabe8043340fba491cc124d50"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f41b21ea03f9d3352812bbee50b720e78beb58bdd12353e0ddb1a7ecea253ccb"
+  "shardHash": "3858c398397e47c3e7260fb4ef24ba39842391ce3b40ac7d065e33718ba6b225"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc29f79a24b6afbe79599f275a8f9d9bba96307de711e043f756d8767705450d"
+  "shardHash": "43f7ac79aeadda6cab540fa85196a99d7d79bad91fc9e6b223d41acaed292b85"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e588f6fbc27a0c2963c13fd39e5fbdd0358bdc77b5e69ccd20748311908071a3"
+  "shardHash": "ce17130a4374d0c95d613f4aff79475aa72bd499ee70c25bc34109d59c4cb39c"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9d90e654b6546419797241162313375ed866df5f27eb17a2934928e8bc4260b8"
+  "shardHash": "ea7fac8eaefc72be68a67b7250553e367ce7cba21bcf4d9ba2c7e68796d7983f"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0f84ba19e2de17aac48fdafc47fbe948151284cde3480cb8a1f1481e46c113ee"
+  "shardHash": "d65d77d233378356278faea0eb50dcd477fe3d6c0a01cfb69bd646951af4c7ba"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "94917f840ee503e32a221f2ea217f515b4dcbfd6d114fddacfb8a95be8fd6a23"
+  "shardHash": "a5de6f3679beb4e197bb4634bc167b23511800621cb6fbab8e52def9f0988a25"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3a64244c143dc0e21298c0d78768a4932cc51a14763a1dca354fb8e47716db27"
+  "shardHash": "84f2c85010bba29f94cd5afb566ef6d7b9bdf7483c26973107254b54027c4398"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f712bb663641f9c9f2ef0a2a591d280a76bd5a8d453581d28bd3e5e4cb211021"
+  "shardHash": "5d006785a6752856816bd661ad3711b6607e0c03f6e520fdc8190eb56b07c0df"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3da9fe6e4a60db34648017c8fbb381571918bb6f3a2e7501572d252a7759b6fd"
+  "shardHash": "9dcaabb40e203e10e07305545060971fec4f3cc8b4abfe52c9cf69b113d5ae29"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fa4faa0277ef99f5e3e0636fef10476c30bae4c843a76eb88df725acc228ecca"
+  "shardHash": "2d608b6cd1aaba886be879f65fa0dc678587f5c7fc71d87cf0f10b21ebc6ac05"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0c7c17f1f92737453aba45d95379fafaef82569a733193a459f5a21af2f54c24"
+  "shardHash": "d0ecda28929c26085e44abdeaf0b4c2296f6f1e1a4ea27a510804a11c6f60905"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d4e72afd142b3af36293ea194176ee7634c48516d8428cc4fd6ecb6c9bf12442"
+  "shardHash": "577780d2e3fc0379762864a47d7fcd185e82718074c044df9159d01d3cc27d1c"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e15c356b314afed0abeceab336017754f69641d45b6af5d54d035731194ffb6d"
+  "shardHash": "590141276af3800f2b26f75c7c35a7e22379ede4e919590d2bde60241e011dfd"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4556e31e139edaf30b8b5b36ff2619f9f283ecb66f850ec17883cecbc5f5d791"
+  "shardHash": "b92bfc145bf42f04ddeef9662b1d3a915ec7ac57b1e9344cd0eeaab080523f75"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -8,15 +8,78 @@
     ],
     "implementingPaths": [
       {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/diagnostics.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
         "source": "spec-edge"
       },
       {
         "path": "crates/spec-spine-core/src/lint.rs",
         "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/config.rs",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/diagnostics.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/diagnostics.rs"
+        }
+      },
       {
         "locations": [
           {
@@ -33,6 +96,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-core/src/lint.rs"
           }
         ],
@@ -41,6 +117,32 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
         }
       },
       {
@@ -74,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ceffd74b3b901d084702768472929745517d690c4fe3b7be2e14a01a689de8cc"
+  "shardHash": "3e635aabcf8974f7d628ff16a44a32b33c47f3128fcedfed8940939aee94e124"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -65,5 +65,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cb781b62b1c54abfa786a7912f84bad8fa6db42ba315d21160fbc2d4ddec6bc1"
+  "shardHash": "7a8c868c2b5e3f3e9b768e8e0aff7db2c0fe02a9e92b72cec10ddc5bb10d709c"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -111,5 +111,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bec655134fc0c876d30906124808b628064c77a1fd9d7f3c9db90ac563326add"
+  "shardHash": "15db1a1b9d59eed7b561a8558668c0ece8ccb299c61ca5331521e92523b4dee4"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -90,5 +90,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "13397aede68514144cf0b33093a3e49b4bdacaad855169c45717323cb34ccf44"
+  "shardHash": "e2db22b6f59ad80820a4343930d4631c2e7b2545aa40925ba3d0db4cbfd3688e"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d21f43174c54d0cab990dd06b91aa6ce67fc95ba5a9a1ecc33bf259bc6bad48f"
+  "shardHash": "0b0ae79e87f84b944caed4e2fd2fd6e747ca4681941bde1836840999903c598e"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -107,5 +107,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7740f26852b266067404b2c6e99482ece576a9a76f55491c4d6c39e3d43108fb"
+  "shardHash": "1fc026eba0cb7c98a66bc27a855c84818452d333c3e9dc35420f90c8b4d183c2"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "646affa2dae797dd3b2fca03b1dcaa6ff2a0be99bb1e31089da4e6cd05b78c43"
+  "shardHash": "52069cc3d1e9c7298081339a532e1a456f205e4e77743536ab2f75fd69dfc48f"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -91,5 +91,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "32faeb2ac4af91359aea61eb7fb7627f537bb141220ee65db1eeec6793dca3bf"
+  "shardHash": "8d51d1f5da5f15ffb94a5d820f704d64e8fd378fe292da63f912d45cbb321c0b"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -125,5 +125,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1514224717dd53054d96fd2bd7285e0405ea4bc585ca9d413c91a1ba1d1481a7"
+  "shardHash": "fd369d42f8d02fb433e9aae39823c2aeaf137440735f9bf0d4557ee4f62f8102"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -57,5 +57,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8a5b701a629bc3d79a5f04276afb8921121ab1d6e94ed41f2bf190263fdff04f"
+  "shardHash": "e26a63cc2746dda84b2a66bf8e54a9d0ffa68d3a0e17e981be15a35f0d81e358"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -74,5 +74,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ec41757efa1f67f96d5529d9853e61b0e9edae6116b2eac096ac71cb0494b155"
+  "shardHash": "fb58460c8edab44b0ab6fa093814a046f65e8453f6e136915027691a5325ea04"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -73,5 +73,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8e37459dc44c7f96e9005f71553ba1a7ebd1d3e8544791e15e3af2d831f7b911"
+  "shardHash": "a72f3825e1db5d0af5a7f149c42597eb5f8218aea02914b38808e7ffa344293f"
 }

--- a/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
@@ -23,10 +23,58 @@
           "kind": "file",
           "path": "crates/spec-spine-core/src/index.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "050-index-diagnostics-reach-a-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/diagnostics.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "050-index-diagnostics-reach-a-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "053-depends-on-ordinal-monotonicity",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "037-machine-readable-verdicts",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
       }
     ],
     "id": "057-claimed-but-unwitnessed",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -55,6 +103,7 @@
       "3.2 `L-008`",
       "3.3 `index check` reports the count",
       "3.4 Nothing is folded into a hash",
+      "3.5 A corpus may declare a gap deliberate",
       "4. Out of scope",
       "5. Verification"
     ],
@@ -63,6 +112,6 @@
     "summary": "A `file` unit carries no span, and only span-backing source files are folded into a per-spec index shard hash. So a spec can claim a file, `index check` can report fresh, `index coverage` can report it claimed, and the file's contents can be rewritten from end to end with no gate noticing. This is not hypothetical in this repository: `AGENTS.md` is claimed by three specs, and appending a line to it leaves both `index check` and `compile --check` reporting fresh. Twenty-four claimed paths here are in that state, and spec 023 signs an attestation over a ledger that never hashed any of them. This spec adds `L-008`, a warning naming each claimed path that contributes to no content hash, and one line of `index check` output reporting the count. It does not fold claimed files into the hash: that would change what staleness means, and the honest first move is to say how large the gap is.\n",
     "title": "A claim no hash witnesses"
   },
-  "shardHash": "08c21103beb8d54e8352e3045fada0e04283d972a1847504466c38043d8099a5",
+  "shardHash": "c7a91dcf535017b75965273346286a29aecd744363d0fd162c1f7e095bfc9d5d",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -13,9 +13,9 @@ use std::path::Path;
 use clap::Subcommand;
 use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
 use spec_spine_core::{
-    DiagnosticCounts, Freshness, IndexCheckReport, check_index_freshness, check_slice_freshness,
-    committed_counts, committed_diagnostics, coverage, index, index_dir, index_shard_files,
-    load_committed_index, orphans, render_markdown, slices_path,
+    DiagnosticCounts, Freshness, IndexCheckReport, UnwitnessedCounts, check_index_freshness,
+    check_slice_freshness, committed_counts, committed_diagnostics, coverage, index, index_dir,
+    index_shard_files, load_committed_index, orphans, render_markdown, slices_path,
 };
 use spec_spine_types::{Config, CoverageReport, Error, Verdict, verdict::verb};
 
@@ -181,6 +181,12 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 None => (check_index_freshness(&cfg, repo)?, "index".to_string()),
             };
             let counts = committed_counts(&cfg, repo)?;
+            // Spec 057 3.3: the count of claimed paths no content hash covers.
+            // Reporting only, never an exit code: `index check` is where a
+            // person reads the word "fresh", and "fresh" is the word this
+            // qualifies. Computed by the same core function the JSON facade
+            // uses, so the two payloads cannot diverge.
+            let unwitnessed = spec_spine_core::unwitnessed_counts(&cfg, repo);
 
             // Spec 050 3.3: staleness outranks unresolution. A stale index's
             // diagnostics describe a tree that no longer exists, so refusing
@@ -202,9 +208,12 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 // and this arm cannot drift; spec 037 pins them against each
                 // other. `compile --check` keeps the bare freshness object:
                 // index diagnostics are meaningless for the registry (3.1).
-                let report =
-                    serde_json::to_value(IndexCheckReport::new(&freshness, counts.clone()))
-                        .map_err(|e| Error::Schema(e.to_string()))?;
+                let report = serde_json::to_value(IndexCheckReport::with_unwitnessed(
+                    &freshness,
+                    counts.clone(),
+                    unwitnessed,
+                ))
+                .map_err(|e| Error::Schema(e.to_string()))?;
                 out::verdict(&Verdict::report(verb::INDEX_CHECK, code, report))?;
                 return Ok(code);
             }
@@ -221,11 +230,17 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 // twice on two streams. `coverage --fail-on-untraced` reports
                 // on stdout and lets the exit code carry the refusal; this
                 // matches it.
-                Freshness::Fresh if code == 1 => outln!(
-                    "{subject} is fresh; --fail-on-unresolved refuses{}",
-                    counts_suffix(&counts)
-                ),
-                Freshness::Fresh => outln!("{subject} is fresh{}", counts_suffix(&counts)),
+                Freshness::Fresh if code == 1 => {
+                    outln!(
+                        "{subject} is fresh; --fail-on-unresolved refuses{}",
+                        counts_suffix(&counts)
+                    );
+                    report_unwitnessed(&unwitnessed);
+                }
+                Freshness::Fresh => {
+                    outln!("{subject} is fresh{}", counts_suffix(&counts));
+                    report_unwitnessed(&unwitnessed);
+                }
                 Freshness::Stale { expected, actual } => {
                     eprintln!("{subject} is STALE (run `spec-spine index` to refresh)");
                     eprintln!("  expected: {expected}");
@@ -395,5 +410,26 @@ fn owner_kind_label(kind: spec_spine_core::OwnerKind) -> &'static str {
         spec_spine_core::OwnerKind::Floor => "floor",
         spec_spine_core::OwnerKind::Header => "header",
         spec_spine_core::OwnerKind::Inherited => "inherited",
+    }
+}
+
+/// The spec 057 §3.3 line: how many claimed paths no content hash witnesses,
+/// and how many of those this corpus has declared deliberate.
+///
+/// Silent at zero. A corpus with no gap does not need to be told it has none,
+/// and the line exists to qualify the word "fresh" only where the
+/// qualification bites.
+fn report_unwitnessed(u: &UnwitnessedCounts) {
+    if u.total == 0 {
+        return;
+    }
+    if u.allowed == 0 {
+        outln!("  unwitnessed claims: {}", u.total);
+    } else {
+        outln!(
+            "  unwitnessed claims: {} ({} allowed by [lint] unwitnessed_allowed)",
+            u.total,
+            u.allowed
+        );
     }
 }

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -1185,10 +1185,17 @@ fn prose_output_is_unchanged_without_the_flag() {
         String::from_utf8_lossy(&compile.stdout)
     );
     let index = run_in(root, &["index", "check"]);
+    // Spec 057 §3.3 adds one line under the verdict when the ledger has a gap,
+    // so the assertion is on the verdict line rather than on the whole stream.
+    // The fixture has one claimed-but-unwitnessed path, which is what that line
+    // reports; the verdict itself is untouched, which is what 037 §3.3 is about.
+    let index_out = String::from_utf8_lossy(&index.stdout);
     assert_eq!(
-        String::from_utf8_lossy(&index.stdout).trim(),
-        "index is fresh"
+        index_out.lines().next(),
+        Some("index is fresh"),
+        "{index_out}"
     );
+    assert!(index_out.contains("unwitnessed claims: 1"), "{index_out}");
     let lint = run_in(root, &["lint"]);
     assert!(
         String::from_utf8_lossy(&lint.stdout).contains("lint: 0 error(s)"),

--- a/crates/spec-spine-core/src/diagnostics.rs
+++ b/crates/spec-spine-core/src/diagnostics.rs
@@ -180,23 +180,55 @@ pub struct IndexCheckReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actual: Option<String>,
     pub diagnostics: DiagnosticCounts,
+    /// Claimed paths that exist and that no content hash covers (spec 057).
+    ///
+    /// Additive on one verb's report payload, so `VERDICT_SCHEMA_VERSION` does
+    /// not move: spec 050 §3.6 settled that, and this follows it rather than
+    /// reopening it. Reporting only; `index check`'s exit code is unchanged
+    /// with and without `--fail-on-unresolved`, because the gate half is the
+    /// lint's and one flag must not mean two conditions.
+    #[serde(default)]
+    pub unwitnessed: UnwitnessedCounts,
+}
+
+/// The claimed-but-unwitnessed tally `index check` reports (spec 057 §3.3).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnwitnessedCounts {
+    /// Every claimed path in no content hash, deliberate ones included. The
+    /// total is the honest number: an allowlist makes a gap explicit, not
+    /// smaller.
+    pub total: usize,
+    /// How many of `total` a `[lint] unwitnessed_allowed` pattern covers.
+    pub allowed: usize,
 }
 
 impl IndexCheckReport {
     /// Build the report from the two answers the CLI already holds.
     pub fn new(freshness: &crate::index::Freshness, counts: DiagnosticCounts) -> Self {
+        Self::with_unwitnessed(freshness, counts, UnwitnessedCounts::default())
+    }
+
+    /// As [`Self::new`], carrying the spec 057 tally.
+    pub fn with_unwitnessed(
+        freshness: &crate::index::Freshness,
+        counts: DiagnosticCounts,
+        unwitnessed: UnwitnessedCounts,
+    ) -> Self {
         match freshness {
             crate::index::Freshness::Fresh => Self {
                 fresh: true,
                 expected: None,
                 actual: None,
                 diagnostics: counts,
+                unwitnessed,
             },
             crate::index::Freshness::Stale { expected, actual } => Self {
                 fresh: false,
                 expected: Some(expected.clone()),
                 actual: Some(actual.clone()),
                 diagnostics: counts,
+                unwitnessed,
             },
         }
     }

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -1225,6 +1225,119 @@ fn status_str(status: spec_spine_types::Status) -> String {
     .to_string()
 }
 
+// ===== spec 057: which paths any content hash witnesses =====
+
+/// Every repo-relative path that contributes to some content hash the index
+/// computes (spec 057 §3.1).
+///
+/// Derived from the same code that builds the hashes rather than restated
+/// beside it: a second list of what is hashed would be wrong the first time the
+/// first list changed, and this whole spec exists because a reader's model of
+/// the hash inputs was wrong. The four contributors, in the order the hashers
+/// consume them:
+///
+/// - each spec's `spec.md` ([`spec_shard_hash`]),
+/// - each mapping's span-backing files ([`span_files_for_mapping`]): a `file`,
+///   `directory` or `crate` unit carries no span and contributes nothing, which
+///   is precisely the gap this spec names,
+/// - each discovered package's manifest ([`package_shard_hash`]),
+/// - `spec-spine.toml` and every `[index] extra_hashed_inputs` match
+///   ([`crate::shard::global_inputs_hash`]).
+///
+/// A path under `layout.state_dir` never appears: spec 039 excludes state from
+/// every content hash, and `global_inputs_hash` filters it out by the same rule.
+pub fn witnessed_paths(cfg: &Config, repo_root: &Path, index: &CodebaseIndex) -> BTreeSet<String> {
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for m in &index.traceability.mappings {
+        out.insert(spec_md_rel(&cfg.layout.specs_dir, &m.spec_id));
+        out.extend(span_files_for_mapping(m));
+    }
+    for p in &index.packages {
+        out.insert(package_manifest_rel(p));
+    }
+    let cfg_path = repo_root.join("spec-spine.toml");
+    if cfg_path.is_file() {
+        out.insert(rel_posix(repo_root, &cfg_path));
+    }
+    for pattern in &cfg.index.extra_hashed_inputs {
+        for file in glob_files(repo_root, pattern) {
+            let rel = rel_posix(repo_root, &file);
+            if cfg.layout.is_state_path(&rel) {
+                continue;
+            }
+            out.insert(rel);
+        }
+    }
+    out
+}
+
+/// A claimed path that exists on disk and that no content hash covers
+/// (spec 057 §3.2).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnwitnessedClaim {
+    pub spec_id: String,
+    pub path: String,
+    /// Covered by a `[lint] unwitnessed_allowed` pattern: this corpus has
+    /// decided the gap is deliberate. Still counted and still reported by
+    /// `index check`; only `L-008` is suppressed (spec 057).
+    pub allowed: bool,
+}
+
+/// True when a `[lint] unwitnessed_allowed` pattern covers the path.
+fn is_allowed_unwitnessed(cfg: &Config, path: &str) -> bool {
+    cfg.lint
+        .unwitnessed_allowed
+        .iter()
+        .any(|pat| glob::Pattern::new(pat).is_ok_and(|p| p.matches(path)))
+}
+
+/// Every ownership-bearing claimed path that exists and is unwitnessed, sorted.
+///
+/// A path that does **not** exist is excluded: it is already diagnosed as an
+/// unresolved unit (`W-001` / `W-002`, spec 025), and telling a specify-first
+/// corpus that a file it has not written yet is also not hashed would put a
+/// second warning on every pending claim.
+pub fn unwitnessed_claims(
+    cfg: &Config,
+    repo_root: &Path,
+    index: &CodebaseIndex,
+) -> Vec<UnwitnessedClaim> {
+    let witnessed = witnessed_paths(cfg, repo_root, index);
+    let mut out: BTreeSet<UnwitnessedClaim> = BTreeSet::new();
+    for m in &index.traceability.mappings {
+        for ru in m.resolved_units.iter().filter(|ru| ru.ownership) {
+            for loc in &ru.locations {
+                // A directory-form claim is a prefix, not a file: it witnesses
+                // nothing itself, and the files under it are judged on their
+                // own. Reporting the prefix would name a path that cannot be
+                // hashed rather than one that is not.
+                if loc.file.ends_with('/') {
+                    continue;
+                }
+                if witnessed.contains(&loc.file) {
+                    continue;
+                }
+                // Spec 039 / `L-006`: a claim inside the ungoverned state root
+                // is already an error-tier diagnosis, and "and it is not
+                // hashed" is noise on a path that has to move regardless.
+                if cfg.layout.is_state_path(&loc.file) {
+                    continue;
+                }
+                if !repo_root.join(&loc.file).is_file() {
+                    continue;
+                }
+                out.insert(UnwitnessedClaim {
+                    spec_id: m.spec_id.clone(),
+                    path: loc.file.clone(),
+                    allowed: is_allowed_unwitnessed(cfg, &loc.file),
+                });
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
 // ===== spec 055: who owns this path =====
 
 /// How a spec comes to own a path.

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -66,13 +66,13 @@ pub use dep_only::{
     is_package_json, is_workflow_yaml, workflow_dependency_only_change,
 };
 pub use diagnostics::{
-    AttributedDiagnostic, DiagnosticCounts, IndexCheckReport, UNRESOLVED_CODES, committed_counts,
-    committed_diagnostics, count as count_diagnostics,
+    AttributedDiagnostic, DiagnosticCounts, IndexCheckReport, UNRESOLVED_CODES, UnwitnessedCounts,
+    committed_counts, committed_diagnostics, count as count_diagnostics,
 };
 pub use index::{
-    Freshness, IndexOutcome, IndexShardSet, OwnerKind, OwnerLink, OwnerReport, authorities,
-    check_index_freshness, check_slice_freshness, index, index_dir, index_shard_files,
-    load_committed_index, owner, owner_with, slices_path,
+    Freshness, IndexOutcome, IndexShardSet, OwnerKind, OwnerLink, OwnerReport, UnwitnessedClaim,
+    authorities, check_index_freshness, check_slice_freshness, index, index_dir, index_shard_files,
+    load_committed_index, owner, owner_with, slices_path, unwitnessed_claims, witnessed_paths,
 };
 pub use lint::{LintReport, lint};
 pub use query::{
@@ -197,7 +197,41 @@ pub fn check_freshness_json(config_json: &str, repo_root: &str) -> Result<String
     let root = std::path::Path::new(repo_root);
     let freshness = check_index_freshness(&config, root)?;
     let counts = diagnostics::committed_counts(&config, root)?;
-    to_json(&IndexCheckReport::new(&freshness, counts))
+    // Spec 057 §3.3: the facade and the CLI emit one shape. `cli.rs` pins them
+    // against each other, and it caught this: a payload member added on one
+    // side only is exactly the drift that test exists to refuse.
+    to_json(&IndexCheckReport::with_unwitnessed(
+        &freshness,
+        counts,
+        unwitnessed_counts(&config, root),
+    ))
+}
+
+/// The distinct-path tally spec 057 §3.3 reports, shared by the facade and the
+/// CLI so the two payloads cannot diverge.
+///
+/// Distinct **paths**, not `(spec, path)` claims: several specs claiming one
+/// unhashed file is one hole in the ledger, and counting it per claimant would
+/// report the corpus's edge density rather than its gap. An unreadable index is
+/// an empty tally rather than an error, because the freshness verdict this
+/// accompanies has already been reached.
+pub fn unwitnessed_counts(config: &Config, repo_root: &std::path::Path) -> UnwitnessedCounts {
+    let Ok(index) = load_committed_index(config, repo_root) else {
+        return UnwitnessedCounts::default();
+    };
+    let claims = unwitnessed_claims(config, repo_root, &index);
+    let mut all: std::collections::BTreeSet<&str> = Default::default();
+    let mut allowed: std::collections::BTreeSet<&str> = Default::default();
+    for c in &claims {
+        all.insert(c.path.as_str());
+        if c.allowed {
+            allowed.insert(c.path.as_str());
+        }
+    }
+    UnwitnessedCounts {
+        total: all.len(),
+        allowed: allowed.len(),
+    }
 }
 
 /// Check registry-shard freshness (spec 031), returning the same

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -132,6 +132,39 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
         }
     }
 
+    // L-008 (spec 057): a claimed path that exists and that no content hash
+    // covers. Its contents can be rewritten end to end with `index check` and
+    // `compile --check` both reporting fresh, which is the sentence this
+    // diagnostic qualifies.
+    //
+    // Read from the **committed** index rather than recomputed: `lint` is a
+    // read verb and indexing here would make it write-shaped and slow. A corpus
+    // with no committed index is silent, which is right: there is no ledger yet
+    // for a claim to be invisible to.
+    if let Ok(index) = crate::index::load_committed_index(cfg, repo_root) {
+        for claim in crate::index::unwitnessed_claims(cfg, repo_root, &index)
+            .into_iter()
+            .filter(|c| !c.allowed)
+        {
+            let spec_path = registry
+                .specs
+                .iter()
+                .find(|s| s.id == claim.spec_id)
+                .map(|s| s.spec_path.clone());
+            violations.push(warn(
+                "L-008",
+                format!(
+                    "spec '{}' claims '{}', which is in no content hash: its contents can \
+                     change without staling any shard. Add a covering glob to [index] \
+                     extra_hashed_inputs, or claim a section or symbol unit, whose span \
+                     is hashed",
+                    claim.spec_id, claim.path
+                ),
+                spec_path,
+            ));
+        }
+    }
+
     Ok(LintReport { violations })
 }
 

--- a/crates/spec-spine-core/tests/lint.rs
+++ b/crates/spec-spine-core/tests/lint.rs
@@ -209,3 +209,204 @@ fn a_forward_dependency_does_not_fail_compile() {
         "the lint's code never appears in compile's report"
     );
 }
+
+// ── spec 057: a claim no hash witnesses ───────────────────────────────────
+
+/// Commit the index shard tree, as `spec-spine index` does. `L-008` reads the
+/// committed index rather than recomputing one, so a corpus without this step
+/// is silent: there is no ledger yet for a claim to be invisible to.
+fn commit_index(cfg: &Config, root: &Path) {
+    use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
+    let outcome = spec_spine_core::index(cfg, root).unwrap();
+    let dir = spec_spine_core::index_dir(cfg, root);
+    let (by_spec, by_package) = spec_spine_core::index_shard_files(&outcome.shards).unwrap();
+    shard::sync_dir(&dir.join(BY_SPEC_DIR), &by_spec).unwrap();
+    shard::sync_dir(&dir.join(BY_PACKAGE_DIR), &by_package).unwrap();
+}
+
+fn l008(cfg: &Config, root: &Path) -> Vec<spec_spine_types::Violation> {
+    spec_spine_core::lint(cfg, root)
+        .unwrap()
+        .violations
+        .into_iter()
+        .filter(|v| v.code == "L-008")
+        .collect()
+}
+
+/// A corpus claiming one existing file that nothing hashes.
+fn unwitnessed_fixture(root: &Path) {
+    write(root, "thing.sh", "echo claimed\n");
+    write(
+        root,
+        "specs/001-x/spec.md",
+        "---\nid: \"001-x\"\ntitle: \"x\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"x\"\nestablishes:\n  - \"thing.sh\"\n---\n# x\n## body\n",
+    );
+}
+
+/// §3.2: a claimed file that exists and that no content hash covers is one
+/// warning naming the spec, the path, and both remedies. They are genuinely
+/// different choices and the right one depends on the file.
+#[test]
+fn an_unwitnessed_claim_is_an_l008_warning_naming_both_remedies() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = Config::default();
+    unwitnessed_fixture(tmp.path());
+    commit_index(&cfg, tmp.path());
+
+    let found = l008(&cfg, tmp.path());
+    assert_eq!(found.len(), 1, "{found:?}");
+    let v = &found[0];
+    assert_eq!(
+        v.severity,
+        Severity::Warning,
+        "a legitimate state, not a defect"
+    );
+    assert!(v.message.contains("001-x"), "{}", v.message);
+    assert!(v.message.contains("thing.sh"), "{}", v.message);
+    assert!(v.message.contains("extra_hashed_inputs"), "{}", v.message);
+    assert!(
+        v.message.contains("section or symbol unit"),
+        "{}",
+        v.message
+    );
+    assert_eq!(v.path.as_deref(), Some("specs/001-x/spec.md"));
+}
+
+/// §3.2: a claimed path that does not exist produces no `L-008`. It is already
+/// diagnosed as an unresolved unit (`W-001` / `W-002`), and a second warning on
+/// every pending claim would make a specify-first corpus unreadable.
+#[test]
+fn a_claim_on_a_file_that_does_not_exist_is_silent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = Config::default();
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        "---\nid: \"001-x\"\ntitle: \"x\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"x\"\nestablishes:\n  - \"not/written/yet.rs\"\n---\n# x\n## body\n",
+    );
+    commit_index(&cfg, tmp.path());
+    assert!(l008(&cfg, tmp.path()).is_empty());
+}
+
+/// §3.1: a covering `extra_hashed_inputs` glob is one of the two remedies the
+/// message names, and it works. This also pins the glob form: `dir/**` matches
+/// directories only, which is how this repository's own two entries came to
+/// match nothing at all.
+#[test]
+fn a_covering_glob_witnesses_the_claim_and_the_directory_form_does_not() {
+    let tmp = tempfile::tempdir().unwrap();
+    unwitnessed_fixture(tmp.path());
+
+    let works = load_config("[index]\nextra_hashed_inputs = [\"*.sh\"]\n").unwrap();
+    commit_index(&works, tmp.path());
+    assert!(
+        l008(&works, tmp.path()).is_empty(),
+        "a matching glob covers it"
+    );
+
+    // The trap: `dir/**` matches directories, so it hashes no files.
+    write(tmp.path(), "sub/thing2.sh", "echo two\n");
+    write(
+        tmp.path(),
+        "specs/002-y/spec.md",
+        "---\nid: \"002-y\"\ntitle: \"y\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"y\"\nestablishes:\n  - \"sub/thing2.sh\"\n---\n# y\n## body\n",
+    );
+    let trap = load_config("[index]\nextra_hashed_inputs = [\"*.sh\", \"sub/**\"]\n").unwrap();
+    commit_index(&trap, tmp.path());
+    assert!(
+        l008(&trap, tmp.path())
+            .iter()
+            .any(|v| v.message.contains("sub/thing2.sh")),
+        "`sub/**` matches directories, not the files under them"
+    );
+
+    let fixed = load_config("[index]\nextra_hashed_inputs = [\"*.sh\", \"sub/**/*\"]\n").unwrap();
+    commit_index(&fixed, tmp.path());
+    assert!(
+        l008(&fixed, tmp.path()).is_empty(),
+        "`sub/**/*` matches them"
+    );
+}
+
+/// §3.2 + the config knob: an allowlisted path is suppressed from `L-008` and
+/// still counted, so an exception is explicit rather than invisible.
+#[test]
+fn the_allowlist_suppresses_the_warning_but_not_the_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    unwitnessed_fixture(tmp.path());
+    let cfg = load_config("[lint]\nunwitnessed_allowed = [\"*.sh\"]\n").unwrap();
+    commit_index(&cfg, tmp.path());
+
+    assert!(l008(&cfg, tmp.path()).is_empty(), "suppressed");
+
+    let index = spec_spine_core::load_committed_index(&cfg, tmp.path()).unwrap();
+    let claims = spec_spine_core::unwitnessed_claims(&cfg, tmp.path(), &index);
+    assert_eq!(claims.len(), 1, "still counted: {claims:?}");
+    assert!(claims[0].allowed, "and marked as a declared exception");
+}
+
+/// §3.1: a claim inside the ungoverned state root is `L-006`'s business, at
+/// error tier. "You claimed the ungoverned directory" is the whole diagnosis,
+/// and "and it is not hashed" is noise on a path that has to move.
+#[test]
+fn a_claim_inside_the_state_root_defers_to_l006() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "tool-state/journal.rs", "// state\n");
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        "---\nid: \"001-x\"\ntitle: \"x\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"x\"\nestablishes:\n  - \"tool-state/journal.rs\"\n---\n# x\n## body\n",
+    );
+    let cfg = load_config("[layout]\nstate_dir = \"tool-state\"\n").unwrap();
+    commit_index(&cfg, tmp.path());
+
+    let report = spec_spine_core::lint(&cfg, tmp.path()).unwrap();
+    assert!(
+        report.violations.iter().any(|v| v.code == "L-006"),
+        "{:?}",
+        report.violations
+    );
+    assert!(
+        !report.violations.iter().any(|v| v.code == "L-008"),
+        "L-008 defers: {:?}",
+        report.violations
+    );
+}
+
+/// §3.1: the predicate is derived from what the hashers actually consume, so
+/// each of the four contributors is witnessed.
+#[test]
+fn witnessed_paths_covers_every_hash_contributor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        root,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n",
+    );
+    write(
+        root,
+        "spec-spine.toml",
+        "[index]\nextra_hashed_inputs = [\"extra.txt\"]\n",
+    );
+    write(root, "extra.txt", "hashed\n");
+    write(
+        root,
+        "specs/001-x/spec.md",
+        "---\nid: \"001-x\"\ntitle: \"x\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"x\"\nestablishes:\n  - \"src/x.rs\"\n---\n# x\n## body\n",
+    );
+    let cfg = load_config(&std::fs::read_to_string(root.join("spec-spine.toml")).unwrap()).unwrap();
+    let index = spec_spine_core::index(&cfg, root).unwrap().index;
+    let witnessed = spec_spine_core::witnessed_paths(&cfg, root, &index);
+
+    assert!(witnessed.contains("specs/001-x/spec.md"), "{witnessed:?}");
+    assert!(witnessed.contains("crate-a/Cargo.toml"), "{witnessed:?}");
+    assert!(witnessed.contains("spec-spine.toml"), "{witnessed:?}");
+    assert!(witnessed.contains("extra.txt"), "{witnessed:?}");
+}

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -304,6 +304,18 @@ pub struct LintConfig {
     /// asked for it by each writing the same script; the knob is how they stop
     /// maintaining it, not a verdict on anybody who did not.
     pub require_ordinal_monotonic_depends_on: bool,
+    /// Glob patterns naming claimed paths this corpus deliberately leaves out
+    /// of every content hash, suppressing `L-008` for them (spec 057).
+    ///
+    /// An unwitnessed claim is a real gap and a legitimate state, and a corpus
+    /// that has decided which of its gaps are deliberate should be able to
+    /// write that decision down rather than carry a permanent warning it has
+    /// agreed to ignore. Every entry is still counted by `index check`, which
+    /// reports the total and how many of it this list covers: the list makes an
+    /// exception explicit, never invisible.
+    ///
+    /// Patterns match the repo-relative POSIX path.
+    pub unwitnessed_allowed: Vec<String>,
 }
 
 /// Where a bypass entry came from (spec 054 §3.2).

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -29,7 +29,45 @@ standalone_rust_workspaces = []
 standalone_npm_packages    = ["npm"]
 
 [index]
-extra_hashed_inputs = ["standards/**", ".github/workflows/**"]
+# Files folded into the global-inputs scalar, so a change to one stales every
+# shard. Spec 057 found the first two entries here matched ZERO files: in the
+# `glob` crate `dir/**` matches directories only, and files need `dir/**/*`.
+# The constitution, the contract, the templates and every workflow had
+# therefore never contributed to any content hash, and spec 023 was signing an
+# attestation over a ledger that had not read them.
+#
+# Every pattern below is deliberately narrow. This list hashes whatever is on
+# disk, tracked or not, so a bare `.claude/**/*` would fold in `.DS_Store`,
+# `agent-memory/` and `settings.local.json` and make the shard hashes
+# machine-dependent, which the four-triple determinism gate would catch as a
+# platform difference. Narrow patterns also keep the blast radius honest: an
+# entry here restales all 69 shards when it changes, so it earns its place by
+# being a governance file some spec claims.
+extra_hashed_inputs = [
+  "standards/**/*.md",
+  ".github/workflows/*.yml",
+  # Governance and harness files specs claim (spec 057).
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".claude/rules/*.md",
+  ".claude/settings.json",
+  ".githooks/*.sh",
+  "scripts/*.sh",
+  "install.sh",
+  "docs/adoption-guide.md",
+  "docs/releasing.md",
+  "docs/schema-versioning.md",
+  "kit/AGENTS.md",
+  "kit/README.md",
+  "kit/settings.json",
+  "kit/.claude/rules/*.md",
+  "py/scripts/*.py",
+  # The embedded JSON Schemas the conformance test validates against. Hashed
+  # rather than allowlisted: a schema edit is exactly the kind of change the
+  # ledger should notice, and it is rare enough that restaling every shard is
+  # the right price.
+  "crates/spec-spine-types/schemas/*.json",
+]
 resolver_exclusions = ["target", "node_modules", ".derived", "dist", "build", ".next"]
 
 [branding]
@@ -76,3 +114,20 @@ code-fingerprint = "fingerprint://"
 
 [frontmatter]
 extra_known_keys = []
+
+[lint]
+# Spec 057: claimed paths this corpus deliberately leaves out of every content
+# hash. A `file` unit carries no span, and only span-backing files enter a
+# shard hash, so every source file claimed as a bare file unit is invisible to
+# the ledger. That is 74 files here, and folding them in is a different change
+# (it would alter what staleness means) that spec 057 4 puts out of scope.
+#
+# They are not undefended: the coupling gate refuses a changed source file
+# whose owning spec did not change, which is the check that actually protects
+# them. What the gap costs is narrower and worth writing down: `index check`
+# will not call the index stale for an edit to one of these, and spec 023's
+# attestation covers a ledger that never hashed their bytes.
+#
+# `index check` still reports the total on every run and says how many of it
+# this list covers, so the exception is explicit rather than invisible.
+unwitnessed_allowed = ["crates/**/*.rs"]

--- a/specs/057-claimed-but-unwitnessed/spec.md
+++ b/specs/057-claimed-but-unwitnessed/spec.md
@@ -4,7 +4,7 @@ title: "A claim no hash witnesses"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -15,6 +15,16 @@ depends_on:
 extends:
   - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
   - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  # The `index check` count line (3.3) and the payload field carrying it.
+  - { spec: "050-index-diagnostics-reach-a-gate", unit: "crates/spec-spine-core/src/diagnostics.rs", nature: additive }
+  - { spec: "050-index-diagnostics-reach-a-gate", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  # The allowlist knob (3.5), beside spec 053's in the same table.
+  - { spec: "053-depends-on-ordinal-monotonicity", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/tests/lint.rs", nature: additive }
+  # The facade half of the payload, and the two acceptance tests that pin the
+  # CLI and the facade against each other (3.3).
+  - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: "docs/schema-versioning.md" }, role: context }
@@ -177,7 +187,10 @@ and "fresh" is the word this spec is qualifying. A count there is the smallest
 honest correction to what the reader is being told.
 
 Under `--json`, the count joins the existing `IndexCheckReport` payload as an
-additive field. `VERDICT_SCHEMA_VERSION` does not move: spec 050 §3.6 settled
+additive field, on **both** sides: the CLI and the `check_freshness_json`
+facade emit one shape, and `cli.rs` pins them against each other. That test
+caught the first cut of this change, where the field existed on the CLI side
+only, which is exactly the drift it was written to refuse. `VERDICT_SCHEMA_VERSION` does not move: spec 050 §3.6 settled
 that adding a member to one verb's report payload is additive and must not move
 the constant that versions the envelope, and this spec follows that decision
 rather than reopening it.
@@ -205,14 +218,64 @@ change to the staleness contract that deserves its own spec, its own argument,
 and a corpus that already knows how big the gap is. This spec produces that
 number.
 
+### 3.5 A corpus may declare a gap deliberate
+
+`[lint] unwitnessed_allowed` MUST accept glob patterns naming claimed paths a
+corpus has decided to leave out of every content hash, suppressing `L-008` for
+them.
+
+It suppresses the **warning**, never the **count**: `index check` reports the
+total and how many of it the list covers, so a declared exception is explicit
+rather than invisible. That is the difference between writing a decision down
+and turning the check off, and it is why this is not simply an opt-in knob on
+the lint.
+
+**Decision, 2026-09-07.** The knob is added because §4's instruction ("resolve
+the corpus to green") turned out to require it. §1 estimated twenty-four
+unwitnessed paths; the predicate found **ninety-four**, of which seventy-four
+are Rust sources under `crates/` claimed as bare `file` units. That is not an
+oversight in those specs: a `file` unit carries no span by design, and folding
+claimed files into the hash is what §4 puts out of scope. Without a way to
+declare the remainder deliberate, the only routes to green were to weaken
+`--fail-on-warn` for every `L-` code or to make `L-008` itself opt-in, and both
+turn the check off rather than record a decision.
+
 ## 4. Out of scope
 
-**Deciding this repository's twenty-four.** The lint reports them; which get a
-glob, which get a narrower unit, and which are deliberately unwitnessed is a
-sequence of judgements about specific files, and none of them is a mechanical
-consequence of this spec. `lint --fail-on-warn` runs in CI here, so the
-implementing change must resolve the corpus to green, and the resolution it
-picks is a decision recorded in this spec at that time, not predetermined now.
+**Deciding this repository's ninety-four.** Decided, 2026-09-07, and recorded in
+`spec-spine.toml` rather than here, because the decision is a configuration:
+
+- **Twenty covered by a hashed-input glob.** The governance and harness files
+  specs claim (`AGENTS.md`, `CLAUDE.md`, `.claude/rules/`, `.githooks/`,
+  `scripts/`, `install.sh`, three `docs/` files, the `kit/` copies) plus the
+  five embedded JSON Schemas, which are hashed rather than allowlisted because a
+  schema edit is exactly what the ledger should notice.
+- **Sixty-nine declared deliberate**, as `crates/**/*.rs`. They are not
+  undefended: the coupling gate refuses a changed source file whose owning spec
+  did not change, which is the check that actually protects them. What the gap
+  costs is narrower and is now written down: `index check` will not call the
+  index stale for an edit to one, and spec 023's attestation covers a ledger
+  that never hashed their bytes.
+
+**Decision, 2026-09-07: two glob entries in this repository matched nothing.**
+`extra_hashed_inputs` was `["standards/**", ".github/workflows/**"]`, and in the
+`glob` crate `dir/**` matches directories only; files need `dir/**/*`. So the
+constitution, the contract, the spec templates and all five CI workflows had
+never contributed to any content hash, and spec 023 has been signing an
+attestation over a ledger that had not read them. Fixed here, and pinned by a
+test that asserts both the trap and the working form, because a silent
+zero-match is the same class of defect as a silent unwitnessed claim.
+
+**Decision, 2026-09-07: the patterns are narrow on purpose.** `extra_hashed_inputs`
+hashes whatever is on disk, tracked or not. A bare `.claude/**/*` folds in
+`.DS_Store`, `agent-memory/` and `settings.local.json`, which would make the
+shard hashes machine-dependent and surface as a platform difference in the
+four-triple determinism gate. Narrow patterns also keep the blast radius
+honest: an entry here restales all sixty-nine shards when it changes, so it
+earns its place by being a governance file some spec claims. A verb that
+reported what a configured glob currently matches would have caught the
+zero-match entries years earlier; spec 054 §4 already defers that idea, and this
+is a second reason to want it.
 
 **Folding claimed files into the hash.** §3.4.
 
@@ -227,21 +290,26 @@ path.
 
 ## 5. Verification
 
+`L-008` and the `index check` line both fail against pre-057 code: neither the
+code nor the line existed.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test lint --locked
-# `index check` reports the count. Until this ships, the line is absent.
+# 3.3: `index check` reports the count, and says how much of it is declared.
 target/release/spec-spine index check | grep -q 'unwitnessed claims'
-# A synthetic corpus claiming an existing file that no hash covers produces
-# L-008. This is the condition 3.2 defines, isolated from this repository's
-# own remedies.
-tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" \
-  && printf 'claimed\n' > "$tmp/thing.sh" \
-  && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "thing.sh"\n---\n\n# x\n' > "$tmp/specs/001-x/spec.md" \
-  && target/release/spec-spine --repo "$tmp" lint | grep -q 'L-008'
-# This corpus is green at the tier CI gates on, which means the twenty-four
-# unwitnessed claims named in 1 were each resolved or deliberately covered by
-# the implementing change.
+# 3.3: reporting only. The exit code is unchanged, with and without the flag.
+target/release/spec-spine index check --fail-on-unresolved
+# 3.2: a synthetic corpus claiming an existing file no hash covers produces
+# L-008, isolated from this repository's own remedies.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" && printf 'claimed\n' > "$tmp/thing.sh" && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "thing.sh"\n---\n\n# x\n## body\n' > "$tmp/specs/001-x/spec.md" && target/release/spec-spine --repo "$tmp" index >/dev/null && target/release/spec-spine --repo "$tmp" lint | grep -q 'L-008'
+# 4: the two entries that matched nothing now match. `standards/` and the
+# workflows contribute to the ledger, which is what this spec found they never
+# had. Asserted through `config show` (spec 054), a governed read.
+target/release/spec-spine config show --json | python3 -c 'import json,sys; g=json.load(sys.stdin)["index"]["extra_hashed_inputs"]; assert "standards/**/*.md" in g, g; assert "standards/**" not in g, g'
+# 4: this corpus is green at the tier CI gates on, which means every one of the
+# ninety-four was either covered or declared.
 target/release/spec-spine lint --fail-on-warn
+target/release/spec-spine compile --check
 ```


### PR DESCRIPTION
Implements spec 057 (adopter-audit backlog items 9 and 10). **This one found
two things bigger than the draft estimated, and one of them is a live defect.**

## The mechanism

A `file` unit carries no span, and only span-backing files enter a per-spec
index shard hash. So a spec can claim a file, `index check` can say fresh,
`index coverage` can say claimed, and the file can be rewritten end to end with
no gate noticing. `L-008` names each such path at warning tier; `index check`
reports the count on the line where a person reads the word "fresh".

The predicate is derived from the code that builds the hashes, not restated
beside it — this spec exists because a reader's model of the hash inputs was
wrong, and a second list would be wrong the first time the first one changed.

## Finding 1: `extra_hashed_inputs` matched zero files

`extra_hashed_inputs = ["standards/**", ".github/workflows/**"]`. In the `glob`
crate **`dir/**` matches directories only**; files need `dir/**/*`. So the
constitution, the contract, the spec templates and all five CI workflows have
**never** contributed to any content hash, and spec 023 has been signing an
attestation over a ledger that had not read them.

Fixed, and pinned by a test asserting both the trap and the working form,
because a silent zero-match is the same class of defect as a silent unwitnessed
claim. A verb reporting what a configured glob currently matches would have
caught this years ago; spec 054 §4 already defers that idea and this is a second
reason to want it.

## Finding 2: the gap is 94 paths, not 24

74 are Rust sources claimed as bare `file` units — not an oversight in those
specs, but what a `file` unit means. I checked the exposure rather than
assuming it: **all of them are defended by the coupling gate** (`C-001` refuses
a changed source file whose owning spec did not change). What the gap actually
costs is narrower: `index check` will not call the index stale for such an edit,
and spec 023's attestation covers a ledger that never hashed those bytes.

## The resolution (your call, recorded in §3.5 and §4)

- **20 covered by hashed-input globs** — governance and harness files specs
  claim, plus the five embedded JSON Schemas, which are hashed rather than
  allowlisted because a schema edit is exactly what the ledger should notice.
- **69 declared deliberate** as `crates/**/*.rs` in a new
  `[lint] unwitnessed_allowed`.

The knob **suppresses the warning, never the count**: `index check` reports
`unwitnessed claims: 69 (69 allowed by [lint] unwitnessed_allowed)`. That is the
difference between writing a decision down and turning the check off, and it is
why this is not simply an opt-in knob on the lint.

**I narrowed the globs from the shape we discussed**, and the reason is
load-bearing: `extra_hashed_inputs` hashes whatever is on disk, tracked or not,
so a bare `.claude/**/*` folds in `.DS_Store`, `agent-memory/` and
`settings.local.json` and makes shard hashes machine-dependent — which the
four-triple determinism gate would surface as a platform difference. Narrow
patterns also keep the blast radius honest: an entry here restales all 69 shards
when it changes.

## An existing test caught a defect in my first cut

`json_report_equals_the_facade_payload` (spec 037) failed: I had added the count
to the CLI's payload and not to `check_freshness_json`'s. That is exactly the
drift that test was written to refuse. Both now call one shared
`unwitnessed_counts`. `prose_output_is_unchanged_without_the_flag` also failed
and was correct to — §3.3 requires the new line — so it now asserts the verdict
line plus the new one rather than the whole stream.

## Verification

`spec-spine verify 057` passes, 8 commands. Full gate green: 69 shards fresh,
index fresh, 0 unresolved, **0 lint warnings**, 74/74 coverage, `couple` clean
over 10 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass. No
waiver.