### PR TITLE
feat(058): the defects heading has one spelling

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5596e7c75410b774e2708d008a2270ad056a26025c1b6ebe5e6d20192ff7fca8"
+  "shardHash": "27a30fda654201cc3dd1274a23d26c18fb2bcce356964591c0355afe0138d2c6"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "548b2607e2e3b3e7139b62921e8ec0b3ed9c834d918c464970e633279ad985f5"
+  "shardHash": "25631229ac4e1ff94a76ab2ccab4665fe52dc617e89f1140e7e335acb98e3191"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "29ab3d293b278a73a95ea7d41832f671a129a5bb267670fec399174a63246496"
+  "shardHash": "d32062aa22e43042ef63a9158ac2721a58bbef44b30262414e0a573d6888fc9f"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9a35da0c66ed9835e21fda2a2416085ac27f4824b4fe538d937eff64a3f56348"
+  "shardHash": "8f5896761c008a2941c341258740cd6479ab5a5bc70981265393c80d7e312bfa"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1a6b9e431fdefc7764ffd2f5a9a8a97614f804ce83e02649e9169cde3978692a"
+  "shardHash": "ae3aac7e72cd5a6c1cd703a789dce52f1c1a57c0d0931d5777a1d557fc27033f"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3f2566e27985855600eb679272984a1aeae1917c4e0e1e1b5b8a0a33b9b2dca9"
+  "shardHash": "92a4e81cbfc05ed127f5dadd2cee125fe36d7a6a8cb7d4a0428bf4a9fe954756"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "56fb2913482180bde53873c24ba15d470dc8c83ac8ec61ff740c3f95d766c6ec"
+  "shardHash": "aa188ef5652f9a43daa4e39a6666b1e15337fe93612e6c9496dab1f3a2554a90"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9c2ae21ae126eed6f780140f765afcbc8ed644e18144faacf51d707576b8a233"
+  "shardHash": "d6cec57bb323d5f47ded63437706a9c41b138cfa5a4c6b816c0001ded2e618f7"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e2950e7ab2a1869f2edcfddaf17069eba9d1b3b4489c0249dbaa3a20fc743bb"
+  "shardHash": "154a74237e0309a498f9c08c5ab92272ecdfe542d22d668f2c7b39bc2f939814"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2df408b2726b030b94d41d35d08b71a97a89a08b9ee450c8f8530b907bf7de7"
+  "shardHash": "b16c7c98c14f96d2658bddb6335df1ca1a545f21f72660f2c18f4a54886cc5a8"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "73a59818566e288ab861566c429ad750aed326f9999af10ccb525858d6236fe6"
+  "shardHash": "833bb6eb605157a3b4db2746e4e8b2bfe41cb081997f3f95a5c03e411aadc962"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "89da9ffbebeb95090ad6128b8ec300602d12090fe6358d7f0f2eee09fd117a54"
+  "shardHash": "5f71eeae32bd6475604be75d6b3e60fd667ad6f90c83201396c8751c3f6c382e"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4908b1616e2f7ebea1f32c3f99974759e85ba25b11f0bc74ecbc2ef5c46dc58d"
+  "shardHash": "7fa892ed82b18feae2ff08808498d51368d12a1bd8d9b099cbfc1801665c3ffc"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "12b075800188f0bb293d02298c36bf5032025a036ee8b2aa6eabf411ba8a14f5"
+  "shardHash": "c50cc7e8147091d07e9844fa551b35ee0d90d9c845c8c4f670bf869a20754194"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "476c63aa449d9ce72ff8d74b00d9bad2c7f1a4c85cf378a8d683357396e4e7c1"
+  "shardHash": "8357ce085587b4f905441023c76e4d641aea76ee29c04a92338ec552f3aaf6a6"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6b8c75ef9be5324343dc35b2a06c23be6986f91ddda3bfc9f63bb40eaee45973"
+  "shardHash": "8bfd4e1b8378ceeee0be5ab9737f50af8e9bc549e7b7c099553a51b3f0c411c8"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3c9ee89e99570d54bb43ae644794f7ea96b7a3d51b7bf3626ea1571fc83c47f9"
+  "shardHash": "95276ddac4b5a64699466f7cff4d4a248c518f0d2f64b7ce825f7d265d9cbd4f"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "93ab9c287e80e2b36167b21e7ded04d5ca0260d50c8c4b33d10b8535ded2a350"
+  "shardHash": "50cd6e7ae9473816c3714899438be2cc6bd7b5022233be7f0ef25c5e48202316"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4e0a6c6be9de3ae79167ad485ebff9c9e3698f3cad4bbfdef65a5921ca03b684"
+  "shardHash": "f089bb6cd374626332780fd7571e67d29e958f194472a1959cb2b3bde952e296"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "95f9172004465f0d75ebb80a04a7d39fe8ee921cf8ddf155de2f5c3deba86f3d"
+  "shardHash": "e38c5f5bc3896a0d2799d4d71a466f2ff9e92534685d71b749a75df34eafe42a"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "eb63a95746dea1af1aa78e448965c0405ee3847848425915948546aa6bf3dd30"
+  "shardHash": "db0a001b9c91c91140208747df0a298f28afc9bcb3d53c760ffe0ddfb198da08"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "aff6e5775a01dc66c8736afa8597395fd91157b87373d751cdb46dc690d45803"
+  "shardHash": "cbd3901af88456e2b8b34601abea19a12520f8e6f870a4f961ab90dccfccd650"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "88c16f476906a0bd9fa0d8e5952923e1cf76db7c7408f280e6fff92d2c4075b6"
+  "shardHash": "56dafdefa6cb10d6b0814449b8d4036f0180a4e18b81adfc25a6c26ccdb3f4d1"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "20ff4a3d239c84830acb2613c5aff89d88f043dfcf86969a6e72d8984d1cd48c"
+  "shardHash": "94d8be500fe95e336eb5513360bdfbda62e920c8e6233a25b102236e83622061"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "aa836146d5b15e361f6cb8efcff96eeccdb60ea1baaf925952709f7ed8b92f93"
+  "shardHash": "e77fefa3b68d5903f0ed4243ec3baf15107735f70e4347750e5d92a7f54d09fc"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a4fba097f9b27c9ace40ce51c9af39140510e43db7e9cbe06734f2789c848d09"
+  "shardHash": "e334cff38e4b240309f76bfddbdcea4237ead70e33ebd86b48a8b8be3fb84ef2"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b4dfb49cf8425eb8dd82925b3cd35c234cdf8c79bf6f3615cb464820ab6543d4"
+  "shardHash": "3976804d02c3126531998d442a9dfc8f41c46dac8b37e05759f8249b7ef097ae"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8df1a869d3291b000e0ad7ca38b1d35c07afd8d13e50ead7581f250602c7d143"
+  "shardHash": "bf8687f709c0d4e343128a59bff8f7c7a204dc037b189d72c2a47e3076c90273"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "04bcca73b652307b25885ce30cb57267a4d92c1348799033db0ef3e3be54d27d"
+  "shardHash": "66af2b2aaf0e582504a01324012614e5a32fc5c3ec6a822bf10c002954e34638"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a04b8e97035eeb22cf54a0b1e87ce82ae253774543f87c0ff1bf106052b8fedd"
+  "shardHash": "8e1fbbc90daf29eec8c68d17dfcbf4ffcbfcbaffbff5965d8d96de9d0e024e4b"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d35870329d1c47d0e02f1072983f534d0165d5985fd282a61d3d46b758ed0b37"
+  "shardHash": "f5ed53116cca94cea30a8b22be070f97f2f960d4f8e7f630ba79108295f9a5c0"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c27b34fa73fedcb9777f5e583a25f0fcc04560534af1df96fb5f0e138a74175c"
+  "shardHash": "4dbec426db6af60552265c165b21b33bb9b6f27a82c05462789f44fdfdf175bf"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f5637e19cf65ec7d8e9f3cfd3f913871fc1877f237514639c92a28ff3b3dfd2b"
+  "shardHash": "d6edf1fc43a2ff428a23170585d35949ec8c699ff7e88aa01599bb9ea64ba052"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5166331f01d22216913c2794fd9ab9a0a802c2b11e6a468e135303347a5c7f4c"
+  "shardHash": "cc138ee273fdc4d7ec0955bcf568e260bdde7540846f14f1eb3d6d9b420063f7"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e140b29c367fad58fa35feb71888634700946fc076bde39ccb2c59adc5f5f44"
+  "shardHash": "bd631191ce34c83acb801eede1fd823876d95be8b14074fc904c19e4ccd15ffc"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "76eecd6432df4b14101e7027c5dfd6703d3da8f58278e868a45b2c237c0b9b8a"
+  "shardHash": "7e8441274c689f9499cb1a9965ca7c352b888493d8520b285b05261d744dd625"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c04924a720fb3c9676257f2dd2a19207f49072ac752a0d919c14d73c1078c47b"
+  "shardHash": "dec026f2cde580715b8dbb163f78e2bc1c2a24dca18d25122ea810e836be4ad1"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "89fecd93af86e2e247a8e531e5aa1cba244d3575f4451e5c91d0c6c88d10951d"
+  "shardHash": "9898da3bf91121e8b08b3b8f51ffb2c46fb29381ab5277dd928c4251d400b070"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9a10df8ce720e5ba25541b7d92015d8dc847db00dc98de1823c5ecf5e32a07b7"
+  "shardHash": "a5621c85179e517d52d00d9c9083a9b4e3762cfe096b5f96d1088eb835a7afe3"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8e81883fcdfbd677e4fcf3f103e6362745913bc905c5ae0bfab3321d08b68f80"
+  "shardHash": "f3e46c5130b464196e6f4b1cf863e86738a092ae4de54cd8699778eabf14f66d"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d796a79c15122240581eaecef2368337450cdac98428c1019696ca3961442f8f"
+  "shardHash": "b583cf14a74b987160139296c4b0ca1c266cb93bd443cee3655d5fe94121f55a"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1d4478850e9dba0c2953d2828e6ecdc9194f0dd3de9fd830da1daf5f5b09d95f"
+  "shardHash": "842a196f41c06ab1455c8d77acd60b20776a250fbd3add0536f08e7ccf2daede"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "012f6c8bc39203405a0e82806336fac7f341160649cc3ca74dd27d53e04e2292"
+  "shardHash": "1496bf7d20b3177e91be1e1adaf9e208157809789ae9abc2f864450fb4af87a7"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "be52237a694fdb9c9f25439f002ea2deefb0d1da59486f7be0d868848b0c1c52"
+  "shardHash": "e0a738fcd048d48867ccc57d952bd707cdc5e1dc03485ab9206d1fc39a81ad7a"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e04f389123d9609ebe81bb05e4236d4bee6673b57d0dfaa2466a42c1e9d6d542"
+  "shardHash": "b3bd5e9a959b79b4376f78f75ad1c3abc198eaf2f4bf9fe0e1064db1c1da8ddf"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "36dbb9f4196d3808e2403cc140691b6409704a98bb80aa9f6f6b8d38c1e4c5ec"
+  "shardHash": "0da76fc93c058572dce1e271545c880549a9dbd45cff526930f78fcc28a5f59b"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "db3a5f8873579f3ec1bf476ab49fe2222ba59e4fabe8043340fba491cc124d50"
+  "shardHash": "39a37f0b432896c159cc90c1855887629ef1b0dba8eb93ca3e1064aa3206affb"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -75,8 +75,8 @@
           {
             "file": "standards/spec/constitution.md",
             "span": {
-              "endLine": 106,
-              "startLine": 74
+              "endLine": 116,
+              "startLine": 84
             }
           }
         ],
@@ -93,7 +93,7 @@
           {
             "file": "standards/spec/constitution.md",
             "span": {
-              "endLine": 73,
+              "endLine": 83,
               "startLine": 53
             }
           }
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3858c398397e47c3e7260fb4ef24ba39842391ce3b40ac7d065e33718ba6b225"
+  "shardHash": "f668161471fa12acd9aa123bd78051be204225d49d3b7321b4a08668da9e8495"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "43f7ac79aeadda6cab540fa85196a99d7d79bad91fc9e6b223d41acaed292b85"
+  "shardHash": "d8c9d74cd07871522d083856fdd0a22d15f3ee91daf0f648996d493ee223ed92"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce17130a4374d0c95d613f4aff79475aa72bd499ee70c25bc34109d59c4cb39c"
+  "shardHash": "f331ebd57bdcc6b17119136e20b3d7b6f9d2dd1903d36db11d18bf04931a4006"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ea7fac8eaefc72be68a67b7250553e367ce7cba21bcf4d9ba2c7e68796d7983f"
+  "shardHash": "6de4f36dffbc3e2ae27805463b89a2e01ea4a4c384e9eaeddb41d32dda00afca"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d65d77d233378356278faea0eb50dcd477fe3d6c0a01cfb69bd646951af4c7ba"
+  "shardHash": "b63ebe04e43fa4db8cacced5719051c78c7f26ca4882ad95fdd7c16daa5e7500"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5de6f3679beb4e197bb4634bc167b23511800621cb6fbab8e52def9f0988a25"
+  "shardHash": "fee66ee5b847bc790c873fef6079731957c7a9144e367f8ca15946ec8c7e696b"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "84f2c85010bba29f94cd5afb566ef6d7b9bdf7483c26973107254b54027c4398"
+  "shardHash": "ae927972dc7881acc62e462f97a88b8a58ae55ed622b3ce0a9eba11c5fcf0ada"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5d006785a6752856816bd661ad3711b6607e0c03f6e520fdc8190eb56b07c0df"
+  "shardHash": "56499b51135910596491cb427a38aa96b856ea6497a9c7fc6a7e7f082d2c6c8f"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9dcaabb40e203e10e07305545060971fec4f3cc8b4abfe52c9cf69b113d5ae29"
+  "shardHash": "f02a8d84f847da943d98a18f2ef2d3a42ebea4087f4dc78453ec17940948fd64"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2d608b6cd1aaba886be879f65fa0dc678587f5c7fc71d87cf0f10b21ebc6ac05"
+  "shardHash": "e19a187e755f033bc7a8d0cf5983d288f67a431ae673043355cc760695efbf63"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d0ecda28929c26085e44abdeaf0b4c2296f6f1e1a4ea27a510804a11c6f60905"
+  "shardHash": "7697edd7045fe6b7aedf610d0c7a7f57bd123065d497efaa2d7b12883b79feed"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "577780d2e3fc0379762864a47d7fcd185e82718074c044df9159d01d3cc27d1c"
+  "shardHash": "14bda43a1abd0522ac6b482bfdda2712b27fc5de993f42991b5f2e7708d753c1"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "590141276af3800f2b26f75c7c35a7e22379ede4e919590d2bde60241e011dfd"
+  "shardHash": "0ec27e9647ae48d40dc02cea3f8c234128e346cef62ba18848ee6f92eab90daa"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b92bfc145bf42f04ddeef9662b1d3a915ec7ac57b1e9344cd0eeaab080523f75"
+  "shardHash": "d040f5222c32727e133e66510d39521b17bc1c523be6d04fed5f401bed67842b"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3e635aabcf8974f7d628ff16a44a32b33c47f3128fcedfed8940939aee94e124"
+  "shardHash": "47b76708938fc8f38ca6a38181f2e3e7e3b47392eb10894b2a3141140b8e4a5d"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -11,6 +11,14 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/sections.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/lint.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "standards/spec/constitution.md",
         "source": "spec-edge"
       }
@@ -32,9 +40,35 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/src/sections.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/sections.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "standards/spec/constitution.md",
             "span": {
-              "endLine": 73,
+              "endLine": 83,
               "startLine": 53
             }
           }
@@ -65,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7a8c868c2b5e3f3e9b768e8e0aff7db2c0fe02a9e92b72cec10ddc5bb10d709c"
+  "shardHash": "00061347eb0d60e40748f0e2b68dd03c9cb8c1b8ec1d8a4fcf07e2b4c6530cde"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -111,5 +111,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "15db1a1b9d59eed7b561a8558668c0ece8ccb299c61ca5331521e92523b4dee4"
+  "shardHash": "88b4b322cc12a7868db09ef35f503aaa4c2613252f699a98b6523fd17ae31972"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -90,5 +90,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2db22b6f59ad80820a4343930d4631c2e7b2545aa40925ba3d0db4cbfd3688e"
+  "shardHash": "65eb27c27684299df03d1145a6e1c953ecca932f8b154ab29f44f9e67cbb7eaa"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0b0ae79e87f84b944caed4e2fd2fd6e747ca4681941bde1836840999903c598e"
+  "shardHash": "44ae968495fc2a292fc383910262d8400089ba9bb85d9fbe7ec6e0bf1bdfad94"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -107,5 +107,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1fc026eba0cb7c98a66bc27a855c84818452d333c3e9dc35420f90c8b4d183c2"
+  "shardHash": "0705dd32d3b85bd3928df193bb6d325da90d2c516e42ee1eb05f802781b05cdc"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "52069cc3d1e9c7298081339a532e1a456f205e4e77743536ab2f75fd69dfc48f"
+  "shardHash": "f6f3bc675edad18ed2e4106b9b9855447b68fef5f3ce0fe345bced5de33b8656"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -91,5 +91,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8d51d1f5da5f15ffb94a5d820f704d64e8fd378fe292da63f912d45cbb321c0b"
+  "shardHash": "300ce43f1307c910eaf616f6b9a1b927fab85b87a7e8b0971c71b676afcb6fab"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -125,5 +125,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fd369d42f8d02fb433e9aae39823c2aeaf137440735f9bf0d4557ee4f62f8102"
+  "shardHash": "2af0f4f1ba9489b58c7cdfaf9c08daac8406c3aeb003e10ce53970dc8f1e8027"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -57,5 +57,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e26a63cc2746dda84b2a66bf8e54a9d0ffa68d3a0e17e981be15a35f0d81e358"
+  "shardHash": "d0e305843e8fdde6ed96789f5dc66376f0520f36315ee7f6b03137d91a6efc6c"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -74,5 +74,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fb58460c8edab44b0ab6fa093814a046f65e8453f6e136915027691a5325ea04"
+  "shardHash": "fff7dd52e630a8568db022b8d34b527dbaa22265cb0fafd73e40592262761665"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -73,5 +73,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a72f3825e1db5d0af5a7f149c42597eb5f8218aea02914b38808e7ffa344293f"
+  "shardHash": "e1dd7a3424c88a91e42662c8bed5b44c57f48a7136fcca293c67ce8e5cad1c58"
 }

--- a/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
@@ -14,10 +14,26 @@
           "kind": "file",
           "path": "crates/spec-spine-core/src/lint.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "022-keypath-section-anchors",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/sections.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
       }
     ],
     "id": "058-retroactive-adoption-shape",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "governance",
     "owner": "The spec-spine Authors",
     "references": [
@@ -57,6 +73,6 @@
     "summary": "Constitution V requires code adopted from outside the corpus to be specced as found, with the behavior the adopting spec would not have chosen recorded under a `## Known defects` heading. It does not say what counts as that heading, and the first consumer to check mechanically got it wrong: claude-observatory's `defects.ts` matches the string `## Known defects` exactly and therefore rejects the numbered headings of the very specs it cites as precedent. This spec settles the spelling as an anchor rather than a string: any heading whose computed slug is or ends with `known-defects`, at any level, under the same slug rule the indexer already uses for section units. It adds `L-009`, an info-tier lint for a near-miss spelling, and it declines to lint `origin.retroactive` into implying the heading, because spec 043 established that the two are orthogonal.\n",
     "title": "The defects heading has one spelling"
   },
-  "shardHash": "f54b6024e52f358c72f50ca37e4b0c7af95fab14e92ffe74dd291ac0724ca17d",
+  "shardHash": "a3078d3df925986851c71c6017da101d6a50e59b30b10502535282d988e86c2b",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -122,6 +122,33 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
             }
         }
 
+        // L-009 (spec 058 §3.2): a heading that is a near miss for the defects
+        // anchor. Info tier, the tier this corpus reserves for a nudge on
+        // otherwise valid prose (`L-005` is the other): it surfaces under
+        // `--fail-on-info`, which no gate here runs, so a corpus is told
+        // without being refused.
+        //
+        // The anchor comes from `sections::anchor_of`, the indexer's own slug
+        // rule, so the lint cannot disagree with what a section unit would
+        // resolve to. Quoting a heading and meaning an anchor is the defect
+        // this spec closes; carrying a second slug rule would reopen it.
+        for heading in &spec.section_headings {
+            let anchor = crate::sections::anchor_of(heading);
+            if crate::sections::is_near_miss_defects_anchor(&anchor) {
+                violations.push(info(
+                    "L-009",
+                    format!(
+                        "spec '{}' has heading '{heading}' (anchor '{anchor}'), which is \
+                         not the defects anchor: a consumer looking for '{}' will not \
+                         find this section",
+                        spec.id,
+                        crate::sections::DEFECTS_ANCHOR
+                    ),
+                    at(),
+                ));
+            }
+        }
+
         // L-005: stub (no body sections).
         if spec.section_headings.is_empty() {
             violations.push(info(

--- a/crates/spec-spine-core/src/sections.rs
+++ b/crates/spec-spine-core/src/sections.rs
@@ -115,6 +115,53 @@ fn markdown_sections(content: &str) -> Vec<(String, LineSpan)> {
 
 /// Kebab-case slug of a heading: lowercase, alnum kept, runs of other chars
 /// collapse to a single `-`, trimmed.
+/// The anchor the indexer computes for a heading (spec 058 §3.1 names this as
+/// the rule the defects heading is judged by).
+///
+/// Public so the lint asks the indexer's own question rather than carrying a
+/// second copy of the slug rule. A governance document that names an anchor and
+/// a consumer that matches a string is exactly the mismatch spec 058 exists to
+/// close, and two slug implementations would reopen it from the other side.
+pub fn anchor_of(heading_text: &str) -> String {
+    slug(heading_text)
+}
+
+/// The defects-section anchor, and the suffix rule §3.1 states.
+pub const DEFECTS_ANCHOR: &str = "known-defects";
+
+/// True when a heading's anchor names a defects section: exactly the anchor, or
+/// ending `-known-defects` so section numbering and prefixing work.
+///
+/// Suffix, not prefix or substring. A prefix rule would accept
+/// `## Known defects and open questions`, whose section is about something
+/// wider and from which a consumer would extract the open questions too. A
+/// substring rule would additionally accept `## Why known defects matter`.
+pub fn is_defects_anchor(anchor: &str) -> bool {
+    anchor == DEFECTS_ANCHOR || anchor.ends_with(&format!("-{DEFECTS_ANCHOR}"))
+}
+
+/// True when an anchor reads as an *attempt* at the defects section that
+/// [`is_defects_anchor`] will not match: the `L-009` near-miss (spec 058 §3.2).
+///
+/// Two shapes, not "contains `defect`". A heading whose anchor **ends** with
+/// `defect`/`defects` is a section named for defects that got the spelling
+/// wrong (`## Known defect`, `## Defects`). A heading **containing**
+/// `known-defect` got the name right and then kept going
+/// (`## Known defects and open questions`), which §3.1 deliberately refuses.
+///
+/// The looser "contains `defect`" this narrows was the draft's wording, and it
+/// fires on this spec's own title (`# 058: The defects heading has one
+/// spelling`), which is prose about defects rather than an attempt at one.
+pub fn is_near_miss_defects_anchor(anchor: &str) -> bool {
+    if is_defects_anchor(anchor) {
+        return false;
+    }
+    anchor.ends_with("defect")
+        || anchor.ends_with("defects")
+        || anchor.contains(&format!("{DEFECTS_ANCHOR}-"))
+        || anchor.contains("known-defect-")
+}
+
 fn slug(text: &str) -> String {
     let mut s = String::new();
     let mut prev_dash = false;

--- a/crates/spec-spine-core/tests/lint.rs
+++ b/crates/spec-spine-core/tests/lint.rs
@@ -410,3 +410,129 @@ fn witnessed_paths_covers_every_hash_contributor() {
     assert!(witnessed.contains("spec-spine.toml"), "{witnessed:?}");
     assert!(witnessed.contains("extra.txt"), "{witnessed:?}");
 }
+
+// ── spec 058: the defects heading has one spelling ────────────────────────
+
+use spec_spine_core::sections::{anchor_of, is_defects_anchor, is_near_miss_defects_anchor};
+
+/// §3.1: the heading is an anchor, not a string. Case, level and section
+/// numbering all come free from the indexer's own slug rule, which is why the
+/// rule is that rule rather than a second copy of it.
+#[test]
+fn the_defects_heading_is_matched_by_anchor_at_any_level_or_numbering() {
+    for heading in [
+        "Known defects",
+        "Known Defects",
+        "KNOWN DEFECTS",
+        "Known defects:",
+        "5. Known defects",
+        "4. Known defects",
+    ] {
+        assert!(
+            is_defects_anchor(&anchor_of(heading)),
+            "'{heading}' -> '{}' should be the defects anchor",
+            anchor_of(heading)
+        );
+    }
+}
+
+/// §3.1: suffix, not prefix or substring. A heading that continues past the
+/// anchor is a section about something wider, and a consumer extracting defects
+/// from it would extract the open questions too.
+#[test]
+fn a_heading_that_continues_past_the_anchor_is_not_the_section() {
+    for heading in [
+        "Known defects and open questions",
+        "Known defect",
+        "Defects",
+        "Why known defects matter",
+    ] {
+        assert!(
+            !is_defects_anchor(&anchor_of(heading)),
+            "'{heading}' must not be the defects anchor"
+        );
+    }
+}
+
+/// §3.2: the near-miss rule catches an attempt at the section, and not prose
+/// that merely mentions defects. This spec's own title is the case that
+/// narrowed the rule: `# 058: The defects heading has one spelling` is about
+/// defects and is not an attempt at a defects section.
+#[test]
+fn the_near_miss_rule_catches_attempts_and_not_prose() {
+    for heading in [
+        "Known defect",
+        "Defects",
+        "Known defects and open questions",
+    ] {
+        assert!(
+            is_near_miss_defects_anchor(&anchor_of(heading)),
+            "'{heading}' is an attempt that a consumer will not find"
+        );
+    }
+    for heading in [
+        "058: The defects heading has one spelling",
+        "Known defects",
+        "5. Known defects",
+        "Purpose",
+    ] {
+        assert!(
+            !is_near_miss_defects_anchor(&anchor_of(heading)),
+            "'{heading}' must not be reported"
+        );
+    }
+}
+
+/// §3.2: `L-009` is info tier, so it surfaces under `--fail-on-info` and
+/// refuses nothing at the tier this repository gates on.
+#[test]
+fn l009_is_info_tier_and_names_the_anchor() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        "---\nid: \"001-x\"\ntitle: \"x\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"x\"\nestablishes:\n  - \"src/x.rs\"\n---\n# x\n\n## Known defect\n\nprose\n",
+    );
+    let report = spec_spine_core::lint(&Config::default(), tmp.path()).unwrap();
+    let found: Vec<_> = report
+        .violations
+        .iter()
+        .filter(|v| v.code == "L-009")
+        .collect();
+    assert_eq!(found.len(), 1, "{:?}", report.violations);
+    assert_eq!(found[0].severity, Severity::Info);
+    assert!(
+        found[0].message.contains("known-defect"),
+        "{}",
+        found[0].message
+    );
+    assert!(
+        found[0].message.contains("known-defects"),
+        "{}",
+        found[0].message
+    );
+    assert_eq!(found[0].path.as_deref(), Some("specs/001-x/spec.md"));
+}
+
+/// §3.3: `origin.retroactive: true` does not imply the heading. The
+/// counterexample is in this corpus: spec 000 declares it and rightly has no
+/// defects section, so a lint implementing the audit's proposal would fire on
+/// the tier-1 bootstrap spec, which is both wrong and unfixable.
+#[test]
+fn retroactive_origin_alone_produces_no_diagnostic() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "specs/001-x/spec.md",
+        "---\nid: \"001-x\"\ntitle: \"x\"\nstatus: draft\ncreated: \"2026-09-07\"\n\
+         summary: \"x\"\nestablishes:\n  - \"src/x.rs\"\norigin:\n  retroactive: true\n\
+         ---\n# x\n\n## Purpose\n\nprose\n",
+    );
+    let report = spec_spine_core::lint(&Config::default(), tmp.path()).unwrap();
+    assert!(
+        !report.violations.iter().any(|v| v.code == "L-009"),
+        "{:?}",
+        report.violations
+    );
+}

--- a/specs/058-retroactive-adoption-shape/spec.md
+++ b/specs/058-retroactive-adoption-shape/spec.md
@@ -4,7 +4,7 @@ title: "The defects heading has one spelling"
 status: draft
 kind: "governance"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -13,6 +13,9 @@ depends_on:
   - "043-governance-document-gaps"
 extends:
   - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
+  # The anchor rule itself, beside the slug it is asked of (3.1).
+  - { spec: "022-keypath-section-anchors", unit: "crates/spec-spine-core/src/sections.rs", nature: additive }
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/tests/lint.rs", nature: additive }
 refines:
   # 043 refined this principle with the aspect `adopted-code-as-evidence`,
   # adding the heading. This spec refines a different aspect of the same
@@ -136,6 +139,23 @@ prose, and info is the tier this corpus reserves for exactly that (`L-005`, the
 stub check). It surfaces under `--fail-on-info`, which no gate here runs, so a
 corpus is told without being refused.
 
+**Decision, 2026-09-07: "contains `defect`" was too loose, and this spec's own
+title proved it.** The first implementation followed the sentence above
+literally and immediately reported
+`# 058: The defects heading has one spelling`, whose anchor contains `defect`
+and which is prose about defects rather than an attempt at a defects section.
+
+The rule is narrowed to the two shapes that are attempts. An anchor **ending**
+`defect` or `defects` is a section named for defects that got the spelling
+wrong (`## Known defect`, `## Defects`). An anchor **containing**
+`known-defects-` got the name right and kept going
+(`## Known defects and open questions`), which §3.1 refuses for its own reason.
+Both of §3.2's motivating cases survive; the title does not match either shape.
+
+That a spec's title can trip its own lint is worth the two lines it costs to
+record: the near-miss check reads every heading in a `spec.md`, and a spec whose
+subject is a heading will always have that subject in its title.
+
 The check reads `section_headings`, which `SpecRecord` already carries and
 `compile` already populates. No new parsing, no new field, no new IO.
 
@@ -192,18 +212,24 @@ in the audit's §5. This spec gives it the rule to implement.
 
 ## 5. Verification
 
+`L-009` and the constitution's anchor sentence both fail against pre-058 state:
+the code did not exist and §V quoted a heading.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test lint --locked
-# The constitution states the anchor rule rather than quoting a heading.
+# 3.1: the constitution states the anchor rule rather than quoting a heading.
 grep -q 'known-defects' standards/spec/constitution.md
-# A near-miss heading is reported at info tier, and only under --fail-on-info.
-tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" \
-  && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n\n## Known defect\n\nprose\n' > "$tmp/specs/001-x/spec.md" \
-  && target/release/spec-spine --repo "$tmp" lint | grep -q 'L-009'
-# The corpus stays green at the tier CI gates on, and the shards were committed.
-target/release/spec-spine lint --fail-on-warn
+grep -q 'identified by its \*\*anchor\*\*' standards/spec/constitution.md
+# 3.2: a near-miss heading is reported, at info tier.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n\n## Known defect\n\nprose\n' > "$tmp/specs/001-x/spec.md" && target/release/spec-spine --repo "$tmp" lint | grep -q 'L-009'
+# 3.2: and only under --fail-on-info. Without it the same corpus exits 0.
+tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n\n## Known defect\n\nprose\n' > "$tmp/specs/001-x/spec.md" && target/release/spec-spine --repo "$tmp" lint --fail-on-warn
+# 3.2: this corpus is clean at info tier, which is the assertion the narrowed
+# rule earns: before it, this spec's own title was reported.
+target/release/spec-spine lint --fail-on-info
+# The shards were committed.
 target/release/spec-spine compile --check
 target/release/spec-spine index check
 ```

--- a/standards/spec/constitution.md
+++ b/standards/spec/constitution.md
@@ -62,12 +62,22 @@ rather than blowing away its history.
 
 Code adopted from outside the corpus is specced **as found**. The adopting spec
 describes the behavior that exists, and records the behavior it would not have
-chosen under a `## Known defects` heading, with the defect named. A defect
-recorded under that heading is not thereby blessed: it is the reason a later spec
-can be written against it. Without that heading an adopting spec has only bad
-options, since describing the code accurately would ratify its defects as the
-specified behavior. `origin.retroactive: true` says *when* the authority began;
-`## Known defects` says what the adopting spec makes of what it found.
+chosen under a defects heading, with the defect named. A defect recorded under
+that heading is not thereby blessed: it is the reason a later spec can be
+written against it. Without that heading an adopting spec has only bad options,
+since describing the code accurately would ratify its defects as the specified
+behavior. `origin.retroactive: true` says *when* the authority began; the
+defects heading says what the adopting spec makes of what it found.
+
+The heading is identified by its **anchor**, not by its text: any heading whose
+computed slug is `known-defects` or ends with `-known-defects`, at any level.
+That is the slug the indexer computes for a section unit, so `## Known defects`,
+`### Known Defects` and `## 5. Known defects` all name the section, while
+`## Known defects and open questions` does not: a section that continues past
+the anchor is about something wider, and a consumer extracting defects from it
+would extract the open questions too. Stated as a rule rather than quoted as a
+string because the first consumer to check mechanically matched the string and
+therefore rejected the numbered headings of the specs it cited as precedent.
 
 ---
 


### PR DESCRIPTION
Implements spec 058 (adopter-audit backlog item 10).

## What changed

Constitution V required adopted code's unwanted behavior under a
`## Known defects` heading and never said what counts as that heading. The first
consumer to check mechanically got it wrong: claude-observatory's `defects.ts`
matches the string exactly and therefore rejects the numbered headings of the
very specs it cites as precedent.

**The spelling is an anchor, not a string.** Any heading whose computed slug is
`known-defects` or ends with `-known-defects`, at any level, under the slug rule
the indexer already uses for section units. Case-insensitivity, heading level,
section numbering and punctuation tolerance all come free from that rule — asked
of it, not reimplemented, because quoting a heading and meaning an anchor is the
defect and a second slug implementation would reopen it from the other side.

**Suffix, not prefix or substring.** `## Known defects and open questions` is
not the section: a heading that continues past the anchor is about something
wider, and a consumer extracting defects from it would extract the open
questions too.

**Constitution V now states the rule**, via a `refines` claim with the aspect
`defects-heading-anchor` on the same section spec 043 refined under
`adopted-code-as-evidence`. Second use of the mechanism 043 defined.

**`L-009`** reports a near miss at info tier — the tier this corpus reserves for
a nudge on otherwise valid prose (`L-005` is the other). No gate here runs
`--fail-on-info`.

**No lint makes `origin.retroactive: true` imply the heading.** The audit
proposed one; spec 043 already settled that the two are orthogonal, and the
counterexample is in this corpus — spec 000 declares it and rightly carries no
defects section, so such a lint would fire on the tier-1 bootstrap spec, where
it is both wrong and *unfixable* (000's `unamendable` anchors are
non-overridable).

## One decision recorded in the spec

**§3.2: "contains `defect`" was too loose, and this spec's own title proved it.**
The first implementation followed the draft literally and immediately reported
`# 058: The defects heading has one spelling` — prose about defects, not an
attempt at a defects section.

Narrowed to the two shapes that *are* attempts: an anchor **ending** `defect` or
`defects` (a section named for defects that got the spelling wrong), or
**containing** `known-defects-` (got the name right and kept going). Both of
§3.2's motivating cases survive; the title matches neither. Worth recording
because the check reads every heading in a `spec.md`, so a spec whose subject is
a heading will always have that subject in its title.

## Verification

`spec-spine verify 058` passes, 9 commands — including `lint --fail-on-info`
clean on this corpus, which is the assertion the narrowed rule earns. Full gate
green: 69 shards fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74
coverage, `couple` clean over 5 paths. Workspace tests, clippy `-D warnings`,
`fmt --check` pass. No waiver.