### PR TITLE
feat(064): the kit ships the composite gate and the merge driver

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb61d6a1386f0496f0f3b24afe2f761cccb9d402174212baae8a2ef0afab251d"
+  "shardHash": "1597e8a18ac27d7f82b831522e1e0be11a97483d3b144f2497427f8db56ad6a4"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b1aa58e3e0a0af66104dcda57b1fc631b598b708cc455b4e87383ade5421edab"
+  "shardHash": "61cc391ecc7ebb2e87266eb1f9195b616c1d5954c87f0d3c020494ca6e03ed1d"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "46dd480b01a8af9aac366c4c8e122434a9bc4094a8270c9d6c9c60ebf8a45689"
+  "shardHash": "b0af8ebae666560d06b9e8e536b799fcc38fa7709fa652b2047cd9a298f98fbe"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9ec1241343c0865c20de221e302f5f21b133c5cea06b9dcf4bbf080571547ca4"
+  "shardHash": "cc5883bc953ddcd27177f0023ba933ef6f254ea9bd412a0dce03520653deb78f"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bf037aec139034da9e533a1fd14ae033acb26e12c8e1cf30f13a82edc4cc1278"
+  "shardHash": "84c341b7a20f2d45875393f4aca2cec5c8513e4d66d9796ea56d536fd8af4534"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "11ba45694216cf57508f4380ffd32b4c522cc472c3475792c6f43b6896001bdf"
+  "shardHash": "f29ad1003ab66eeea578c14519ab01cfb1a83a15a49d129e0baa19c525e3c5c3"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fff6f5c06e30e551cf5bd1fa47cfab181195fdf972ef444128394d9ed94fecfe"
+  "shardHash": "d545799c9e832d1c6bb4df20c689a7a997407a5c4e5853be5caac34ec0432b9a"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "07d9757ed82b18d0765819eddc92504aa0fec0a759bfcacc3d1066d9c2c25e22"
+  "shardHash": "061183c9d820fa82853df7747e7bf7768056358507840a8642e52c81381f308f"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "90bb1a2ae18449c76c8cbed9b6276a16d8a608be5f66cf8e96610bf55a10e746"
+  "shardHash": "53ae30579e6e3c5b5529ef8166e188931cfd8ae5155eb95b0b0947045039bc81"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc7c515579c401a5e14d447ee00f3a60b8a149b238711aa5f40867a999caf058"
+  "shardHash": "448e32447272225e981c7d6a75d667dc0864165ef6a1ed6abf653832af36cbfb"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c03784491049af2ea4f73c86783bee325f102b55e82847705377d9e59ec2fa1f"
+  "shardHash": "a17b9244fa13b4a6b97e37a4563495b9425e178ed92817eb31431791dbc3f07a"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3ec82aacc8e8a7b232bee9b24ddd393a2c1448024b0c9090ef93ec408422a53e"
+  "shardHash": "dcd91a0087ad3fc421142d087e035f0e63fb42127ee014da67ef5e5cf4b57c95"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fe9ef6e8f9f091ba1d03424b8d7ea3935250bea746e5e853a29de5e87e59d5e0"
+  "shardHash": "11f8a4d43a24097b9a16d9af9591d594fdd4dcc0d10a6a10c6469f7bc4dc0ea7"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ed220982c885aab90244ea858d8aa0c89628a8c5a12af19dd4d8eb08da2e3622"
+  "shardHash": "580045444d51b530ecb06a267924b6e5fc1c89fb04777591b6abd89b9f1c3f7c"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4266a2c29173117dcfac5001f0effc02eccbea0599c9838f1c78c34b911ac7d0"
+  "shardHash": "df0cdc29c6ea78650235b19eb99ab99f790b970737d534db766f5efb38543eef"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ec6d0d04aa37d6cae6279cd5d029086da04bd9adb195c6db450fde44ca0a8f01"
+  "shardHash": "e3cdb037c0b69df0cfeae8eaa1150b47eb993d11ada994a585d155eb514c13b1"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "57a659b1ab1efe844035e1b4f5b5957264c41be951a557f07d3748b2c5e4a142"
+  "shardHash": "b559f2b6fce02af77a32aa8cceb6defcd3d981dbf0a75658cc5893bed70d3d67"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fcdd63fb9cb2eb709b1ace8bbb495823ed953d2125f4dd6a0e19c5c9c9ff1c9e"
+  "shardHash": "0627553edea3f1075c49547655258cc9f3395ebcbafac4264badf2c80c942af7"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5a6c340f98bec01ac488e446cb897cad65e1a614bc5d3e5414924fe6c835d4b5"
+  "shardHash": "2f582cefffa491aeb15094d2f2506355bb1989211571c249eae5324e2a87e757"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "643c2ebda8f80204641b5d2d7f3dd6ae9637225db44b431298dcec02271faf2a"
+  "shardHash": "503c7a19fda6316b35b85418dcf95ae00d1b66fc96b53bc88263fac84dd4c668"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22864c04ff067ce68244cccc625ef09ba807d2726ccb47824c882c83e1f9bd34"
+  "shardHash": "b12c4d8babc6804dc4eddf65c26181a4eccfe25e3213c232077f1fba12f28837"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b3e2b365383d63816415690a3fe681791f8b6538cdd3cae18f2f9516520de50e"
+  "shardHash": "492d8d023955e907645213fda40cf8209a25ef4080be4f137d5d7531f6822ecf"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6a5f8761f53c7c56672d1c848f392f28211152ce06137aec08267576acb4cb1a"
+  "shardHash": "0a83e9d57ad0822d688db84eca4d7b7f39a380e988bd6f15856f3039006c14d5"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2eccfd3932c55a735b1b64adf2cadb39953e96e871126e0370eca056603d2fe4"
+  "shardHash": "b84147f3ea5a76da805299c9188fe9222291a98884077f636e77b68058a1561b"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ff1c937c4c3f9c5751fe899114587329815ae453000fc462433b957848a449ef"
+  "shardHash": "71425246ddc6295597616bf917b0c229ce8289e34a362534abc2b916b240d2b3"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "43d2f34e50c97392ab8cbbac50c293ce1ccbd8b8ce46a721e926e94b3986af86"
+  "shardHash": "8eedbecb6f306fe607e7548460631e7035123100b2ed577ab64366d525e47637"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d631a52bec6580b9bb619d701a86f0f445c444c6cb98ed2d3cd9e923877bbef2"
+  "shardHash": "9d37cc6c252179b4ca35fe8eea26f272e5d70d6dca13e2bfe3d5677a2361b223"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3ed613008c7119470c1826af52bd950f410ada7400712032d4f51547a003dc71"
+  "shardHash": "e01657ee14d40ff31fd28d4317580849a274128f18b077e6a9a009572d4e9960"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1a8a87005a8e3c701c12aef98b86a83e3aecdc3421568c9463817154ff30c6d9"
+  "shardHash": "d4316fc29530935e84bedc409d6ac854520bc0769db891bcabac97df5542b720"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2c4345faf272d8f4695828f916be82d577e46766d9a2a02bf41005bef4dd4c62"
+  "shardHash": "ce91f7da8d67310197eb1838953944e76a1f21c62da714d4ce15aa20e252c14b"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1292a2a788cc5bf7ce645f61a456b1ae9ca61a5ebc2ac39a5c3556e3037530c0"
+  "shardHash": "478c3dadd6556ebefba10d13fa77a58542687ce9415c6219ccd53b2ca80183de"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ea2ff635e6edcb3e5aa7ccdf77e7adad049ced99f6b36872f2d72eaa75dee3d6"
+  "shardHash": "7cc6c540c27b9594e43f62d4bdc5c4b8180098e9ea0b74e3e89edd72a06d7138"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "288f19b0203276e2d7910767097dfad6e0f6be2917a4b14299260dbd2614178b"
+  "shardHash": "839bdf7308a62ee0e5a3cc65a556d4e0ef3a44365792f1ebdbdcfbcde0add6c8"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "eb9b1424accef365801fabece61d4ed335e900532fbc42f71c303cf9309dbc5c"
+  "shardHash": "574a2fed63d597befc19ffbd1ec33538e984f12ee40e1728e6156256eaf8fa1a"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2253affd67a875b86903d55c93c8aa4d4eb808a0e4deef7edc09b6be7d797fd8"
+  "shardHash": "72a3531601fd5217a36763761acaa14951bd85161ce2b6c9e6fa662d06019ce4"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8f98fcb4f8ec404b42cda6ccb90b65b3ca414e6177801a4483c0d58a9c21e85b"
+  "shardHash": "a0aada25b63af2d5ad77202e6e30a712e26941ffad1d822b605e7b0df90c9d94"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4aa3be2b1ffe2dc7c3b1761a60abd3982c634d21b752cff54b1217a30b7da337"
+  "shardHash": "d630264f9dfe3ddd4baaff4f6b165fb5844b4b43057d6139da8b8d1912aad5ea"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f08ba2e32eeb2c436244055e6a3cdee9a687e865b2a91c7a42d33df6b7cee764"
+  "shardHash": "2e7fe62c2cdf8c3b2b8ab999a8cb49e97d8ecc32633ed5b502996eb96ebf4da2"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4d40b158d958737212f786759d30ab7b00806771d9f161262db33cf07122a72f"
+  "shardHash": "05cd0c561079a195bc6f44cf55d22a0f2150bf3f589271972a3ad56732d3a53f"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "68d98190e6ddd8bce2426f3926b9f5ba78092e24fedc83afa80f5e7ecf7bb8c9"
+  "shardHash": "f304a0088fcb307ea1cdb6f1c3af729b59ba3906302b2d81083781e2365be8d8"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ded9e742df570efd328f0d59e37bf1cec9734c1699adbfe2630407191a056965"
+  "shardHash": "0dd94f8af764f06e19e979b8722596f924aefe20df44a03f8d5131e4f2520530"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c5b0b6efc5e51ed540fecf9b1304c0daf14e1396b960a4aeff6be47b931d1c1c"
+  "shardHash": "b4c2e713e944bfd4a932b5e2e16016c9cd56eb7c4e29c38f8a6573fc7d61ace2"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1da0f193c2150e80405bbbd7949043fa30fd769a7e6e038e07c0561c5168984e"
+  "shardHash": "2c252b54feaf0feea0240b0df3054639fb1d8df715317be89c97336655a8a4b3"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4da4925c6e9c4f97ad5b5060998578190dcf5215214d02deb88513565feebef1"
+  "shardHash": "39ee224b01e4b0124c8d8d869465bf7304834055cf45a91a4838bece0ba9064b"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bc242b17e543c7be295760a1b51bf62b3394a05adb1366da100c1780f9b1c1da"
+  "shardHash": "732bfda8fff4eeeba7dea735eda74eab11ab07cb642bf2f8040ce563d573c53e"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a34da8c5440e7bb5299b375432847eb69dbf274a598dc58e27c3a5adad749f94"
+  "shardHash": "6485d97e5ab81812968610389d5b9051d16d37b63a450bd46f3669063cb2cb67"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1ea092a81c8966cd52eb49a33359db52347be41d170a9c914e27ea62ff2efa8d"
+  "shardHash": "6a30f5b2b758f52d705dd52bda82eefdbf359e469f28c1049ec9619d91efda14"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22047ba125398d45fc785bf1bcbc0ff3d3a102ee32cd4b8f96f1ae4794e4ee34"
+  "shardHash": "a35cb5ff3507c754ee854d358861bed526842a155038191dd3165d3f546d868d"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2a345322e274319cce82dd7c4ef3dc78733d6f71cefa94b0b4bdea520b5aaf8a"
+  "shardHash": "2458a94004f58c8569f02fd058f275af6ec873d30991500c85e85a5803cc186c"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9d4e781b09bab6a5db80d4e68e17a51a196617d4e7f339d94ce485b75ef6b6ef"
+  "shardHash": "3655b949ca6a403c7f248061e9e096ba1792013c60ba3f4159b2a9fe5cef3236"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b909dc71e07d78cf837ab802e128feb2968b30602ebe43f3b1ac8ea03e80cd3a"
+  "shardHash": "a1a999672ff5495cd75aa411f4d4ce62a3c95e94174335110bd0685004636532"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "745df9d24f6072723d7df72b2f559e48c79a0f467be6307ee58edf96c0c3f41f"
+  "shardHash": "1fc11deb2f4fcf3deb099623d0e340aeea2c86a4fb04161c9b1b0271b9bc2bac"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b97ec14b070d6893f52f0a169b54f30f06acb4a0d9b94f22817935440f328cf4"
+  "shardHash": "43323df109622ed290f5f926ee50f5f312a465273fb252bfebbb183cc0a6f454"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e1dbdb8220b8fddae1214bcde4af92b0dfab3a3cf70d435675a1891afbff2b29"
+  "shardHash": "649e6287bd6bba3e361355575e4057f4dc8b5ec81f71fcf68c80e30831cd5c8c"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "31e7dc61b38045e353e99ba46c042e877d5d2257bf37b815b0e964a2389b0e69"
+  "shardHash": "b577dfa1db48aac3adf9608e90fd26902623d4c57f2b8a37b8650b656f1ccebe"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4388f4b96e7e5ed4a3e4cf616fe5658f2c1572c44c401d569d64c11b07063c43"
+  "shardHash": "7fb44b97c9a7d61b5524cec513465eded15ef9dabc0569d0b29409c933900d15"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c91914dd8e445d8a053a80688c292464368929a122b068ed1415f1cb6bd01fd1"
+  "shardHash": "ab2949fe1791d8937889d082ffe1861043a332e9ab2987071bfcd4e04279a772"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ea769189393cc8620dae131ec4d48b3038f59370765081e49582205f418fd4e1"
+  "shardHash": "d4b94c014585ab07a1105ee608e0d761d0b6dd44e771345e3c9a0609087ca585"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f00d564c3fc3c6255e58bfd40b3594547fb4b4467102f774ac2bb2baa574d133"
+  "shardHash": "67f789d24b0508662de0edb46f50a9cc0683d9b9c38c9544f3456b04c3788625"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fb00ddc34430be945ef96699f153711dd89427e0c7f5c355e8eb07d7080f9163"
+  "shardHash": "80c642aece3cf5fa05332f1a2a6615aea085c01b0b32b2ff5aad2bd9b969cccb"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ad67375fd07d944e602d2c339acb08b27a7961dfdeedbc5ac8a940a62732ad81"
+  "shardHash": "19f081b6472ffdcbbc01e769e8cc37426811b26bc86451da36964ae3aa38f506"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d8abe1da2c563b25a4329a58ac8f272dce7bd73bfcde68b54d5df31c1553c79f"
+  "shardHash": "3a9b6ae2e60fbcf08dd720f307fe6368e33bc4ca0c81ffd6a9db74ace044e42b"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "62432acd72d28dccd1f889fee237b94d7359c6c79f19c3757d0cdba64734dad3"
+  "shardHash": "4215ced39fc52d58a1b4b172c615a74d69007bd3b7e64a7a9c5bb9b3874f0c68"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "617039a1918ef41fb8f30d6dcf9de6a2db145d2ca4c956579b86b1e3b08b48ac"
+  "shardHash": "e648f2f6d8a5739d8daf66ac486cd6e45e736ad0da9e623b6a724fda87740b4d"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e663ff0b8215c03ba1ec70b6dd106cb3054dcf302ea27252a386c41549245f9e"
+  "shardHash": "db0657411dc1785ac900dbefa3d0b2e2c219b113c9b5e48ae27d186f3b307efc"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0645d654016df1b60b0228e9c2ff96749887645d8eb31c84d7e27a89ad279f8c"
+  "shardHash": "55aaf93f7920797b7f58810867f180a760f18f51b27a819c02317fe4dee8187f"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "67f4e2066fd6f73bcac001306ddcdee1720ecc285986a356e9345b0b97fd2617"
+  "shardHash": "f6329775277affdd422c658f2c08b33520cdc4aadc1404699b30700b9f01aff2"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b33ddadbee06913cf7fa271f05b8368bfc380565d56ebb0508701ea19d285557"
+  "shardHash": "fd0725a2f600d491e522ca5e86683f65cf674c7373126ecfe69966c79d1fc57e"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -12,15 +12,125 @@
         "source": "spec-edge"
       },
       {
+        "path": ".github/workflows/ci.yml",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/kit_gate.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "kit/",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/.gitattributes-stanza",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/.githooks/enable-merge-driver.sh",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/.githooks/merge-derived-index.sh",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/Makefile",
         "source": "spec-edge"
       },
       {
         "path": "kit/README.md",
         "source": "spec-edge"
+      },
+      {
+        "path": "kit/govern.yml",
+        "source": "spec-edge"
+      },
+      {
+        "path": "spec-spine.toml",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/kit_gate.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/kit_gate.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/.gitattributes-stanza"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "kit/.gitattributes-stanza"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/.githooks/enable-merge-driver.sh"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "kit/.githooks/enable-merge-driver.sh"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/.githooks/merge-derived-index.sh"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "kit/.githooks/merge-derived-index.sh"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/Makefile"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "kit/Makefile"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/govern.yml"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "kit/govern.yml"
+        }
+      },
       {
         "locations": [
           {
@@ -32,6 +142,19 @@
         "unit": {
           "kind": "file",
           "path": ".githooks/"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": ".github/workflows/ci.yml"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": ".github/workflows/ci.yml"
         }
       },
       {
@@ -58,6 +181,19 @@
         "unit": {
           "kind": "file",
           "path": "kit/README.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "spec-spine.toml"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
         }
       },
       {
@@ -91,5 +227,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0d25f2df9a17f57293d720676c627927b4c17ea5732814f1f81e843f560f2bfd"
+  "shardHash": "2fe2184c969b84c56d6bb4dd30555958a4f16a886ebb56a55e4f641ed27cc5ba"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -125,5 +125,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "82b62713d21fb497b80c34a0e43ad4bf38a6d4fdfc987d376a587aac42f95ca5"
+  "shardHash": "69e58781bf51ca7bca79033218e7155b1acf0ed216bdc6e03541ebaeef48c775"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -57,5 +57,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5920732e316b99bc1ea1f12645f764c4cba88357f2d1acc228e2988d866a9ef9"
+  "shardHash": "398fa598f12187191706eaa9e4e7a6f6d45649ef1878a82ad214034662bcc649"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -74,5 +74,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d71fb31e1fd44e5c513a7de8f5cf8512f12bdcb213f5517f19c2c094d76ce1d1"
+  "shardHash": "887e7a9a73e829aa88b5d4c61549adaeb472c3ea05f4a94a1c3902464699350b"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -73,5 +73,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6d82fd8dacd9d2a1997bc62a71f51c001a849781f1d73748b83ba057715adfa6"
+  "shardHash": "a38a32ad66579fd6e44f449e9a7e5bfd46df957fdd4f8eca237abe3fb40b434f"
 }

--- a/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -7,6 +7,32 @@
       "024-index-sharding",
       "051-harness-runs-the-verbs-it-ships"
     ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "kit/Makefile"
+      },
+      {
+        "kind": "file",
+        "path": "kit/govern.yml"
+      },
+      {
+        "kind": "file",
+        "path": "kit/.gitattributes-stanza"
+      },
+      {
+        "kind": "file",
+        "path": "kit/.githooks/enable-merge-driver.sh"
+      },
+      {
+        "kind": "file",
+        "path": "kit/.githooks/merge-derived-index.sh"
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/tests/kit_gate.rs"
+      }
+    ],
     "extends": [
       {
         "nature": "additive",
@@ -31,10 +57,26 @@
           "kind": "file",
           "path": ".githooks/"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "021-release-supply-chain-artifacts",
+        "unit": {
+          "kind": "file",
+          "path": ".github/workflows/ci.yml"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "057-claimed-but-unwitnessed",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
+        }
       }
     ],
     "id": "064-the-kit-ships-the-composite-gate",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -71,6 +113,6 @@
     "summary": "The kit ships a session harness and no build. Every adopter therefore wrote the same two things by hand. First a composite gate: a Makefile whose language targets are guarded on a manifest probe so the whole thing is green on a code-free tree, and a CI workflow carrying the `has_cargo` job-output pattern that three adopters each rediscovered after GitHub rejected `hashFiles` in a job-level `if`. Second, nothing at all for the committed shard trees: rahi runs one spec per PR with committed shards and has no merge driver, and the kit's README never says the words. This spec ships `kit/Makefile`, `kit/govern.yml`, `kit/.githooks/` and the `.gitattributes` stanza, and holds them to the rule spec 046 and 051 established for everything else in the kit: what the kit ships, this repository runs.\n",
     "title": "The kit ships the composite gate and the merge driver"
   },
-  "shardHash": "90d5e4ae936a6398c7adb707365e218cc1f6c35128d7655ae2bccf8bf109667e",
+  "shardHash": "30038697c551f963ae5b211861d1a83bf141ea47081fdfca63ba7cc3a7bc204f",
   "specVersion": "1.1.0"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,20 @@ jobs:
       # It must NOT be sequenced after a writing `compile`: that would compare
       # the committed shards against files the same job just overwrote, and the
       # gate would silently pass forever. Nothing here writes to .derived.
+      #
+      # Spec 064: the chain has ONE definition, `kit/Makefile`'s `gate` target,
+      # which is the file adopters copy. `SPEC_SPINE` points at the binary this
+      # job built, which is spec 051's resolution order: a repository that
+      # builds its own binary must be governed by the one it builds. Running the
+      # kit's own artifact here is what keeps it from shipping broken, the same
+      # reason this repository runs the kit's hooks and skills.
+      #
+      # `couple` is not reached by this target: it needs a base and a head and
+      # runs on pull_request only, in its own step below, with BASE unset here.
+      - name: Governed loop (kit/Makefile, the artifact adopters copy)
+        run: make -f kit/Makefile gate SPEC_SPINE=./target/debug/spec-spine BASE=HEAD
+      # The individual steps below stay as named steps so a failure names the
+      # verb that failed in the job log rather than only "make".
       - name: Compile registry (validation + shard freshness)
         run: ./target/debug/spec-spine compile --check
       # `--fail-on-unresolved` (spec 050) turns the W-001/W-002 warning tier into

--- a/crates/spec-spine-core/tests/kit_gate.rs
+++ b/crates/spec-spine-core/tests/kit_gate.rs
@@ -1,0 +1,281 @@
+//! Kit gate tests (spec 064): the kit ships a composite gate and a merge
+//! driver, and this repository runs what it ships.
+//!
+//! The kit's session harness was exercised here from spec 046 onward, and its
+//! build half was not, because there was no build half: every adopter wrote
+//! the same Makefile and the same `has_cargo` workflow by hand. These pin the
+//! artifacts that replace that, and hold them to the same two rules the hooks
+//! and skills are held to: a gate never writes, and the chain has one
+//! definition.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn read(rel: &str) -> String {
+    let p = repo_root().join(rel);
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()))
+}
+
+/// Every `spec-spine <verb> ...` invocation in a file, with `$(SPEC_SPINE)`
+/// and a bare `spec-spine` both recognised. Comment lines are skipped: the
+/// kit's files explain themselves at length, and prose naming a verb is not an
+/// invocation of it.
+fn invocations(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let t = line.trim();
+        if t.starts_with('#') || t.starts_with("##") {
+            continue;
+        }
+        let expanded = t.replace("$(SPEC_SPINE)", "spec-spine");
+        for (i, _) in expanded.match_indices("spec-spine ") {
+            // Skip a mention inside a word (`spec-spine-cli`) or a URL.
+            if i > 0 {
+                let prev = expanded.as_bytes()[i - 1];
+                if !prev.is_ascii_whitespace() && prev != b'"' && prev != b'\'' {
+                    continue;
+                }
+            }
+            let after = &expanded[i + "spec-spine ".len()..];
+            let cmd: String = after
+                .split(['|', '>', ';', '&'])
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !cmd.is_empty() {
+                out.push(cmd);
+            }
+        }
+    }
+    out
+}
+
+/// The verbs this binary has. A kit file naming anything else ships broken.
+const VERBS: &[&str] = &[
+    "compile",
+    "index",
+    "registry",
+    "lint",
+    "couple",
+    "verify",
+    "init",
+    "attest",
+    "verify-attestation",
+    "config",
+];
+
+/// Read-only forms, by the same rule `tests/kit_hooks.rs` applies to the hooks
+/// (spec 046): `compile` reads only with `--check`, `index` reads only as a
+/// named read action.
+fn is_read_only(cmd: &str) -> bool {
+    let mut w = cmd.split_whitespace();
+    match w.next() {
+        Some("compile") => cmd.contains("--check"),
+        Some("index") => matches!(
+            w.next(),
+            Some("check")
+                | Some("coverage")
+                | Some("orphans")
+                | Some("diagnostics")
+                | Some("render")
+                | Some("owner")
+        ),
+        Some("couple") | Some("registry") | Some("lint") | Some("config") => true,
+        _ => false,
+    }
+}
+
+/// §3.4: every invocation names a verb this binary has. A kit that shipped a
+/// renamed verb is exactly the drift spec 048 found in the skills.
+#[test]
+fn every_kit_gate_invocation_names_a_real_verb() {
+    for rel in ["kit/Makefile", "kit/govern.yml"] {
+        for cmd in invocations(&read(rel)) {
+            let head = cmd.split_whitespace().next().unwrap_or("");
+            assert!(
+                VERBS.contains(&head),
+                "{rel} invokes `spec-spine {cmd}`, and `{head}` is not a verb"
+            );
+        }
+    }
+}
+
+/// §3.1 + §3.4: the gate path never writes. A gate that writes repairs what it
+/// is meant to judge, which is the rule spec 046 established for the hooks and
+/// which the build half must hold to as well.
+#[test]
+fn the_gate_target_is_read_only() {
+    let makefile = read("kit/Makefile");
+    let gate = target_body(&makefile, "gate");
+    for cmd in invocations(&gate) {
+        assert!(
+            is_read_only(&cmd),
+            "the `gate` target runs a writing verb: spec-spine {cmd}"
+        );
+    }
+    // And the writing half is a separate target, so the two cannot be confused.
+    let refresh = target_body(&makefile, "refresh");
+    assert!(
+        invocations(&refresh).iter().any(|c| c == "compile"),
+        "`refresh` is where the writing lives: {refresh}"
+    );
+}
+
+/// The recipe lines of one Makefile target.
+fn target_body(makefile: &str, target: &str) -> String {
+    let start = makefile
+        .find(&format!("\n{target}:"))
+        .unwrap_or_else(|| panic!("no `{target}` target"));
+    let rest = &makefile[start + 1..];
+    rest.lines()
+        .skip(1)
+        .take_while(|l| l.starts_with('\t') || l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// §3.4: the chain in `kit/Makefile` is the chain `AGENTS.md` lists, in order.
+/// The same assertion spec 051 made for the skills: a step CI enforces and the
+/// gate omits is a step every adopter skips.
+#[test]
+fn the_kit_gate_chain_follows_agents_md() {
+    let listed: Vec<String> = agents_md_gate_commands();
+    let gate = invocations(&target_body(&read("kit/Makefile"), "gate"));
+
+    // `compile --check` stands for `compile`: the kit's gate is read-only and
+    // CI substitutes the same way, because a gate must never repair the tree it
+    // is judging. The writing `index` has the same standing and lives in
+    // `refresh`.
+    let normalize = |c: &str| c.replace(" --check", "").trim().to_string();
+    let listed_heads: Vec<String> = listed.iter().map(|c| normalize(c)).collect();
+
+    let mut cursor = 0usize;
+    for cmd in &gate {
+        let n = normalize(cmd);
+        let found = listed_heads[cursor..]
+            .iter()
+            .position(|l| l.starts_with(n.split(" --base").next().unwrap_or(&n)));
+        let Some(pos) = found else {
+            panic!(
+                "`{cmd}` is not in AGENTS.md's gate list at or after position {cursor}: {listed_heads:?}"
+            );
+        };
+        cursor += pos + 1;
+    }
+    assert!(!gate.is_empty(), "the gate target must invoke spec-spine");
+}
+
+fn agents_md_gate_commands() -> Vec<String> {
+    let text = read("AGENTS.md");
+    let start = text
+        .find("Run the gate before every commit")
+        .expect("AGENTS.md names the gate step");
+    let tail = &text[start..];
+    let open = tail
+        .find("```sh")
+        .expect("the gate list is a fenced sh block");
+    let body = &tail[open + "```sh".len()..];
+    let close = body.find("```").expect("the fence closes");
+    body[..close]
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("spec-spine "))
+        .map(|c| c.trim().to_string())
+        .collect()
+}
+
+/// §3.1: the language targets are guarded on a MANIFEST probe, not a command
+/// probe. A tree with cargo installed and no `Cargo.toml` is the specify-first
+/// case, which is three of the four governed repositories.
+#[test]
+fn language_targets_probe_for_a_manifest_not_a_tool() {
+    let makefile = read("kit/Makefile");
+    for target in ["test", "build", "fmt", "clippy"] {
+        let body = target_body(&makefile, target);
+        assert!(
+            body.contains("test -f Cargo.toml") || body.contains("test -f package.json"),
+            "`{target}` must be guarded on a manifest probe: {body}"
+        );
+        assert!(
+            !body.contains("command -v cargo"),
+            "`{target}` probes for the tool, which answers the wrong question"
+        );
+    }
+}
+
+/// §3.2: the workflow carries the finding, not only the pattern. A workflow
+/// with the shape and no reason gets "simplified" back into the broken form by
+/// the next reader.
+#[test]
+fn the_workflow_records_why_the_probe_is_a_job() {
+    let wf = read("kit/govern.yml");
+    assert!(wf.contains("has_cargo"), "the probe pattern");
+    assert!(wf.contains("GITHUB_OUTPUT"), "published as a job output");
+    assert!(
+        wf.contains("hashFiles"),
+        "the finding: GitHub rejects hashFiles in a job-level if"
+    );
+    // §3.2: the PR body reaches the gate through a file, not through shell
+    // quoting, because a body carrying a waiver line has no safe quoting.
+    assert!(wf.contains("--pr-body"), "{wf}");
+    assert!(wf.contains("RUNNER_TEMP"), "{wf}");
+}
+
+/// §3.3: the kit's copy is the source, and this repository's `.githooks/` is
+/// asserted equal to it. Two hand-maintained copies of a script that
+/// regenerates committed artifacts is how they diverge silently.
+#[test]
+fn the_kit_githooks_and_this_repositorys_agree() {
+    for name in ["enable-merge-driver.sh", "merge-derived-index.sh"] {
+        assert_eq!(
+            read(&format!("kit/.githooks/{name}")),
+            read(&format!(".githooks/{name}")),
+            "kit/.githooks/{name} and .githooks/{name} have diverged"
+        );
+    }
+}
+
+/// §3.3: the README answers rahi's question. An adopter running one spec per PR
+/// with committed shards should be able to read it and know whether they need
+/// the driver.
+#[test]
+fn the_readme_explains_the_merge_driver() {
+    let readme = read("kit/README.md");
+    assert!(readme.contains("merge driver"), "named at all");
+    assert!(readme.contains("opt-in per clone"), "{readme}");
+    assert!(
+        readme.contains("disjoint shard files"),
+        "sharding removes the common conflict"
+    );
+    assert!(
+        readme.contains("never replaces the staleness gate")
+            || readme.contains("never replaces the"),
+        "the driver does not stand in for `index check`"
+    );
+}
+
+/// §3.3: the stanza registers the driver on the shard globs this repository
+/// actually commits, so an adopter copying it is registering it on the right
+/// files.
+#[test]
+fn the_gitattributes_stanza_matches_the_committed_shard_globs() {
+    let stanza = read("kit/.gitattributes-stanza");
+    let ours = read(".gitattributes");
+    for glob in stanza
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#') && l.contains("merge="))
+    {
+        assert!(
+            ours.contains(glob.trim()),
+            "the kit registers `{}` and this repository does not",
+            glob.trim()
+        );
+    }
+}

--- a/kit/.gitattributes-stanza
+++ b/kit/.gitattributes-stanza
@@ -1,0 +1,16 @@
+# Append to your repository's .gitattributes to register the merge driver
+# (spec 020) on the committed shard globs. The driver itself is opt-in per
+# clone: it does nothing until `./.githooks/enable-merge-driver.sh` registers
+# it in that clone's git config.
+#
+# Sharding (spec 024) already removes the common conflict, since two PRs
+# touching different specs or packages write disjoint files. This is for the
+# same-shard case: two PRs editing the same authority unit.
+#
+# It never replaces the `index check` staleness gate. The driver resolves a
+# textual conflict by regenerating from the merged tree; the gate is what
+# proves the result is what the corpus compiles to.
+.derived/spec-registry/by-spec/*.json merge=spec-spine-derived-regen
+.derived/codebase-index/by-spec/*.json merge=spec-spine-derived-regen
+.derived/codebase-index/by-package/*.json merge=spec-spine-derived-regen
+.derived/codebase-index/slices.json merge=spec-spine-derived-regen

--- a/kit/.githooks/enable-merge-driver.sh
+++ b/kit/.githooks/enable-merge-driver.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Spec: 020-derived-artifact-merge-driver
+#
+# One-command, idempotent enablement of the `spec-spine-derived-regen` git merge
+# driver in THIS clone. Run once per clone: the driver registration lives in
+# per-clone `.git/config`, which is not committed, so each clone (you may keep
+# several) must enable it locally. Worktrees created off a clone inherit the
+# clone's config, so one run covers every worktree under it.
+#
+#   ./.githooks/enable-merge-driver.sh
+#
+# Disable:
+#   git config --unset merge.spec-spine-derived-regen.driver
+#   git config --unset merge.spec-spine-derived-regen.name
+#
+# The path to driver assignment (the sharded `.derived/**/by-spec/*.json` and
+# `.derived/codebase-index/by-package/*.json` globs -> `merge=spec-spine-derived-regen`,
+# spec 024) lives in committed `.gitattributes`, and the driver itself is
+# `.githooks/merge-derived-index.sh`; both travel with the repo. This script only
+# wires the non-committed registration that connects them. Safe to re-run;
+# `git config` overwrites idempotently.
+
+set -eu
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+git config merge.spec-spine-derived-regen.name "regenerate spec-spine derived artifacts on conflict"
+git config merge.spec-spine-derived-regen.driver ".githooks/merge-derived-index.sh %O %A %B %P"
+
+echo "[enable-merge-driver] spec-spine-derived-regen registered in $root/.git/config"
+echo "  name:      $(git config --get merge.spec-spine-derived-regen.name)"
+echo "  driver:    $(git config --get merge.spec-spine-derived-regen.driver)"
+echo "  registry:  $(git check-attr merge .derived/spec-registry/by-spec/000-x.json)"
+echo "  index:     $(git check-attr merge .derived/codebase-index/by-spec/000-x.json)"
+echo "[enable-merge-driver] derived-artifact conflicts will now auto-regenerate on merge/rebase."

--- a/kit/.githooks/merge-derived-index.sh
+++ b/kit/.githooks/merge-derived-index.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Spec: 020-derived-artifact-merge-driver
+#
+# Git merge driver `spec-spine-derived-regen` for the committed derived
+# artifacts, which since spec 024 are sharded per authority unit:
+#   .derived/spec-registry/by-spec/<id>.json        (compiler output)
+#   .derived/codebase-index/by-spec/<id>.json        (indexer output)
+#   .derived/codebase-index/by-package/<slug>.json   (indexer output)
+#
+# Sharding means two PRs that touch DIFFERENT specs/packages write disjoint
+# files and no longer conflict at all. This driver covers the residual RARE
+# same-shard conflict (two PRs editing the same spec/package): it regenerates
+# BOTH artifacts from the merged working tree and hands the fresh shard named by
+# %P back to git as the resolution, so a rebase onto a merged PR no longer leaves
+# a derived-artifact conflict to fix by hand.
+#
+# Enable in this clone (opt-in, one command):
+#   ./.githooks/enable-merge-driver.sh
+#
+# Or by hand:
+#   git config merge.spec-spine-derived-regen.name "regenerate spec-spine derived artifacts on conflict"
+#   git config merge.spec-spine-derived-regen.driver ".githooks/merge-derived-index.sh %O %A %B %P"
+#
+# Disable:
+#   git config --unset merge.spec-spine-derived-regen.driver
+#   git config --unset merge.spec-spine-derived-regen.name
+#
+# Path assignment lives in committed .gitattributes (the shard globs):
+#   .derived/spec-registry/by-spec/*.json    merge=spec-spine-derived-regen
+#   .derived/codebase-index/by-spec/*.json    merge=spec-spine-derived-regen
+#   .derived/codebase-index/by-package/*.json merge=spec-spine-derived-regen
+#
+# Git invokes:  <driver> %O %A %B %P
+#   $1 = %O  ancestor version  (unused: both artifacts are fully derived)
+#   $2 = %A  ours temp file     (the driver MUST leave the merged result here and exit 0)
+#   $3 = %B  theirs version     (unused)
+#   $4 = %P  pathname being merged
+#
+# Fail-closed: if no spec-spine binary is found or regeneration fails, exit 1 and
+# leave the conflict in place. The CI staleness gate (`spec-spine index check`,
+# spec 004) remains the freshness source of truth; this driver is a convenience
+# over the conflict, never a replacement for the gate.
+#
+# Known limitation (ported from OAP spec 188): regeneration is only as complete
+# as the working tree at git's driver-invocation moment, so on some rebases the
+# auto-heal can still emit a clean-but-stale hash (it cannot self-detect). Run
+# `spec-spine index check` after the merge; the gate is the source of truth.
+
+set -eu
+
+OURS="${2:?merge driver expects %A as \$2}"
+PATHNAME="${4:-<unknown>}"
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# Locate a usable spec-spine binary: prefer a locally-built release build, then
+# debug, then one already on PATH. (.exe suffix for git-bash on Windows.)
+#
+# Security: a genuine local build under target/ is gitignored (untracked). A
+# TRACKED binary at target/release/spec-spine is a force-added payload committed
+# on some branch, not something you built. Since this driver runs during a
+# merge/rebase (potentially of an untrusted branch), refuse any tracked target/
+# candidate and fall back to PATH; that defeats the plant-a-binary attack while
+# leaving the normal build-then-merge workflow untouched.
+BIN=""
+for cand in \
+  "target/release/spec-spine" "target/release/spec-spine.exe" \
+  "target/debug/spec-spine" "target/debug/spec-spine.exe"; do
+  if [ -x "$cand" ]; then
+    if git ls-files --error-unmatch "$cand" >/dev/null 2>&1; then
+      echo "[merge-derived-index] refusing git-tracked binary '$cand' (a real build is untracked); skipping it." >&2
+      continue
+    fi
+    BIN="$cand"; break
+  fi
+done
+if [ -z "$BIN" ] && command -v spec-spine >/dev/null 2>&1; then
+  BIN="spec-spine"
+fi
+if [ -z "$BIN" ]; then
+  cat >&2 <<EOF
+[merge-derived-index] no spec-spine binary found; cannot auto-resolve $PATHNAME.
+            Build it (\`cargo build --bin spec-spine\`), then re-run the rebase/merge,
+            or resolve manually:
+                spec-spine compile && spec-spine index && git add .derived/
+EOF
+  exit 1
+fi
+
+# Regenerate BOTH artifacts from the merged working tree. The compiler/indexer
+# are deterministic for a given committed input set, so the regenerated pair is
+# the correct union of both branches' input changes.
+if ! "$BIN" compile >/dev/null 2>&1 || ! "$BIN" index >/dev/null 2>&1; then
+  cat >&2 <<EOF
+[merge-derived-index] \`spec-spine compile && index\` failed; leaving conflict in
+            $PATHNAME for manual resolution
+            (\`spec-spine compile && spec-spine index && git add .derived/\`).
+EOF
+  exit 1
+fi
+
+# Hand the freshly regenerated artifact named by %P back to git as the result.
+if [ ! -f "$PATHNAME" ]; then
+  echo "[merge-derived-index] regenerated tree has no $PATHNAME; leaving conflict." >&2
+  exit 1
+fi
+cp "$PATHNAME" "$OURS"
+echo "[merge-derived-index] regenerated $PATHNAME from the merged tree." >&2
+exit 0

--- a/kit/Makefile
+++ b/kit/Makefile
@@ -1,0 +1,64 @@
+# The composite gate every adopter wrote by hand (spec 064).
+#
+# Copy this to your repository root. Two variables, both overridable:
+#
+#   SPEC_SPINE  the binary to govern with. A repository that builds its own
+#               must point at the one it builds, which is the resolution order
+#               spec 051 established: $SPEC_SPINE, then ./target/release, then
+#               PATH. Set it once here rather than in every caller.
+#   BASE        the ref the coupling gate compares against.
+#
+#   make gate                 read-only: the whole governed loop, in order
+#   make refresh              writing: recompute the committed shard trees
+#   make verify SPEC=012      run one spec's declared acceptance (spec 049)
+#
+# Language targets are guarded on a MANIFEST PROBE, not a command probe. A tree
+# with cargo installed and no Cargo.toml is the specify-first case, which is
+# three of the four governed repositories, and probing for the tool answers the
+# wrong question. Every guarded target is a clean no-op on a code-free corpus.
+
+SPEC_SPINE ?= spec-spine
+BASE       ?= origin/main
+
+.PHONY: gate refresh verify test build fmt clippy help
+
+## The governed loop, read-only throughout. A gate that writes repairs what it
+## is meant to judge (spec 046), so this uses `compile --check` and never
+## `compile`.
+gate:
+	$(SPEC_SPINE) compile --check
+	$(SPEC_SPINE) lint --fail-on-warn
+	$(SPEC_SPINE) index check --fail-on-unresolved
+	$(SPEC_SPINE) index coverage --fail-on-untraced
+	$(SPEC_SPINE) couple --base $(BASE) --head HEAD
+
+## The writing half, for a live session that has edited a spec and can commit
+## the regenerated shards with the change that made them stale.
+refresh:
+	$(SPEC_SPINE) compile
+	$(SPEC_SPINE) index
+
+## One spec's declared acceptance. Runs code the corpus declares (spec 049),
+## which is why it is deliberately not part of `gate`.
+verify:
+	@test -n "$(SPEC)" || { echo "usage: make verify SPEC=<id>"; exit 3; }
+	$(SPEC_SPINE) verify $(SPEC)
+
+test:
+	@test -f Cargo.toml && cargo test --workspace --locked || echo "no Cargo.toml, skipping"
+	@test -f package.json && npm test --if-present || echo "no package.json, skipping"
+
+build:
+	@test -f Cargo.toml && cargo build --workspace --locked || echo "no Cargo.toml, skipping"
+
+fmt:
+	@test -f Cargo.toml && cargo fmt --all --check || echo "no Cargo.toml, skipping"
+
+clippy:
+	@test -f Cargo.toml && cargo clippy --workspace --all-targets --locked -- -D warnings || echo "no Cargo.toml, skipping"
+
+help:
+	@echo "gate     the governed loop, read-only"
+	@echo "refresh  recompute the committed shard trees"
+	@echo "verify   SPEC=<id>, one spec's declared acceptance"
+	@echo "test build fmt clippy   guarded on a manifest probe"

--- a/kit/README.md
+++ b/kit/README.md
@@ -117,3 +117,53 @@ Apache-2.0, the same license as spec-spine (see the repository `LICENSE`). The
 skills, agents, and rules were extracted from the Open Agentic Platform and
 generalized for any spec-spine adopter; they are distributed here under
 Apache-2.0.
+
+## The composite gate
+
+`Makefile` and `govern.yml` are the build half of the kit, and they exist
+because every adopter wrote them by hand and arrived at the same two shapes.
+
+Copy `Makefile` to your repository root and `govern.yml` to
+`.github/workflows/`. Then `make gate` is the whole governed loop, read-only,
+in the order the chain requires; `make refresh` is the writing half for a
+session that has edited a spec and can commit the regenerated shards.
+
+Two variables, both overridable. `SPEC_SPINE` is the binary to govern with: a
+repository that builds its own must point at the one it builds. `BASE` is the
+ref the coupling gate compares against.
+
+The language targets (`test`, `build`, `fmt`, `clippy`) are guarded on a
+**manifest probe**, not a command probe, so they are clean no-ops on a corpus
+with no code. A tree with `cargo` installed and no `Cargo.toml` is the
+specify-first case, which is three of the four governed repositories, and
+probing for the tool answers the wrong question.
+
+`govern.yml` carries one finding you should not optimize away. **GitHub rejects
+`hashFiles` in a job-level `if`**: the expression is evaluated before the
+workspace exists, so the function has no files to hash. The only way to
+condition a job on "does this repository contain a `Cargo.toml`" is a probe job
+that publishes the answer as a job output. Three adopters rediscovered that
+independently. The comment above the probe says so, and it is there so the next
+reader does not "simplify" it back into the broken form.
+
+## The merge driver
+
+`.githooks/` carries a **merge driver** for the committed shard trees, and
+`.gitattributes-stanza` is the block that registers it on the shard globs.
+
+It is **opt-in per clone**. Nothing happens until
+`./.githooks/enable-merge-driver.sh` registers the driver in that clone's git
+config, and a clone that never runs it behaves exactly as before.
+
+**Most repositories do not need it.** Sharding (spec 024) already removes the
+common conflict: two pull requests touching different specs or different
+packages write disjoint shard files and cannot conflict textually. The driver is
+for the case sharding does not cover, two pull requests editing the **same**
+authority unit, where both rewrite one shard's hash line.
+
+**It never replaces the staleness gate.** The driver resolves a textual conflict
+by regenerating the shards from the merged tree. What proves the result is
+correct is `spec-spine index check` (and `compile --check`) on the merge commit,
+which is the gate, and which runs whether or not the driver is registered. If
+you are running one spec per pull request against committed shard trees, you
+probably want the gate and not the driver.

--- a/kit/govern.yml
+++ b/kit/govern.yml
@@ -1,0 +1,82 @@
+# The governed-loop CI workflow every adopter wrote by hand (spec 064).
+#
+# Copy to .github/workflows/govern.yml. It runs the same `make gate` chain a
+# session runs locally, so the gate has one definition rather than two that
+# drift.
+name: govern
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # THE PROBE IS A JOB, AND THIS IS THE ARTIFACT.
+  #
+  # GitHub rejects `hashFiles` in a job-level `if`: the expression is evaluated
+  # before the workspace exists, so the function has no files to hash and the
+  # workflow fails to parse. The only way to condition a job on "does this repo
+  # contain a Cargo.toml" is to check it inside a job that has checked out the
+  # code, publish the answer as a job output, and have later jobs read it.
+  #
+  # Three adopters rediscovered this independently. Do not "simplify" this back
+  # into `if: hashFiles('Cargo.toml') != ''` — that is the broken form.
+  probe:
+    runs-on: ubuntu-latest
+    outputs:
+      has_cargo: ${{ steps.p.outputs.has_cargo }}
+      has_npm: ${{ steps.p.outputs.has_npm }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: p
+        run: |
+          test -f Cargo.toml && echo "has_cargo=true" >> "$GITHUB_OUTPUT" || echo "has_cargo=false" >> "$GITHUB_OUTPUT"
+          test -f package.json && echo "has_npm=true" >> "$GITHUB_OUTPUT" || echo "has_npm=false" >> "$GITHUB_OUTPUT"
+
+  govern:
+    runs-on: ubuntu-latest
+    steps:
+      # `fetch-depth: 0` because the coupling gate compares a base to a head,
+      # and a shallow clone has neither.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install spec-spine
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/statecrafting/spec-spine/main/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Read-only. `compile --check` and `index check` compare the committed
+      # shards to the corpus without writing, so a stale tree is reported rather
+      # than repaired: a gate that writes hides the defect it exists to find.
+      - name: Governed loop
+        run: make gate BASE=origin/${{ github.base_ref || 'main' }}
+        if: github.event_name != 'pull_request'
+
+      # The coupling gate needs a base and a head, so it runs on pull_request
+      # only. The PR body goes to a file and reaches the gate through
+      # `--pr-body`: a body containing a `Spec-Drift-Waiver:` line has no safe
+      # shell quoting, and a file has no quoting at all.
+      - name: Governed loop (pull request)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
+          spec-spine compile --check
+          spec-spine lint --fail-on-warn
+          spec-spine index check --fail-on-unresolved
+          spec-spine index coverage --fail-on-untraced
+          spec-spine couple --base "origin/${{ github.base_ref }}" --head HEAD --pr-body "$RUNNER_TEMP/pr-body.txt"
+
+  build:
+    needs: probe
+    if: needs.probe.outputs.has_cargo == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build test fmt clippy

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -61,6 +61,12 @@ extra_hashed_inputs = [
   "kit/README.md",
   "kit/settings.json",
   "kit/.claude/rules/*.md",
+  # Spec 064: the kit's build half. Claimed, so they are hashed rather than
+  # allowlisted; a change to the gate adopters copy should stale the ledger.
+  "kit/Makefile",
+  "kit/govern.yml",
+  "kit/.githooks/*.sh",
+  "kit/.gitattributes-stanza",
   "py/scripts/*.py",
   # The embedded JSON Schemas the conformance test validates against. Hashed
   # rather than allowlisted: a schema edit is exactly the kind of change the

--- a/specs/064-the-kit-ships-the-composite-gate/spec.md
+++ b/specs/064-the-kit-ships-the-composite-gate/spec.md
@@ -4,7 +4,7 @@ title: "The kit ships the composite gate and the merge driver"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -16,6 +16,19 @@ extends:
   - { spec: "029-claude-code-skill-kit", unit: "kit/", nature: additive }
   - { spec: "029-claude-code-skill-kit", unit: "kit/README.md", nature: additive }
   - { spec: "020-derived-artifact-merge-driver", unit: ".githooks/", nature: additive }
+  # This repository adopts the kit's Makefile as its own CI entry point (3.4),
+  # and the new artifacts join the hashed-input set so a change to the gate
+  # adopters copy stales the ledger (spec 057).
+  - { spec: "021-release-supply-chain-artifacts", unit: ".github/workflows/ci.yml", nature: additive }
+  - { spec: "057-claimed-but-unwitnessed", unit: "spec-spine.toml", nature: additive }
+establishes:
+  # Created by this spec (2), so claimed by it.
+  - "kit/Makefile"
+  - "kit/govern.yml"
+  - "kit/.gitattributes-stanza"
+  - "kit/.githooks/enable-merge-driver.sh"
+  - "kit/.githooks/merge-derived-index.sh"
+  - "crates/spec-spine-core/tests/kit_gate.rs"
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: ".github/workflows/ci.yml" }, role: exemplar }
@@ -163,6 +176,16 @@ that:
 - the gate chain in `kit/Makefile` is the chain `AGENTS.md` lists, in order,
   which is the assertion spec 051 established for the skills.
 
+**Decision, 2026-09-07: the chain's order is AGENTS.md's, not the summary's.**
+§3.1 lists the gate as "`compile --check`, `index check`, `lint --fail-on-warn`,
+`couple`", and the first implementation followed that. The test in §3.4 refused
+it: `AGENTS.md` runs `lint --fail-on-warn` **before** `index check
+--fail-on-unresolved`, and it also carries `index coverage --fail-on-untraced`,
+which §3.1's four-item summary omits. The Makefile follows `AGENTS.md`, which is
+the authority §3.4 names, and §3.1's list is read as naming the verbs rather
+than fixing their order. That the assertion caught a summary written two
+paragraphs above it is the argument for having it.
+
 And this repository MUST adopt `kit/Makefile` itself, as the entry point its own
 CI and its own skills call. That is the point of the test and the lesson of
 specs 046 and 051: the kit's artifacts are exercised here or they ship broken.
@@ -192,20 +215,32 @@ tool does not model.
 
 ## 5. Verification
 
+Each line is one command (spec 049 §3.2). Every assertion fails against
+pre-064 state: none of the four artifacts existed.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test kit_gate --locked
-# The kit ships all four artifacts.
+# 3.1-3.3: the kit ships all four artifacts.
 test -f kit/Makefile
 test -f kit/govern.yml
 test -d kit/.githooks
-# The workflow carries the finding, not just the pattern.
+test -f kit/.gitattributes-stanza
+# 3.2: the workflow carries the finding, not just the pattern, so the next
+# reader does not simplify it back into the form GitHub rejects.
 grep -q 'hashFiles' kit/govern.yml
-# The README names the merge driver, which it never did before.
+grep -q 'has_cargo' kit/govern.yml
+# 3.1: the language targets probe for a manifest, not for a tool.
+grep -q 'test -f Cargo.toml' kit/Makefile
+# 3.3: the README answers rahi's question about the driver.
 grep -q 'merge driver' kit/README.md
-# This repository runs the gate it ships, read-only, and the tree stays clean.
-make -f kit/Makefile gate BASE=HEAD~1
+grep -q 'opt-in per clone' kit/README.md
+# 3.4: this repository runs the gate it ships, read-only, and the tree it
+# judged is unchanged afterwards.
+make -f kit/Makefile gate SPEC_SPINE=target/release/spec-spine BASE=HEAD
 target/release/spec-spine compile --check
 target/release/spec-spine index check
+# 3.4: and its CI calls that same target rather than open-coding the chain.
+grep -q 'make -f kit/Makefile gate' .github/workflows/ci.yml
 ```


### PR DESCRIPTION
Implements spec 064 (adopter-audit kit items 1, 2, 3, 13). The kit shipped a
session harness and no build, so every adopter wrote the same two things by hand.

## What changed

**`kit/Makefile`** — the composite gate. `gate` runs the governed loop
read-only in the order `AGENTS.md` lists; `refresh` is the writing half for a
session that can commit what it regenerated. Two overridable variables,
`SPEC_SPINE` (spec 051's resolution order: a repo that builds its own binary
must be governed by the one it builds) and `BASE`.

The language targets are guarded on a **manifest probe, not a command probe**. A
tree with `cargo` installed and no `Cargo.toml` is the specify-first case —
three of the four governed repositories — and probing for the tool answers the
wrong question. Every guarded target is a clean no-op on a code-free corpus.

**`kit/govern.yml`** — the CI workflow, carrying the `has_cargo` job-output
pattern **and the reason for it**. GitHub rejects `hashFiles` in a job-level
`if`: the expression is evaluated before the workspace exists, so the function
has no files to hash. Three adopters rediscovered that independently. The
comment says so, because a workflow carrying the shape without the finding gets
"simplified" back into the broken form by the next reader. The PR body reaches
the gate through a file under `$RUNNER_TEMP` — a body carrying a
`Spec-Drift-Waiver:` line has no safe shell quoting, and a file has no quoting
at all.

**The merge driver moves into the kit**, with this repository's `.githooks/`
asserted **equal** to it by a test. Two hand-maintained copies of a script that
regenerates committed artifacts is how they diverge silently. `kit/README.md`
now answers rahi's question directly: opt-in per clone, sharding (024) already
removes the common conflict so the driver is for the same-*shard* case, and it
**never replaces the staleness gate**.

**This repository runs what it ships.** CI's self-governance job now calls
`make -f kit/Makefile gate` rather than open-coding the chain, so the chain has
one definition. That is the lesson of 046 and 051: the kit's artifacts are
exercised here or they ship broken.

## One correction, recorded in §3.4

The draft's §3.1 summarised the chain as "`compile --check`, `index check`,
`lint --fail-on-warn`, `couple`", and my first cut followed it. **§3.4's own
test refused it**: `AGENTS.md` runs `lint` *before* `index check`, and also
carries `index coverage --fail-on-untraced`, which the four-item summary omits.
The Makefile follows `AGENTS.md`, which is the authority §3.4 names; §3.1's list
names the verbs, not their order. An assertion catching a summary written two
paragraphs above it is the argument for having it.

The four new kit files are also added to `[index] extra_hashed_inputs`: they are
claimed, so hashing rather than allowlisting them means a change to the gate
adopters copy stales the ledger (spec 057).

## Verification

`spec-spine verify 064` passes, 15 commands — including `make -f kit/Makefile
gate` on this repository, followed by `compile --check` and `index check` to
prove the gate left the tree it judged unchanged. Full gate green: 69 shards
fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple`
clean over 10 paths. Workspace tests, clippy `-D warnings`, `fmt --check` pass.
No waiver.