### PR TITLE
feat(062): a version pin the CLI can check

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "27a30fda654201cc3dd1274a23d26c18fb2bcce356964591c0355afe0138d2c6"
+  "shardHash": "d6f7b6f524092a71207008df0e942afa369e6bddd9620c9e7d2759504e2acb1f"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "25631229ac4e1ff94a76ab2ccab4665fe52dc617e89f1140e7e335acb98e3191"
+  "shardHash": "9f930065a78d6edd976d6fdff901c7e939420218b0941eac591e7da192399dc6"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d32062aa22e43042ef63a9158ac2721a58bbef44b30262414e0a573d6888fc9f"
+  "shardHash": "2e1b79de0e48d4e26c293c63375fa4643571eb6d45bc8b9edc90c5f2376cdc95"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8f5896761c008a2941c341258740cd6479ab5a5bc70981265393c80d7e312bfa"
+  "shardHash": "592403fbdaeba4be0fb76da778a9201d852b3574a95ee31aa45ed3b82e5cd612"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ae3aac7e72cd5a6c1cd703a789dce52f1c1a57c0d0931d5777a1d557fc27033f"
+  "shardHash": "6c8b1433e4296a9a51e131dae1a325526fb6269d359f82a5d687fcc756d48161"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "92a4e81cbfc05ed127f5dadd2cee125fe36d7a6a8cb7d4a0428bf4a9fe954756"
+  "shardHash": "e2d06992857efc2470346c1968d69df29be7d99faa5f00c27d71296eb6b1a1ff"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "aa188ef5652f9a43daa4e39a6666b1e15337fe93612e6c9496dab1f3a2554a90"
+  "shardHash": "08a4a8a52b0c456116153b8131db65ef029e1d188c66e849c3eb022a4a0e40b6"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d6cec57bb323d5f47ded63437706a9c41b138cfa5a4c6b816c0001ded2e618f7"
+  "shardHash": "bc98944c20f97b46f317d2a9581212fa404312640162f6a21a88078125d98b8b"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "154a74237e0309a498f9c08c5ab92272ecdfe542d22d668f2c7b39bc2f939814"
+  "shardHash": "7d4120ac52d1523759e07810a8cda722036e77fd92626dde5ef858e34dd19cac"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b16c7c98c14f96d2658bddb6335df1ca1a545f21f72660f2c18f4a54886cc5a8"
+  "shardHash": "4bb560d4937428fbeb62d155f7be571872cb20d958ef99603677decf859444f0"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "833bb6eb605157a3b4db2746e4e8b2bfe41cb081997f3f95a5c03e411aadc962"
+  "shardHash": "d87b9ea115acdbaa1245ff4bb50918e037ab054c9a162fefbf3827b91af7eef7"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5f71eeae32bd6475604be75d6b3e60fd667ad6f90c83201396c8751c3f6c382e"
+  "shardHash": "827bcb7ed52a5d46e7d1f9a8a44f4eab6ab1cc39f1c38c0017d5c1840da787ca"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7fa892ed82b18feae2ff08808498d51368d12a1bd8d9b099cbfc1801665c3ffc"
+  "shardHash": "f730e606e88a2b1ccda176581f8ef96d8eda3781cf20e2bda76664f05c5d223e"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c50cc7e8147091d07e9844fa551b35ee0d90d9c845c8c4f670bf869a20754194"
+  "shardHash": "48b5534dd1b839a3fb30d066e03cd77bc8f0777c81fb3aaf8cbe427cee6028b4"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8357ce085587b4f905441023c76e4d641aea76ee29c04a92338ec552f3aaf6a6"
+  "shardHash": "657086382e6047216bcfe4e8ca0dca85c593e7eeb1c02ae895d3969cbc05b662"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8bfd4e1b8378ceeee0be5ab9737f50af8e9bc549e7b7c099553a51b3f0c411c8"
+  "shardHash": "c7bb67371475826b6e7e6001e4362985e64c1b0220709f7591bd42a6f95a7042"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "95276ddac4b5a64699466f7cff4d4a248c518f0d2f64b7ce825f7d265d9cbd4f"
+  "shardHash": "f7d804730fae838fedcbbef248e2bcf87f80814f326ba92fb0b070cc35c37649"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "50cd6e7ae9473816c3714899438be2cc6bd7b5022233be7f0ef25c5e48202316"
+  "shardHash": "f457e886220a05f84d0831aba55ab87d8e7599605c089694601b1210df169d14"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f089bb6cd374626332780fd7571e67d29e958f194472a1959cb2b3bde952e296"
+  "shardHash": "6f24bf448f29397554118f917952bf6dd5644d6c24235c0321a58c869225d12e"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e38c5f5bc3896a0d2799d4d71a466f2ff9e92534685d71b749a75df34eafe42a"
+  "shardHash": "b7a3b932f9e8503552b4f5aa010badff7ef4b40ca1dd91f780dfe950e4d3faa9"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "db0a001b9c91c91140208747df0a298f28afc9bcb3d53c760ffe0ddfb198da08"
+  "shardHash": "e7f1812b91ca308c4dfcd1d54b84b62bf6e05507a7cc670d1deedc86badc0f11"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cbd3901af88456e2b8b34601abea19a12520f8e6f870a4f961ab90dccfccd650"
+  "shardHash": "b37b754ad9566c3bfb26f4f8c6725ba69cc1489d215269066449fdd45b97b9d3"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "56dafdefa6cb10d6b0814449b8d4036f0180a4e18b81adfc25a6c26ccdb3f4d1"
+  "shardHash": "1157b99f164051a2501ca7a897ad844ec0dcc419b49bd2d1844be92ec211c565"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "94d8be500fe95e336eb5513360bdfbda62e920c8e6233a25b102236e83622061"
+  "shardHash": "6afac754bd6a3a9de5632125b0f6eb1c84df0e34a37b9e5c5e332e98d3769f35"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e77fefa3b68d5903f0ed4243ec3baf15107735f70e4347750e5d92a7f54d09fc"
+  "shardHash": "c04bd0e6ea12bc8f454037eb5c7a6323d0ca6881d5738fa9887ec0435459d301"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e334cff38e4b240309f76bfddbdcea4237ead70e33ebd86b48a8b8be3fb84ef2"
+  "shardHash": "1ba09f1d0f3da6e5076d622157da25558c66a35548c2613979d00f92c1df2cc0"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3976804d02c3126531998d442a9dfc8f41c46dac8b37e05759f8249b7ef097ae"
+  "shardHash": "0c674d2b7242119b76ab4b11b989d1cbcc9707b21101e0e7604f9e96df3a8d98"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bf8687f709c0d4e343128a59bff8f7c7a204dc037b189d72c2a47e3076c90273"
+  "shardHash": "b0e6b5b4da54c7e3aa9cb6c1da9e5c3641e6aa0784e638120ae74ec8f5a89a1f"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "66af2b2aaf0e582504a01324012614e5a32fc5c3ec6a822bf10c002954e34638"
+  "shardHash": "ba1d0e945e45e6235d71e390080f1e8c535df502f7f46c158b38a86d3985e185"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8e1fbbc90daf29eec8c68d17dfcbf4ffcbfcbaffbff5965d8d96de9d0e024e4b"
+  "shardHash": "abc6fda5c173290af43dfb042f9bd9ff42ad16088fe59bf2fb7bd093d80ebcf0"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f5ed53116cca94cea30a8b22be070f97f2f960d4f8e7f630ba79108295f9a5c0"
+  "shardHash": "57a90af97308f78c313a16d2a8cd61774690e8a83023462a63bb145fa4cb8bb2"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4dbec426db6af60552265c165b21b33bb9b6f27a82c05462789f44fdfdf175bf"
+  "shardHash": "05bbf04f6ce7697c79c7d52f5b338b9a9e139b3eec63695b2ac30b419b437ef4"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d6edf1fc43a2ff428a23170585d35949ec8c699ff7e88aa01599bb9ea64ba052"
+  "shardHash": "29e875fca769aa8bba8aeec7af1d56108c42a8fbc5807ac29c08c675c1b24af6"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc138ee273fdc4d7ec0955bcf568e260bdde7540846f14f1eb3d6d9b420063f7"
+  "shardHash": "173f1136009b9d9097cb1583fe8148895b44779409fe5b7b8d52de076e5ca538"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bd631191ce34c83acb801eede1fd823876d95be8b14074fc904c19e4ccd15ffc"
+  "shardHash": "4fcb045a5f3e22d5cbcd49346f3b5e043035436fbfc13d9d51b7321d8207eedb"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7e8441274c689f9499cb1a9965ca7c352b888493d8520b285b05261d744dd625"
+  "shardHash": "9b74103c06a5319167c9089a1dc5794e1f975ce5f70322784cd635a83ec61646"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dec026f2cde580715b8dbb163f78e2bc1c2a24dca18d25122ea810e836be4ad1"
+  "shardHash": "200b1c77174b5d1525fca4df9f6f56dffbe0ac204c11e7475b8b14cdd8dcbf2a"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9898da3bf91121e8b08b3b8f51ffb2c46fb29381ab5277dd928c4251d400b070"
+  "shardHash": "68a86be1cd923de7749e7b2e0e14332d8134f1d4aa9fb76cc2c0cf4fa21a9c2e"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5621c85179e517d52d00d9c9083a9b4e3762cfe096b5f96d1088eb835a7afe3"
+  "shardHash": "cee25180eda2f4691447812611721df4aaa35b5cdca5ace5f0bc0b036849492a"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f3e46c5130b464196e6f4b1cf863e86738a092ae4de54cd8699778eabf14f66d"
+  "shardHash": "0ab34dfd47a046f103997e3b497ad99c4c7a4c89fbb99c40ea3fa64c14a7a2ec"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b583cf14a74b987160139296c4b0ca1c266cb93bd443cee3655d5fe94121f55a"
+  "shardHash": "d55456b87ccc2f88e3643bde34cf7500674ac5a16cbcbf1be142b228873ad6cf"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "842a196f41c06ab1455c8d77acd60b20776a250fbd3add0536f08e7ccf2daede"
+  "shardHash": "dadca851698ed03d81c073129189e0bf8ee4fc4d6886e9212f1a5d5b51a05c5e"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1496bf7d20b3177e91be1e1adaf9e208157809789ae9abc2f864450fb4af87a7"
+  "shardHash": "2299681050dc9fe880e2ccf494ac58337a0f72e930d8992e36fecd97036b295e"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e0a738fcd048d48867ccc57d952bd707cdc5e1dc03485ab9206d1fc39a81ad7a"
+  "shardHash": "ca68db43a5efbcd6ed48e9de9492f3a208c49c5d0985c0b6fecc425975117363"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b3bd5e9a959b79b4376f78f75ad1c3abc198eaf2f4bf9fe0e1064db1c1da8ddf"
+  "shardHash": "5c9e87331967617c6fdeff1caa6d1eca2bc5c230d32b6e6e8756a0598fc009d0"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0da76fc93c058572dce1e271545c880549a9dbd45cff526930f78fcc28a5f59b"
+  "shardHash": "ae5b4fd93fffa173b77b8c03e0b7cf044b0e2df49bc3d5643ff9b62dd3c9941b"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "39a37f0b432896c159cc90c1855887629ef1b0dba8eb93ca3e1064aa3206affb"
+  "shardHash": "98cd38b60d48af2aeb80169e849df95fd34053558d6b2294fd58117b8f9d3c8f"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f668161471fa12acd9aa123bd78051be204225d49d3b7321b4a08668da9e8495"
+  "shardHash": "7444cde85c6e0028c23d6794faed7aa8c3944dd2dbff48297345e432c267b434"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d8c9d74cd07871522d083856fdd0a22d15f3ee91daf0f648996d493ee223ed92"
+  "shardHash": "79eaf0a6fa8c1db96a8792eba230625f62faab205f1a6f7b04b54147778c388e"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f331ebd57bdcc6b17119136e20b3d7b6f9d2dd1903d36db11d18bf04931a4006"
+  "shardHash": "cf98c2e69af5f6d0ea5e3955a2931f1c4a991c1035fb44d1c445cd9d4a301220"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6de4f36dffbc3e2ae27805463b89a2e01ea4a4c384e9eaeddb41d32dda00afca"
+  "shardHash": "139f9a8e171348a5a1c28a90e1e804a52f21af94a91ea027c1ff12bfffe96e45"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b63ebe04e43fa4db8cacced5719051c78c7f26ca4882ad95fdd7c16daa5e7500"
+  "shardHash": "657579c04c5fc45120f1164e1f205b201d8f14009529885833a9e0634294d1fe"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fee66ee5b847bc790c873fef6079731957c7a9144e367f8ca15946ec8c7e696b"
+  "shardHash": "a333289845e98f112581c936b85baa00ce317819deb8d61c1e18ef57b17d94ba"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ae927972dc7881acc62e462f97a88b8a58ae55ed622b3ce0a9eba11c5fcf0ada"
+  "shardHash": "d280d537f7f779cd2d13cf588e50c7ad3045e2d604b31dace083f5ea5c0a1c90"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "56499b51135910596491cb427a38aa96b856ea6497a9c7fc6a7e7f082d2c6c8f"
+  "shardHash": "eb4154e94825151341e365c9eb21b439c4eba2999165bc522f1c5cb517fb7ee3"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f02a8d84f847da943d98a18f2ef2d3a42ebea4087f4dc78453ec17940948fd64"
+  "shardHash": "bd0fea31cd37906a4c6051f9c3a1c20b19a404a846b57133e3e5507f5eb2210f"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e19a187e755f033bc7a8d0cf5983d288f67a431ae673043355cc760695efbf63"
+  "shardHash": "38392506bda0c801342925f7e72d839f1733c9519a9db8259a5fbbf433771ed8"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7697edd7045fe6b7aedf610d0c7a7f57bd123065d497efaa2d7b12883b79feed"
+  "shardHash": "71a690319666f621f1884d49ace5b30bc0276209acd6b37651a96cc2159468ed"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "14bda43a1abd0522ac6b482bfdda2712b27fc5de993f42991b5f2e7708d753c1"
+  "shardHash": "a894182204499e2a5a960203c67cb91a8a3991f7029a46e1e163ab01e060d603"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0ec27e9647ae48d40dc02cea3f8c234128e346cef62ba18848ee6f92eab90daa"
+  "shardHash": "88a2126188cd8b26d52e9bbed2f4d7356cc516bdfc1a4a2372dbb73e57ba54b1"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d040f5222c32727e133e66510d39521b17bc1c523be6d04fed5f401bed67842b"
+  "shardHash": "473da5ab51aca86350781058e10400cc8d76ecfe6a16a0e688e4c844787ee68a"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "47b76708938fc8f38ca6a38181f2e3e7e3b47392eb10894b2a3141140b8e4a5d"
+  "shardHash": "f371b06c713ce42dfd32c23ed74875a417d112e45343eb89f6f3a9efda2ce3ba"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "00061347eb0d60e40748f0e2b68dd03c9cb8c1b8ec1d8a4fcf07e2b4c6530cde"
+  "shardHash": "5d36f1824961d68e131207661cdb989542b01e89393950b7c6c4656514084dd2"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5be2138f2411bab4f7bf01494e7c8f52b126fdae804b3819d69b402bcd894e46"
+  "shardHash": "3f6ded949d55012895213f3d4cb972d7250c65aea8ccb8e7aa641d48f0f58f9e"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7d4d61ce4fdc710462cc635f3e74b755a59d4dd614bd19c1d846e84de8aeaa4f"
+  "shardHash": "54a14184b5e1eb649bdaa04bd5de412b51504a7f953b4a7c6a5bd8a666bc34ce"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "813fe7cf776ed3f3ba802277066abb3fc8a09161bdc7e153da99fa6679e7b5cb"
+  "shardHash": "2cb1d42c0ba178c9178200f0ea28e6514afccf3fc580d9e1875008a6c9875dd5"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -7,6 +7,10 @@
     ],
     "implementingPaths": [
       {
+        "path": "crates/spec-spine-cli/src/cmd_config.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-cli/src/main.rs",
         "source": "spec-edge"
       },
@@ -19,11 +23,32 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-types/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-types/tests/config.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/schema-versioning.md",
         "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_config.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_config.rs"
+        }
+      },
       {
         "locations": [
           {
@@ -66,6 +91,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-types/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-types/tests/config.rs"
           }
         ],
@@ -74,6 +112,19 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-types/tests/config.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/schema-versioning.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
         }
       },
       {
@@ -107,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0705dd32d3b85bd3928df193bb6d325da90d2c516e42ee1eb05f802781b05cdc"
+  "shardHash": "19e7bd42bdf7b8b1b1404020d0d264f14b7f7fc5dac7fe7d5d423ae0a139556e"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f6f3bc675edad18ed2e4106b9b9855447b68fef5f3ce0fe345bced5de33b8656"
+  "shardHash": "b96c91ccb06816890abc17de095027867a66613cd3d74010feb78d6e9432fdd6"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -91,5 +91,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "300ce43f1307c910eaf616f6b9a1b927fab85b87a7e8b0971c71b676afcb6fab"
+  "shardHash": "5419126b3bf60db4c27cbfdf1a7b4896d54b06f297702ba6564795a39658304d"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -125,5 +125,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2af0f4f1ba9489b58c7cdfaf9c08daac8406c3aeb003e10ce53970dc8f1e8027"
+  "shardHash": "01c9689cac3f8495ffa0ece1c3fc46dbb58a965788442996ebc25443fad076c7"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -57,5 +57,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d0e305843e8fdde6ed96789f5dc66376f0520f36315ee7f6b03137d91a6efc6c"
+  "shardHash": "73a85ad110af5e893b8ebd469e57a7ecb9eb0c2fc7f3361a9057ac3a65a9ae40"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -74,5 +74,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fff7dd52e630a8568db022b8d34b527dbaa22265cb0fafd73e40592262761665"
+  "shardHash": "686b94b88fcb370ea50bab7ec6d86b3727f2f8868e5a148d31a2569617a1b17f"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -73,5 +73,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e1dd7a3424c88a91e42662c8bed5b44c57f48a7136fcca293c67ce8e5cad1c58"
+  "shardHash": "00327640bff5604b3e280b61233b2da36aeb42b223814fa7627df59b61b66667"
 }

--- a/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -38,10 +38,34 @@
           "kind": "file",
           "path": "crates/spec-spine-types/tests/config.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "054-effective-config-is-a-governed-read",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_config.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "067-the-docs-name-what-adopters-derived",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
       }
     ],
     "id": "062-a-version-pin-the-cli-can-check",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -79,6 +103,6 @@
     "summary": "A repository is governed by whichever spec-spine binary happens to be on the path, and nothing anywhere says which one it should be. rahi states 0.11.0 in three files that must agree by hand. All four governed repositories are two to four releases behind the fixes their own experience motivated, and rahi cannot see spec 044, which was written for rahi's exact state, because it is pinned below it. This spec adds `[meta] required_version`, a semver requirement the CLI checks on every run, refusing with a message that names both the requirement and the running version. The schema versions already tell a loader whether it can read an artifact; this tells an operator whether they are running the tool the corpus was governed by, which is a different question and currently has no answer at all.\n",
     "title": "A version pin the CLI can check"
   },
-  "shardHash": "4bcd1a42d21a8914fbebaefa44a437ffb32b31aed4d2eb944d896544181f476a",
+  "shardHash": "fe2ca3f48246293bd20b298b638cbaa76eb82e0f65b5e80b9bef97f2d241e3bb",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/src/cmd_config.rs
+++ b/crates/spec-spine-cli/src/cmd_config.rs
@@ -133,6 +133,12 @@ fn render(e: &EffectiveConfig) {
     out::line(format_args!("\n[frontmatter]"));
     list("extra_known_keys", &e.frontmatter.extra_known_keys);
 
+    out::line(format_args!("\n[meta]"));
+    match &e.meta.required_version {
+        Some(v) => kv("required_version", v),
+        None => out::line(format_args!("  required_version = (unpinned)")),
+    }
+
     out::line(format_args!("\n[lint]"));
     flag(
         "require_ordinal_monotonic_depends_on",

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -197,6 +197,15 @@ fn main() -> ExitCode {
     };
 
     let json_verb = cli.command.json_verb();
+    // Spec 062 §3.2: the version pin is checked before any work. A read from a
+    // mismatched binary is the quiet failure this exists to prevent: `registry
+    // plan` from an old binary answers a question about a corpus it may
+    // misunderstand, and answers it confidently.
+    if let Err(e) = check_version_pin(&repo, &cli.command) {
+        eprintln!("spec-spine: {e}");
+        return ExitCode::from(e.exit_code());
+    }
+
     let result = match &cli.command {
         Command::Compile { check, json, spec } => {
             cmd_compile::run(&repo, *check, *json, spec.as_deref())
@@ -341,5 +350,24 @@ pub(crate) fn load_repo_config(repo: &Path) -> Result<Config, Error> {
         Ok(src) => spec_spine_types::load_config(&src),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
         Err(e) => Err(Error::Io(format!("read {}: {e}", path.display()))),
+    }
+}
+
+/// Enforce `[meta] required_version` (spec 062 §3.2), except for the verbs that
+/// must stay available when the pin is unsatisfiable.
+///
+/// `--version` and `--help` are clap's, and never reach here. `init` is exempt
+/// because it scaffolds a repository that has no configuration yet, and in one
+/// that does it is the verb an operator reaches for when things are wrong.
+///
+/// A configuration that cannot be read at all is left to the verb: this returns
+/// `Ok` rather than pre-empting the real error with a worse one.
+fn check_version_pin(repo: &Path, command: &Command) -> Result<(), Error> {
+    if matches!(command, Command::Init { .. }) {
+        return Ok(());
+    }
+    match load_repo_config(repo) {
+        Ok(cfg) => cfg.check_required_version(env!("CARGO_PKG_VERSION")),
+        Err(_) => Ok(()),
     }
 }

--- a/crates/spec-spine-core/src/scaffold.rs
+++ b/crates/spec-spine-core/src/scaffold.rs
@@ -101,6 +101,14 @@ fn config_toml(cfg: &Config) -> String {
          # `spec-spine config show` prints the effective configuration, including\n\
          # the built-in bypass floor this file cannot see.\n\
          \n\
+         # [meta]\n\
+         # Pin the spec-spine version this repository is governed by. Uncomment to\n\
+         # refuse a binary that does not satisfy it. A pin is not only about\n\
+         # features: the coupling gate\x27s built-in bypass floor is compiled into\n\
+         # the binary, so two versions can judge the same diff differently.\n\
+         # Cargo semantics: a bare version is a caret range, `=` is exact.\n\
+         # required_version = \"{running_version}\"\n\
+         \n\
          [manifest]\n\
          # Drives the Cargo `[package.metadata.{ns}].spec` and package.json `\"{ns}\".spec` reads.\n\
          metadata_namespace = \"{ns}\"\n\
@@ -195,6 +203,7 @@ fn config_toml(cfg: &Config) -> String {
          # Keys this corpus recognizes beyond the grammar, so the unknown-key\n\
          # lint stays quiet about them. They still land in `extraFrontmatter`.\n\
          # extra_known_keys = [\"owner\", \"risk\"]\n",
+        running_version = env!("CARGO_PKG_VERSION"),
         ns = cfg.manifest.metadata_namespace,
         specs = cfg.layout.specs_dir,
         derived = cfg.layout.derived_dir,

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub provenance: ProvenanceConfig,
     pub frontmatter: FrontmatterConfig,
     pub lint: LintConfig,
+    pub meta: MetaConfig,
 }
 
 /// `[manifest]`: how a manifest links a compilation unit back to its spec.
@@ -318,6 +319,212 @@ pub struct LintConfig {
     pub unwitnessed_allowed: Vec<String>,
 }
 
+/// `[meta]`: facts about the governed repository itself (spec 062).
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct MetaConfig {
+    /// The spec-spine version this repository is governed by, as a semver
+    /// **requirement** (`"0.15.0"`, `">=0.15, <0.16"`, `"=0.15.0"`).
+    ///
+    /// Absent means unpinned, which is every existing repository.
+    ///
+    /// A requirement rather than an exact version, because both intentions are
+    /// legitimate: an adopter reproducing a byte-identical ledger pins exactly
+    /// with `=`, and one who wants fixes but not a MAJOR writes a range. A
+    /// single exact string would force the first on everybody and produce a pin
+    /// that is bumped without being thought about.
+    ///
+    /// A config key rather than a `.spec-spine-version` sidecar: one file
+    /// already governs the repository, `spec-spine config show` reports it with
+    /// everything else, and a sidecar would be a second configuration surface
+    /// with its own discovery rules for one scalar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_version: Option<String>,
+}
+
+/// One comparator of a version requirement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Op {
+    /// `=1.2.3`: every stated field must match.
+    Exact,
+    /// `^1.2` or a bare `1.2`: up to the next breaking change.
+    Caret,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+/// A parsed comparator: an operator and a possibly-partial version.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Comparator {
+    op: Op,
+    major: u64,
+    minor: Option<u64>,
+    patch: Option<u64>,
+}
+
+/// A semver requirement: comparators joined by `,`, all of which must hold.
+///
+/// Cargo's conventions, deliberately, because that is what an adopter writing
+/// `"^0.15"` or `">=0.15, <0.16"` will expect: a bare version is a caret
+/// requirement, `=` is the exact one, `*` matches anything, and a missing minor
+/// or patch is a wildcard rather than a zero.
+///
+/// Hand-written rather than pulled in as a dependency. The requirement grammar
+/// this needs is small and closed, and `spec-spine-types` is the substrate every
+/// binding wraps: it carries four serde crates and nothing else, and a version
+/// pin is not the reason to change that.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VersionReq(Vec<Comparator>);
+
+impl VersionReq {
+    /// Parse a requirement, or say why it is not one.
+    pub fn parse(src: &str) -> std::result::Result<Self, String> {
+        let mut out = Vec::new();
+        for part in src.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            if part == "*" {
+                continue; // matches anything, so it constrains nothing
+            }
+            let (op, rest) = if let Some(r) = part.strip_prefix(">=") {
+                (Op::Ge, r)
+            } else if let Some(r) = part.strip_prefix("<=") {
+                (Op::Le, r)
+            } else if let Some(r) = part.strip_prefix('>') {
+                (Op::Gt, r)
+            } else if let Some(r) = part.strip_prefix('<') {
+                (Op::Lt, r)
+            } else if let Some(r) = part.strip_prefix('=') {
+                (Op::Exact, r)
+            } else if let Some(r) = part.strip_prefix('^') {
+                (Op::Caret, r)
+            } else {
+                (Op::Caret, part)
+            };
+            out.push(parse_comparator(op, rest.trim())?);
+        }
+        Ok(VersionReq(out))
+    }
+
+    /// Does `version` satisfy every comparator?
+    ///
+    /// An empty requirement (`"*"`, or an empty string) matches everything,
+    /// which is the same as being unpinned.
+    pub fn matches(&self, version: (u64, u64, u64)) -> bool {
+        self.0.iter().all(|c| c.matches(version))
+    }
+}
+
+fn parse_comparator(op: Op, src: &str) -> std::result::Result<Comparator, String> {
+    // Strip any pre-release / build metadata: this tool's own versions carry
+    // none, and comparing them would be grammar nobody here needs.
+    let core = src.split(['-', '+']).next().unwrap_or(src);
+    let mut parts = core.split('.');
+    let major = next_number(&mut parts, src)?.ok_or_else(|| format!("'{src}' has no major"))?;
+    let minor = next_number(&mut parts, src)?;
+    let patch = next_number(&mut parts, src)?;
+    if parts.next().is_some() {
+        return Err(format!("'{src}' has more than three components"));
+    }
+    Ok(Comparator {
+        op,
+        major,
+        minor,
+        patch,
+    })
+}
+
+fn next_number<'a>(
+    parts: &mut impl Iterator<Item = &'a str>,
+    src: &str,
+) -> std::result::Result<Option<u64>, String> {
+    match parts.next() {
+        None => Ok(None),
+        Some("*") | Some("x") | Some("X") => Ok(None),
+        Some(n) => n
+            .parse::<u64>()
+            .map(Some)
+            .map_err(|_| format!("'{src}' is not a version: '{n}' is not a number")),
+    }
+}
+
+impl Comparator {
+    fn matches(&self, (vmaj, vmin, vpat): (u64, u64, u64)) -> bool {
+        let lower = (self.major, self.minor.unwrap_or(0), self.patch.unwrap_or(0));
+        let v = (vmaj, vmin, vpat);
+        match self.op {
+            // Only the stated fields are compared, so `=0.15` accepts any patch
+            // of 0.15, which is what writing two components asks for.
+            Op::Exact => {
+                vmaj == self.major
+                    && self.minor.is_none_or(|m| vmin == m)
+                    && self.patch.is_none_or(|p| vpat == p)
+            }
+            Op::Gt => v > lower,
+            Op::Ge => v >= lower,
+            Op::Lt => v < lower,
+            Op::Le => v <= lower,
+            // Up to the next breaking change, with 0.x treated as its own
+            // major line, exactly as Cargo reads it: `^0.15` is
+            // `>=0.15.0, <0.16.0`, and `^1.2` is `>=1.2.0, <2.0.0`.
+            Op::Caret => {
+                if v < lower {
+                    return false;
+                }
+                if self.major > 0 {
+                    return vmaj == self.major;
+                }
+                match self.minor {
+                    // `^0` allows any 0.x.
+                    None => vmaj == 0,
+                    Some(m) => vmaj == 0 && vmin == m,
+                }
+            }
+        }
+    }
+}
+
+impl Config {
+    /// Refuse when `[meta] required_version` is present and `running` does not
+    /// satisfy it (spec 062 §3.2).
+    ///
+    /// [`Error::Config`] (exit 3): a configuration the tool cannot honour, which
+    /// is what 3 means. Emphatically not 1 (nothing was validated), not 2
+    /// (nothing is stale), and not 0.
+    ///
+    /// The message names the requirement, the running version, and where the
+    /// pin lives, because an operator told only "version mismatch" has to go
+    /// find all three.
+    pub fn check_required_version(&self, running: &str) -> Result<()> {
+        let Some(req_src) = &self.meta.required_version else {
+            return Ok(());
+        };
+        let req = VersionReq::parse(req_src).map_err(|e| {
+            Error::Config(format!(
+                "[meta] required_version '{req_src}' is not a semver requirement: {e}"
+            ))
+        })?;
+        let Some(version) = crate::parse_semver(running) else {
+            return Err(Error::Config(format!(
+                "cannot compare the running version '{running}' against [meta] \
+                 required_version '{req_src}'"
+            )));
+        };
+        if req.matches(version) {
+            return Ok(());
+        }
+        Err(Error::Config(format!(
+            "this repository requires spec-spine {req_src} (spec-spine.toml [meta] \
+             required_version); running {running}. Install the required version, or \
+             change the pin deliberately"
+        )))
+    }
+}
+
 /// Where a bypass entry came from (spec 054 §3.2).
 ///
 /// Attribution is the load-bearing part of `config show`, and the reason it is
@@ -407,6 +614,7 @@ pub struct EffectiveConfig {
     pub provenance: ProvenanceConfig,
     pub frontmatter: FrontmatterConfig,
     pub lint: LintConfig,
+    pub meta: MetaConfig,
 }
 
 impl EffectiveConfig {
@@ -433,6 +641,7 @@ impl EffectiveConfig {
             provenance: config.provenance.clone(),
             frontmatter: config.frontmatter.clone(),
             lint: config.lint.clone(),
+            meta: config.meta.clone(),
         }
     }
 }

--- a/crates/spec-spine-types/src/lib.rs
+++ b/crates/spec-spine-types/src/lib.rs
@@ -50,7 +50,7 @@ pub use codebase::{
 pub use config::{
     AllowlistConfig, BrandingConfig, BypassEntry, BypassSource, Config, CouplingConfig,
     EffectiveConfig, EffectiveCouplingConfig, FrontmatterConfig, IndexConfig, LayoutConfig,
-    LintConfig, ManifestConfig, ProvenanceConfig, load_config,
+    LintConfig, ManifestConfig, MetaConfig, ProvenanceConfig, VersionReq, load_config,
 };
 pub use coverage::{CoverageReport, PackageCoverage};
 pub use edges::{

--- a/crates/spec-spine-types/tests/config.rs
+++ b/crates/spec-spine-types/tests/config.rs
@@ -212,3 +212,113 @@ fn the_overlap_check_reads_the_configured_roots() {
         "specs/ is not a governed root in this layout: {accepted:?}"
     );
 }
+
+// ── spec 062: a version pin the CLI can check ─────────────────────────────
+
+use spec_spine_types::VersionReq;
+
+fn v(s: &str) -> (u64, u64, u64) {
+    spec_spine_types::parse_semver(s).unwrap()
+}
+
+fn req(s: &str) -> VersionReq {
+    VersionReq::parse(s).unwrap_or_else(|e| panic!("'{s}' should parse: {e}"))
+}
+
+/// §3.1: Cargo's conventions, because that is what an adopter writing `^0.15`
+/// expects. A bare version is a caret requirement, and 0.x is its own major
+/// line.
+#[test]
+fn a_bare_version_is_a_caret_requirement() {
+    assert!(req("0.15.0").matches(v("0.15.0")));
+    assert!(req("0.15.0").matches(v("0.15.9")), "patch is allowed");
+    assert!(!req("0.15.0").matches(v("0.16.0")), "0.x minor is breaking");
+    assert!(!req("0.15.3").matches(v("0.15.1")), "below the floor");
+    assert!(req("^0.15").matches(v("0.15.7")));
+    assert!(!req("^0.15").matches(v("0.14.9")));
+
+    // For 1.x and above the minor is not breaking.
+    assert!(req("1.2.0").matches(v("1.9.9")));
+    assert!(!req("1.2.0").matches(v("2.0.0")));
+    assert!(!req("1.2.0").matches(v("1.1.9")));
+}
+
+/// §3.1: `=` is the exact pin, which is how an adopter reproducing a
+/// byte-identical ledger says so. Only the stated fields are compared.
+#[test]
+fn the_equals_operator_is_the_exact_pin() {
+    assert!(req("=0.15.0").matches(v("0.15.0")));
+    assert!(!req("=0.15.0").matches(v("0.15.1")));
+    assert!(!req("=0.15.0").matches(v("0.16.0")));
+    // Two components pin two components: any patch of 0.15.
+    assert!(req("=0.15").matches(v("0.15.4")));
+    assert!(!req("=0.15").matches(v("0.16.0")));
+}
+
+/// §3.1: a range, which is the adopter who wants fixes but not a MAJOR. Every
+/// comparator must hold.
+#[test]
+fn comma_separated_comparators_are_conjunctive() {
+    let r = req(">=0.15, <0.16");
+    assert!(r.matches(v("0.15.0")));
+    assert!(r.matches(v("0.15.12")));
+    assert!(!r.matches(v("0.14.9")), "below the lower bound");
+    assert!(!r.matches(v("0.16.0")), "at the exclusive upper bound");
+
+    assert!(req(">0.15.0").matches(v("0.15.1")));
+    assert!(!req(">0.15.0").matches(v("0.15.0")));
+    assert!(req("<=0.15.0").matches(v("0.15.0")));
+}
+
+/// §3.1: `*` and an empty requirement constrain nothing, which is the same as
+/// being unpinned.
+#[test]
+fn a_wildcard_constrains_nothing() {
+    assert!(req("*").matches(v("0.1.0")));
+    assert!(req("*").matches(v("99.0.0")));
+    assert!(req("").matches(v("0.15.0")));
+    assert!(req("0.15.*").matches(v("0.15.9")));
+    assert!(!req("0.15.*").matches(v("0.16.0")));
+}
+
+/// §3.1: a malformed requirement is a config error naming what is wrong, not a
+/// silent pass. A pin nobody can parse must not read as "unpinned".
+#[test]
+fn a_malformed_requirement_is_refused() {
+    for bad in ["not-a-version", ">=", "1.2.3.4", "0.x.y.z"] {
+        assert!(VersionReq::parse(bad).is_err(), "'{bad}' should be refused");
+    }
+}
+
+/// §3.2: an absent pin is silent, a satisfied pin is silent, and an
+/// unsatisfied one names all three facts an operator needs.
+#[test]
+fn check_required_version_names_requirement_running_and_location() {
+    let unpinned = Config::default();
+    assert!(unpinned.check_required_version("0.15.0").is_ok());
+
+    let pinned = load_config("[meta]\nrequired_version = \">=0.15, <0.16\"\n").unwrap();
+    assert!(pinned.check_required_version("0.15.3").is_ok());
+
+    let err = pinned.check_required_version("0.11.0").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains(">=0.15, <0.16"), "the requirement: {msg}");
+    assert!(msg.contains("0.11.0"), "the running version: {msg}");
+    assert!(
+        msg.contains("spec-spine.toml"),
+        "where the pin lives: {msg}"
+    );
+    // §3.2: exit 3. Not 1 (nothing was validated), not 2 (nothing is stale).
+    assert_eq!(err.exit_code(), 3);
+}
+
+/// §3.1: `CONFIG_VERSION` does not move, and a config written before this spec
+/// still parses. An added optional table with a default is the additive case
+/// the constant exists to make safe.
+#[test]
+fn the_meta_table_is_additive() {
+    assert_eq!(spec_spine_types::CONFIG_VERSION, "0.1.0");
+    let old = load_config("[layout]\nspecs_dir = \"specs\"\n").unwrap();
+    assert_eq!(old.meta.required_version, None);
+    assert!(old.check_required_version("0.15.0").is_ok());
+}

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -177,3 +177,38 @@ without breaking readers:
 - **`frontmatter.extra_known_keys` / `extra_frontmatter`**: overlay-specific
   fields ride through without a schema bump (see
   [overlay-contract.md](overlay-contract.md) §5).
+
+## Pinning the binary: `[meta] required_version`
+
+The schema versions above tell a **loader** what it can read. They say nothing
+about which **binary** should be reading it, and a repository is otherwise
+governed by whichever `spec-spine` happens to be on the path. Spec 062 adds
+`[meta] required_version` for that: a semver requirement the CLI checks before
+doing any work, refusing with exit `3` and naming the requirement, the running
+version, and where the pin lives.
+
+Cargo's conventions: a bare `"0.15.0"` is a caret range, `"=0.15.0"` is exact,
+`">=0.15, <0.16"` is a range, `"*"` constrains nothing. `--version`, `--help`
+and `init` are exempt, because they are how an operator finds out what they are
+running and what to do about it.
+
+**A binary older than the pin refuses too, for the wrong reason.** Every
+`Config` table carries `deny_unknown_fields`, so a binary released before spec
+062 rejects the whole `[meta]` table as an unknown field:
+
+```
+spec-spine: config error: TOML parse error at line 1, column 2
+unknown field `meta`, expected one of `manifest`, `domains`, ...
+```
+
+That is worth knowing rather than discovering. It is the property that makes the
+pin usable at all: an adopter adding the key today is protected from every older
+binary immediately, not only from future ones. The message is poor, naming a
+parse error rather than a version mismatch, and it cannot be improved, because
+the binary producing it was built before the key existed. **If you see "unknown
+field `meta`", your binary is out of date; it is not a corrupt config.**
+
+The two axes stay separate. `required_version` constrains the binary; a
+repository can pin a binary without pinning a schema (the ordinary case), or
+find its shards rejected by a binary that satisfies its pin, which is the pin
+being too loose and the loader being right to refuse.

--- a/specs/062-a-version-pin-the-cli-can-check/spec.md
+++ b/specs/062-a-version-pin-the-cli-can-check/spec.md
@@ -4,7 +4,7 @@ title: "A version pin the CLI can check"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -16,6 +16,12 @@ extends:
   - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
   - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
   - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/tests/config.rs", nature: additive }
+  # `MetaConfig` and `VersionReq` join the crate root's export list, and the
+  # new table joins `config show`'s report (3.1).
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  - { spec: "054-effective-config-is-a-governed-read", unit: "crates/spec-spine-cli/src/cmd_config.rs", nature: additive }
+  # The docs note 3.3 requires.
+  - { spec: "067-the-docs-name-what-adopters-derived", unit: "docs/schema-versioning.md", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: "docs/schema-versioning.md" }, role: context }
@@ -97,6 +103,13 @@ file already governs the repository, `spec-spine config show` (spec 054) reports
 it with everything else, and a sidecar would be a second configuration surface
 with its own discovery rules for one scalar.
 
+**Decision, 2026-09-07.** "Reports it with everything else" is not free: spec
+054 §3.4 mirrors `Config`'s tables one for one in `EffectiveConfig`, and its
+drift guard failed the moment `[meta]` existed and was not mirrored. That guard
+is the reason this was a build failure rather than a table silently missing from
+every `config show`, and adding the table to the report is part of adding it to
+`Config`.
+
 `CONFIG_VERSION` does not move. An added optional table with a default is the
 additive case that constant exists to make safe.
 
@@ -152,6 +165,19 @@ before the key existed.
 will otherwise read "unknown field `meta`" as a corrupt config rather than as an
 out-of-date binary.
 
+**Decision, 2026-09-07: the requirement parser is hand-written.** Neither
+`spec-spine-types` nor the workspace carries a semver crate, and this spec does
+not add one. The substrate every binding wraps has four serde dependencies and
+nothing else, and the grammar needed here is small and closed: comparators
+(`=`, `^`, `>`, `>=`, `<`, `<=`, bare, `*`), a possibly-partial version, and
+comma as conjunction. Cargo's semantics are followed exactly, including 0.x
+being its own major line, because that is what an adopter writing `^0.15`
+expects, and the acceptance pins each arm of it.
+
+A malformed requirement is a config error naming what is wrong, never a silent
+pass: a pin nobody can parse must not read as "unpinned", which would be the
+failure mode of treating a parse error as absence.
+
 ### 3.4 The scaffold writes it, commented out
 
 `config_toml` MUST emit the key commented out, with the running version as the
@@ -202,22 +228,36 @@ inputs. That property is worth more than the notification.
 
 ## 5. Verification
 
+Each line is one command (spec 049 §3.2), so the fixture lives at a fixed path
+rather than in a `$(mktemp -d)` that would not survive to the next line.
+
+Every assertion fails against pre-062 code: `[meta]` was an unknown table and
+every one of these exited 3 with a parse error.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-types --test config --locked
-# A satisfiable pin is silent. Until this ships, `[meta]` is an unknown table
-# and every one of these exits 3.
-tmp=$(mktemp -d) && mkdir -p "$tmp/specs" \
-  && printf '[meta]\nrequired_version = ">=0.1"\n' > "$tmp/spec-spine.toml" \
-  && target/release/spec-spine --repo "$tmp" lint
-# An unsatisfiable pin refuses, and the refusal names the requirement.
-printf '[meta]\nrequired_version = "=0.0.1"\n' > "$tmp/spec-spine.toml"
-target/release/spec-spine --repo "$tmp" lint 2>&1 | grep -q '0.0.1'
-! target/release/spec-spine --repo "$tmp" lint 2>/dev/null
-# --version stays available under an unsatisfiable pin: it is the diagnostic.
-target/release/spec-spine --repo "$tmp" --version
-# The scaffold writes the key, commented out.
-tmp2=$(mktemp -d) && target/release/spec-spine --repo "$tmp2" init >/dev/null \
-  && grep -q 'required_version' "$tmp2/spec-spine.toml"
+# 3.2: a satisfiable pin is silent.
+rm -rf "${TMPDIR:-/tmp}/ss062" && mkdir -p "${TMPDIR:-/tmp}/ss062/specs" && printf '[meta]\nrequired_version = ">=0.1"\n' > "${TMPDIR:-/tmp}/ss062/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" lint
+# 3.2: an unsatisfiable pin refuses at exit 3...
+printf '[meta]\nrequired_version = "=0.0.1"\n' > "${TMPDIR:-/tmp}/ss062/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" lint ; test $? -eq 3
+# ...naming the requirement, the running version, and where the pin lives.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" lint 2>&1 | grep -q '0.0.1'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" lint 2>&1 | grep -q 'required_version'
+# 3.2: a read is refused too. An old binary answering `registry plan` about a
+# corpus it may misunderstand is the quiet failure this spec prevents.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" registry plan ; test $? -eq 3
+# 3.2: --version stays available under an unsatisfiable pin. It is how an
+# operator finds out what they are running.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" --version
+# 3.2: and so does `init`, the verb reached for when things are wrong.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062" init --force >/dev/null
+# 3.4: the scaffold writes the key, commented out, so a new repository is not
+# pinned to whichever version happened to scaffold it.
+rm -rf "${TMPDIR:-/tmp}/ss062b" && mkdir -p "${TMPDIR:-/tmp}/ss062b" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss062b" init >/dev/null && grep -q '# required_version' "${TMPDIR:-/tmp}/ss062b/spec-spine.toml"
+# 3.3: the docs record the older-binary refusal, so "unknown field `meta`" is
+# not read as a corrupt config.
+grep -q 'unknown field' docs/schema-versioning.md
+rm -rf "${TMPDIR:-/tmp}/ss062" "${TMPDIR:-/tmp}/ss062b"
 ```


### PR DESCRIPTION
Implements spec 062 (adopter-audit backlog item 16). Unblocks 063.

## Why

A repository is governed by whichever `spec-spine` happens to be on the path,
and nothing said which one it should be. rahi states 0.11.0 in three files that
must agree by hand. All four governed repositories are two to four releases
behind the fixes their own experience motivated — and rahi **cannot see spec
044, which was written for rahi's exact state**, because it is pinned below it.

## What changed

**`[meta] required_version`**, a semver requirement checked before any work.
Absent means unpinned (every existing repository). A *requirement* rather than
an exact version because both intentions are legitimate: pin with `=` to
reproduce a byte-identical ledger, or write a range to take fixes but not a
MAJOR.

**The refusal is exit 3** — a configuration the tool cannot honour, which is
what 3 means; not 1 (nothing was validated), not 2 (nothing is stale). It names
the requirement, the running version, and where the pin lives.

**`--version`, `--help` and `init` are exempt.** They are how an operator finds
out what they are running and what to do about it; refusing them would remove
the diagnostic exactly when it is needed. **Every other verb is refused, reads
included** — a read from a mismatched binary is the quiet failure this prevents.

**An older binary refuses too, for the wrong reason.** Every config table is
`deny_unknown_fields`, so a pre-062 binary rejects `[meta]` as an unknown field.
That is the property that makes the pin usable at all: an adopter adding the key
today is protected from every older binary immediately. The message is poor and
cannot be improved, so `docs/schema-versioning.md` now records it — "unknown
field `meta`" means an out-of-date binary, not a corrupt config.

**The scaffold writes it commented out**, with the running version as the
example. Pinning a new repository to whichever version happened to scaffold it
would be a decision made on the adopter's behalf.

## Two decisions recorded in the spec

**§3.3: the requirement parser is hand-written.** Neither the types crate nor
the workspace carries a semver crate, and this spec does not add one — the
substrate every binding wraps has four serde dependencies and nothing else, and
the grammar here is small and closed. Cargo's semantics exactly, 0.x as its own
major line included, with each arm pinned by a test. A malformed requirement is
a config error, never a silent pass: a pin nobody can parse must not read as
"unpinned".

**§3.1: spec 054's drift guard earned its keep.** `EffectiveConfig` mirrors
`Config`'s tables one for one, and 054's `the_report_covers_every_config_table`
failed the moment `[meta]` existed and was not mirrored. That is why this was a
build failure rather than a table silently missing from every `config show`.

## Verification

`spec-spine verify 062` passes, 12 commands — including that a *read*
(`registry plan`) is refused, and that `--version` and `init` survive an
unsatisfiable pin. Full gate green: 69 shards fresh, index fresh, 0 unresolved,
0 lint warnings, 74/74 coverage, `couple` clean over 8 paths. Workspace tests,
clippy `-D warnings`, `fmt --check` pass. No waiver.