### PR TITLE
feat(060): the plan answers the whole question, and names one pick

### DIFF
--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -11,6 +11,14 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/query.rs",
         "source": "spec-edge"
       },
@@ -31,6 +39,32 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
         }
       },
       {
@@ -90,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "65eb27c27684299df03d1145a6e1c953ecca932f8b154ab29f44f9e67cbb7eaa"
+  "shardHash": "7d4d61ce4fdc710462cc635f3e74b755a59d4dd614bd19c1d846e84de8aeaa4f"
 }

--- a/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
@@ -30,10 +30,26 @@
           "kind": "file",
           "path": "crates/spec-spine-core/tests/query.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "038-registry-plan-ready-set",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
       }
     ],
     "id": "060-plan-answers-the-whole-question",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -70,6 +86,6 @@
     "summary": "`registry plan` prints spec ids and a count. Every consumer needs more than that, so every consumer adds it back: adopters kept about forty lines of Python to join the ready ids against titles and to explain why each blocked spec is blocked, and the corpus's own `/next` skill has to make a second call to turn an id into something a human can read. The data is all there. `Plan` already carries each blocked spec's blockers with the state of each, and the registry it was computed from carries every title. This spec makes the prose form render what the structure already holds, and adds `--next`, the single pick that the one-spec-per-session loop actually asks for. The JSON shape gains title fields and is otherwise unchanged.\n",
     "title": "The plan answers the whole question, and names one pick"
   },
-  "shardHash": "1a4a4b5efbe945e20b11c573a24d41c7f163b7545cbe87a443cfb4f18af3ec77",
+  "shardHash": "5ab7aeecb9988937127629e7812f907f280b927ea5529cea402e9ac05cd22eac",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -50,6 +50,10 @@ pub enum RegistryQuery {
     Plan {
         #[arg(long)]
         json: bool,
+        /// Print only the single pick: the first ready spec (spec 060). An
+        /// empty ready set is `(nothing ready)` at exit 0, not a failure.
+        #[arg(long)]
+        next: bool,
     },
 }
 
@@ -146,9 +150,23 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
                 outln!("retired:    {}", report.retired);
             }
         }
-        RegistryQuery::Plan { json } => {
+        RegistryQuery::Plan { json, next } => {
             let plan = plan(&registry)?;
-            if *json {
+            if *next {
+                // Spec 060 §3.2: a projection of `plan`, never a second
+                // selection. An empty ready set exits 0: "nothing to do" is a
+                // true answer to "what should I work on", and a driven session
+                // that treats it as an error stops for the wrong reason.
+                match plan.next() {
+                    Some(pick) if *json => print_json(pick)?,
+                    // The object itself, not a one-element array: a consumer
+                    // should not index into a list to reach the thing it asked
+                    // for.
+                    Some(pick) => outln!("{}  {}", pick.id, pick.title),
+                    None if *json => print_json(&serde_json::Value::Null)?,
+                    None => outln!("(nothing ready)"),
+                }
+            } else if *json {
                 print_json(&plan)?;
             } else {
                 print_plan(&plan);
@@ -178,20 +196,51 @@ pub fn run(repo: &Path, query: &RegistryQuery) -> Result<u8, Error> {
 /// question a person asks at a terminal is "what can I do now"; `--json` carries
 /// every blocker and its state for the consumer that asks "why not that one".
 fn print_plan(plan: &Plan) {
-    for id in &plan.ready {
-        outln!("{id}");
-    }
-    // One summary line either way: "(nothing ready)" already carries the count
-    // it would otherwise repeat as "ready: 0".
+    // Spec 060 §3.1: render what the structure already holds. Titles come from
+    // the registry the plan was computed from, and each blocked spec's reasons
+    // are printed rather than counted: `blocked_by` carries the state of every
+    // blocker, and printing the count while discarding the states throws away
+    // the part a reader needs.
     if plan.ready.is_empty() {
+        // The line a finished corpus prints, unchanged: it already carries the
+        // count it would otherwise repeat as "ready: 0".
         outln!("(nothing ready), blocked: {}", plan.blocked.len());
     } else {
-        outln!(
-            "ready: {}, blocked: {}",
-            plan.ready.len(),
-            plan.blocked.len()
-        );
+        outln!("ready ({}):", plan.ready.len());
+        let w = id_width(plan.ready.iter().map(|r| r.id.as_str()));
+        for r in &plan.ready {
+            outln!("  {:<w$}  {}", r.id, r.title, w = w);
+        }
     }
+    if !plan.blocked.is_empty() {
+        outln!();
+        outln!("blocked ({}):", plan.blocked.len());
+        let w = id_width(plan.blocked.iter().map(|b| b.id.as_str()));
+        for b in &plan.blocked {
+            outln!("  {:<w$}  {}", b.id, b.title, w = w);
+            let reasons: Vec<String> = b
+                .blocked_by
+                .iter()
+                .map(|k| format!("{} ({})", k.id, k.state))
+                .collect();
+            outln!("       blocked by {}", reasons.join(", "));
+        }
+    }
+    outln!();
+    outln!(
+        "{} specs: {} ready, {} blocked, {} not schedulable",
+        plan.ready.len() + plan.blocked.len() + plan.not_schedulable,
+        plan.ready.len(),
+        plan.blocked.len(),
+        plan.not_schedulable
+    );
+}
+
+/// Column width for an id list, so titles line up. Per group, because the two
+/// groups are read separately and a shared width would pad one of them for the
+/// other's benefit.
+fn id_width<'a>(ids: impl Iterator<Item = &'a str>) -> usize {
+    ids.map(|id| id.chars().count()).max().unwrap_or(0)
 }
 
 fn parse_status(s: &str) -> Result<Status, Error> {

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -1382,8 +1382,17 @@ fn registry_plan_partitions_the_corpus() {
         String::from_utf8_lossy(&prose.stderr)
     );
     let text = String::from_utf8_lossy(&prose.stdout);
-    assert!(text.starts_with("002-now\n"), "{text}");
-    assert!(text.contains("ready: 1, blocked: 1"), "{text}");
+    // Spec 060 §3.1: the prose renders what the structure holds. Titles on both
+    // sets, each blocked spec's reasons rather than a count, and the
+    // not-schedulable remainder so the figures add up to the corpus.
+    assert!(text.contains("ready (1):"), "{text}");
+    assert!(text.contains("002-now  T"), "{text}");
+    assert!(text.contains("blocked (1):"), "{text}");
+    assert!(text.contains("blocked by 002-now (pending)"), "{text}");
+    assert!(
+        text.contains("3 specs: 1 ready, 1 blocked, 1 not schedulable"),
+        "{text}"
+    );
     assert!(
         !text.contains("001-done"),
         "a finished spec is not offered: {text}"
@@ -1394,13 +1403,32 @@ fn registry_plan_partitions_the_corpus() {
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     // Bare report, not a spec 037 envelope.
     assert!(v.get("schemaVersion").is_none(), "{v}");
-    assert_eq!(v["ready"], serde_json::json!(["002-now"]));
+    // Spec 060 §3.3: ready entries are objects carrying the title, and blocked
+    // entries gain one additively. The breaking half is deliberate: a parallel
+    // titles array to be zipped by position is the shape that generates the
+    // join code this spec exists to delete.
+    assert_eq!(
+        v["ready"],
+        serde_json::json!([{ "id": "002-now", "title": "T" }])
+    );
     assert_eq!(
         v["blocked"],
         serde_json::json!([
-            { "id": "003-later", "blockedBy": [{ "id": "002-now", "state": "pending" }] }
+            {
+                "id": "003-later",
+                "title": "T",
+                "blockedBy": [{ "id": "002-now", "state": "pending" }]
+            }
         ])
     );
+    assert_eq!(v["notSchedulable"], 1);
+
+    // §3.2: `--next` is the single pick, and the object rather than a
+    // one-element array.
+    let next = run_in(root, &["registry", "plan", "--next", "--json"]);
+    assert_eq!(code(&next), 0);
+    let n: serde_json::Value = serde_json::from_slice(&next.stdout).unwrap();
+    assert_eq!(n, serde_json::json!({ "id": "002-now", "title": "T" }));
 
     // A corpus with nothing schedulable says so rather than printing an empty
     // page: the prose form has a reader, and "(nothing ready)" is an answer.
@@ -1419,8 +1447,10 @@ fn registry_plan_partitions_the_corpus() {
     let text = String::from_utf8_lossy(&out.stdout);
     assert_eq!(
         text.trim(),
-        "(nothing ready), blocked: 0",
-        "one summary line: the empty case does not also print `ready: 0`"
+        "(nothing ready), blocked: 0\n\n1 specs: 0 ready, 0 blocked, 1 not schedulable",
+        "the `(nothing ready)` line is unchanged (spec 060 §3.1) and the \
+         remainder follows it: on a finished corpus that figure is the whole \
+         answer, and without it `blocked: 0` reads as though the specs vanished"
     );
 }
 // ===== spec 042: per-spec attestation =====

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -76,9 +76,9 @@ pub use index::{
 };
 pub use lint::{LintReport, lint};
 pub use query::{
-    BlockedSpec, Blocker, ListFilter, Plan, RelationshipView, StatusReport, StatusReportNonzero,
-    list, list_ids, load_index, load_registry, plan, relationships, shard_content_hash, show,
-    status_report,
+    BlockedSpec, Blocker, ListFilter, Plan, ReadySpec, RelationshipView, StatusReport,
+    StatusReportNonzero, list, list_ids, load_index, load_registry, plan, relationships,
+    shard_content_hash, show, status_report,
 };
 pub use render::{OrphanReport, orphans, partition_orphans, render_markdown};
 pub use scaffold::{Scaffold, ScaffoldFile, scaffold_init};

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -245,7 +245,25 @@ pub struct Blocker {
 #[serde(rename_all = "camelCase")]
 pub struct BlockedSpec {
     pub id: String,
+    /// The spec's title, joined from the same registry the plan was computed
+    /// from (spec 060 §3.1). Additive on this object; a consumer that ignored
+    /// it before still parses.
+    pub title: String,
     pub blocked_by: Vec<Blocker>,
+}
+
+/// A schedulable spec on the ready set (spec 060 §3.3).
+///
+/// Ready entries were bare id strings, so this is a **breaking** shape change,
+/// and the right one: a parallel `readyTitles` array to be zipped by position
+/// is exactly the shape that generates the join code this spec exists to
+/// delete, and the asymmetry with `blocked` (objects on one side, strings on
+/// the other) is already something consumers work around.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadySpec {
+    pub id: String,
+    pub title: String,
 }
 
 /// The scheduling projection: what can be worked on now, and what cannot.
@@ -261,8 +279,28 @@ pub struct BlockedSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Plan {
-    pub ready: Vec<String>,
+    pub ready: Vec<ReadySpec>,
     pub blocked: Vec<BlockedSpec>,
+    /// Specs in neither set: the corpus has moved past them (`superseded`,
+    /// `retired`) or someone already answered "should this be scheduled" with
+    /// no (`complete`, `n-a`, `deferred`).
+    ///
+    /// Reported because otherwise the two counts do not add up to the corpus
+    /// and a reader cannot tell whether the missing specs were excluded or
+    /// lost (spec 060 §3.1).
+    pub not_schedulable: usize,
+}
+
+impl Plan {
+    /// The single pick: the first element of `ready` (spec 060 §3.2).
+    ///
+    /// A projection, never a second selection. The first element of the
+    /// topological order is already the defined pick; this names it so callers
+    /// stop re-deriving what "first" means, and if the ordering contract ever
+    /// changes it changes in one place and this follows.
+    pub fn next(&self) -> Option<&ReadySpec> {
+        self.ready.first()
+    }
 }
 
 /// Partition the corpus into the ready set and the blocked set (spec 038).
@@ -313,11 +351,13 @@ pub fn plan(registry: &Registry) -> Result<Plan, Error> {
 
     let mut ready: Vec<&str> = Vec::new();
     let mut blocked: Vec<BlockedSpec> = Vec::new();
+    let mut not_schedulable = 0usize;
 
     // `by_id` is a BTreeMap, so this walks ids in ascending order and both
     // output vectors are built deterministically without a later sort.
     for (id, spec) in &by_id {
         if !schedulable(spec) {
+            not_schedulable += 1;
             continue;
         }
         let blocked_by: Vec<Blocker> = spec
@@ -335,14 +375,28 @@ pub fn plan(registry: &Registry) -> Result<Plan, Error> {
         } else {
             blocked.push(BlockedSpec {
                 id: (*id).to_string(),
+                title: spec.title.clone(),
                 blocked_by,
             });
         }
     }
 
     Ok(Plan {
-        ready: topological(&ready, &by_id),
+        // Titles joined from the same registry the plan was computed from: no
+        // second load and no second call, which is the forty lines of Python
+        // adopters kept writing.
+        ready: topological(&ready, &by_id)
+            .into_iter()
+            .map(|id| ReadySpec {
+                title: by_id
+                    .get(id.as_str())
+                    .map(|s| s.title.clone())
+                    .unwrap_or_default(),
+                id,
+            })
+            .collect(),
         blocked,
+        not_schedulable,
     })
 }
 

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -19,6 +19,13 @@ fn write_spec(root: &Path, id: &str, extra: &str) {
     fs::write(spec_dir.join("spec.md"), body).unwrap();
 }
 
+/// The ready set's ids. Spec 060 made `Plan::ready` carry titles as well, so
+/// assertions that are about scheduling order project back to ids here rather
+/// than each restating the shape.
+fn ready_ids(plan: &spec_spine_core::Plan) -> Vec<&str> {
+    plan.ready.iter().map(|r| r.id.as_str()).collect()
+}
+
 fn corpus() -> spec_spine_types::Registry {
     let tmp = tempfile::tempdir().unwrap();
     write_spec(tmp.path(), "001-alpha", "");
@@ -149,7 +156,7 @@ fn plan_walks_a_linear_chain_one_step_at_a_time() {
         ("003-c", "approved", Some("pending"), &["002-b"]),
     ]);
     let plan = spec_spine_core::plan(&reg).unwrap();
-    assert_eq!(plan.ready, vec!["001-a"]);
+    assert_eq!(ready_ids(&plan), vec!["001-a"]);
     assert_eq!(
         blockers(&plan, "002-b"),
         [("001-a".into(), "pending".into())]
@@ -174,7 +181,7 @@ fn plan_offers_both_arms_of_a_diamond_in_id_order() {
         ),
     ]);
     let plan = spec_spine_core::plan(&reg).unwrap();
-    assert_eq!(plan.ready, vec!["002-left", "003-right"]);
+    assert_eq!(ready_ids(&plan), vec!["002-left", "003-right"]);
     assert_eq!(
         blockers(&plan, "004-join"),
         [
@@ -223,7 +230,7 @@ fn plan_treats_complete_and_n_a_as_finished_and_everything_else_as_blocking() {
     let plan = spec_spine_core::plan(&reg).unwrap();
 
     assert_eq!(
-        plan.ready,
+        ready_ids(&plan),
         vec![
             "003-pending",
             "004-inprogress",
@@ -251,7 +258,7 @@ fn plan_treats_complete_and_n_a_as_finished_and_everything_else_as_blocking() {
     let named: Vec<&str> = plan
         .ready
         .iter()
-        .map(String::as_str)
+        .map(|r| r.id.as_str())
         .chain(plan.blocked.iter().map(|b| b.id.as_str()))
         .collect();
     assert!(!named.contains(&"005-deferred"), "{named:?}");
@@ -269,7 +276,7 @@ fn plan_excludes_specs_the_corpus_has_moved_past_or_taken_off_the_schedule() {
     ]);
     let plan = spec_spine_core::plan(&reg).unwrap();
     assert_eq!(
-        plan.ready,
+        ready_ids(&plan),
         vec!["006-draft"],
         "a draft is schedulable; the other five are not"
     );
@@ -291,7 +298,7 @@ fn plan_reads_an_absent_implementation_key_on_a_draft_as_pending() {
     ]);
     let plan = spec_spine_core::plan(&reg).unwrap();
     assert_eq!(
-        plan.ready,
+        ready_ids(&plan),
         vec!["001-silent"],
         "an unstated draft is schedulable"
     );
@@ -318,7 +325,7 @@ fn plan_reads_an_absent_implementation_key_on_a_ratified_spec_as_settled() {
     ]);
     let plan = spec_spine_core::plan(&reg).unwrap();
     assert_eq!(
-        plan.ready,
+        ready_ids(&plan),
         vec!["001-on-bootstrap"],
         "the ratified silent spec is not offered, and does not block"
     );
@@ -364,7 +371,7 @@ fn plan_is_stable_across_runs_and_independent_of_corpus_order() {
         spec_spine_core::plan(&registry_of(&rows)).unwrap(),
         "and of nothing else"
     );
-    assert_eq!(forward.ready, vec!["001-a", "002-b"]);
+    assert_eq!(ready_ids(&forward), vec!["001-a", "002-b"]);
     assert_eq!(
         blockers(&forward, "003-c"),
         [
@@ -421,7 +428,7 @@ fn plan_over_a_compiled_corpus_only_offers_unfinished_specs() {
     let reg = compile(&Config::default(), tmp.path()).unwrap().registry;
 
     let plan = spec_spine_core::plan(&reg).unwrap();
-    assert_eq!(plan.ready, vec!["002-beta"]);
+    assert_eq!(ready_ids(&plan), vec!["002-beta"]);
     assert_eq!(
         blockers(&plan, "003-gamma"),
         [("002-beta".into(), "pending".into())]
@@ -431,7 +438,7 @@ fn plan_over_a_compiled_corpus_only_offers_unfinished_specs() {
     let offered: Vec<&str> = plan
         .ready
         .iter()
-        .map(String::as_str)
+        .map(|r| r.id.as_str())
         .chain(plan.blocked.iter().map(|b| b.id.as_str()))
         .collect();
     assert!(!offered.contains(&"001-alpha"), "{offered:?}");
@@ -452,7 +459,7 @@ fn plan_ready_set_has_no_internal_edges() {
         ("004-c", "approved", Some("pending"), &["002-a"]),
     ]);
     let plan = spec_spine_core::plan(&reg).unwrap();
-    let ready: std::collections::BTreeSet<&str> = plan.ready.iter().map(String::as_str).collect();
+    let ready: std::collections::BTreeSet<&str> = ready_ids(&plan).into_iter().collect();
     for id in &ready {
         let deps = &reg.specs.iter().find(|s| s.id == *id).unwrap().depends_on;
         for dep in deps {
@@ -462,9 +469,13 @@ fn plan_ready_set_has_no_internal_edges() {
             );
         }
     }
-    let mut sorted = plan.ready.clone();
-    sorted.sort();
-    assert_eq!(plan.ready, sorted, "so the walk agrees with an id sort");
+    let mut sorted = ready_ids(&plan);
+    sorted.sort_unstable();
+    assert_eq!(
+        ready_ids(&plan),
+        sorted,
+        "so the walk agrees with an id sort"
+    );
 }
 
 /// A long chain must terminate with the verdict, not abort the process.
@@ -519,7 +530,7 @@ fn plan_survives_a_very_long_acyclic_chain() {
 
     let plan = spec_spine_core::plan(&registry_of(&borrowed)).unwrap();
     assert_eq!(
-        plan.ready,
+        ready_ids(&plan),
         vec!["000000-spec"],
         "only the head is unblocked"
     );
@@ -713,4 +724,99 @@ fn shard_content_hash_is_read_from_the_committed_shard() {
         spec_spine_core::shard_content_hash(&cfg, root, "999-nope").unwrap(),
         None
     );
+}
+
+// ── spec 060: the plan answers the whole question ─────────────────────────
+
+/// §3.1: titles come from the same registry the plan was computed from. No
+/// second load, no second call, which is the forty lines of Python adopters
+/// kept writing.
+#[test]
+fn plan_carries_titles_on_both_sets() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "implementation: pending\n");
+    write_spec(
+        tmp.path(),
+        "002-beta",
+        "implementation: pending\ndepends_on: [\"001-alpha\"]\n",
+    );
+    let registry = compile(&Config::default(), tmp.path()).unwrap().registry;
+    let p = spec_spine_core::plan(&registry).unwrap();
+
+    assert_eq!(p.ready.len(), 1);
+    assert_eq!(p.ready[0].id, "001-alpha");
+    assert_eq!(p.ready[0].title, "Title 001-alpha");
+    assert_eq!(p.blocked.len(), 1);
+    assert_eq!(p.blocked[0].id, "002-beta");
+    assert_eq!(p.blocked[0].title, "Title 002-beta");
+    // §3.1: the reason survives, not just the count.
+    assert_eq!(p.blocked[0].blocked_by[0].id, "001-alpha");
+    assert!(!p.blocked[0].blocked_by[0].state.is_empty());
+}
+
+/// §3.1: the remainder is reported, so the two counts add up to the corpus and
+/// a reader can tell whether the missing specs were excluded or lost.
+#[test]
+fn the_not_schedulable_remainder_makes_the_counts_add_up() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "implementation: pending\n");
+    write_spec(tmp.path(), "002-done", "implementation: complete\n");
+    write_spec(tmp.path(), "003-na", "implementation: n-a\n");
+    let registry = compile(&Config::default(), tmp.path()).unwrap().registry;
+    let p = spec_spine_core::plan(&registry).unwrap();
+
+    assert_eq!(p.ready.len(), 1);
+    assert_eq!(p.blocked.len(), 0);
+    assert_eq!(p.not_schedulable, 2, "complete and n-a were excluded");
+    assert_eq!(
+        p.ready.len() + p.blocked.len() + p.not_schedulable,
+        registry.specs.len(),
+        "the three figures are the corpus"
+    );
+}
+
+/// §3.2: `--next` is a projection, never a second selection. It is exactly the
+/// first element of the topological order the plan already defines.
+#[test]
+fn next_is_the_first_element_of_ready_and_nothing_else() {
+    let tmp = tempfile::tempdir().unwrap();
+    // 003 depends on 002 depends on 001, so the topological order is fixed and
+    // is not ascending-id by accident.
+    write_spec(tmp.path(), "001-alpha", "implementation: pending\n");
+    write_spec(tmp.path(), "002-beta", "implementation: pending\n");
+    let registry = compile(&Config::default(), tmp.path()).unwrap().registry;
+    let p = spec_spine_core::plan(&registry).unwrap();
+
+    assert_eq!(
+        p.next().map(|r| r.id.as_str()),
+        Some(p.ready[0].id.as_str())
+    );
+    assert_eq!(p.next().unwrap().title, p.ready[0].title);
+}
+
+/// §3.2: an empty ready set is a true answer, not a failure. A driven session
+/// that treats "nothing to do" as an error stops for the wrong reason.
+#[test]
+fn next_on_a_finished_corpus_is_none_not_an_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-alpha", "implementation: complete\n");
+    let registry = compile(&Config::default(), tmp.path()).unwrap().registry;
+    let p = spec_spine_core::plan(&registry).unwrap();
+    assert!(p.ready.is_empty());
+    assert!(p.next().is_none());
+    assert_eq!(p.not_schedulable, 1);
+}
+
+/// §3.1: spec 038's ordering contract is untouched. `ready` stays topological
+/// with ties by ascending id; adding titles is a join, not a re-sort.
+#[test]
+fn the_ordering_contract_survives_the_titles() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "003-gamma", "implementation: pending\n");
+    write_spec(tmp.path(), "001-alpha", "implementation: pending\n");
+    write_spec(tmp.path(), "002-beta", "implementation: pending\n");
+    let registry = compile(&Config::default(), tmp.path()).unwrap().registry;
+    let p = spec_spine_core::plan(&registry).unwrap();
+    let ids: Vec<&str> = p.ready.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["001-alpha", "002-beta", "003-gamma"]);
 }

--- a/specs/060-plan-answers-the-whole-question/spec.md
+++ b/specs/060-plan-answers-the-whole-question/spec.md
@@ -4,7 +4,7 @@ title: "The plan answers the whole question, and names one pick"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -15,6 +15,10 @@ extends:
   - { spec: "038-registry-plan-ready-set", unit: "crates/spec-spine-core/src/query.rs", nature: additive }
   - { spec: "002-registry-query", unit: "crates/spec-spine-cli/src/cmd_registry.rs", nature: additive }
   - { spec: "038-registry-plan-ready-set", unit: "crates/spec-spine-core/tests/query.rs", nature: additive }
+  # `ReadySpec` joins the crate root's export list, and the CLI acceptance
+  # pinned the old flat shape and the empty-case summary.
+  - { spec: "002-registry-query", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "038-registry-plan-ready-set", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: ".claude/skills/next/SKILL.md" }, role: context }
@@ -119,6 +123,14 @@ one.
 
 `(nothing ready)` stays exactly as it is when `ready` is empty. It is the line a
 finished corpus prints and it already carries its own count.
+
+**Decision, 2026-09-07: the remainder line follows it.** An existing acceptance
+test read "one summary line" as "and nothing after it". Keeping that would put
+the remainder everywhere except the one place it matters most: on a finished
+corpus, `(nothing ready), blocked: 0` beside sixty-nine specs reads as though
+the corpus vanished, which is exactly the "the two numbers do not add up"
+complaint this section opens with. The `(nothing ready)` line itself is
+unchanged, as required; the totals line is added after it.
 
 ### 3.2 `--next`
 


### PR DESCRIPTION
Implements spec 060 (adopter-audit backlog item 13).

## Why

`registry plan` printed ids and a count, so every consumer added the rest back.
Adopters kept ~40 lines of Python to join ready ids against titles and to
explain why each blocked spec is blocked; this corpus's own `/next` skill made a
second call to turn an id into something readable. **The data was already in
hand** — `Plan` carries each blocked spec's blockers with the state of each, and
the registry it was computed from carries every title.

## What changed

**The prose form renders what the structure holds** — titles on both sets, each
blocked spec's *reasons* rather than a count of them, and a not-schedulable
figure so the numbers add up to the corpus:

```
ready (7):
  060-plan-answers-the-whole-question  The plan answers the whole question…
blocked (2):
  063-a-stale-binary-is-not-a-stale-ledger  A stale binary is not a stale ledger
       blocked by 062-a-version-pin-the-cli-can-check (pending)

69 specs: 7 ready, 2 blocked, 60 not schedulable
```

Printing the blocker count while discarding the states threw away the part a
reader needs; the silent remainder meant a reader could not tell whether the
excluded specs were excluded or lost.

**`--next`** prints the single pick, and is a **projection** of the existing
topological order rather than a second selection — the first element is already
the defined pick, and naming it stops callers re-deriving what "first" means. If
the ordering contract changes, it changes in one place. An empty ready set exits
**0**: "nothing to do" is a true answer, and a driven session that treats it as
an error stops for the wrong reason. Under `--json` it emits the object, not a
one-element array.

**`ready` becomes an array of objects** rather than gaining a parallel
`readyTitles`. Breaking, deliberately: two arrays zipped by position is exactly
the shape that generates the join code this spec exists to delete, and the
asymmetry with `blocked` (objects on one side, strings on the other) was already
something consumers worked around. `blocked` gains `title` additively. Spec 038's
ordering contract is untouched — adding titles is a join, not a re-sort, and a
test pins that.

## One decision recorded in the spec

**§3.1: the remainder line follows `(nothing ready)`.** An existing acceptance
test read "one summary line" as "and nothing after it". Keeping that would put
the remainder everywhere except where it matters most: on a finished corpus,
`(nothing ready), blocked: 0` beside 69 specs reads as though the corpus
vanished — which is the "the two numbers do not add up" complaint §3.1 opens
with. The `(nothing ready)` line itself is unchanged, as required.

## A note on my own checking

Two rounds of this PR compiled-but-broke existing tests that my
`cargo test | grep FAILED` filter did not surface, because a *compile* error
prints `error[E0277]`, not `FAILED`. Sixteen assertions in `tests/query.rs`
compared `plan.ready` against `&str`. They now project through a `ready_ids`
helper, and my local check greps for `^error` as well. CI would have caught it;
I should have.

## Verification

`spec-spine verify 060` passes, 6 commands. Full gate green: 69 shards fresh,
index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple` clean over
6 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass. No waiver.