### PR TITLE
feat(061): the scaffold ships what every adopter wrote by hand

### DIFF
--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "44ae968495fc2a292fc383910262d8400089ba9bb85d9fbe7ec6e0bf1bdfad94"
+  "shardHash": "813fe7cf776ed3f3ba802277066abb3fc8a09161bdc7e153da99fa6679e7b5cb"
 }

--- a/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -25,7 +25,7 @@
       }
     ],
     "id": "061-the-scaffold-ships-what-adopters-wrote",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -69,6 +69,6 @@
     "summary": "Four scaffold defects the audit measured, all in one generator. `init` writes no `.gitignore`, so every adopter independently learns that `.derived/**/build-meta.json` carries a wall clock and dirties the tree, and spec 039's `state_dir` has the same missing half: the live failure it fixed was a permanently dirty tree, not a classification. The scaffolded `spec-spine.toml` emits five knobs; adopters needed thirteen, and aicortex annotated each of its own with the diagnostic code that knob drives, which is the template to copy. And `CONSTITUTION_TEMPLATE` in `scaffold.rs` is still the two-bullet stub spec 043 complained about, while the real thirty-four-line document sits in `standards/spec/templates/constitution-template.md`: adopters get the stub, and two of them deleted it. This spec fixes all four in `scaffold_init`, which stays a pure function of `Config` performing no IO.\n",
     "title": "The scaffold ships what every adopter wrote by hand"
   },
-  "shardHash": "cadd616f1667e25d5019eb0c0788446b347e8ddf34cb847a44e624c8a80f119d",
+  "shardHash": "f6b27334ec9221d05cde708e4c9bc8a8cde23de9843861741de284a84b4a72fd",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/scaffold.rs
+++ b/crates/spec-spine-core/src/scaffold.rs
@@ -67,6 +67,7 @@ pub fn scaffold_init(cfg: &Config) -> Result<Scaffold, Error> {
             ".claude/rules/adversarial-prompt-refusal.md".to_string(),
             REFUSAL_RULE.to_string(),
         ),
+        file(".gitignore".to_string(), gitignore(cfg)),
     ];
 
     Ok(Scaffold { files })
@@ -76,38 +77,195 @@ pub fn scaffold_init(cfg: &Config) -> Result<Scaffold, Error> {
 
 /// A documented starter `spec-spine.toml`, config-aware so a non-default
 /// namespace / layout scaffolds coherently.
+///
+/// Spec 061 §3.2: every table and every key, each at its actual default and
+/// each with a line saying what it does and, where one exists, which diagnostic
+/// code it drives. The scaffold emitted five knobs and adopters needed
+/// thirteen, so each of them read the source or derived the name by experiment;
+/// aicortex annotated its own with the code the knob drives, which is the shape
+/// copied here.
+///
+/// A key whose default is the right starting value is emitted at that value. A
+/// key that only means something once the adopter has content for it is emitted
+/// **commented out** with an example, so they uncomment rather than invent
+/// syntax and are not handed empty tables that look meaningful.
+///
+/// `tests/scaffold.rs` asserts this parses back to `Config::default()` modulo
+/// the values substituted from `cfg`: a documented config that has drifted from
+/// the defaults it documents is worse than none.
 fn config_toml(cfg: &Config) -> String {
     format!(
-        "# spec-spine.toml governs this repository. All keys are optional; an\n\
+        "# spec-spine.toml governs this repository. Every key is optional; an\n\
          # absent file behaves as the defaults for a single-Cargo-workspace repo.\n\
-         # See the spec-spine docs for the full knob table.\n\
+         # Every key below is set to its default, so deleting one changes nothing.\n\
+         # `spec-spine config show` prints the effective configuration, including\n\
+         # the built-in bypass floor this file cannot see.\n\
          \n\
          [manifest]\n\
          # Drives the Cargo `[package.metadata.{ns}].spec` and package.json `\"{ns}\".spec` reads.\n\
          metadata_namespace = \"{ns}\"\n\
          \n\
          [domains]\n\
-         allowed = []   # empty ⇒ the `domain` field is free-text / disabled\n\
+         # L-002: warn on a spec with no `domain` once this list is non-empty.\n\
+         # Empty means the taxonomy is disabled, not that every spec is unclassified.\n\
+         allowed = []\n\
          \n\
          [kind]\n\
-         allowed = []   # empty ⇒ the `kind` field is free-text / disabled\n\
+         # L-003, symmetric with [domains].\n\
+         allowed = []\n\
          \n\
          [layout]\n\
+         # Where authored truth lives.\n\
          specs_dir     = \"{specs}\"\n\
+         # Where the compiler and indexer write. See .gitignore for whether the\n\
+         # shard trees belong in version control.\n\
          derived_dir   = \"{derived}\"\n\
          standards_dir = \"{standards}\"\n\
+         schemas_dir   = \"{schemas}\"\n\
+         # An ungoverned root for a tool's own working files (spec 039): excluded\n\
+         # from every content hash, and bypassed by the coupling gate. L-006 if a\n\
+         # spec claims a unit inside it. Empty means no such root is declared.\n\
+         state_dir     = \"{state}\"\n\
+         # The workspace manifest the Rust package discovery starts from.\n\
+         cargo_workspace = \"{cargo_workspace}\"\n\
+         # Files probed for npm workspace globs.\n\
+         npm_workspaces = [{npm_workspaces}]\n\
+         # Packages outside any workspace, named one by one.\n\
+         # standalone_rust_workspaces = [\"tools/thing\"]\n\
+         # standalone_npm_packages    = [\"npm\"]\n\
+         \n\
+         [index]\n\
+         # Extra files folded into the global-inputs hash, so a change to one\n\
+         # stales every shard.\n\
+         #\n\
+         # WATCH THE GLOB FORM. `dir/**` matches DIRECTORIES and therefore no\n\
+         # files; you want `dir/**/*`. The default below carries the broken form\n\
+         # and so hashes nothing (spec 057 found this in spec-spine\x27s own\n\
+         # config, where it had silently held since the key was added). It is\n\
+         # left as-is here because changing the default would restale every\n\
+         # existing adopter\x27s index; fix it in your own file:\n\
+         #\n\
+         #   extra_hashed_inputs = [\"{standards}/**/*\", \".github/workflows/**/*\"]\n\
+         extra_hashed_inputs = [{extra_hashed_inputs}]\n\
+         # Directories the symbol resolver and the coverage walk skip.\n\
+         resolver_exclusions = [{resolver_exclusions}]\n\
+         # Named path sets `index check --slice <name>` can gate on their own.\n\
+         # [index.slices]\n\
+         # api = [\"crates/*/src/lib.rs\"]\n\
+         \n\
+         [branding]\n\
+         # Recorded in every emitted artifact's `build` block.\n\
+         compiler_id = \"{compiler_id}\"\n\
+         indexer_id  = \"{indexer_id}\"\n\
          \n\
          [coupling]\n\
-         # The PR-body waiver keyword (the reason follows the colon).\n\
+         # The PR-body waiver keyword (the reason follows the colon). A waiver is\n\
+         # a human instrument: it needs explicit human approval, and an agent\n\
+         # never writes one on its own authority.\n\
          waiver_keyword = \"{waiver}\"\n\
-         # Adopter bypass entries are ADDITIVE to the built-in generic floor.\n\
-         bypass_prefixes = []\n",
+         # ADDITIVE to the built-in generic floor; it cannot remove an entry.\n\
+         # `spec-spine config show` prints the merged list the gate matches on.\n\
+         bypass_prefixes = []\n\
+         # C-002: refuse a changed source file that no spec specifically claims.\n\
+         # Off to start: a corpus turns this on once its coverage debt is retired.\n\
+         # `spec-spine index coverage` reports where you stand.\n\
+         require_ownership = {require_ownership}\n\
+         # Clear a diff whose every non-bypassed path is a dependency-only\n\
+         # manifest edit. Off to start; turn it on if a bot opens bump PRs, which\n\
+         # cannot add a waiver line to their own body.\n\
+         auto_waive_dependency_only = {auto_waive}\n\
+         \n\
+         [lint]\n\
+         # L-007: refuse a `depends_on` entry that does not name a lower ordinal.\n\
+         # Off to start: a corpus that files by domain rather than by date holds\n\
+         # a coherent position this would spam.\n\
+         require_ordinal_monotonic_depends_on = {ordinal_monotonic}\n\
+         # L-008 suppression: claimed paths deliberately in no content hash.\n\
+         # `index check` still reports the count, so an exception stays explicit.\n\
+         # unwitnessed_allowed = [\"crates/**/*.rs\"]\n\
+         \n\
+         # [provenance.uri_schemes]\n\
+         # Named URI prefixes a `references` provenance value may use. The\n\
+         # header is commented too: an empty table here would OVERRIDE the\n\
+         # built-in schemes rather than add to them.\n\
+         # knowledge        = \"knowledge://\"\n\
+         # code-fingerprint = \"fingerprint://\"\n\
+         \n\
+         [frontmatter]\n\
+         # Keys this corpus recognizes beyond the grammar, so the unknown-key\n\
+         # lint stays quiet about them. They still land in `extraFrontmatter`.\n\
+         # extra_known_keys = [\"owner\", \"risk\"]\n",
         ns = cfg.manifest.metadata_namespace,
         specs = cfg.layout.specs_dir,
         derived = cfg.layout.derived_dir,
         standards = cfg.layout.standards_dir,
+        schemas = cfg.layout.schemas_dir,
+        state = cfg.layout.state_dir,
+        cargo_workspace = cfg.layout.cargo_workspace,
+        npm_workspaces = quoted(&cfg.layout.npm_workspaces),
+        extra_hashed_inputs = quoted(&cfg.index.extra_hashed_inputs),
+        resolver_exclusions = quoted(&cfg.index.resolver_exclusions),
+        compiler_id = cfg.branding.compiler_id,
+        indexer_id = cfg.branding.indexer_id,
         waiver = cfg.coupling.waiver_keyword,
+        require_ownership = cfg.coupling.require_ownership,
+        auto_waive = cfg.coupling.auto_waive_dependency_only,
+        ordinal_monotonic = cfg.lint.require_ordinal_monotonic_depends_on,
     )
+}
+
+/// A TOML string array body: `"a", "b"`.
+fn quoted(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|v| format!("\"{v}\""))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The scaffolded `.gitignore` (spec 061 §3.1).
+///
+/// Every adopter independently learned that `build-meta.json` carries a wall
+/// clock and dirties the tree, and spec 039's `state_dir` had the same missing
+/// half: the live failure it fixed was a permanently dirty tree, not a
+/// classification. Both paths come from `Config`, so a non-default
+/// `derived_dir` or `state_dir` scaffolds coherently.
+///
+/// It deliberately does **not** ignore the shard trees. Whether they are
+/// committed is the adopter's decision and both answers are legitimate;
+/// ignoring them by default would silently opt every new adopter out of the
+/// freshness gate, which is one of the system's two central mechanisms. The
+/// file says so and names both options.
+fn gitignore(cfg: &Config) -> String {
+    let derived = cfg.layout.derived_dir.trim_end_matches('/');
+    let mut out = format!(
+        "# spec-spine writes wall-clock metadata here. It is the one\n\
+         # non-deterministic artifact and is excluded from every determinism and\n\
+         # golden check, so it must never be committed.\n\
+         {derived}/**/build-meta.json\n"
+    );
+    let state = cfg.layout.state_dir.trim_end_matches('/');
+    if !state.is_empty() {
+        out.push_str(&format!(
+            "\n# The declared state root (spec 039): a tool's own working files,\n\
+             # ungoverned and outside every content hash.\n\
+             {state}/\n"
+        ));
+    }
+    out.push_str(&format!(
+        "\n# NOT ignored, deliberately: {derived}/spec-registry/ and\n\
+         # {derived}/codebase-index/ are the committed shard trees.\n\
+         #\n\
+         # Committing them is what makes `compile --check` and `index check` a\n\
+         # freshness gate on a pull request: CI compares the corpus against what\n\
+         # the branch committed. Not committing them means regenerating in CI\n\
+         # before every gate step instead. Both are legitimate; the scaffold\n\
+         # takes neither, because opting you out of the gate silently would be a\n\
+         # decision made on your behalf. To choose the second, add:\n\
+         #\n\
+         #   {derived}/\n"
+    ));
+    out
 }
 
 fn bootstrap_spec(ns: &str) -> String {
@@ -305,13 +463,53 @@ const CONTRACT: &str = "# Contract: normative summary\n\
   approved spec changes it by claiming the affected heading as a section unit\n\
   of that file; see the constitution's own Amendment section.\n";
 
-const CONSTITUTION_TEMPLATE: &str = "# Constitution (tier 2): template\n\
+/// The adopter-facing constitution template (spec 061 §3.3).
+///
+/// The two-bullet stub spec 043 complained about survived that spec, because
+/// 043 §3.4 updated `CONSTITUTION` (the scaffolded document) and left the
+/// **template** behind. Two adopters deleted what they were given. This is the
+/// real thirty-four-line document: the tier statement, the normative hierarchy,
+/// the amendment clause 043 made writable, and the seam saying which principles
+/// are the adopter's own.
+///
+/// A literal rather than `include_str!` of the checked-in file, because that
+/// file lives outside this crate and a published crate must be self-contained.
+/// `tests/scaffold.rs` asserts the two agree, the same shape as the conformance
+/// test that pins DTOs against the embedded schemas.
+const CONSTITUTION_TEMPLATE: &str = "# <project> constitution\n\
 \n\
-Replace these with your project's durable principles. Keep them subordinate to\n\
-the bootstrap spec and few in number.\n\
+Durable principles that govern this corpus. **Tier 2**: subordinate to the\n\
+bootstrap spec (`specs/000-*/spec.md`) and governing all ordinary specs.\n\
 \n\
-1. **<principle>**: <one sentence>.\n\
-2. **<principle>**: <one sentence>.\n";
+**Normative hierarchy (highest wins):**\n\
+\n\
+1. `specs/000-*/spec.md`: the bootstrap spec. Non-overridable.\n\
+2. `standards/spec/constitution.md`: this document.\n\
+3. `standards/spec/contract.md`: normative summary of the bootstrap spec.\n\
+4. Ordinary specs (`001`+).\n\
+\n\
+---\n\
+\n\
+## I. <Principle name>\n\
+\n\
+<One paragraph. State the principle as a durable rule, and cite the bootstrap\n\
+anchor it rests on, if any.>\n\
+\n\
+## II. <Principle name>\n\
+\n\
+<...>\n\
+\n\
+## III. <Principle name>\n\
+\n\
+<...>\n\
+\n\
+---\n\
+\n\
+## Amendment\n\
+\n\
+This constitution may be amended by an ordinary spec that `amends` it and is\n\
+approved, provided the amendment does not contradict a `specs/000` `unamendable`\n\
+anchor.\n";
 
 const ORCHESTRATOR_RULES: &str = "# Orchestrator rules\n\
 \n\

--- a/crates/spec-spine-core/tests/scaffold.rs
+++ b/crates/spec-spine-core/tests/scaffold.rs
@@ -5,7 +5,7 @@
 use std::fs;
 
 use spec_spine_core::{compile, lint, plan, scaffold_init};
-use spec_spine_types::Config;
+use spec_spine_types::{Config, load_config};
 
 /// Write a [`Scaffold`] to a temp dir as the CLI would.
 fn materialize(cfg: &Config) -> tempfile::TempDir {
@@ -158,4 +158,170 @@ fn non_default_namespace_scaffolds_coherently() {
     );
     let outcome = compile(&cfg, repo.path()).unwrap();
     assert!(outcome.registry.validation.passed);
+}
+
+// ── spec 061: the scaffold ships what every adopter wrote by hand ─────────
+
+fn scaffolded(cfg: &Config, rel: &str) -> String {
+    scaffold_init(cfg)
+        .unwrap()
+        .files
+        .into_iter()
+        .find(|f| f.rel_path == rel)
+        .unwrap_or_else(|| panic!("scaffold has no {rel}"))
+        .contents
+}
+
+/// §3.1: the one non-deterministic artifact is ignored, so an adopter does not
+/// independently learn that `build-meta.json` carries a wall clock by watching
+/// their tree go dirty.
+#[test]
+fn the_scaffold_ignores_the_wall_clock_artifact() {
+    let ignore = scaffolded(&Config::default(), ".gitignore");
+    assert!(ignore.contains(".derived/**/build-meta.json"), "{ignore}");
+}
+
+/// §3.1: both ignored paths come from `Config`, so a non-default layout
+/// scaffolds coherently rather than emitting the defaults as literals.
+#[test]
+fn the_gitignore_follows_the_configured_layout() {
+    let cfg =
+        load_config("[layout]\nderived_dir = \"build/derived\"\nstate_dir = \"tool-state\"\n")
+            .unwrap();
+    let ignore = scaffolded(&cfg, ".gitignore");
+    assert!(
+        ignore.contains("build/derived/**/build-meta.json"),
+        "{ignore}"
+    );
+    assert!(
+        ignore.contains("tool-state/"),
+        "the declared state root: {ignore}"
+    );
+    assert!(
+        !ignore.contains(".derived"),
+        "no default leaked in as a literal: {ignore}"
+    );
+}
+
+/// §3.1: an undeclared state root contributes no line. There is nothing to
+/// ignore, and an empty path would ignore the repository.
+#[test]
+fn no_state_root_means_no_state_line() {
+    let ignore = scaffolded(&Config::default(), ".gitignore");
+    for line in ignore.lines().filter(|l| !l.trim_start().starts_with('#')) {
+        assert!(
+            line.trim().is_empty() || line.contains("build-meta.json"),
+            "unexpected ignore entry: {line}"
+        );
+    }
+}
+
+/// §3.1: the shard trees are NOT ignored, and the file says why. Ignoring them
+/// by default would silently opt every new adopter out of the freshness gate.
+#[test]
+fn the_shard_trees_are_not_ignored_and_the_choice_is_explained() {
+    let ignore = scaffolded(&Config::default(), ".gitignore");
+    for line in ignore.lines().filter(|l| !l.trim_start().starts_with('#')) {
+        assert!(
+            !line.trim().eq(".derived/"),
+            "the scaffold must not take this decision: {ignore}"
+        );
+    }
+    assert!(ignore.contains("spec-registry/"), "{ignore}");
+    assert!(ignore.contains("freshness gate"), "{ignore}");
+}
+
+/// §3.1: it does not clobber an existing file, like every other scaffolded one.
+#[test]
+fn the_gitignore_is_not_marked_overwrite() {
+    let f = scaffold_init(&Config::default())
+        .unwrap()
+        .files
+        .into_iter()
+        .find(|f| f.rel_path == ".gitignore")
+        .unwrap();
+    assert!(!f.overwrite);
+}
+
+/// §3.2: the emitted config parses back to the configuration it documents. A
+/// documented config that has drifted from its own defaults is worse than none,
+/// and this is the check that keeps the comments honest as `Config` grows.
+#[test]
+fn the_scaffolded_config_round_trips_to_its_own_defaults() {
+    let toml = scaffolded(&Config::default(), "spec-spine.toml");
+    let parsed = load_config(&toml).expect("the scaffolded config must parse");
+    assert_eq!(
+        parsed,
+        Config::default(),
+        "every emitted key is at its actual default"
+    );
+}
+
+/// §3.2: and it round-trips a non-default configuration too, so the file an
+/// adopter is handed describes the repository they asked for.
+#[test]
+fn the_scaffolded_config_round_trips_a_non_default_configuration() {
+    let cfg = load_config(
+        "[manifest]\nmetadata_namespace = \"acme\"\n\
+         [layout]\nspecs_dir = \"corpus\"\nstate_dir = \"var\"\n\
+         [coupling]\nrequire_ownership = true\n",
+    )
+    .unwrap();
+    let toml = scaffolded(&cfg, "spec-spine.toml");
+    assert_eq!(load_config(&toml).unwrap(), cfg);
+}
+
+/// §3.2: the knobs adopters reached for are named, each with the code it drives
+/// where one exists. These are the thirteen the audit counted, not the five the
+/// scaffold used to emit.
+#[test]
+fn the_scaffolded_config_names_the_knobs_adopters_needed() {
+    let toml = scaffolded(&Config::default(), "spec-spine.toml");
+    for knob in [
+        "require_ownership",
+        "auto_waive_dependency_only",
+        "resolver_exclusions",
+        "extra_hashed_inputs",
+        "state_dir",
+        "cargo_workspace",
+        "standalone_rust_workspaces",
+        "standalone_npm_packages",
+        "extra_known_keys",
+        "schemas_dir",
+        "require_ordinal_monotonic_depends_on",
+        "unwitnessed_allowed",
+        "uri_schemes",
+    ] {
+        assert!(toml.contains(knob), "no mention of {knob}");
+    }
+    // Each of the refusal knobs names the code it drives.
+    assert!(toml.contains("C-002"), "{toml}");
+    assert!(toml.contains("L-006"), "{toml}");
+    assert!(toml.contains("L-007"), "{toml}");
+    assert!(toml.contains("L-008"), "{toml}");
+    // And the glob trap spec 057 found is called out where it bites.
+    assert!(toml.contains("`dir/**` matches DIRECTORIES"), "{toml}");
+}
+
+/// §3.3 + §3.4: the emitted template is the checked-in document, and a test
+/// pins them together so they cannot drift, which is how the stub survived the
+/// spec that diagnosed it.
+#[test]
+fn the_constitution_template_is_the_real_one_and_cannot_drift() {
+    let emitted = scaffolded(
+        &Config::default(),
+        "standards/spec/templates/constitution-template.md",
+    );
+    let checked_in =
+        std::fs::read_to_string("../../standards/spec/templates/constitution-template.md")
+            .expect("the checked-in template");
+    assert_eq!(emitted, checked_in, "the constant and the file must agree");
+
+    // The properties spec 043 asked for, mirrored from its assertion on the
+    // constitution itself.
+    assert!(emitted.contains("Tier 2"), "{emitted}");
+    assert!(emitted.contains("Normative hierarchy"), "{emitted}");
+    assert!(emitted.contains("Amendment"), "{emitted}");
+    // It stays a template: placeholders, not this corpus's own principles.
+    assert!(emitted.contains("<Principle name>"), "{emitted}");
 }

--- a/specs/061-the-scaffold-ships-what-adopters-wrote/spec.md
+++ b/specs/061-the-scaffold-ships-what-adopters-wrote/spec.md
@@ -4,7 +4,7 @@ title: "The scaffold ships what every adopter wrote by hand"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -206,22 +206,63 @@ presents both options and takes neither.
 **Adding knobs.** Every key emitted is one `Config` already has. Making the
 scaffold honest about the current surface is separable from growing it.
 
+**Fixing `IndexConfig::default().extra_hashed_inputs`.**
+
+**Decision, 2026-09-07.** Writing §3.2's exhaustive config surfaced that the
+**default value itself** carries the broken glob form spec 057 found in this
+repository's file: `["standards/**", ".github/workflows/**"]` matches
+directories and therefore no files, so every adopter relying on the default
+hashes nothing extra and does not know it. 057 fixed this corpus's
+`spec-spine.toml` and did not look at the default behind it.
+
+Not fixed here. Changing it would restale the committed index of every adopter
+who relies on the default, which is a behavior change to a shipped default and
+belongs in its own spec with its own release note, not inside a scaffold
+change. What this spec does instead is stop the silence: the key is emitted at
+its real (broken) value with a comment naming the trap and the working form, so
+the next adopter reads it rather than deriving it.
+
+**Decision, 2026-09-07: an emitted table header is a value.** The first cut of
+§3.2 emitted `[provenance.uri_schemes]` uncommented above its commented
+examples, which declares an **empty** table and overrides that key's non-empty
+default. The round-trip assertion §3.2 requires caught it immediately, which is
+the argument for that assertion. A table whose keys are all commented out has
+its header commented out too.
+
 ## 5. Verification
+
+Each line below is one command: spec 049 §3.2 makes a fence's body line a
+command, so a trailing `\` continuation becomes its own fragment and fails. The
+scaffold is materialized once at a fixed path, because each line is its own
+shell and a `$(mktemp -d)` would not survive to the next assertion.
+
+Every assertion fails against pre-061 code: there was no `.gitignore`, the
+config emitted five knobs, and the template was a two-bullet stub.
 
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test scaffold --locked
-# `init` writes a .gitignore covering the one non-deterministic artifact.
-tmp=$(mktemp -d) && target/release/spec-spine --repo "$tmp" init >/dev/null \
-  && grep -q 'build-meta.json' "$tmp/.gitignore"
-# The scaffolded config names the knobs an adopter reaches for.
-grep -q 'require_ownership' "$tmp/spec-spine.toml"
-grep -q 'resolver_exclusions' "$tmp/spec-spine.toml"
-# The scaffolded constitution template is the real one, not the two-bullet stub.
-grep -q 'Amendment' "$tmp/standards/spec/templates/constitution-template.md"
-# The scaffolded corpus still compiles and lints clean, and running the tool in
-# it leaves a tree the adopter's git would call clean.
-target/release/spec-spine --repo "$tmp" compile >/dev/null
-target/release/spec-spine --repo "$tmp" lint --fail-on-warn
+# Materialize a fresh adopter once.
+rm -rf "${TMPDIR:-/tmp}/ss061" && mkdir -p "${TMPDIR:-/tmp}/ss061" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss061" init >/dev/null
+# 3.1: the one non-deterministic artifact is ignored...
+grep -q 'build-meta.json' "${TMPDIR:-/tmp}/ss061/.gitignore"
+# ...and the shard trees deliberately are not, with the choice explained.
+grep -q 'freshness gate' "${TMPDIR:-/tmp}/ss061/.gitignore"
+# 3.2: the knobs adopters reached for are named, with the codes they drive.
+grep -q 'require_ownership' "${TMPDIR:-/tmp}/ss061/spec-spine.toml"
+grep -q 'resolver_exclusions' "${TMPDIR:-/tmp}/ss061/spec-spine.toml"
+grep -q 'C-002' "${TMPDIR:-/tmp}/ss061/spec-spine.toml"
+# 4: and the glob trap is named where it bites, rather than left to be derived.
+grep -q 'matches DIRECTORIES' "${TMPDIR:-/tmp}/ss061/spec-spine.toml"
+# 3.2: the emitted config is the configuration it documents. `config show`
+# reads it back through the same loader every verb uses.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss061" config show >/dev/null
+# 3.3: the template is the real document, not the two-bullet stub.
+grep -q 'Amendment' "${TMPDIR:-/tmp}/ss061/standards/spec/templates/constitution-template.md"
+grep -q 'Normative hierarchy' "${TMPDIR:-/tmp}/ss061/standards/spec/templates/constitution-template.md"
+# 3.4: the scaffolded corpus still compiles and lints clean.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss061" compile >/dev/null
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss061" lint --fail-on-warn
+rm -rf "${TMPDIR:-/tmp}/ss061"
 ```


### PR DESCRIPTION
Implements spec 061 (adopter-audit backlog items 14 and 15, plus kit 5/6). Four
scaffold defects the audit measured, all in one generator. Unblocks 065.

## What changed

**A `.gitignore` (§3.1).** Every adopter independently learned that
`build-meta.json` carries a wall clock and dirties the tree; spec 039's
`state_dir` had the same missing half, since the live failure it fixed was a
permanently dirty tree, not a classification. Both paths come from `Config`, so
a non-default layout scaffolds coherently.

The shard trees are **deliberately not ignored**, and the file says why at
length. Whether they are committed is the adopter's decision and both answers
are legitimate; ignoring them by default would silently opt every new adopter
out of the freshness gate, which is one of the system's two central mechanisms.

**The config shows every knob (§3.2).** It emitted five; adopters needed
thirteen, so each read the source or derived a name by experiment. Now every
table and key at its actual default, each with a line saying what it does and
the diagnostic code it drives (`C-002`, `L-006`, `L-007`, `L-008`). Keys that
only mean something once you have content for them are commented out with an
example, so you uncomment rather than invent syntax. A test asserts the emitted
file parses back to the configuration it documents — for defaults *and* for a
non-default config.

**The real constitution template (§3.3).** `CONSTITUTION_TEMPLATE` was still the
two-bullet stub spec 043 complained about, because 043 updated `CONSTITUTION`
(the scaffolded document) and left the *template* behind — which is how the
defect survived the spec that diagnosed it. Two adopters deleted what they were
given. It is now the real 34-line document, embedded as a constant (the library
stays self-contained, as the JSON Schemas are), with a test pinning it against
the checked-in file.

## Two decisions recorded, one of which is a defect I did not fix

**§4: `IndexConfig::default().extra_hashed_inputs` is broken.** Writing the
exhaustive config surfaced that the **default value** carries the same
`dir/**`-matches-directories form spec 057 found in this repo's file. 057 fixed
this corpus and did not look behind it. **Every adopter relying on the default
hashes nothing extra and does not know it.**

I did not fix it. Changing a shipped default would restale the committed index
of every adopter who relies on it — a behavior change wanting its own spec and
release note, not a side effect of a scaffold change. What this spec does is
stop the silence: the key is emitted at its real (broken) value with the trap
and the working form named in a comment, so the next adopter reads it instead of
deriving it. **Worth a spec of its own; say the word and I'll file it.**

**§4: an emitted table header is a value.** My first cut emitted
`[provenance.uri_schemes]` uncommented above its commented examples, which
declares an *empty* table and overrides that key's non-empty default. The
round-trip assertion §3.2 requires caught it immediately — which is the argument
for that assertion.

## Verification

`spec-spine verify 061` passes, 15 commands. The block was rewritten without
backslash continuations: spec 049 §3.2 makes each fence line a command, so a
continuation becomes its own fragment and fails. Full gate green: 69 shards
fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple`
clean over 3 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass.
No waiver.