### PR TITLE
docs(067): the docs name what adopters derived by experiment

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb781bfdb3077fa1bb51e65fd5c266eb80234925bf637c3085cd288a27a1b652"
+  "shardHash": "f070bda593e3dcb157b31074845623c3902a2f543d7649ce893710fe0a416e4a"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0d027c7d9414b97dd0a43d1c98fd22f7197b980c7ac8407752adf37db00423ab"
+  "shardHash": "e2f069002f67d7939d39274e38051e073147ccef54755ad1efad4e10f08bed59"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "70c9e57b36d0026b65ee358eec90c0204bbe0e12886f4169c2ea18fb41c584e3"
+  "shardHash": "77bceb39f8e00f3e5e243d11366ac976f3c0a0ba5a9fbb82dc013b51e67b7bfc"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c86c5a224e0b382925dc6b4ee5c53e4305ea545aed72fbc8625107df609ab323"
+  "shardHash": "b9b46efd209da5a9ac23a5de69d07daede46500d9525a84594c909446c16fbd0"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cabe33b5a6ac4fb1469cb0c1201600e17f832e954bc69b826874713375e71f99"
+  "shardHash": "19958491185113f562a27e7a5e91858d4d783131782131b11277dc023c139e4e"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e964fc8f6a05c30acad24f1a518327cdf6eadd028f7ac8eed3a8b480865e06fe"
+  "shardHash": "ea0200e1bef202530fcc5a4312142708e813ce5ede5147ee2a042433d82ebc3b"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09164701361805e21c17513895d8998b7030cb9601d146f976a0cd08d25d7f84"
+  "shardHash": "6f49d1618f80ee71fa733062ab186d518dd5c5da12ccd0d823ebb68b592b45bc"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3787d4d2add655f989f41a37d8b13a9111db77adb26b6ab146554328e0c351dc"
+  "shardHash": "6785fc134f39db5183cf1652029dbbb28991aaf52096d142a5d913577d7bddbc"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "715c0e9236e16eccb809fa984016ad75574825b54295ba2d24fcaed0f7cb01b9"
+  "shardHash": "cec8f1fe40ece81fad2eb4ba00e0dfaababe8a9db01756744f0ecf83276cf9fd"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5bfdae7f3514a9eae9d08468243f876bcae12eeec4ef9a2603d32445163d4455"
+  "shardHash": "93d26c39cc6f599898721d9e60c6c46ab33cf2f349e27f4558a3f053eed18fe2"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ae009166cfbea5fdb85940a4c7ae849fddf76b4076660945f9e6240bcb7ae3f9"
+  "shardHash": "2a67d7472262467b0311d05513c95ab030f6b64de37bfbbbdbebd92008eb690b"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0db96d478fb9a4225cac9d22805afaefb9afbba8dc7f8a430eda5d762ca9fac1"
+  "shardHash": "37e96a97f642b3e8ad361330568cdf8ad71e25204939b80988f8b1bb8db2d1ab"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "508aafba550f86fc9f658d47efdd36b8d2b2c7591dbe6d9148629babd0e0f23f"
+  "shardHash": "33ce8a6f4599f0008daa7f30ab64a6433af80c566233fb4075cacba0b60f0b68"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e407c6b34564361cd77d83fc194f56cca500554be6689477ed714aab4456ba0e"
+  "shardHash": "6970d19ca58465e0595ca0c6d170970a1b2928d4f0e1c5e2738d5ee269adebaf"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05a7c80909b89b30b0d2234ba681334009ef61be16660930822eee48a9292cb2"
+  "shardHash": "147ed8af3a7c7b16819c278dd732e495bfb61fa074e4577ec996743f71984318"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5b2904aa605ec1faa359155cb5726468f995744ca9c027e29d218da53109d5f1"
+  "shardHash": "24ce64fff96b8f00d75f8ef8491c76770a200f99a274b430c944ac8ff9f332e0"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ee7b68630cabb27778d33b7cacb09c3cc745865ba423c1d2adf390c4ffdfebb3"
+  "shardHash": "5e5247a7b70448ee7e3c25db4df199209beea94e854ac3b7cb019e5abfac57cb"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e8e6a0d2c42114adec7b4a12def0e5b0740b168aadccf86dcae87a7574c6fb6b"
+  "shardHash": "215332bfd7301e261b7c849320524f15820bb07533a1f163f3f42b707a174f43"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1afe320ea45f75b5c5e77e1b9517bbb533f35e8f2e20c2633f2323a84bb633ae"
+  "shardHash": "a7a87a25c09bcf681020cbf42ce14f0a67c2c55378deeae5739eda0bb74858db"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a78d374ea4e24d8d0e949f10ab03f2775f04b3d7e2a87e292c0d56c27f355d34"
+  "shardHash": "c174999d649e6e16cbef1b9e4f43ec852e97ad364b0c3ce03bce9a44efea7f10"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5d1aaa48f083d262eca7f5703f94fc2bc2f3a54a64ced903e6354c853f8b2058"
+  "shardHash": "48791f22347eea7e425c222d883a923de609cdf2ae0615a00ee197572fd8d09b"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6ecd1cf89fdb9d9b2a9f811f65e46904a7ec2cfe2dcb4bae7279f8542fc3e113"
+  "shardHash": "2dea6268848c2ce52dd8ff0c1661a98078fb87f4447a5ed23a3d1d01810e72bb"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0df1f2c301cc23a5644c5e232ad1c5f06a28194e1682ec042e349f0acca51a0b"
+  "shardHash": "f222cf675c719ee3527ae19b35c4318faf755c5536d5df19b30d270819e2e5ef"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "deeb869b8c41729711de5436d5e5650faf8f3eaa50477cd8e2b5e7d25aa463f6"
+  "shardHash": "c6d4605847c2d317b633bfadc6ec88cc5c0e439aea10ada692e440da8fabed4b"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "627f76b0751a6c52729d2a98a0bb5083b7a0804faa1652ad44184161878eb36b"
+  "shardHash": "4627f827980d2f29ad4b6878ccc735e330f2d4c2d085d303a999cc5d8aa5504c"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "73951eb9acb6a356c1db2d33c55c94297babd046170a5dbcaff8074c335855c3"
+  "shardHash": "8a3d790e26f3fe249978de244272d85c79bec68ef9818508e17fe94953885f8a"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "af633e01fb78d7ca707d84cf0437d1cb392569bf363fcd1ab47068957a15102c"
+  "shardHash": "ea297e0c2d85c04af4a700ceca0d20d9e96bda3d4032abdfa730042bfe2ada81"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2ed8d96642225d677584104250275c65223f32b7ba99ab93b8f5b9d1ce15c79e"
+  "shardHash": "94f7ca14817918f8d4942895cff6646d6f335aa714564d7c24e2f1aebd1bf945"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2dbdf120227a0888c826e9e6057a478832227b2839ac4d63fde23518acf5377"
+  "shardHash": "043bfdfa05d87bad05ac7723aafc7bb73ad58d3acda8f8584e38c5f330c357a5"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7782c719684a460973dfb59ea5f2c06659b4b486e738651d56a9850eb66455f6"
+  "shardHash": "ca48ed8a9bd4c89687776b8bd964f840279afcef8f7ae5df8d1a49d87d535d9d"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a419cd4b14fbd7d2df205dda3464f71ecebfb1787b773bb67b794ec1fdb561b1"
+  "shardHash": "0329978171fed39981eccd81005fac09c39cb9af3baf24b98587d3ee0d27f12a"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1de40de7c07b7705f4301288dc8db3d25019ffd0dffbf004b1303778618b4784"
+  "shardHash": "0a9a8f1abc607843c78bc2427f04063d55b867cdf5e55a0d848820dc458ac550"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "581deb926abdd5fab892b384bb592c94c90027cee6b02a17cf078e60686d5e1a"
+  "shardHash": "9df5dbf69bbf266d7134d9f57a241a47ffe0c8d3590726a837a81d47e422bbfa"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0f337b06ad6e7912e0991b82f536f19cc1d6e12b36a9b098fb8f251619a28192"
+  "shardHash": "85ebf3f9945e15f561255c28822f39a051c692cc619a8cfbf34e8578b6411d90"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "13ddbdd72c498b1d38258afd86d8b6810dd4b277f25517d15264fb92cb597574"
+  "shardHash": "ef78531f350717d89fa004bee3b61a5d35c6f29174d9cf9b74316b76de60db94"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "64755d96b540d6696c2fc16bd06af39d4ecafd6c4fc31f5783a50ac4881f9467"
+  "shardHash": "4ea0dcaba20cfca88fb19db54f1f292a43dd1a9edabd890d37d9c9fa25a1987e"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "75fe069544dc31b620503247b03dc53f2066a81cdc420b6aafd068d8d51eccc6"
+  "shardHash": "c3ee2d7d526fa0ec7ba55028683f1b1281ccf61540908d3be9d7424d54511e50"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d5df426bcaf5caf0573c6fb449b7c97e9a5ca8574b25e85eb399b52731109efa"
+  "shardHash": "1ae06aacc9d57c59ef28afdf9dd9bf2c8e1b909084894d1608d18524d255d4eb"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22e0d39b8ccd660b61d569efc342a033b4fdac9005a60f134faa890a1e0e0489"
+  "shardHash": "a588027f51a71a9f5cd1caca26120a1671a9640547c56b3951d04bee37476163"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6282a0eb627c667c0216cf8d88f175718b2f03e55fe1f2d296eebab27956696d"
+  "shardHash": "ba6f3a9c7ada1c6d024a4a86cd532e0dcfd3ecdabbf6c1fa1e43c4e76791c629"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2fba70d1a05b96c42edde49f15d37fa5857fff639dbb2e8a01bee66021a724b3"
+  "shardHash": "0a37e7b45ca57be76850721f5013381ea1891a04c2c9ffb9477a091268b3c8fa"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "754485c66c66c810fc7b1cb7c377bf779c6d640e9b7a9c43f44a34022319f4b7"
+  "shardHash": "ae036030afc96c65b74c03f0dacba69cedc362c7048c3fb7fbdf8f07322f12a6"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5948df6d56a016fe870ca83be733a402558189124c017e19b8117685bd74b6bd"
+  "shardHash": "bb8aca478a72cc581759cce4c663c46a0aa5148a61ffe0bc27b19c9142f0bb18"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "38ca7381daeaea956e6154ff1af01677b76b3b2c68b96a4ddbd70dcb6e7d97e3"
+  "shardHash": "6ca94fc09f6993d17ff1ae008c628a337c07fea8c9af2c31ffc9e541043af8ef"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ef0bfb6bd918f36b6928022dd9b2f1fc472c6ec5a5f69386ff939f929e54f77c"
+  "shardHash": "0d9e28f8d77865dd72822c3d8939679d338fd346cea990268329386a9f319aaf"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "be53ea24e7d706c6799b434037a943aa50e7bf7e297a9858827439fdc6735c12"
+  "shardHash": "7546c179c91e76168e11658600956a25141d5ef20bfab9333bdc96362926b443"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0782d309c9ddd0c494e1688a688d2fdb3342d8448100838f708dbfa360e48131"
+  "shardHash": "e46bafc4de69db86dbcddab00027f3baec164ce1e4363ae97a6deb527ba19e97"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "68af61ad133ba172d47eb26fa4f62c5346009c7a9e79f1d34ddfd1316037b2fc"
+  "shardHash": "19cfd17b8556105d1d9b3f83a0ed2b23363e9c73c0210526fd2aea732dd9b07b"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "83bbaea6da96a0a03ad29a24230f12025175949fbc6f8e7a1aaf347f972de616"
+  "shardHash": "0efe5a326571c185440a549d4ac40fc26188e90e3701b35ff46cd42910f96e89"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9cd48ebf5ea60b29cda8391f470e3070ec8a62cbcd968c5b6aefd60f5a4ad66e"
+  "shardHash": "f94ffad8246aebee2aff2fbaf50d22f8cac0c3f2ca5a0973fc62b7538e5525d1"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a3f82558a8e1d9544183628b2d8789eb91267f7bd7b7b1504840b078aeb66852"
+  "shardHash": "69196fe567cd5456078970465dcb5fba32c980ec0a6d1015adf831632a70101a"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e8a0ea4c112ee292575fba3fccbe8f3b4bde609eff1e012fcd2776f231900c00"
+  "shardHash": "7814dcca6a9ed4e8a9541829d4c755e17b337f4c86f7dc5feb4b0c2c0e7ef180"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0eda2a7118e4fba8dd188291371a5fc6c118522d47a665a189d4631cfec8a043"
+  "shardHash": "2f0a593ffe40b95ad1d1991ba28b3e90cf5ed6f2d29eff02fcce5602979b03d1"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "577e481b949d82fb7fa9410d93fbcb6b2b289b58c672740b51a475979990af20"
+  "shardHash": "ec220eb31e3942c7b60508ea3ddfe610d60014ac098bc2db30198470033d9829"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e65920298dc33f2724fcac2e5b30475a8af33925cd0598c5f4d064f15f6c6e1d"
+  "shardHash": "f2af56c933516ac506ae1f7979d5d6a9b4f9ce38add198c870878d354067befc"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dfe97189f661fc25419c1679e92731c10e3dee6e4eb71a47f1cce13b7791399b"
+  "shardHash": "f422b07c083467a1ed6dde400c00eb2b22dd55379d55b9ff028b2ed69b840fd0"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8c48823c39a65fbedd82849b91febacc2b56e1ec3cf2bf5de2d065dea0a73795"
+  "shardHash": "3a75f5b3212760c5349ee3612e396a4f8e7ef0ce32464f2c439e835a4b50679e"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f7e8d01e67020a18018ef2b95de590583aa41b23d608bccca5038065a6277cb8"
+  "shardHash": "f9ee76dc8c6286519d6c0a91a4179f7035d46a71a8337baeae896341a064c51f"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "97000f4ba570a58a0ec43198f2a41bcf8ffa03d0f73d4fcef4c804c7f87a2ca8"
+  "shardHash": "80dc2a52c5b7a41b1e6945c62a5626999b411f5df9c47224a1bbaa284873c0c7"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "aa007214838fa992f8299480354a72eb8910278a19eb68302c3ea24425fc9daa"
+  "shardHash": "a320b3d4429388a8f2cff3cd77a4acc02ed3d75133365e33bb4e4e60319054ab"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "76fe46e75d0e01efb5010e1760ec79a891880d7cdb41676334f3559ff269e805"
+  "shardHash": "3042ad2080f069bb2f48dce3f58c925998980658730c68aaa5ef9bdfc63c38a2"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc0a633c5d67f7ad541b67e589ff9cb66f55bb62aae68d6eaa672face4419db4"
+  "shardHash": "acab98ea7c4612c21e068745236df9054f86a3235009b2ae3e84d98af1251b66"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "59e2d340ccbf7e815205e5f7d5432f371afbbc5caa2db2fecbc0d61baa910367"
+  "shardHash": "9d4d705c9f78fd7c07c75513a05342a71e91cbb7cd40a47f6aa0f3f6381800c9"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ddc165fbb88de9faa08f0c1c50556547e3197f20b30f745f27fb9d84a59cd987"
+  "shardHash": "3c85fdcda55056d896a837f6e996829967b913c5cb0555a8e1dec696fe32d217"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0d4b290ed6d60dd05e0fc9562096fd079a5aebfa3a11b15d94762899d5802268"
+  "shardHash": "757cbe7bcd2f651e23ffc06cc2585f6fc892f17b1ec9a4fd4a6b17201b1715b1"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "70976c0bd7e1aa486079f85c7c7d8c4592dc04fbca7393ce7eee2e0e876cc989"
+  "shardHash": "dd25389b183278bcfd8bffad43feec1f39df354ac78717455329097fc7878c64"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a9063fe08eff24ebb1fcc82133eff873bc175c71d1ee6095a8fab2a93a29e667"
+  "shardHash": "0f3e242529080fa7c6d8c599901dcc0eaaad53dd916b585291b5348d88c35ddd"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bbbb8627128e26553d427e1bd1ca95510ea75a1f2dfb2b8e9a35cd719ac4590e"
+  "shardHash": "3bcd9e18581ee7a7ef0b94ad5edacd0a7738c8b44b6f8da407f11f525e7766d0"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ed33f57e4e2f53ab700a9dbb507f6fa346baeee43d8d572d2cd67ee39bdcc8f2"
+  "shardHash": "0d9dee2ccdb921ba5811ade624d4f1b3b58230f8e4145b960547a8ef23c650c4"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "95bf41cf07d50d04108c6967b51fc3b0d1431131d0cd55723a0e999c9bae1f38"
+  "shardHash": "c3adeb50ff05981f4fbe73f6456192ede00fee7b3224f582850b150a4e9a56db"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -57,5 +57,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c45278a99f8c3c2fe9a115cb527b1ea0347c7047ce2aa6f82902e824bc86e845"
+  "shardHash": "5b2dfe538c9e440c15bbdf5d47c026f17a9a66a9db34d1c212e2d6990c844aa6"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -14,6 +14,14 @@
       {
         "path": "docs/schema-versioning.md",
         "source": "spec-edge"
+      },
+      {
+        "path": "docs/specify-first.md",
+        "source": "spec-edge"
+      },
+      {
+        "path": "spec-spine.toml",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
@@ -41,6 +49,32 @@
         "unit": {
           "kind": "file",
           "path": "docs/schema-versioning.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/specify-first.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "docs/specify-first.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "spec-spine.toml"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
         }
       },
       {
@@ -74,5 +108,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4ba4449882bcd33d4b4db53344f83428d924ba59f21882128ab294585cf0b9c1"
+  "shardHash": "b523a1a6ff000d0c572e60c29deed3c34381be9af5b587c20a356a7741ae70a7"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -73,5 +73,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b63270f9501c334398e468888f4c8c04fa7c73148e4a8cb14231d8a8547f875b"
+  "shardHash": "8b94fd5ccbf1958e7ad0d9608fed9db15307e8675c64435644295645d88c3d4e"
 }

--- a/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -15,10 +15,24 @@
       {
         "kind": "file",
         "path": "docs/schema-versioning.md"
+      },
+      {
+        "kind": "file",
+        "path": "docs/specify-first.md"
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "064-the-kit-ships-the-composite-gate",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
+        }
       }
     ],
     "id": "067-the-docs-name-what-adopters-derived",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "documentation",
     "owner": "The spec-spine Authors",
     "references": [
@@ -55,6 +69,6 @@
     "summary": "Three documentation gaps the audit measured, each with a named victim. There is no page for specify-first adoption, which is how three of the four governed repositories work, so each of them independently derived the guarded Makefile, the CI manifest probe, `implementation: n-a` for record specs, and the fact that two hundred and forty-eight W-001 warnings is the defined state rather than a backlog. Two interactions are documented nowhere and were found by experiment: a path can be on the coupling bypass floor and simultaneously a hashed input, and a trailing-slash directory unit in `establishes` satisfies ownership recursively. And spec 037 changed `attest`'s stdout, which claude-observatory regexes in two places, with no migration note. This spec writes the page and the three paragraphs.\n",
     "title": "The docs name what adopters derived by experiment"
   },
-  "shardHash": "6bf220acf5cfc366794f24e7d33252507e82469fe8ae2f779977a7d1aee9a40d",
+  "shardHash": "df0cdb5263c776fa8fe1d0e4ed063dd31e48afd387c10602be59a967021f2b1f",
   "specVersion": "1.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ operation has a JSON-in/JSON-out facade (`compile_json`, `query_json`, …); see
 | [concept.md](docs/concept.md) | the origin story and the model: what spec-spine is and why it exists |
 | [design/00-architecture.md](docs/design/00-architecture.md) | the full design: crate layout, `Config`, public API, exit codes, schema plan |
 | [adoption-guide.md](docs/adoption-guide.md) | install → init → annotate → wire CI; the full `Config` knob table |
+| [specify-first.md](docs/specify-first.md) | governing a corpus before the code exists: what the counts, warnings and gates mean in that mode |
 | [api.md](docs/api.md) | the `spec-spine-core` public API + JSON facade |
 | [overlay-contract.md](docs/overlay-contract.md) | layer domain output on top without forking the core |
 | [bindings-plan.md](docs/bindings-plan.md) | the napi / pyo3 / cgo path (design only; no binding code yet) |

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -299,3 +299,56 @@ the public loaders and emits its own sibling artifact. See
   equivalent), and `spec-spine index` maps them to specs.
 - `.derived/` is committed (except `build-meta.json`).
 - CI runs `compile` → `index check` → `lint` → `couple` on every PR.
+
+## If your corpus has no code yet
+
+Three of the four repositories governed by spec-spine ratify the whole corpus
+before writing a line of code, and stay that way for months.
+[docs/specify-first.md](specify-first.md) says what the counts, the warnings and
+the gates mean in that mode, and what to run first.
+
+## Bypass and hashing are independent
+
+Two mechanisms decide what happens to a path, and they are **separate axes**.
+
+**Bypassed** means the coupling gate will not refuse a change to it. The
+built-in floor plus your `[coupling] bypass_prefixes`; `spec-spine config show`
+prints the merged list.
+
+**Hashed** means a change to it stales shards. `spec-spine.toml`, every spec's
+`spec.md`, each discovered package's manifest, the span-backing files of
+resolved units, and everything matched by `[index] extra_hashed_inputs`.
+
+A path can be on both, neither, or either, and neither implies the other:
+
+- `docs/` here is **bypassed and not hashed**: a documentation edit raises no
+  `C-001`, and stales nothing.
+- `standards/**` here is **bypassed and hashed**: an edit to the constitution
+  raises no `C-001`, and does stale every shard.
+
+Bypassed answers "will the gate refuse this change"; hashed answers "does this
+change make the ledger stale". They are different questions, and reading one as
+the other is how a governance file ends up outside both.
+
+> **Watch the glob form** in `extra_hashed_inputs`. `dir/**` matches
+> **directories**, so it hashes no files; you want `dir/**/*`. This repository
+> carried `["standards/**", ".github/workflows/**"]` for a long time, matching
+> nothing, until spec 057's predicate found it.
+
+## Directory units claim recursively
+
+A `file` unit with a **trailing slash** is a subtree claim:
+
+```yaml
+establishes:
+  - "crates/spec-spine-core/src/"
+```
+
+Every file under it counts as **specifically claimed** — for `index coverage`,
+and for `C-002` when `[coupling] require_ownership` is on. That is the intended
+instrument for retiring coverage debt across a directory: claim the subtree,
+rather than enumerating its files and re-enumerating them every time one is
+added.
+
+The trailing slash is load-bearing. Without it the same string is an exact file
+claim and matches nothing, since no file is named `src`.

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -178,6 +178,35 @@ without breaking readers:
   fields ride through without a schema bump (see
   [overlay-contract.md](overlay-contract.md) §5).
 
+## Migration note: spec 037, the verdict envelope
+
+**If you regex a field out of a verdict verb's stdout, stop, and parse the
+`--json` envelope instead.**
+
+The case that broke: `spec-spine attest` printed its `attestationHash` in a
+prose line, and claude-observatory matched that line with a regular expression
+at two call sites. Prose is a rendering. It is allowed to change wording, and it
+did. The envelope is the contract.
+
+```sh
+# Don't
+spec-spine attest | grep -o 'attestationHash: .*' | cut -d' ' -f2
+
+# Do
+spec-spine attest --json | jq -r '.report.attestationHash'
+```
+
+Every verb that renders a verdict takes `--json`: `compile --check`,
+`index check`, `lint`, `couple`, `attest`, `verify-attestation`, `verify`, and
+`compile --spec`. Each writes one envelope with `schemaVersion`, `verb`, `ok`,
+`exitCode`, and either `report` or `error`.
+
+**The guarantee that makes migrating safe:** `--json` changes what is written
+and never what is decided. Every exit code is identical with and without it. A
+consumer switching to the envelope is changing its parsing, not its control
+flow, so the migration can be done one call site at a time with no behavioral
+risk.
+
 ## Pinning the binary: `[meta] required_version`
 
 The schema versions above tell a **loader** what it can read. They say nothing

--- a/docs/specify-first.md
+++ b/docs/specify-first.md
@@ -1,0 +1,82 @@
+# Specify-first: governing a corpus before the code exists
+
+Three of the four repositories governed by spec-spine work this way: the whole
+corpus is ratified before a line of code is written, and it stays that way for
+months. Every read verb, every count, and every warning tier means something
+slightly different in that mode, and this page says what.
+
+## What specify-first means
+
+A spec is `approved` when the corpus has agreed to it, and `implementation:
+pending` until somebody builds it. **Those two together are the steady state,
+not a transitional one.** A repository can hold sixty approved-and-pending specs
+for a quarter and be in perfect health.
+
+The table of which combinations are schedulable, and how strictly each holds
+its claims, lives under **Lifecycle as scheduling** in
+[`standards/spec/contract.md`](../standards/spec/contract.md). It is not
+repeated here: two tables that must agree by hand is a defect waiting to
+happen, and the contract is the one that ships to adopters.
+
+## `implementation: n-a` for a spec that owns no code
+
+A spec that defines a convention, records a decision, or bootstraps the system
+owns no code and never will. Left `pending` it is offered as ready forever, and
+a scheduler that keeps proposing it is a scheduler nobody trusts.
+
+`implementation: n-a` is the answer: ratified, owns nothing, not schedulable.
+The scaffolded bootstrap spec already carries it for exactly this reason.
+
+## The warnings are the defined state, not debt
+
+On an unbuilt corpus, every claimed unit resolves to nothing, because nothing
+has been written. That is `W-001` per unit, and on a large corpus it is a large
+number: aicortex carried 248 and was in exactly the state its specs described.
+
+Three things follow, and all three are correct:
+
+- **`index check` calls the ledger fresh.** Freshness is "do the committed
+  shards match what the corpus compiles to", and they do. Unresolved units are a
+  separate axis, reported alongside rather than folded into the verdict.
+- **`W-001` is a warning, not an error.** A draft or a pending spec is expected
+  to claim territory it has not written yet. The error tier is reserved for a
+  spec claiming `complete` while its units resolve to nothing, which is a claim
+  contradicted by the ledger.
+- **`--fail-on-unresolved` is the flag for a corpus that has moved past this
+  stage.** Turn it on when your repository builds what it claims within one pull
+  request. Turning it on earlier refuses your own normal state.
+
+`spec-spine index diagnostics` lists them, and `spec-spine index orphans`
+separates the specs that are genuinely orphaned from the ones merely in flight.
+
+## The composite gate on a code-free tree
+
+`kit/Makefile` and `kit/govern.yml` are the gate and the CI workflow, and both
+are built for this mode: the language targets are guarded on a **manifest
+probe**, so `make test` on a tree with no `Cargo.toml` is a clean no-op rather
+than a failure. Install them with `spec-spine init --with-kit`.
+
+One finding from that workflow is worth carrying even if you write your own:
+**GitHub rejects `hashFiles` in a job-level `if`.** The expression is evaluated
+before the workspace exists, so the function has no files to hash. Conditioning
+a job on "does this repository contain a `Cargo.toml`" needs a probe job that
+checks after checkout and publishes the answer as a job output. Three adopters
+rediscovered that independently.
+
+## What to run first, on a repository with no code
+
+```sh
+spec-spine compile          # the corpus is the thing that exists; validate it
+spec-spine index            # emits the index; every unit is unresolved, and that is fine
+spec-spine lint             # corpus conformance
+```
+
+**Not `couple` yet.** The coupling gate compares a base to a head and refuses
+code that drifts from its owning spec. With no code and no pull request there is
+nothing for it to compare, and wiring it in before there is will only teach you
+to ignore it.
+
+`spec-spine index coverage` is worth running early anyway: on a code-free tree
+it reports an empty universe, and with `--fail-on-untraced` it **refuses** rather
+than passing vacuously, which is the honest answer to "is every source file
+owned" when there are no source files.

--- a/spec-spine.toml
+++ b/spec-spine.toml
@@ -57,6 +57,7 @@ extra_hashed_inputs = [
   "docs/adoption-guide.md",
   "docs/releasing.md",
   "docs/schema-versioning.md",
+  "docs/specify-first.md",
   "kit/AGENTS.md",
   "kit/README.md",
   "kit/settings.json",

--- a/specs/067-the-docs-name-what-adopters-derived/spec.md
+++ b/specs/067-the-docs-name-what-adopters-derived/spec.md
@@ -4,7 +4,7 @@ title: "The docs name what adopters derived by experiment"
 status: draft
 kind: "documentation"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -18,6 +18,12 @@ establishes:
   # implementing change that creates it.
   - "docs/adoption-guide.md"
   - "docs/schema-versioning.md"
+  # Created by the implementing change (3.1), so claimed here.
+  - "docs/specify-first.md"
+extends:
+  # The new page joins the hashed-input set beside its sibling docs, so a
+  # change to a claimed document stales the ledger (spec 057).
+  - { spec: "064-the-kit-ships-the-composite-gate", unit: "spec-spine.toml", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: "README.md" }, role: context }
@@ -176,6 +182,20 @@ the ledger did not move.
 **Restructuring the documentation set.** One new page, two sections and one
 note, each in an existing document's register.
 
+**Claiming `README.md`.** §3.1 requires the new page to be linked from the
+README's documentation table, which is an edit and not a claim.
+
+**Decision, 2026-09-07.** The first cut declared an `extends` edge on
+`README.md` for that one row, which was defensive and wrong in a way worth
+recording: `README.md` is on the coupling gate's built-in bypass floor, so
+editing it needs no claim at all, and a resolved unit claim **overrides** the
+bypass (spec 009). The edge would have made every future README edit a `C-001`
+against this spec, for a documentation file the floor exists to exempt. It also
+raised `L-008`, since nothing hashes the README, which is how it was caught.
+
+The one edge kept is on `spec-spine.toml`, so `docs/specify-first.md` joins the
+hashed-input set beside the sibling docs this spec claims.
+
 **Fixing claude-observatory's two call sites.** An adopter-side follow-up, in
 the audit's §5. This spec gives it the note to act on.
 
@@ -185,19 +205,39 @@ and a separate one.
 
 ## 5. Verification
 
+Each line is one command (spec 049 §3.2).
+
+This spec's whole output is prose, so its acceptance is weaker than a code
+spec's, and §3.4 says so rather than dressing it up: the mechanical check is
+that the pages exist, say the things they were written to say, are linked from
+where a reader would look, and that the ledger did not move. A documentation
+spec is verified by a reader.
+
 ```verify:cli
-# Self-contained: the commands below invoke the release binary.
-cargo build --release --locked
-# The page exists and is linked from the places its readers were already in.
+# 3.1: the page exists and covers what three adopters each derived alone.
 test -f docs/specify-first.md
-grep -q 'specify-first' README.md
-grep -q 'specify-first' docs/adoption-guide.md
-# The two interactions are written down.
-grep -q 'bypass' docs/adoption-guide.md
-grep -q 'trailing slash' docs/adoption-guide.md
-# The 037 migration note names the field that broke a real consumer.
+grep -q 'implementation: n-a' docs/specify-first.md
+grep -q 'hashFiles' docs/specify-first.md
+grep -q '248' docs/specify-first.md
+# 3.1: and it defers to the contract's table rather than keeping a second one.
+grep -q 'Lifecycle as scheduling' docs/specify-first.md
+! grep -q '| .draft. | absent' docs/specify-first.md
+# 3.1: a page nobody links is a page nobody finds.
+grep -q 'docs/specify-first.md' README.md
+grep -q 'specify-first.md' docs/adoption-guide.md
+# 3.2: the two interactions, each in the adoption guide.
+grep -q 'Bypass and hashing are independent' docs/adoption-guide.md
+grep -q 'Directory units claim recursively' docs/adoption-guide.md
+# 3.2: with the worked examples, since the claim without them is a slogan.
+grep -q 'bypassed and not hashed' docs/adoption-guide.md
+grep -q 'bypassed and hashed' docs/adoption-guide.md
+# 3.3: the migration note names the case that broke, not just the rule.
 grep -q 'attestationHash' docs/schema-versioning.md
-# Prose only: the ledger did not move.
+grep -q 'never what is decided' docs/schema-versioning.md
+# 3.4: nothing mechanical moved. These are bypassed paths, and the ledger is
+# unchanged by them.
+cargo build --release --locked
 target/release/spec-spine compile --check
 target/release/spec-spine index check
+target/release/spec-spine lint --fail-on-warn
 ```


### PR DESCRIPTION
Implements spec 067 (adopter-audit backlog items 19, 20, 21). Three
documentation gaps the audit measured, each with a named victim.

## What changed

**`docs/specify-first.md`** — the page for the mode three of four governed
repositories work in. Each of them independently derived the guarded Makefile,
the CI manifest probe, `implementation: n-a` for a spec that owns no code, and
the fact that **248 `W-001` warnings is the defined state rather than a
backlog** (aicortex is the worked example). It also says what to run first on a
code-free tree, and specifically **not `couple`** until there is a base and a
head — wiring the gate in before there is only teaches you to ignore it.

It **defers to the contract** (spec 066) for the lifecycle table rather than
keeping a second copy: two tables that must agree by hand is the defect this
page would otherwise create. Linked from the README's documentation table and
from the adoption guide, because a page nobody links is a page nobody finds and
the adopters who needed it were reading both.

**Two interactions in the adoption guide**, both found by experiment and
documented nowhere:

- **Bypass and hashing are independent axes.** Bypassed means the gate will not
  refuse a change; hashed means a change stales shards. Neither implies the
  other. With the worked examples that make it more than a slogan: `docs/` here
  is bypassed and not hashed, `standards/**` is bypassed *and* hashed. Plus the
  `dir/**` glob trap spec 057 found.
- **Directory units claim recursively.** A trailing slash makes a `file` unit a
  subtree claim, and everything under it counts as specifically claimed for
  `index coverage` and `C-002` — the intended instrument for retiring coverage
  debt across a directory rather than enumerating files.

**The spec 037 migration note** in `docs/schema-versioning.md`, naming `attest`
and `attestationHash` specifically, because that is the case that broke and a
general note would not have told claude-observatory which of its call sites were
affected. It states the guarantee that makes migrating safe: `--json` changes
what is written and never what is decided, so a consumer switching to the
envelope changes its parsing, not its control flow.

## One correction, recorded in §4

My first cut declared an `extends` edge on `README.md` for the one table row.
That was defensive and **wrong**: `README.md` is on the coupling gate's built-in
bypass floor, so editing it needs no claim at all, and a resolved unit claim
*overrides* the bypass (spec 009). The edge would have made every future README
edit a `C-001` against this spec, for a file the floor exists to exempt.

`L-008` caught it — nothing hashes the README — which is spec 057 earning its
keep two specs later.

## Verification

This spec's output is prose, so its acceptance is weaker than a code spec's, and
§5 says so rather than dressing it up: the check is that the pages exist, say
what they were written to say, are linked from where a reader would look, and
that the ledger did not move. A documentation spec is verified by a reader.

`spec-spine verify 067` passes, 18 commands. Full gate green: 69 shards fresh,
index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage, `couple` clean.
Workspace tests pass. No waiver.