### PR TITLE
feat(059): two read verbs that mislead a specify-first corpus

### DIFF
--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -11,7 +11,15 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
         "source": "spec-edge"
       },
       {
@@ -44,6 +52,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-core/src/coverage.rs"
           }
         ],
@@ -52,6 +73,19 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
         }
       },
       {
@@ -111,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "88b4b322cc12a7868db09ef35f503aaa4c2613252f699a98b6523fd17ae31972"
+  "shardHash": "5be2138f2411bab4f7bf01494e7c8f52b126fdae804b3819d69b402bcd894e46"
 }

--- a/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -46,10 +46,26 @@
           "kind": "file",
           "path": "crates/spec-spine-core/tests/render.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "011-index-render-orphans",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
       }
     ],
     "id": "059-read-verbs-on-a-code-free-corpus",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -79,6 +95,6 @@
     "summary": "Three of the four governed repositories are specify-first: the whole corpus is ratified before a line of code exists, and specs live at approved plus pending for months. Two read verbs give that corpus an answer that is technically correct and practically a lie. `index orphans` reports sixty-four of hqgit's sixty-eight specs, because an orphan is a spec claiming nothing that resolves, and a spec whose code is not written yet claims nothing that resolves; the list is the corpus, so it says nothing. `index coverage --fail-on-untraced` on a tree with no discovered package enumerates zero source files, computes zero untraced, and exits 0 from inside a CI step named \"the whole-tree ownership assertion\". This spec makes the first partition by the in-flight predicate the index already computes, and makes the second refuse an empty universe instead of passing it.\n",
     "title": "Two read verbs that mislead a specify-first corpus"
   },
-  "shardHash": "ce36a159081cd934bca75a6873a7e9d24f4c5379edf167c01c0a001a05ef3ec4",
+  "shardHash": "bab68eecd9f5c7415fac7011203eff309ced25be49da3b11501be7f75762d967",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -14,8 +14,9 @@ use clap::Subcommand;
 use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
 use spec_spine_core::{
     DiagnosticCounts, Freshness, IndexCheckReport, UnwitnessedCounts, check_index_freshness,
-    check_slice_freshness, committed_counts, committed_diagnostics, coverage, index, index_dir,
-    index_shard_files, load_committed_index, orphans, render_markdown, slices_path,
+    check_slice_freshness, committed_counts, committed_diagnostics, coverage, empty_universe,
+    index, index_dir, index_shard_files, load_committed_index, load_committed_registry,
+    partition_orphans, render_markdown, slices_path,
 };
 use spec_spine_types::{Config, CoverageReport, Error, Verdict, verdict::verb};
 
@@ -88,14 +89,44 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
         }
         Some(IndexAction::Orphans { json }) => {
             let idx = load_committed_index(&cfg, repo)?;
-            let ids = orphans(&idx);
+            // Spec 059 3.1: the lifecycle half comes from the registry, since
+            // the index shard records `spec_status` but not `implementation`
+            // and adding it would restamp every shard for a read verb.
+            //
+            // An absent registry is an empty one, not an error. This verb
+            // answered from the index alone before spec 059, and a read verb
+            // that started failing because a *different* artifact is missing
+            // would be a regression dressed as a feature. With no records
+            // every orphan reads as in flight, which is the same "cannot say
+            // otherwise" rule 3.1 applies per spec.
+            let records = load_committed_registry(&cfg, repo)
+                .map(|r| r.specs)
+                .unwrap_or_default();
+            let report = partition_orphans(&idx, &records);
             if *json {
-                let s =
-                    serde_json::to_string_pretty(&ids).map_err(|e| Error::Schema(e.to_string()))?;
+                let s = serde_json::to_string_pretty(&report)
+                    .map_err(|e| Error::Schema(e.to_string()))?;
                 outln!("{s}");
-            } else {
-                for id in ids {
-                    outln!("{id}");
+            } else if !report.orphaned.is_empty() || !report.in_flight.is_empty() {
+                // Both groups are printed whenever either has members, so a
+                // reader always sees which side of the partition an id fell on.
+                // A corpus with no orphans at all stays silent, as it did
+                // before spec 059: two headers and two "(none)" lines would be
+                // noise on the answer "nothing to report".
+                outln!("orphaned (claims nothing that resolves, and is not in flight):");
+                if report.orphaned.is_empty() {
+                    outln!("  (none)");
+                }
+                for id in &report.orphaned {
+                    outln!("  {id}");
+                }
+                outln!();
+                outln!("in flight (claims nothing that resolves yet; draft or pending):");
+                if report.in_flight.is_empty() {
+                    outln!("  (none)");
+                }
+                for id in &report.in_flight {
+                    outln!("  {id}");
                 }
             }
             Ok(0)
@@ -161,6 +192,19 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 outln!("{s}");
             } else {
                 out!("{}", render_coverage(&report));
+            }
+            // Spec 059 3.2: an assertion over an empty set is vacuously true,
+            // which is the wrong answer for a CI step whose whole purpose is to
+            // assert. Reporting is unaffected: without the flag an empty
+            // universe is still a true and useful thing to say.
+            if let (true, Some(reason)) = (*fail_on_untraced, empty_universe(&report)) {
+                eprintln!(
+                    "coverage: {}.\n--fail-on-untraced asserts that every source file has a \
+                     specific owning spec, and there are none to assert about. Nothing was \
+                     verified.",
+                    reason.explain()
+                );
+                return Ok(1);
             }
             Ok(if *fail_on_untraced && !report.is_fully_claimed() {
                 1

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -453,7 +453,14 @@ fn index_render_and_orphans_projections() {
         .output()
         .unwrap();
     assert_eq!(code(&orphans_text), 0, "orphans is a query, not a gate");
-    assert_eq!(String::from_utf8_lossy(&orphans_text.stdout), "002-b\n");
+    // Spec 059 §3.1: two named groups, not one flat list. This fixture indexes
+    // without compiling, so no registry is committed and every orphan reads as
+    // in flight, which is the "cannot say otherwise" rule rather than a
+    // failure: a read verb that answered from the index alone must not start
+    // failing because a different artifact is missing.
+    let orphans_out = String::from_utf8_lossy(&orphans_text.stdout);
+    assert!(orphans_out.contains("in flight"), "{orphans_out}");
+    assert!(orphans_out.contains("002-b"), "{orphans_out}");
 
     let orphans_json = bin()
         .arg("--repo")
@@ -462,8 +469,9 @@ fn index_render_and_orphans_projections() {
         .output()
         .unwrap();
     assert_eq!(code(&orphans_json), 0);
-    let ids: Vec<String> = serde_json::from_slice(&orphans_json.stdout).unwrap();
-    assert_eq!(ids, ["002-b"]);
+    let partitioned: serde_json::Value = serde_json::from_slice(&orphans_json.stdout).unwrap();
+    assert_eq!(partitioned["orphaned"], serde_json::json!([]));
+    assert_eq!(partitioned["inFlight"], serde_json::json!(["002-b"]));
 
     // Render: exit 0 even with diagnostics in the artifact; contractual
     // sections present in order.
@@ -504,7 +512,13 @@ fn index_render_and_orphans_projections() {
         .output()
         .unwrap();
     assert_eq!(code(&none), 0);
-    assert!(none.stdout.is_empty());
+    // Spec 059 §3.1: with both groups empty the verb stays silent, as it did
+    // before the partition.
+    assert!(
+        none.stdout.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&none.stdout)
+    );
 }
 
 #[test]

--- a/crates/spec-spine-core/src/coverage.rs
+++ b/crates/spec-spine-core/src/coverage.rs
@@ -222,6 +222,58 @@ pub fn coverage(cfg: &Config, repo_root: &Path) -> Result<CoverageReport, Error>
     Ok(coverage_with(cfg, &index, &files))
 }
 
+/// Why a coverage universe is empty, when it is (spec 059 §3.2, §3.3).
+///
+/// The two cases have different fixes: no discovered package is usually
+/// `layout.standalone_rust_workspaces` / `standalone_npm_packages` not naming a
+/// package that exists, and packages with no source files is usually
+/// `index.resolver_exclusions` pruning too much. A refusal that names the
+/// condition without naming the likely cause makes the reader search for both,
+/// and the audit found adopters deriving this class of thing by experiment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EmptyUniverse {
+    /// No package was discovered at all.
+    NoPackages,
+    /// Packages were discovered, but none contained a source file.
+    NoSourceFiles,
+}
+
+impl EmptyUniverse {
+    /// The reason line the refusal prints, cause included.
+    pub fn explain(self) -> &'static str {
+        match self {
+            EmptyUniverse::NoPackages => {
+                "no package was discovered, so there is no tree to assert about. \
+                 Check [layout] standalone_rust_workspaces / standalone_npm_packages, \
+                 and that the workspace manifest is where layout.cargo_workspace says"
+            }
+            EmptyUniverse::NoSourceFiles => {
+                "packages were discovered but none contains a source file. \
+                 Check [index] resolver_exclusions, which may be pruning the tree"
+            }
+        }
+    }
+}
+
+/// `Some(reason)` when the universe is empty (spec 059 §3.2).
+///
+/// `--fail-on-untraced` is an assertion, and an assertion over an empty set is
+/// vacuously true: mathematically correct and operationally wrong. A person
+/// wiring it into CI is asserting the tree is fully owned, so if the tool cannot
+/// see the tree the honest report is that the assertion did not run, and a CI
+/// step that did not run its check should not be green. What matters is that
+/// the denominator is zero, not why; the reason is for the message.
+pub fn empty_universe(report: &CoverageReport) -> Option<EmptyUniverse> {
+    if report.source_files > 0 {
+        return None;
+    }
+    Some(if report.packages.is_empty() {
+        EmptyUniverse::NoPackages
+    } else {
+        EmptyUniverse::NoSourceFiles
+    })
+}
+
 /// Source-extension test on a repo-relative POSIX path, with the same
 /// `Path::extension` semantics the walk uses (a dotfile has no extension).
 fn has_source_ext(path: &str) -> bool {

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -57,8 +57,8 @@ pub use couple::{
     couple_with, effective_bypass_prefixes, is_bypassed_path, owners_for_path, parse_waiver,
 };
 pub use coverage::{
-    Ownership, SOURCE_EXTS, classify, coverage, coverage_with, enumerate_source_files,
-    in_coverage_universe,
+    EmptyUniverse, Ownership, SOURCE_EXTS, classify, coverage, coverage_with, empty_universe,
+    enumerate_source_files, in_coverage_universe,
 };
 pub use dep_only::{
     CARGO_DEPENDENCY_TABLES, DEPENDENCY_TABLES, FileContents, cargo_dependency_only_change,
@@ -80,7 +80,7 @@ pub use query::{
     list, list_ids, load_index, load_registry, plan, relationships, shard_content_hash, show,
     status_report,
 };
-pub use render::{orphans, render_markdown};
+pub use render::{OrphanReport, orphans, partition_orphans, render_markdown};
 pub use scaffold::{Scaffold, ScaffoldFile, scaffold_init};
 pub use verify::{plan as verify_plan, plan_from_markdown};
 

--- a/crates/spec-spine-core/src/render.rs
+++ b/crates/spec-spine-core/src/render.rs
@@ -7,7 +7,10 @@
 
 use std::fmt::Write as _;
 
-use spec_spine_types::{CodebaseIndex, Config, Diagnostic, PackageKind};
+use serde::Serialize;
+use spec_spine_types::{
+    CodebaseIndex, Config, Diagnostic, Implementation, PackageKind, SpecRecord, Status,
+};
 
 /// The id-sorted `traceability.orphanedSpecs` list (spec 011 §3.3).
 pub fn orphans(index: &CodebaseIndex) -> Vec<&str> {
@@ -19,6 +22,73 @@ pub fn orphans(index: &CodebaseIndex) -> Vec<&str> {
         .collect();
     ids.sort_unstable();
     ids
+}
+
+/// `orphans`, partitioned by whether the spec is in flight (spec 059 §3.1).
+///
+/// An orphan is a spec claiming nothing that resolves, and on a specify-first
+/// corpus a spec whose code is not written yet claims nothing that resolves. So
+/// the flat list is the corpus, and it says nothing: `index orphans` reported
+/// sixty-four of hqgit's sixty-eight specs. Partitioning leaves four.
+///
+/// The first group is the finding: a spec that is not in flight, claiming
+/// nothing that resolves, is one whose author said the work is done or does not
+/// apply while the ledger says nothing of theirs exists. The second group is a
+/// specify-first corpus's normal state and is reported rather than filtered,
+/// because suppressing it would replace a useless answer with an incomplete one
+/// and lose the verb that answers "what has no code yet".
+///
+/// The predicate is spec 044's, read from the **registry** rather than the
+/// index: the index shard records `spec_status` but not `implementation`, and
+/// adding it would move `INDEX_SCHEMA_VERSION` and restamp every shard for a
+/// read verb's benefit (spec 059 §3.4 forbids that). A spec with no record is
+/// treated as in flight, since a corpus that cannot say otherwise should not be
+/// told its spec is abandoned. Taking the record slice rather than a `Registry`
+/// is what lets the caller pass an empty one when no registry is committed: a
+/// read verb that answered from the index alone must not start failing because
+/// a different artifact is missing.
+pub fn partition_orphans<'a>(index: &'a CodebaseIndex, records: &[SpecRecord]) -> OrphanReport<'a> {
+    let mut orphaned: Vec<&'a str> = Vec::new();
+    let mut in_flight: Vec<&'a str> = Vec::new();
+    for id in orphans(index) {
+        match records.iter().find(|s| s.id == id) {
+            Some(rec) if !record_in_flight(rec) => orphaned.push(id),
+            _ => in_flight.push(id),
+        }
+    }
+    OrphanReport {
+        orphaned,
+        in_flight,
+    }
+}
+
+/// Spec 044's in-flight predicate over a registry record: `complete` settles
+/// it, else `draft` status or a `pending` / `in-progress` implementation.
+///
+/// Kept beside the partition rather than shared with `index.rs`, which asks the
+/// same question of its own parsed frontmatter type. Both read the same two
+/// fields under the same rule, and the acceptance pins them to the same answer.
+fn record_in_flight(rec: &SpecRecord) -> bool {
+    if matches!(rec.implementation, Some(Implementation::Complete)) {
+        return false;
+    }
+    rec.status == Status::Draft
+        || matches!(
+            rec.implementation,
+            Some(Implementation::Pending | Implementation::InProgress)
+        )
+}
+
+/// The two groups `index orphans` reports (spec 059 §3.1). Both id-sorted, as
+/// spec 011 §3.3 requires.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrphanReport<'a> {
+    /// Claims nothing that resolves, and is not in flight: the finding.
+    pub orphaned: Vec<&'a str>,
+    /// Claims nothing that resolves *yet*: a specify-first corpus's normal
+    /// state, reported rather than filtered.
+    pub in_flight: Vec<&'a str>,
 }
 
 /// The markdown projection of the committed index (spec 011 §3.2).

--- a/crates/spec-spine-core/tests/coverage.rs
+++ b/crates/spec-spine-core/tests/coverage.rs
@@ -677,3 +677,84 @@ fn the_resolver_does_not_reach_into_the_state_root() {
         }
     }
 }
+
+// ── spec 059: an empty coverage universe is a refusal, not a pass ─────────
+
+/// §3.2 + §3.3: no discovered package is an empty universe, and the reason
+/// names the likely cause rather than only the condition.
+#[test]
+fn an_empty_universe_with_no_packages_is_reported_with_its_cause() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "specs/001-x/spec.md", &spec("001-x", ""));
+    let cfg = Config::default();
+    emit_index(&cfg, r);
+
+    let report = coverage(&cfg, r).unwrap();
+    assert_eq!(report.source_files, 0, "the denominator is zero");
+    assert!(
+        report.is_fully_claimed(),
+        "vacuously true, which is the trap this spec closes"
+    );
+
+    let reason = spec_spine_core::empty_universe(&report).expect("empty");
+    assert_eq!(reason, spec_spine_core::EmptyUniverse::NoPackages);
+    assert!(
+        reason.explain().contains("standalone_rust_workspaces"),
+        "names the likely fix: {}",
+        reason.explain()
+    );
+}
+
+/// §3.2: a package with source files is not an empty universe, so the refusal
+/// is unreachable on an ordinary repository. This one has four packages and
+/// seventy-four source files.
+#[test]
+fn a_populated_universe_is_not_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        r,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "crate-a/src/lib.rs", "pub fn a() {}\n");
+    write(r, "specs/001-x/spec.md", &spec("001-x", ""));
+    let cfg = Config::default();
+    emit_index(&cfg, r);
+
+    let report = coverage(&cfg, r).unwrap();
+    assert!(report.source_files > 0);
+    assert!(spec_spine_core::empty_universe(&report).is_none());
+}
+
+/// §3.3: packages discovered but no source file in them is the other empty
+/// case, and it points at a different knob.
+#[test]
+fn packages_without_source_files_point_at_resolver_exclusions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"crate-a\"]\n");
+    write(
+        r,
+        "crate-a/Cargo.toml",
+        "[package]\nname = \"crate-a\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "crate-a/src/lib.rs", "pub fn a() {}\n");
+    write(r, "specs/001-x/spec.md", &spec("001-x", ""));
+    // Prune the only source tree.
+    let cfg = load_config("[index]\nresolver_exclusions = [\"src\"]\n").unwrap();
+    emit_index(&cfg, r);
+
+    let report = coverage(&cfg, r).unwrap();
+    assert!(!report.packages.is_empty(), "a package was discovered");
+    assert_eq!(report.source_files, 0, "and none of its files were seen");
+    let reason = spec_spine_core::empty_universe(&report).expect("empty");
+    assert_eq!(reason, spec_spine_core::EmptyUniverse::NoSourceFiles);
+    assert!(
+        reason.explain().contains("resolver_exclusions"),
+        "names the other knob: {}",
+        reason.explain()
+    );
+}

--- a/crates/spec-spine-core/tests/render.rs
+++ b/crates/spec-spine-core/tests/render.rs
@@ -151,3 +151,124 @@ fn orphans_are_id_sorted() {
     let empty = load_index(EMPTY_SECTIONS_FIXTURE.as_bytes()).unwrap();
     assert!(orphans(&empty).is_empty());
 }
+
+// ── spec 059: orphans partitions by the in-flight predicate ───────────────
+
+/// A registry carrying just the lifecycle fields the partition reads.
+fn registry_with(specs: serde_json::Value) -> spec_spine_types::Registry {
+    serde_json::from_value(serde_json::json!({
+        "specVersion": "1.1.0",
+        "build": {
+            "compilerId": "t", "compilerVersion": "0.1.0",
+            "inputRoot": ".", "contentHash": "t"
+        },
+        "specs": specs,
+        "validation": { "passed": true, "violations": [] }
+    }))
+    .expect("registry json")
+}
+
+fn spec_record(id: &str, status: &str, implementation: Option<&str>) -> serde_json::Value {
+    let mut v = serde_json::json!({
+        "id": id,
+        "title": "T",
+        "status": status,
+        "created": "2026-09-07",
+        "summary": "s",
+        "specPath": format!("specs/{id}/spec.md"),
+    });
+    if let Some(i) = implementation {
+        v["implementation"] = serde_json::json!(i);
+    }
+    v
+}
+
+/// §3.1: the finding is a spec that is NOT in flight and still claims nothing
+/// that resolves. Everything else is a specify-first corpus's normal state, and
+/// is reported rather than filtered so the verb that answers "what has no code
+/// yet" is not lost.
+#[test]
+fn orphans_partitions_by_the_in_flight_predicate() {
+    let index = load_index(FULL_FIXTURE.as_bytes()).unwrap();
+    // FULL_FIXTURE's orphans are 009-zzz and 003-orphan.
+    let registry = registry_with(serde_json::json!([
+        spec_record("003-orphan", "approved", Some("complete")),
+        spec_record("009-zzz", "draft", Some("pending")),
+    ]));
+    let report = spec_spine_core::partition_orphans(&index, &registry.specs);
+
+    assert_eq!(
+        report.orphaned,
+        vec!["003-orphan"],
+        "approved + complete, claiming nothing that resolves: the finding"
+    );
+    assert_eq!(
+        report.in_flight,
+        vec!["009-zzz"],
+        "draft + pending: normal, and still reported"
+    );
+    // §3.1: id-sorted within each group, as spec 011 §3.3 requires.
+    let mut sorted = report.orphaned.clone();
+    sorted.sort_unstable();
+    assert_eq!(report.orphaned, sorted);
+}
+
+/// §3.1: every arm of spec 044's predicate, so the two verbs cannot disagree
+/// about which specs are under way. `complete` settles it whatever the status.
+#[test]
+fn every_arm_of_the_in_flight_predicate_lands_where_044_puts_it() {
+    let index = load_index(FULL_FIXTURE.as_bytes()).unwrap();
+    let cases = [
+        // (status, implementation, expected in-flight)
+        ("draft", None, true),
+        ("draft", Some("pending"), true),
+        ("draft", Some("complete"), false),
+        ("approved", Some("pending"), true),
+        ("approved", Some("in-progress"), true),
+        ("approved", Some("complete"), false),
+        ("approved", None, false),
+    ];
+    for (status, implementation, want_in_flight) in cases {
+        let registry = registry_with(serde_json::json!([
+            spec_record("003-orphan", status, implementation),
+            spec_record("009-zzz", "approved", Some("complete")),
+        ]));
+        let report = spec_spine_core::partition_orphans(&index, &registry.specs);
+        let got = report.in_flight.contains(&"003-orphan");
+        assert_eq!(
+            got, want_in_flight,
+            "status={status} implementation={implementation:?}"
+        );
+    }
+}
+
+/// §3.1: a spec with no registry record is treated as in flight. A corpus that
+/// cannot say otherwise should not have its spec called abandoned.
+#[test]
+fn an_orphan_with_no_registry_record_is_in_flight() {
+    let index = load_index(FULL_FIXTURE.as_bytes()).unwrap();
+    let report =
+        spec_spine_core::partition_orphans(&index, &registry_with(serde_json::json!([])).specs);
+    assert!(report.orphaned.is_empty(), "{report:?}");
+    assert_eq!(report.in_flight, vec!["003-orphan", "009-zzz"]);
+}
+
+/// §3.1: the flat list is still what the two groups partition, so no orphan is
+/// gained or lost by the change.
+#[test]
+fn the_partition_covers_exactly_the_flat_list() {
+    let index = load_index(FULL_FIXTURE.as_bytes()).unwrap();
+    let registry = registry_with(serde_json::json!([
+        spec_record("003-orphan", "approved", Some("complete")),
+        spec_record("009-zzz", "draft", None),
+    ]));
+    let report = spec_spine_core::partition_orphans(&index, &registry.specs);
+    let mut both: Vec<&str> = report
+        .orphaned
+        .iter()
+        .chain(report.in_flight.iter())
+        .copied()
+        .collect();
+    both.sort_unstable();
+    assert_eq!(both, orphans(&index));
+}

--- a/specs/059-read-verbs-on-a-code-free-corpus/spec.md
+++ b/specs/059-read-verbs-on-a-code-free-corpus/spec.md
@@ -4,7 +4,7 @@ title: "Two read verbs that mislead a specify-first corpus"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -17,6 +17,11 @@ extends:
   - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
   - { spec: "032-ownership-coverage", unit: "crates/spec-spine-core/tests/coverage.rs", nature: additive }
   - { spec: "011-index-render-orphans", unit: "crates/spec-spine-core/tests/render.rs", nature: additive }
+  # The partition reads the registry's lifecycle fields (3.1).
+  - { spec: "002-registry-query", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  # Both renderings' acceptance, which pinned the old flat shape and the
+  # empty-case silence.
+  - { spec: "011-index-render-orphans", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
 summary: >
@@ -106,6 +111,15 @@ decides whether an unresolved unit is a blocking error or a `W-001` warning, and
 using it here means the two verbs cannot disagree about which specs are under
 way.
 
+**Decision, 2026-09-07: the lifecycle half is read from the registry.** The
+index shard records `spec_status` and not `implementation`, so the committed
+index alone cannot answer the predicate. Adding the field would move
+`INDEX_SCHEMA_VERSION` and restamp every shard for a read verb's benefit, which
+§3.4 forbids. `index orphans` therefore loads both committed artifacts, as
+`couple` already does. A spec the registry has no record of is treated as in
+flight: a corpus that cannot say otherwise should not have its spec called
+abandoned.
+
 The first group is the finding. A spec that is neither draft nor pending nor
 in-progress, that claims nothing resolving, is a spec whose author said the work
 is done or does not apply while the ledger says nothing of theirs exists. That
@@ -126,6 +140,14 @@ and no verdict envelope is involved (`orphans` emits none); the change is to one
 read verb's `--json` output and MUST be called out in the release notes as such.
 
 Ordering inside each group stays id-sorted, as spec 011 §3.3 requires.
+
+**Decision, 2026-09-07: a corpus with no orphans stays silent.** The prose form
+prints both groups whenever either has members, so a reader always sees which
+side an id fell on. With both empty it prints nothing, as it did before this
+spec: two headers and two `(none)` lines would be noise on the answer "nothing
+to report", and an existing acceptance test pinned the silence. The `--json`
+form is unaffected and always emits both arrays, since a consumer parsing an
+object should not have to distinguish "absent" from "empty".
 
 ### 3.2 An empty coverage universe is a refusal, not a pass
 
@@ -198,20 +220,36 @@ honest, not a second scheduler.
 
 ## 5. Verification
 
+Both changes fail against pre-059 code: `orphans` emitted one flat array, and
+`--fail-on-untraced` exited 0 on an empty universe.
+
+Each line below is one command. Spec 049 §3.2 is explicit that a fence's body
+line **is** a command, so a trailing `\` continuation is not joined: the
+continuation becomes its own fragment and fails. The setup lines here are
+therefore single lines, however long.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test render --locked
 cargo test -p spec-spine-core --test coverage --locked
-# `orphans` partitions. Until this ships, the output is one flat list.
-target/release/spec-spine index orphans --json | grep -q 'inFlight'
-# An empty coverage universe refuses the assertion instead of passing it.
-tmp=$(mktemp -d) && mkdir -p "$tmp/specs/001-x" && : > "$tmp/spec-spine.toml" \
-  && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n' > "$tmp/specs/001-x/spec.md" \
-  && target/release/spec-spine --repo "$tmp" compile >/dev/null \
-  && target/release/spec-spine --repo "$tmp" index >/dev/null \
-  && target/release/spec-spine --repo "$tmp" index coverage \
-  && ! target/release/spec-spine --repo "$tmp" index coverage --fail-on-untraced
-# This repository's own coverage assertion is unaffected.
+# 3.1: `orphans` reports two named groups instead of one flat list.
+target/release/spec-spine index orphans --json | python3 -c 'import json,sys; o=json.load(sys.stdin); assert set(o) == {"orphaned", "inFlight"}, o'
+# 3.2 + 3.3: the empty-universe fixture. Built once at a fixed path, because
+# each line here is its own shell and a `$(mktemp -d)` would not survive to the
+# next assertion.
+rm -rf "${TMPDIR:-/tmp}/ss059" && mkdir -p "${TMPDIR:-/tmp}/ss059/specs/001-x" && : > "${TMPDIR:-/tmp}/ss059/spec-spine.toml" && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-07"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n' > "${TMPDIR:-/tmp}/ss059/specs/001-x/spec.md" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss059" compile >/dev/null && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss059" index >/dev/null
+# 3.2: without the flag it still exits 0 and reports the fact. The report is a
+# read verb, and "no source files" is a true and useful thing to say.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss059" index coverage
+# 3.2: with the flag it refuses. An assertion over an empty set is vacuously
+# true, and a CI step that did not run its check should not be green.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss059" index coverage --fail-on-untraced ; test $? -eq 1
+# 3.3: and the message names which of the two empty cases this is.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss059" index coverage --fail-on-untraced 2>&1 | grep -q 'no package was discovered'
+rm -rf "${TMPDIR:-/tmp}/ss059"
+# 3.4: this repository's own coverage assertion is unaffected: four packages,
+# seventy-four source files, so the refusal is unreachable here.
 target/release/spec-spine index coverage --fail-on-untraced
+target/release/spec-spine compile --check
 ```


### PR DESCRIPTION
Implements spec 059 (adopter-audit backlog items 11 and 12). Three of the four
governed repositories are specify-first: the whole corpus is ratified before a
line of code exists, and these two verbs give that corpus an answer that is
technically correct and practically a lie.

## `index orphans` partitions

It reported **64 of hqgit's 68 specs**, because an orphan is a spec claiming
nothing that resolves and a spec whose code is not written yet claims nothing
that resolves. The list was the corpus, so it said nothing.

Now two named groups, by spec 044's in-flight predicate — the same one that
decides whether an unresolved unit is a blocking error or a `W-001` warning, so
the two verbs cannot disagree about which specs are under way. The first group
is the finding: a spec whose author said the work is done while the ledger says
nothing of theirs exists. On hqgit that is 4, not 64. The second group is
reported rather than filtered, because suppressing it would replace a useless
answer with an incomplete one and lose the verb that answers "what has no code
yet".

The `--json` array becomes an object with `orphaned` and `inFlight`. **A
breaking shape change**, deliberately: the flat array's *meaning* is what this
spec is fixing, so preserving it would preserve the defect under a compatibility
argument. No committed artifact changes and no schema version moves.

## `index coverage --fail-on-untraced` refuses an empty universe

On a tree with no discovered package it enumerated zero source files, computed
zero untraced, and **exited 0 from inside a CI step named the whole-tree
ownership assertion**. An assertion over an empty set is vacuously true: the
mathematically correct answer and the operationally wrong one. A person wiring
that flag into CI is asserting the tree is fully owned; if the tool cannot see
the tree, the check did not run, and a CI step that did not run its check should
not be green.

The message names which of the two empty cases it is (§3.3), because no
discovered package points at `standalone_rust_workspaces` and packages-with-no-
sources points at `resolver_exclusions`. Without the flag, coverage still exits
0 and reports the fact plainly — only the assertion refuses. This repo has 4
packages and 74 source files, so the refusal is unreachable here.

## Three decisions recorded in the spec

**§3.1, the lifecycle half comes from the registry.** The index shard records
`spec_status` but not `implementation`, and adding it would move
`INDEX_SCHEMA_VERSION` and restamp every shard for a read verb's benefit, which
§3.4 forbids. An **absent registry is an empty one**, not an error — an existing
test caught this: the fixture indexes without compiling, and a read verb that
answered from the index alone must not start failing because a different
artifact is missing.

**§3.1, a corpus with no orphans stays silent.** Both groups print whenever
either has members; with both empty the verb prints nothing, as before. An
existing acceptance test pinned that silence and was right to.

**§5, the verification block's line grammar.** The draft used trailing `\`
continuations. Spec 049 §3.2 is explicit that each fence body line **is** a
command, so a continuation becomes its own fragment and fails. Worth knowing:
`\` is ordinary shell and an author will reach for it. The block now uses a
fixture at a fixed path, because each line is its own shell and a
`$(mktemp -d)` does not survive to the next assertion.

## Verification

`spec-spine verify 059` passes, 11 commands. Full gate green: 69 shards fresh,
index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple` clean over
8 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass. No waiver.