### PR TITLE
docs(066): the contract records the lifecycle table and the extra keys

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "90bb5f6cfd46d5abc1bb7d6748275feb0c06e88221e526849e62573131d920ed"
+  "shardHash": "90a16055d60610092cd0e2683f0866b624e1212b7ac2be35b9d81f75cb12e770"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "95aa660a9e84569d1d7519d6d1ee547ef29644cf654db0fd5d900cf4bfb4e952"
+  "shardHash": "ccb41bcd7b1a2598b9aebe827e8c1b285bfddb43d00a4634578199e98da8bbca"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "55a31a33bf1fea3d0f4158e2b86e9db6f9f0c5afe9cca14acdd5f5378e3321bb"
+  "shardHash": "69f527b491e2397e745ec89483e8691f580fdc71c568ad021cf72963f15f281f"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b292f8f02116ca780815229934a79f07b389483c15fff5bd9fa9cd6a684f19fe"
+  "shardHash": "b7c5374fce25606a5bc4505cc6b763ca3f45d032dae31e82124914404fe5b71c"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cf067cea528bfb6b8ae4d04912e5d744de2b6999836eb1e4db0059229902b286"
+  "shardHash": "347c2d2de07f1fc83da8a19ca9c130efee2079dc8f30b51106b487ddfd03090c"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "78b136077e30ad1656a3d9a436ed9dc27d30148c8129ad654ae783d5e817d78c"
+  "shardHash": "8b20dbf54236ce8c99f7eceb4f1f869abad0641472d3a7d6b769d470d127febb"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "45251fb5869a59d8e22795d705fa241780bd491fc0fa33e41dda4c58ee7f3191"
+  "shardHash": "375213278a72532693461b31bcc44d5e01b83e3a217bcc946abd5bd81aaeea03"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f2d73bcd83afb143e5ade400b07f38128d4e58952d1e2cf48c7fb457bd52433c"
+  "shardHash": "5db45bb21d43c014fa6ac345c33a0e88eee0ad88d9c0680173db2655a1103a08"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c10411cf57f454f4ddb73120dd71cc29c8dbe0d408b279de9cf3bd365c343a14"
+  "shardHash": "27459c7efeddb47cc4160d3191e50f62ac50cdb04caf80776443f4d82019a1a6"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8f22e814af48f96b64707216b45e9130198205c9b87f78dfe5ff639d203b163e"
+  "shardHash": "c2abba526419354acbbb347c0a7ef4b5dec4757533563fb904ab7994622559b2"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8ea99d4a279b7a1f28e21762b791a8717f3b3a7512bc55761259aa7f30fa74da"
+  "shardHash": "d02948c84052dd349bc8dff36929f509d9032dade7e2aaae58057420d9dfcf87"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "24e00ea17fceddcb527253f32d5212c367f2c703f00c50dcb604d4813a169504"
+  "shardHash": "b7c5470a45bd9cf0abbf44de2d13c5d0420c65dd316c2259dd64a838fa39fca4"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "78bb3df1e8f44b4b41cb0ae652e20b6c77e15b4b2e3b52bfdcf01007b4325e9b"
+  "shardHash": "356fe2ea291f0a17ed9abb044bf492b2a1e12fac3c83ebe99ca79bcece96bb3a"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4294cfcab6f2cc84820c11fc06f19b0dc24cfbc1fae923dffdc89374287924cb"
+  "shardHash": "747f72fd928bcb53a1ffbfe793d7e6cfb826474a861feccbe869b23f3c7fed9d"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4fda5844928edb78b6d0e207c715b0acfd750fbde54e395dad0f66a706eff8f2"
+  "shardHash": "5eac212730fa8f8aeca7045819313b5b482072ef43ef71ecfb70876d701c7a6e"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9971c034c0a2dade87b1668aa164be28deaa265e8a7550bd0e37aa4c38d4ebf0"
+  "shardHash": "fefa11918225c4d41bf4a3140afbad1962c82fa88f3d8f952f083d0b11044270"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6ca99f209f6359e99fdad47dd02793b13d829dd5eeb6f0d2aeb7d503c7f96a8d"
+  "shardHash": "62b9430a31c5d1e0c948e6a00851b3640dbbd9b1951b5c1fc5968b5fe188f88c"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b73c5b347e4b45f23037553f52a255f7f27aceb1b8be62d77af6a020c8593bac"
+  "shardHash": "6c96023ab41f6f771ab46e10cf8b4b90a4a8b6549aa02436ca4c5a2216e811b0"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "438f9ef8300eb815a82312af29939654f6f715a7461fcba68b0d1b63d3b40d93"
+  "shardHash": "435d30e4d0f16830096ba0d2a64a3f5891ac34930400fca5b89f4011bee1aed4"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c809dab4e18b1d44a9e364bcc3e546c1ab330ccdeaa976d5ad5a772358b0a723"
+  "shardHash": "a48989ce2ff8da8a13d29f56a7d664aa7f28483160a80e3aa3e3aa8aa99f4a66"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ac89179f5d60a2278170d3cb316283f2607a4963c4a5109dc6161d632830d406"
+  "shardHash": "2e0570792ed054f2cc9482285bb06d902e6fb5f2c7218da7af841e541324c790"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "abbddad578df386d68f0b586caffdf8d9ef9234d249f7ca20f2ddbf907245ff1"
+  "shardHash": "7ded4398d205918932d57bf0525394bb0a608526208159d00da7aa9292f7f154"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2eba0c2103305ad20545c6f05e91b830c2167bf698e584c8a9947abbd282387b"
+  "shardHash": "96836941d14200a4cc1a0aef691149d1447bc1b211f0b21cc59b7cd48bbdbff7"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8fc31b165d2e04d5fc8d9962d602dd9a631298af153fd54f6ddb4c0973347dde"
+  "shardHash": "fda283a1168ae25af9d0502ea01786d76848d7fb2aa41b5b800c7be13f69e8db"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c17149d9731e3010697d956752e7451b499b483181ad18551981a46fe706abdf"
+  "shardHash": "a2f13ddbfaa0e647230dc720c157912ec7228b22401c8798cb4bacefd02df6cb"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9a49f374af49339a1a540ec92ae1bc70ee44dcd462dc2c8a654ae684fc398e62"
+  "shardHash": "8d8ca4c657c36469c0e436a6e730b45950f2d2ddda587b4e9b1248d7d973dd43"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1762c3646fc6024c17bb14ad9f715cd88b2b034e6fd369ea8d4d1ead65421d2e"
+  "shardHash": "5a61eeca94302bdf8883934a3b36dc1e39b104feaed08646a4c41b915bfc005d"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7ecd1b3edf348e1cff97dbb639434516bc44cf6add7e4f965481ec45fa543e5c"
+  "shardHash": "d59ab7bf6350046d45947584d1872d2ab705b1f7c399e91aa57e3945f74c9027"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1d8b12f09d90a947b35b6255257392ad6421bab12efc56ee373b78d09bde7235"
+  "shardHash": "4d6c391bb00be33945263664755cbf27e1737d8db2416be6e18426974864e90c"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7fd43ea48b67525a9bd41cf960adca18836419e6921e20d7532e4a20c5376a89"
+  "shardHash": "b714716c9087df4ba9ea0ae3a8ffd222af423ee3449f7548222d578c3ce920b7"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cecdffa83e57db85fe389c51d2fe5386a9d358536001206bca1163db42616cd6"
+  "shardHash": "dbc036e83b3813f8e6c2200c354b87551e8d4cdba9d177f82e6e69c854f8fc24"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "54dbdf398d43780d87835647d7916c5fb39f905375c1867fa4fc51e015667602"
+  "shardHash": "b09e2fd6ff37cf60f44c388c059904e3ab3e4b4803faba702e5097ca87f38b33"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f49db334b3926449c38557aa739b7da7213626f63260eb826d7d233853f1f1c4"
+  "shardHash": "c361dce6c115c85904efdcfd67066342de08ce1184278994b4f960a9d8eccf3b"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "33c956e06a0af672269cecd5c0f3479a46d184c33d82fbe1cf04c2251cb2f313"
+  "shardHash": "f0025189f00d3861c4407a3179ed63e6f5eb61f14c128319c8c56b435490ea9b"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b616bff272fa2152c3a399ff09dac534479b4922feb61bb74a62629f0c2d3338"
+  "shardHash": "49ca6955275d83d803c8a327a6808192700528831e660fc162a7a499e392ea81"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "20dae8e8196da9ee7ce1d57fdf427db99ce65c4dd942bdf3e2efc2111833926d"
+  "shardHash": "0efbf8bcba771c94c7f29577daa3890c8b709cb8f0a12bba6e77d4aeea6b3b87"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f1a3147f211e1bc593b6d75c4c972ff2377e20ca124a0c87d313f11a1b5c8b99"
+  "shardHash": "b622d7fc98efad8395e21ae58e0d3ed41a2fc8287f82af010c18fbb4b248ff9d"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ae3f55282804df520b5d12b49676b16835d16e36b162ef315361b3e0a42c795e"
+  "shardHash": "852ae7329f949b2785ea6ee11ce2e00aabc35a4d9d4f884fab74614453f7887f"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fd9cc28824f9295c9b2ffeb0388f7ca3fb4b538d326f3f2b5fb24f556f483a02"
+  "shardHash": "ca8e026e8c5fff528f30b6112741f572de516190457c7c7f47965feb6a2107f7"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "de96a82c681c3806168f635191962f1de52229a22e07d44080e1b02dc0499ddf"
+  "shardHash": "2024245a67a797a112547105268ec8a8f94f82992cf7283ab8ffc43a95fe9c4f"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f9c62559af242ccfd7d5f713bfad44b22fef22e2b09f3941919a8350c549e48a"
+  "shardHash": "c6eabc6a5d6bc61f940de0cb50d0136987fcef9e88ee42741193fb765f24dfb9"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "87786b3410a4eebca6b360b71b86841b5d9b7374f5155562f62cca8469705eea"
+  "shardHash": "9dcebc957da80e58064fa423110767c53b0d9c67c82b377a74d9dd90eebd2e0b"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "26dc10eacbc47540ad49bdff4f7a5f692b00a5a1e304e0bae656c8e7bffbe3fc"
+  "shardHash": "ed34e34296f03893cd64dc1c80e16f53fff33511d35690e05ac066c9ca16acda"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "42277730723b4040b83d7614275bcc52036209f355a7ae117a4646032bee0da9"
+  "shardHash": "86e717f677c2e43aaeef8ea5644d5b7c0cf4440c76cbf49b3e333e64993a17df"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05adcf35f39325c932b2a8a572191a7039e9ea029da07659597884c11feffeb8"
+  "shardHash": "2b6d6cea2f8d6a23f838e8aa8485cc094ff79864f715b4c769307ebc82605e37"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6d59d6596cd7862d729305a587f68cf83c5b7a92d2cc030c1afec38bacc63f24"
+  "shardHash": "230605d58721c347448f8ade97e483782dd61fd914ff93489bf94288d154a631"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7abd0522a2def7affd6e031f2f25fdae6f5b9aa3e1a4c40a7efadad6cea03529"
+  "shardHash": "4d6ab83a20f4ea077c5afd651234ce398bed3b1b77bdea751b090e7adffc94ac"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ae430c548534da3cd1492f23bb0fe2787b1ed2c3207c7e05922c066a68297c92"
+  "shardHash": "05867803de5d420fb73ac6f5b0af338677c190c2bea10b58843e704d2ae4e071"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "476164cabcc2dc37b70c95e0a810cd89f47cb01e4ea14f30caec503b7af0883d"
+  "shardHash": "79a9aea4282d0c3d123d09b5cd6273dd1e1d92d424f5a1187e2be6dcbd730a81"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "010d1a2295e9f5e21dbb0072d8ff63a92b34a7f727390d93777acd7276cab348"
+  "shardHash": "999b6056e5cf4b0d44a93a22e7f5e2816c9c5b55b47f71f404de5dc69f173cc2"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "34cd963517db212b48e555d7c6a320853800d3f18117f6e2909ef31b5bf83391"
+  "shardHash": "207dbf70c21f43b23a7a944dd998ae1cb6690751ac8903313a97496070d83297"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc6925a22cae2f7f2d17acd60a5bacf9973e7f4f72f9901ea2dc949f42479188"
+  "shardHash": "76aae3e2c270ef40c1838e0b6adf1ff03eb8739ef339fd7ef69830c8135df3b0"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5c8dffe4399fea1edf950d88afc68fad1d1612e21f46700cba64ab2933843f10"
+  "shardHash": "a9dcec263684e0a8671bd87b7e71906c08e9489921fb25bd25a3222b80c084b3"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bee4f66a91c9340305e73b2ee08779d20f20d210458265df40460ccf8c87e058"
+  "shardHash": "3024c3fc162c8c3ed1c15b96fc0f48b8114f3649f2df7a32a3f0f510b6b70d1b"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "510e31091bdca241f8e42314517cbb3eb5291ed71fc365b201b1d84f8f361b4f"
+  "shardHash": "261a4cdd6f684abecadab55681aea32bfb4059d30c461afc7e9f806afc4b6d90"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4519cd534034a9415a58ca683463e813d78ececcd21d26b347715796123d15e1"
+  "shardHash": "f0db26ae8883f6f93766d1ebf221c8e9c54731a36cdf455810cf393eb9b8d321"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0d7fa3ad1964841ded4e996bfd74046421957a37480ca9988842c04acea3066a"
+  "shardHash": "199ee39096d3d944a213d17d1afe23d94933bcfb4eadaaa4762ca9377e22a626"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1277f77a36d9afb89127ea97b9491e1cab73d3c627bd6d2d495d785764f3c046"
+  "shardHash": "6610b35b31a4f692215bb4463853a178c6a7e8249206a7e5b4601c74bf777f7a"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2b77537b9adc96667124b1db499796b7a1e2a6342f89f415d72c12135237c6bc"
+  "shardHash": "910e4322bdb59a2d2ba1b0d26b100a2313eccf18b44233409522fd8117eb0b1d"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "06324a3f7ba0d93be1ff12ad11c6cec7d7f1bb2733316562d586e3e892057b8e"
+  "shardHash": "c1e6c698eb5f3e8a00f459d2646c6cfef9a7bdfdea959aa04d7410949343aa1b"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "50d2aaaddc20141ea8b3244bc68b786a89552c928ee2cfaae3fb8732c17f2866"
+  "shardHash": "5ed5622f5fcbf89b25fcec81dd9747696fd1700575fa82a7fe92a2701d90d06b"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "08e65fb02cf7ff36df1a1d1a53d72d204fb9531f9c8e4dd6d4f90db1fa8d9ee0"
+  "shardHash": "afb0adaaa6cc017e06162eaf9463c1c5487856ad1eefec663f369fec54516d07"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "02b870e558034fba8832bc6a34a3b7950543ddb93f85ce85d4cefa1395185cbe"
+  "shardHash": "7b059890c1e103f49cae6a7506cb09b8901b70a85b7082274975d70d7badf617"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0aa2c5028320b8dd23d58b173339b09922a31e610216c023b078ede34dbd74d3"
+  "shardHash": "6285ea0e537217b928caa4d7bf80ae0af9b12f045e379953e069fce26ba40eca"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f0154778cac6485dbf402db8cfa2126592099ad1dcce7a5befa4efdb060139fb"
+  "shardHash": "80cc4d834dc2b8dd41cb0a8d0d768b36d8e5ceb9d827ebb50ef75521b003a1e3"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f6fef81e7a2eef9684ee7c3a0508491b2dc0d8ba50e2d59b6d52a861c2e8614b"
+  "shardHash": "9f459774e4b9841732aaef90c9f3f3b2a8afab825ac5d39a5f25ab6352a032c9"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "18953541a54af98eb7b227f8183c1da4e8d99d26a2a610e5ccca9cb77fc5abbe"
+  "shardHash": "c216cb8e611697eef69e3670f7b5f09dae407311379366a4cd50f3e8cbf4a44a"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "58c29e93c166efe1d039cab13ec319382799cf43097abb480b2cd7eba9cd9e5d"
+  "shardHash": "d9487393f55096bd3aa80e41f1b1b178fe892f8d828f3be0b528af0ba280f28a"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ab09936282ac528c4d6ed0dfac3772b3fd5eff1f193fd770769393fdf4324553"
+  "shardHash": "dae663de22cb4ac53231976f08fb48b1edbac80714911fbee9f499dea1781ac8"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "653d96b7671bee09ca198caf397cb3a0b68d76fce493ed17f0e19c60d28b09ec"
+  "shardHash": "bfbca9af821b43c3ab7671d5dae05115fa8fd290430de2888c2489b9cc52927f"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -10,6 +10,14 @@
       {
         "path": "crates/spec-spine-core/src/scaffold.rs",
         "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/scaffold.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "standards/spec/contract.md",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
@@ -24,6 +32,32 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/scaffold.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "standards/spec/contract.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "standards/spec/contract.md"
         }
       },
       {
@@ -57,5 +91,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3faf2c8baf0b868b8f674a68de8cdc6ff2990921928fa158960baef652b671ec"
+  "shardHash": "57722a3a2a13de4d62507b1dcb71217bcecea8a9615385717883603fac2861a7"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e62e0365dc2c28d6c38aab8cdf148ade5ac8baeac2523f94cdc540a7262289ee"
+  "shardHash": "dba8ab500b27caf23e8e38effeda05949ecaa5eab86a57ce26c01d5fae070bb0"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e8a4b9cc60833275d1d5c2ace6795c1e1667e9b5929e32e21a005188df820f12"
+  "shardHash": "2fddecbf4e4990815c2853661c02de739152bfe5fa991b1cded61eba778d4274"
 }

--- a/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -15,10 +15,26 @@
           "kind": "file",
           "path": "crates/spec-spine-core/src/scaffold.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "006-init-scaffold",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "043-governance-document-gaps",
+        "unit": {
+          "kind": "file",
+          "path": "standards/spec/contract.md"
+        }
       }
     ],
     "id": "066-the-contract-records-the-lifecycle-table",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "governance",
     "owner": "The spec-spine Authors",
     "references": [
@@ -56,6 +72,6 @@
     "summary": "`status` and `implementation` are the two keys every adopter reasons about daily, and the contract mentions `status` once, in a list of required frontmatter, and `implementation` not at all. The mechanical consequences are spread across four specs: 041 makes a `complete` claim checkable, 044 defines the in-flight window, 045 says an absent key takes its answer from `status`, and 038 reads both to build the ready set. Every specify-first adopter wrote the resulting table into its own contract by hand, and hqgit had to invent a section called \"Lifecycle as scheduling\" because ours has none. This spec adds that section and an \"Extra keys\" section telling adopters to document their `extra_known_keys`, and claims both as section units of the contract.\n",
     "title": "The contract records the lifecycle table and the extra keys"
   },
-  "shardHash": "06cc9520f7bf654da7bbd25aa4b731a1c4d18e4d841c4e053968cae53ff16f1d",
+  "shardHash": "aef7458271bd8e9124ce57f3b51767444092d882e0283609be7c53f9433a3907",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/scaffold.rs
+++ b/crates/spec-spine-core/src/scaffold.rs
@@ -596,7 +596,44 @@ const CONTRACT: &str = "# Contract: normative summary\n\
   amended `spec.md` is not edited to record it.\n\
 - The constitution is not amended by `amends` (its targets are spec ids). An\n\
   approved spec changes it by claiming the affected heading as a section unit\n\
-  of that file; see the constitution's own Amendment section.\n";
+  of that file; see the constitution's own Amendment section.\n\
+\n\
+## Lifecycle as scheduling\n\
+\n\
+Two frontmatter keys decide whether a spec is offered as work and how strictly\n\
+its claims are held. `status` is `draft` / `approved` / `superseded` /\n\
+`retired`; `implementation` is `pending` / `in-progress` / `complete` / `n-a` /\n\
+`deferred`, or absent.\n\
+\n\
+| `status` | `implementation` | schedulable | unresolved unit is |\n\
+|---|---|---|---|\n\
+| `draft` | absent, `pending`, `in-progress` | yes | `W-001` warning |\n\
+| `approved` | `pending`, `in-progress` | yes | `W-001` warning |\n\
+| `approved` | absent | no (settled) | error |\n\
+| any | `complete` | no | error |\n\
+| any | `n-a`, `deferred` | no | takes its answer from `status` |\n\
+| `superseded`, `retired` | any | no | takes its answer from `status` |\n\
+\n\
+- **`approved` plus `pending` is a work order.** It is the state a\n\
+  specify-first corpus lives in for months, and the state `registry plan`\n\
+  offers as ready.\n\
+- **`draft` is never a claim about code.** A draft's unresolved units are\n\
+  expected, which is why they warn instead of refusing.\n\
+- **An absent `implementation` is not a third value.** It defers to `status`:\n\
+  on a `draft` it reads as `pending`, on anything ratified as settled. That is\n\
+  what keeps a bootstrap spec owning no code from being offered as ready\n\
+  forever, and why `n-a` exists for a ratified spec that owns nothing.\n\
+\n\
+## Extra keys\n\
+\n\
+`frontmatter.extra_known_keys` in `spec-spine.toml` declares frontmatter keys\n\
+this corpus recognizes beyond the grammar. A declared key stops the lint\n\
+warning about it, and its value is preserved verbatim into the registry as\n\
+`extraFrontmatter`, so a consumer can read it.\n\
+\n\
+The config lists the names and records nothing about what they mean. If you\n\
+declare keys, write down their semantics here or in your constitution, next to\n\
+the rest of what governs the corpus.\n";
 
 /// The adopter-facing constitution template (spec 061 §3.3).
 ///

--- a/crates/spec-spine-core/tests/scaffold.rs
+++ b/crates/spec-spine-core/tests/scaffold.rs
@@ -448,3 +448,51 @@ fn the_embedded_kit_matches_the_checked_in_tree() {
         "the whole harness is embedded, not a subset"
     );
 }
+
+// ── spec 066: the contract records the lifecycle table ────────────────────
+
+/// §3.3: the scaffolded contract carries both sections, so a new adopter gets
+/// them rather than writing them. This is the pattern spec 043 §3.4
+/// established when it added the amendment mechanism to the scaffolded
+/// constitution.
+#[test]
+fn the_scaffolded_contract_carries_the_lifecycle_table_and_extra_keys() {
+    let contract = scaffolded(&Config::default(), "standards/spec/contract.md");
+    assert!(
+        contract.contains("## Lifecycle as scheduling"),
+        "{contract}"
+    );
+    assert!(contract.contains("## Extra keys"), "{contract}");
+
+    // §3.1: the table's load-bearing rows, and the three sentences.
+    assert!(contract.contains("| `approved` | `pending`, `in-progress` | yes |"));
+    assert!(contract.contains("is a work order"), "{contract}");
+    assert!(
+        contract.contains("never a claim about code"),
+        "a draft's unresolved units are expected"
+    );
+    assert!(
+        contract.contains("not a third value"),
+        "an absent implementation defers to status"
+    );
+    // §3.2: the discoverability point.
+    assert!(contract.contains("extra_known_keys"), "{contract}");
+    assert!(contract.contains("extraFrontmatter"), "{contract}");
+}
+
+/// §3.4: the scaffolded corpus still compiles and lints clean with the longer
+/// contract, and the generator stays a pure function of `Config`.
+#[test]
+fn the_longer_contract_does_not_break_the_scaffolded_corpus() {
+    let cfg = Config::default();
+    let a = scaffold_init(&cfg).unwrap();
+    let b = scaffold_init(&cfg).unwrap();
+    assert_eq!(
+        a.files.len(),
+        b.files.len(),
+        "pure: same input, same output"
+    );
+    for (x, y) in a.files.iter().zip(b.files.iter()) {
+        assert_eq!(x.contents, y.contents);
+    }
+}

--- a/specs/066-the-contract-records-the-lifecycle-table/spec.md
+++ b/specs/066-the-contract-records-the-lifecycle-table/spec.md
@@ -4,7 +4,7 @@ title: "The contract records the lifecycle table and the extra keys"
 status: draft
 kind: "governance"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -14,6 +14,10 @@ depends_on:
   - "045-absent-implementation-defers-to-status"
 extends:
   - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
+  - { spec: "006-init-scaffold", unit: "crates/spec-spine-core/tests/scaffold.rs", nature: additive }
+  # The two sections are added to this repository's own contract as well, whose
+  # section units spec 043 established are claimed rather than amended.
+  - { spec: "043-governance-document-gaps", unit: "standards/spec/contract.md", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: "standards/spec/contract.md" }, role: context }
@@ -185,21 +189,26 @@ of the page.
 
 ## 5. Verification
 
+Each line is one command (spec 049 §3.2). Both sections fail against pre-066
+state: neither existed, in this repository's contract or the scaffolded one.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test scaffold --locked
-# Both sections exist and are claimable as section units, which is what the
-# frontmatter of this spec asserts.
-target/release/spec-spine index render | grep -q '066-the-contract-records-the-lifecycle-table'
-grep -q 'Lifecycle as scheduling' standards/spec/contract.md
-grep -q 'Extra keys' standards/spec/contract.md
-# The scaffolded contract carries them too.
-tmp=$(mktemp -d) && target/release/spec-spine --repo "$tmp" init >/dev/null \
-  && grep -q 'Lifecycle as scheduling' "$tmp/standards/spec/contract.md" \
-  && grep -q 'extra_known_keys' "$tmp/standards/spec/contract.md"
-# This spec's own units resolve, so it is not an orphan, and the shards were
-# regenerated after editing a hashed input under standards/.
+# 3.1 + 3.2: this repository's contract carries both sections.
+grep -q '## Lifecycle as scheduling' standards/spec/contract.md
+grep -q '## Extra keys' standards/spec/contract.md
+# 3.1: and the row a specify-first corpus lives in for months.
+grep -q 'approved. | .pending., .in-progress. | yes' standards/spec/contract.md
+# 3.3: a new adopter gets them rather than writing them.
+rm -rf "${TMPDIR:-/tmp}/ss066" && mkdir -p "${TMPDIR:-/tmp}/ss066" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss066" init >/dev/null
+grep -q 'Lifecycle as scheduling' "${TMPDIR:-/tmp}/ss066/standards/spec/contract.md"
+grep -q 'Extra keys' "${TMPDIR:-/tmp}/ss066/standards/spec/contract.md"
+# 3.4: and the scaffolded corpus still compiles and lints clean.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss066" compile >/dev/null
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss066" lint --fail-on-warn
+rm -rf "${TMPDIR:-/tmp}/ss066"
+# The ledger is untouched by a documentation change to a bypassed path.
 target/release/spec-spine compile --check
-target/release/spec-spine index check --fail-on-unresolved
 ```

--- a/standards/spec/contract.md
+++ b/standards/spec/contract.md
@@ -62,6 +62,53 @@ spec 043.
 `crate`/`module` (added by spec 017 as an additive minor, no schema-file edit).
 Symbol resolution covers Rust + TS in v1; Python is deferred.
 
+## Lifecycle as scheduling
+
+Two frontmatter keys decide whether a spec is offered as work and how strictly
+its claims are held. `status` is `draft` / `approved` / `superseded` / `retired`;
+`implementation` is `pending` / `in-progress` / `complete` / `n-a` / `deferred`,
+or absent.
+
+| `status` | `implementation` | schedulable | unresolved unit is |
+|---|---|---|---|
+| `draft` | absent, `pending`, `in-progress` | yes | `W-001` warning |
+| `approved` | `pending`, `in-progress` | yes | `W-001` warning |
+| `approved` | absent | no (settled, spec 045) | error |
+| any | `complete` | no | error (spec 041) |
+| any | `n-a`, `deferred` | no | takes its answer from `status` |
+| `superseded`, `retired` | any | no | takes its answer from `status` |
+
+Three sentences make the table usable.
+
+**`approved` plus `pending` is a work order.** It is the state a specify-first
+corpus lives in for months, and it is the state `spec-spine registry plan`
+offers as ready.
+
+**`draft` is never a claim about code.** A draft's unresolved units are expected,
+which is why they warn (`W-001`) instead of refusing. Spec 044 defines that
+window.
+
+**An absent `implementation` is not a third value.** It defers to `status` (spec
+045): on a `draft` it reads as `pending`, and on anything ratified it reads as
+settled. That is what keeps a bootstrap spec owning no code from being offered
+as ready forever, and it is why `n-a` exists for a record spec that is ratified
+and owns nothing.
+
+The specs behind the rows are 041 (completion held to claims), 044 (in-progress
+is in flight) and 045 (absent implementation defers to status). This page is a
+summary; those are the argument.
+
+## Extra keys
+
+`frontmatter.extra_known_keys` in `spec-spine.toml` declares frontmatter keys
+this corpus recognizes beyond the grammar. A declared key stops the conformance
+lint warning about it, and its value is preserved verbatim into the registry as
+`extraFrontmatter` (spec 013), so a consumer can read it.
+
+The config lists the names and records nothing about what they mean. An adopter
+who declares keys should write down their semantics, in their own constitution
+or contract, next to the rest of what governs the corpus.
+
 ## The gate chain
 
 `compile` → `index` → `lint` → `couple`: the coupling gate refuses a merge where


### PR DESCRIPTION
Implements spec 066 (adopter-audit backlog item 18).

## What changed

**`## Lifecycle as scheduling`** in `standards/spec/contract.md`. Two
frontmatter keys decide whether a spec is offered as work and how strictly its
claims are held, and the answer lived across specs 041, 044 and 045 — nowhere a
reader looking for it would go. The section carries the joint table and names
the spec behind each row, so this page stays a summary rather than becoming a
fifth authority.

Three sentences make it usable:

- **`approved` plus `pending` is a work order** — the state a specify-first
  corpus lives in for months, and the state `registry plan` offers as ready.
- **`draft` is never a claim about code** — which is why a draft's unresolved
  units warn (`W-001`) instead of refusing.
- **An absent `implementation` is not a third value** — it defers to `status`,
  which keeps a bootstrap spec owning no code from being offered as ready
  forever, and is why `n-a` exists.

**`## Extra keys`.** What `frontmatter.extra_known_keys` does, that a declared
key's value is preserved verbatim into the registry as `extraFrontmatter`, and
that the config lists the names while nothing records the semantics — so an
adopter who declares keys should write down what they mean.

**The scaffold ships both**, terser, without citations to specs an adopter does
not have. That is the pattern spec 043 §3.4 established when it added the
amendment mechanism to the scaffolded constitution.

Both sections are claimed on `standards/spec/contract.md` via an `extends` edge
on spec 043, which is the mechanism 043 defined for governance documents.

## Verification

`spec-spine verify 066` passes, 12 commands — including scaffolding a fresh
adopter, checking both sections arrived, and confirming that corpus still
compiles and lints clean. Full gate green: 69 shards fresh, index fresh, 0
unresolved, 0 lint warnings, 74/74 coverage, `couple` clean. Workspace tests,
clippy `-D warnings`, `fmt --check` pass. No waiver.