### PR TITLE
feat(068): a path-scoped rule the kit actually ships

### DIFF
--- a/.claude/rules/derived-artifacts-are-compiler-output.md
+++ b/.claude/rules/derived-artifacts-are-compiler-output.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - ".derived/**"
+---
+
+# Derived artifacts are compiler output
+
+The files under this directory are emitted by `spec-spine compile` and
+`spec-spine index`. They are machine truth, not authored truth.
+
+**Do not hand-edit one.** A shard is a pure function of the corpus and the
+source tree; editing it makes the ledger disagree with what it describes, and
+the next `compile --check` or `index check` reports it as staleness with no clue
+that a person put it there. The way to change a shard is to change its input and
+regenerate.
+
+**Do not read one with `jq`, `grep`, `sed`, `awk` or `python`.** An ad-hoc
+parser encodes today's shape and then goes quietly wrong when the schema moves.
+Read through a `spec-spine` subcommand instead: `registry show`, `registry
+list`, `registry plan`, `index render`, `index owner`, `index coverage`,
+`index diagnostics`. A typed read fails at the deserializer with a clean error
+rather than silently returning the wrong answer.
+
+**Parsing the output of a subcommand is fine.** `spec-spine registry plan
+--json`, or the `--json` verdict envelope any gate verb emits, is a typed read:
+the tool has already deserialized the shards and is answering in a contract it
+versions. The rule is about the shard files, not about the CLI's answers.
+
+---
+
+**This rule does not replace `governed-artifact-reads.md`, and cannot.**
+
+That rule is unconditional, and it has to be. The mistake it prevents is
+reaching for `jq` **instead of** the subcommand, and an agent about to make that
+mistake may never open a file under this directory, so a rule scoped to these
+paths would never load. The unconditional rule is what prevents the mistake.
+This one reinforces it at the moment somebody actually has a shard open.
+
+If the two look redundant, the redundant-looking one is the one doing the work.

--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f070bda593e3dcb157b31074845623c3902a2f543d7649ce893710fe0a416e4a"
+  "shardHash": "90bb5f6cfd46d5abc1bb7d6748275feb0c06e88221e526849e62573131d920ed"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2f069002f67d7939d39274e38051e073147ccef54755ad1efad4e10f08bed59"
+  "shardHash": "95aa660a9e84569d1d7519d6d1ee547ef29644cf654db0fd5d900cf4bfb4e952"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "77bceb39f8e00f3e5e243d11366ac976f3c0a0ba5a9fbb82dc013b51e67b7bfc"
+  "shardHash": "55a31a33bf1fea3d0f4158e2b86e9db6f9f0c5afe9cca14acdd5f5378e3321bb"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b9b46efd209da5a9ac23a5de69d07daede46500d9525a84594c909446c16fbd0"
+  "shardHash": "b292f8f02116ca780815229934a79f07b389483c15fff5bd9fa9cd6a684f19fe"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "19958491185113f562a27e7a5e91858d4d783131782131b11277dc023c139e4e"
+  "shardHash": "cf067cea528bfb6b8ae4d04912e5d744de2b6999836eb1e4db0059229902b286"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ea0200e1bef202530fcc5a4312142708e813ce5ede5147ee2a042433d82ebc3b"
+  "shardHash": "78b136077e30ad1656a3d9a436ed9dc27d30148c8129ad654ae783d5e817d78c"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6f49d1618f80ee71fa733062ab186d518dd5c5da12ccd0d823ebb68b592b45bc"
+  "shardHash": "45251fb5869a59d8e22795d705fa241780bd491fc0fa33e41dda4c58ee7f3191"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6785fc134f39db5183cf1652029dbbb28991aaf52096d142a5d913577d7bddbc"
+  "shardHash": "f2d73bcd83afb143e5ade400b07f38128d4e58952d1e2cf48c7fb457bd52433c"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cec8f1fe40ece81fad2eb4ba00e0dfaababe8a9db01756744f0ecf83276cf9fd"
+  "shardHash": "c10411cf57f454f4ddb73120dd71cc29c8dbe0d408b279de9cf3bd365c343a14"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "93d26c39cc6f599898721d9e60c6c46ab33cf2f349e27f4558a3f053eed18fe2"
+  "shardHash": "8f22e814af48f96b64707216b45e9130198205c9b87f78dfe5ff639d203b163e"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2a67d7472262467b0311d05513c95ab030f6b64de37bfbbbdbebd92008eb690b"
+  "shardHash": "8ea99d4a279b7a1f28e21762b791a8717f3b3a7512bc55761259aa7f30fa74da"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "37e96a97f642b3e8ad361330568cdf8ad71e25204939b80988f8b1bb8db2d1ab"
+  "shardHash": "24e00ea17fceddcb527253f32d5212c367f2c703f00c50dcb604d4813a169504"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "33ce8a6f4599f0008daa7f30ab64a6433af80c566233fb4075cacba0b60f0b68"
+  "shardHash": "78bb3df1e8f44b4b41cb0ae652e20b6c77e15b4b2e3b52bfdcf01007b4325e9b"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6970d19ca58465e0595ca0c6d170970a1b2928d4f0e1c5e2738d5ee269adebaf"
+  "shardHash": "4294cfcab6f2cc84820c11fc06f19b0dc24cfbc1fae923dffdc89374287924cb"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "147ed8af3a7c7b16819c278dd732e495bfb61fa074e4577ec996743f71984318"
+  "shardHash": "4fda5844928edb78b6d0e207c715b0acfd750fbde54e395dad0f66a706eff8f2"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "24ce64fff96b8f00d75f8ef8491c76770a200f99a274b430c944ac8ff9f332e0"
+  "shardHash": "9971c034c0a2dade87b1668aa164be28deaa265e8a7550bd0e37aa4c38d4ebf0"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e5247a7b70448ee7e3c25db4df199209beea94e854ac3b7cb019e5abfac57cb"
+  "shardHash": "6ca99f209f6359e99fdad47dd02793b13d829dd5eeb6f0d2aeb7d503c7f96a8d"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "215332bfd7301e261b7c849320524f15820bb07533a1f163f3f42b707a174f43"
+  "shardHash": "b73c5b347e4b45f23037553f52a255f7f27aceb1b8be62d77af6a020c8593bac"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a7a87a25c09bcf681020cbf42ce14f0a67c2c55378deeae5739eda0bb74858db"
+  "shardHash": "438f9ef8300eb815a82312af29939654f6f715a7461fcba68b0d1b63d3b40d93"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c174999d649e6e16cbef1b9e4f43ec852e97ad364b0c3ce03bce9a44efea7f10"
+  "shardHash": "c809dab4e18b1d44a9e364bcc3e546c1ab330ccdeaa976d5ad5a772358b0a723"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "48791f22347eea7e425c222d883a923de609cdf2ae0615a00ee197572fd8d09b"
+  "shardHash": "ac89179f5d60a2278170d3cb316283f2607a4963c4a5109dc6161d632830d406"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2dea6268848c2ce52dd8ff0c1661a98078fb87f4447a5ed23a3d1d01810e72bb"
+  "shardHash": "abbddad578df386d68f0b586caffdf8d9ef9234d249f7ca20f2ddbf907245ff1"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f222cf675c719ee3527ae19b35c4318faf755c5536d5df19b30d270819e2e5ef"
+  "shardHash": "2eba0c2103305ad20545c6f05e91b830c2167bf698e584c8a9947abbd282387b"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c6d4605847c2d317b633bfadc6ec88cc5c0e439aea10ada692e440da8fabed4b"
+  "shardHash": "8fc31b165d2e04d5fc8d9962d602dd9a631298af153fd54f6ddb4c0973347dde"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4627f827980d2f29ad4b6878ccc735e330f2d4c2d085d303a999cc5d8aa5504c"
+  "shardHash": "c17149d9731e3010697d956752e7451b499b483181ad18551981a46fe706abdf"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8a3d790e26f3fe249978de244272d85c79bec68ef9818508e17fe94953885f8a"
+  "shardHash": "9a49f374af49339a1a540ec92ae1bc70ee44dcd462dc2c8a654ae684fc398e62"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ea297e0c2d85c04af4a700ceca0d20d9e96bda3d4032abdfa730042bfe2ada81"
+  "shardHash": "1762c3646fc6024c17bb14ad9f715cd88b2b034e6fd369ea8d4d1ead65421d2e"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "94f7ca14817918f8d4942895cff6646d6f335aa714564d7c24e2f1aebd1bf945"
+  "shardHash": "7ecd1b3edf348e1cff97dbb639434516bc44cf6add7e4f965481ec45fa543e5c"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "043bfdfa05d87bad05ac7723aafc7bb73ad58d3acda8f8584e38c5f330c357a5"
+  "shardHash": "1d8b12f09d90a947b35b6255257392ad6421bab12efc56ee373b78d09bde7235"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ca48ed8a9bd4c89687776b8bd964f840279afcef8f7ae5df8d1a49d87d535d9d"
+  "shardHash": "7fd43ea48b67525a9bd41cf960adca18836419e6921e20d7532e4a20c5376a89"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0329978171fed39981eccd81005fac09c39cb9af3baf24b98587d3ee0d27f12a"
+  "shardHash": "cecdffa83e57db85fe389c51d2fe5386a9d358536001206bca1163db42616cd6"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0a9a8f1abc607843c78bc2427f04063d55b867cdf5e55a0d848820dc458ac550"
+  "shardHash": "54dbdf398d43780d87835647d7916c5fb39f905375c1867fa4fc51e015667602"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9df5dbf69bbf266d7134d9f57a241a47ffe0c8d3590726a837a81d47e422bbfa"
+  "shardHash": "f49db334b3926449c38557aa739b7da7213626f63260eb826d7d233853f1f1c4"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "85ebf3f9945e15f561255c28822f39a051c692cc619a8cfbf34e8578b6411d90"
+  "shardHash": "33c956e06a0af672269cecd5c0f3479a46d184c33d82fbe1cf04c2251cb2f313"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ef78531f350717d89fa004bee3b61a5d35c6f29174d9cf9b74316b76de60db94"
+  "shardHash": "b616bff272fa2152c3a399ff09dac534479b4922feb61bb74a62629f0c2d3338"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4ea0dcaba20cfca88fb19db54f1f292a43dd1a9edabd890d37d9c9fa25a1987e"
+  "shardHash": "20dae8e8196da9ee7ce1d57fdf427db99ce65c4dd942bdf3e2efc2111833926d"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c3ee2d7d526fa0ec7ba55028683f1b1281ccf61540908d3be9d7424d54511e50"
+  "shardHash": "f1a3147f211e1bc593b6d75c4c972ff2377e20ca124a0c87d313f11a1b5c8b99"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1ae06aacc9d57c59ef28afdf9dd9bf2c8e1b909084894d1608d18524d255d4eb"
+  "shardHash": "ae3f55282804df520b5d12b49676b16835d16e36b162ef315361b3e0a42c795e"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a588027f51a71a9f5cd1caca26120a1671a9640547c56b3951d04bee37476163"
+  "shardHash": "fd9cc28824f9295c9b2ffeb0388f7ca3fb4b538d326f3f2b5fb24f556f483a02"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ba6f3a9c7ada1c6d024a4a86cd532e0dcfd3ecdabbf6c1fa1e43c4e76791c629"
+  "shardHash": "de96a82c681c3806168f635191962f1de52229a22e07d44080e1b02dc0499ddf"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0a37e7b45ca57be76850721f5013381ea1891a04c2c9ffb9477a091268b3c8fa"
+  "shardHash": "f9c62559af242ccfd7d5f713bfad44b22fef22e2b09f3941919a8350c549e48a"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ae036030afc96c65b74c03f0dacba69cedc362c7048c3fb7fbdf8f07322f12a6"
+  "shardHash": "87786b3410a4eebca6b360b71b86841b5d9b7374f5155562f62cca8469705eea"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb8aca478a72cc581759cce4c663c46a0aa5148a61ffe0bc27b19c9142f0bb18"
+  "shardHash": "26dc10eacbc47540ad49bdff4f7a5f692b00a5a1e304e0bae656c8e7bffbe3fc"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6ca94fc09f6993d17ff1ae008c628a337c07fea8c9af2c31ffc9e541043af8ef"
+  "shardHash": "42277730723b4040b83d7614275bcc52036209f355a7ae117a4646032bee0da9"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0d9e28f8d77865dd72822c3d8939679d338fd346cea990268329386a9f319aaf"
+  "shardHash": "05adcf35f39325c932b2a8a572191a7039e9ea029da07659597884c11feffeb8"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7546c179c91e76168e11658600956a25141d5ef20bfab9333bdc96362926b443"
+  "shardHash": "6d59d6596cd7862d729305a587f68cf83c5b7a92d2cc030c1afec38bacc63f24"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e46bafc4de69db86dbcddab00027f3baec164ce1e4363ae97a6deb527ba19e97"
+  "shardHash": "7abd0522a2def7affd6e031f2f25fdae6f5b9aa3e1a4c40a7efadad6cea03529"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "19cfd17b8556105d1d9b3f83a0ed2b23363e9c73c0210526fd2aea732dd9b07b"
+  "shardHash": "ae430c548534da3cd1492f23bb0fe2787b1ed2c3207c7e05922c066a68297c92"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0efe5a326571c185440a549d4ac40fc26188e90e3701b35ff46cd42910f96e89"
+  "shardHash": "476164cabcc2dc37b70c95e0a810cd89f47cb01e4ea14f30caec503b7af0883d"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f94ffad8246aebee2aff2fbaf50d22f8cac0c3f2ca5a0973fc62b7538e5525d1"
+  "shardHash": "010d1a2295e9f5e21dbb0072d8ff63a92b34a7f727390d93777acd7276cab348"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "69196fe567cd5456078970465dcb5fba32c980ec0a6d1015adf831632a70101a"
+  "shardHash": "34cd963517db212b48e555d7c6a320853800d3f18117f6e2909ef31b5bf83391"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7814dcca6a9ed4e8a9541829d4c755e17b337f4c86f7dc5feb4b0c2c0e7ef180"
+  "shardHash": "cc6925a22cae2f7f2d17acd60a5bacf9973e7f4f72f9901ea2dc949f42479188"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2f0a593ffe40b95ad1d1991ba28b3e90cf5ed6f2d29eff02fcce5602979b03d1"
+  "shardHash": "5c8dffe4399fea1edf950d88afc68fad1d1612e21f46700cba64ab2933843f10"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ec220eb31e3942c7b60508ea3ddfe610d60014ac098bc2db30198470033d9829"
+  "shardHash": "bee4f66a91c9340305e73b2ee08779d20f20d210458265df40460ccf8c87e058"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f2af56c933516ac506ae1f7979d5d6a9b4f9ce38add198c870878d354067befc"
+  "shardHash": "510e31091bdca241f8e42314517cbb3eb5291ed71fc365b201b1d84f8f361b4f"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f422b07c083467a1ed6dde400c00eb2b22dd55379d55b9ff028b2ed69b840fd0"
+  "shardHash": "4519cd534034a9415a58ca683463e813d78ececcd21d26b347715796123d15e1"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3a75f5b3212760c5349ee3612e396a4f8e7ef0ce32464f2c439e835a4b50679e"
+  "shardHash": "0d7fa3ad1964841ded4e996bfd74046421957a37480ca9988842c04acea3066a"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f9ee76dc8c6286519d6c0a91a4179f7035d46a71a8337baeae896341a064c51f"
+  "shardHash": "1277f77a36d9afb89127ea97b9491e1cab73d3c627bd6d2d495d785764f3c046"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80dc2a52c5b7a41b1e6945c62a5626999b411f5df9c47224a1bbaa284873c0c7"
+  "shardHash": "2b77537b9adc96667124b1db499796b7a1e2a6342f89f415d72c12135237c6bc"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a320b3d4429388a8f2cff3cd77a4acc02ed3d75133365e33bb4e4e60319054ab"
+  "shardHash": "06324a3f7ba0d93be1ff12ad11c6cec7d7f1bb2733316562d586e3e892057b8e"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3042ad2080f069bb2f48dce3f58c925998980658730c68aaa5ef9bdfc63c38a2"
+  "shardHash": "50d2aaaddc20141ea8b3244bc68b786a89552c928ee2cfaae3fb8732c17f2866"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "acab98ea7c4612c21e068745236df9054f86a3235009b2ae3e84d98af1251b66"
+  "shardHash": "08e65fb02cf7ff36df1a1d1a53d72d204fb9531f9c8e4dd6d4f90db1fa8d9ee0"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9d4d705c9f78fd7c07c75513a05342a71e91cbb7cd40a47f6aa0f3f6381800c9"
+  "shardHash": "02b870e558034fba8832bc6a34a3b7950543ddb93f85ce85d4cefa1395185cbe"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3c85fdcda55056d896a837f6e996829967b913c5cb0555a8e1dec696fe32d217"
+  "shardHash": "0aa2c5028320b8dd23d58b173339b09922a31e610216c023b078ede34dbd74d3"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "757cbe7bcd2f651e23ffc06cc2585f6fc892f17b1ec9a4fd4a6b17201b1715b1"
+  "shardHash": "f0154778cac6485dbf402db8cfa2126592099ad1dcce7a5befa4efdb060139fb"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dd25389b183278bcfd8bffad43feec1f39df354ac78717455329097fc7878c64"
+  "shardHash": "f6fef81e7a2eef9684ee7c3a0508491b2dc0d8ba50e2d59b6d52a861c2e8614b"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0f3e242529080fa7c6d8c599901dcc0eaaad53dd916b585291b5348d88c35ddd"
+  "shardHash": "18953541a54af98eb7b227f8183c1da4e8d99d26a2a610e5ccca9cb77fc5abbe"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3bcd9e18581ee7a7ef0b94ad5edacd0a7738c8b44b6f8da407f11f525e7766d0"
+  "shardHash": "58c29e93c166efe1d039cab13ec319382799cf43097abb480b2cd7eba9cd9e5d"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0d9dee2ccdb921ba5811ade624d4f1b3b58230f8e4145b960547a8ef23c650c4"
+  "shardHash": "ab09936282ac528c4d6ed0dfac3772b3fd5eff1f193fd770769393fdf4324553"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c3adeb50ff05981f4fbe73f6456192ede00fee7b3224f582850b150a4e9a56db"
+  "shardHash": "653d96b7671bee09ca198caf397cb3a0b68d76fce493ed17f0e19c60d28b09ec"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -57,5 +57,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5b2dfe538c9e440c15bbdf5d47c026f17a9a66a9db34d1c212e2d6990c844aa6"
+  "shardHash": "3faf2c8baf0b868b8f674a68de8cdc6ff2990921928fa158960baef652b671ec"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b523a1a6ff000d0c572e60c29deed3c34381be9af5b587c20a356a7741ae70a7"
+  "shardHash": "e62e0365dc2c28d6c38aab8cdf148ade5ac8baeac2523f94cdc540a7262289ee"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -7,15 +7,91 @@
     ],
     "implementingPaths": [
       {
+        "path": ".claude/rules/derived-artifacts-are-compiler-output.md",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/kit_embedded.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/kit_skills.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "kit/.claude/rules/",
+        "source": "spec-edge"
+      },
+      {
+        "path": "kit/.claude/rules/derived-artifacts-are-compiler-output.md",
         "source": "spec-edge"
       },
       {
         "path": "kit/README.md",
         "source": "spec-edge"
+      },
+      {
+        "path": "scripts/gen-kit-embedded.py",
+        "source": "spec-edge"
+      },
+      {
+        "path": "spec-spine.toml",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": ".claude/rules/derived-artifacts-are-compiler-output.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": ".claude/rules/derived-artifacts-are-compiler-output.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "kit/.claude/rules/derived-artifacts-are-compiler-output.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "kit/.claude/rules/derived-artifacts-are-compiler-output.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/kit_embedded.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/kit_embedded.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/kit_skills.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/kit_skills.rs"
+        }
+      },
       {
         "locations": [
           {
@@ -40,6 +116,32 @@
         "unit": {
           "kind": "file",
           "path": "kit/README.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "scripts/gen-kit-embedded.py"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "scripts/gen-kit-embedded.py"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "spec-spine.toml"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
         }
       },
       {
@@ -73,5 +175,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8b94fd5ccbf1958e7ad0d9608fed9db15307e8675c64435644295645d88c3d4e"
+  "shardHash": "e8a4b9cc60833275d1d5c2ace6795c1e1667e9b5929e32e21a005188df820f12"
 }

--- a/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
@@ -6,6 +6,16 @@
       "047-harness-rules-name-the-legitimate-edits",
       "048-kit-ships-the-governed-loop-skills"
     ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "kit/.claude/rules/derived-artifacts-are-compiler-output.md"
+      },
+      {
+        "kind": "file",
+        "path": ".claude/rules/derived-artifacts-are-compiler-output.md"
+      }
+    ],
     "extends": [
       {
         "nature": "additive",
@@ -22,10 +32,42 @@
           "kind": "file",
           "path": "kit/README.md"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "048-kit-ships-the-governed-loop-skills",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/kit_skills.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "065-init-and-the-kit-are-one-adoption",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/kit_embedded.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "065-init-and-the-kit-are-one-adoption",
+        "unit": {
+          "kind": "file",
+          "path": "scripts/gen-kit-embedded.py"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "064-the-kit-ships-the-composite-gate",
+        "unit": {
+          "kind": "file",
+          "path": "spec-spine.toml"
+        }
       }
     ],
     "id": "068-a-path-scoped-rule-example",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -63,6 +105,6 @@
     "summary": "The kit's three rules are unconditional: every one loads in every session regardless of what the session touches. Claude Code supports `paths:` frontmatter that loads a rule only when a matching file is touched, and the kit's README lists that pattern under \"intentionally excluded\" while hqgit carries three good ones, including per-file scoping. The exclusion was a judgement made before any adopter had tried it, and an adopter has now tried it and kept it. This spec ships one path-scoped rule, scoped to the derived artifact tree, whose content is the one instruction that is only ever relevant when someone has a compiled artifact open: do not hand-edit it. One rule, as a worked example of the mechanism, with the README's exclusion replaced by a description of when to reach for it.\n",
     "title": "A path-scoped rule the kit actually ships"
   },
-  "shardHash": "a7f600605c6e7ca06a8ac74f89cbf1012a934423dab03650920bfeb5274da247",
+  "shardHash": "c2b3fe382b1681601e596460bac14ea424b0dc264f7013489a3a1ac9360590c3",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-core/src/kit_embedded.rs
+++ b/crates/spec-spine-core/src/kit_embedded.rs
@@ -596,6 +596,46 @@ spec *requires* is never yours to do mid-build. If the code needs to touch a
 unit another spec owns, declare an `extends` edge naming that spec and unit;
 that amends nobody.
 "#),
+    (r#".claude/rules/derived-artifacts-are-compiler-output.md"#, r#"---
+paths:
+  - ".derived/**"
+---
+
+# Derived artifacts are compiler output
+
+The files under this directory are emitted by `spec-spine compile` and
+`spec-spine index`. They are machine truth, not authored truth.
+
+**Do not hand-edit one.** A shard is a pure function of the corpus and the
+source tree; editing it makes the ledger disagree with what it describes, and
+the next `compile --check` or `index check` reports it as staleness with no clue
+that a person put it there. The way to change a shard is to change its input and
+regenerate.
+
+**Do not read one with `jq`, `grep`, `sed`, `awk` or `python`.** An ad-hoc
+parser encodes today's shape and then goes quietly wrong when the schema moves.
+Read through a `spec-spine` subcommand instead: `registry show`, `registry
+list`, `registry plan`, `index render`, `index owner`, `index coverage`,
+`index diagnostics`. A typed read fails at the deserializer with a clean error
+rather than silently returning the wrong answer.
+
+**Parsing the output of a subcommand is fine.** `spec-spine registry plan
+--json`, or the `--json` verdict envelope any gate verb emits, is a typed read:
+the tool has already deserialized the shards and is answering in a contract it
+versions. The rule is about the shard files, not about the CLI's answers.
+
+---
+
+**This rule does not replace `governed-artifact-reads.md`, and cannot.**
+
+That rule is unconditional, and it has to be. The mistake it prevents is
+reaching for `jq` **instead of** the subcommand, and an agent about to make that
+mistake may never open a file under this directory, so a rule scoped to these
+paths would never load. The unconditional rule is what prevents the mistake.
+This one reinforces it at the moment somebody actually has a shard open.
+
+If the two look redundant, the redundant-looking one is the one doing the work.
+"#),
     (r#".claude/rules/governed-artifact-reads.md"#, r#"# Governed artifact reads
 
 The compiled artifacts under the derived directory are read **only** through

--- a/crates/spec-spine-core/tests/kit_skills.rs
+++ b/crates/spec-spine-core/tests/kit_skills.rs
@@ -450,3 +450,122 @@ fn no_skill_names_a_gate_flag_agents_md_omits() {
         }
     }
 }
+
+// ── spec 068: one path-scoped rule, exercised here ────────────────────────
+
+/// §3.4: the kit's rules and this repository's agree, the scoped one included.
+/// Spec 046 found three kit hooks that wrote when they should read, because
+/// this repository never ran them; a rule shipped to adopters and never loaded
+/// here would be the third instance of that mistake.
+#[test]
+fn the_kit_rules_and_this_repositorys_agree() {
+    let root = repo_root();
+    let kit = root.join("kit/.claude/rules");
+    let mine = root.join(".claude/rules");
+
+    let names = |dir: &Path| -> BTreeSet<String> {
+        fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("{}: {e}", dir.display()))
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".md"))
+            .collect()
+    };
+    assert_eq!(names(&kit), names(&mine), "the rule sets must be the same");
+
+    for name in names(&kit) {
+        assert_eq!(
+            fs::read_to_string(kit.join(&name)).unwrap(),
+            fs::read_to_string(mine.join(&name)).unwrap(),
+            "{name} has diverged between kit/ and this repository"
+        );
+    }
+}
+
+/// §3.1: exactly one rule carries `paths:` frontmatter. The value is the worked
+/// example and the fit; a directory of conditional rules would make adopters
+/// read scoping decisions that are theirs to make.
+#[test]
+fn exactly_one_rule_is_path_scoped() {
+    let dir = repo_root().join("kit/.claude/rules");
+    let scoped: Vec<String> = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
+        .filter(|e| {
+            let body = fs::read_to_string(e.path()).unwrap();
+            body.starts_with("---\n") && body.contains("\npaths:\n")
+        })
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        scoped,
+        vec!["derived-artifacts-are-compiler-output.md".to_string()],
+        "one path-scoped rule, not three"
+    );
+}
+
+/// §3.1: it is scoped to the derived tree and carries the artifact-specific
+/// half of the governed-reads rule, including the clarification spec 047 added
+/// and that adopters most needed: parsing a subcommand's OUTPUT is a typed read.
+#[test]
+fn the_scoped_rule_covers_the_derived_tree_and_allows_reading_cli_output() {
+    let body = fs::read_to_string(
+        repo_root().join("kit/.claude/rules/derived-artifacts-are-compiler-output.md"),
+    )
+    .unwrap();
+    assert!(body.contains(".derived/**"), "{body}");
+    assert!(body.contains("Do not hand-edit"), "{body}");
+    assert!(body.contains("jq"), "{body}");
+    assert!(
+        body.contains("Parsing the output of a subcommand is fine"),
+        "the clarification spec 047 added: {body}"
+    );
+}
+
+/// §3.2: the rule says, in its own text, that it does not replace the
+/// unconditional one and cannot. A reader comparing the two files will
+/// otherwise conclude one is redundant, and the redundant-looking one is the
+/// one that does the work.
+#[test]
+fn the_scoped_rule_says_it_does_not_replace_the_unconditional_one() {
+    let root = repo_root();
+    let scoped =
+        fs::read_to_string(root.join("kit/.claude/rules/derived-artifacts-are-compiler-output.md"))
+            .unwrap();
+    assert!(
+        scoped.contains("does not replace `governed-artifact-reads.md`"),
+        "{scoped}"
+    );
+    assert!(
+        scoped.contains("may never open a file under this directory"),
+        "the reason a scoped rule cannot prevent this mistake: {scoped}"
+    );
+
+    // And the unconditional rule keeps its full content.
+    let unconditional =
+        fs::read_to_string(root.join("kit/.claude/rules/governed-artifact-reads.md")).unwrap();
+    assert!(unconditional.contains("jq"), "{unconditional}");
+    assert!(
+        !unconditional.contains("\npaths:\n"),
+        "it stays unconditional"
+    );
+}
+
+/// §3.3: the README says when to scope, names the shipped rule as the example,
+/// and carries the caveat rather than only the pattern.
+#[test]
+fn the_readme_describes_when_to_scope_a_rule() {
+    let readme = fs::read_to_string(repo_root().join("kit/README.md")).unwrap();
+    assert!(readme.contains("When to scope a rule to paths"), "{readme}");
+    assert!(
+        readme.contains("derived-artifacts-are-compiler-output.md"),
+        "names the shipped example"
+    );
+    assert!(readme.contains("hqgit"), "the field evidence");
+    assert!(
+        readme.contains("never a replacement for a\nstanding constraint")
+            || readme.contains("never a replacement for a standing constraint"),
+        "the caveat: {readme}"
+    );
+}

--- a/kit/.claude/rules/derived-artifacts-are-compiler-output.md
+++ b/kit/.claude/rules/derived-artifacts-are-compiler-output.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - ".derived/**"
+---
+
+# Derived artifacts are compiler output
+
+The files under this directory are emitted by `spec-spine compile` and
+`spec-spine index`. They are machine truth, not authored truth.
+
+**Do not hand-edit one.** A shard is a pure function of the corpus and the
+source tree; editing it makes the ledger disagree with what it describes, and
+the next `compile --check` or `index check` reports it as staleness with no clue
+that a person put it there. The way to change a shard is to change its input and
+regenerate.
+
+**Do not read one with `jq`, `grep`, `sed`, `awk` or `python`.** An ad-hoc
+parser encodes today's shape and then goes quietly wrong when the schema moves.
+Read through a `spec-spine` subcommand instead: `registry show`, `registry
+list`, `registry plan`, `index render`, `index owner`, `index coverage`,
+`index diagnostics`. A typed read fails at the deserializer with a clean error
+rather than silently returning the wrong answer.
+
+**Parsing the output of a subcommand is fine.** `spec-spine registry plan
+--json`, or the `--json` verdict envelope any gate verb emits, is a typed read:
+the tool has already deserialized the shards and is answering in a contract it
+versions. The rule is about the shard files, not about the CLI's answers.
+
+---
+
+**This rule does not replace `governed-artifact-reads.md`, and cannot.**
+
+That rule is unconditional, and it has to be. The mistake it prevents is
+reaching for `jq` **instead of** the subcommand, and an agent about to make that
+mistake may never open a file under this directory, so a rule scoped to these
+paths would never load. The unconditional rule is what prevents the mistake.
+This one reinforces it at the moment somebody actually has a shard open.
+
+If the two look redundant, the redundant-looking one is the one doing the work.

--- a/kit/README.md
+++ b/kit/README.md
@@ -133,11 +133,36 @@ Project-specific pieces are not shipped; recreate them for your own stack:
 - a domain-specialist agent (a framework expert, a ledger guardian): the
   generic "read-only specialist" pattern, named by the invariant rule it
   serves;
-- `build-commands.md` and invariant rules: the generic "paths-scoped context
-  rule" pattern (`paths:` frontmatter), which the harness spec lists
-  individually;
+- `build-commands.md` and further invariant rules: the kit ships one worked
+  example of the pattern (below); the rest are yours;
 - a `Makefile` composite and a CI workflow: every adopter's differ; the gate
   command list in `AGENTS.md` is the contract the skills read.
+
+## When to scope a rule to paths
+
+A rule file with `paths:` frontmatter loads only when the session touches a
+matching path. The kit ships exactly one, `derived-artifacts-are-compiler-output.md`,
+scoped to `.derived/**`, as the worked example.
+
+**Unconditional** when the rule is about how to work at all: the loop, the
+refusals, the standing constraints. The three rules `spec-spine init` writes are
+all of this kind.
+
+**Scoped** when the rule is only actionable while a particular kind of file is
+open, and loading it always would spend context on a case most sessions never
+reach. hqgit carries three, one of them scoped to a single file, which is the
+field evidence that the pattern earns its place on a real corpus.
+
+**The caveat is the important part.** A scoped rule cannot prevent a mistake
+whose whole shape is *not* touching the path. The shipped example says so in its
+own text: reaching for `jq` instead of a `spec-spine` subcommand is exactly that
+mistake, so `governed-artifact-reads.md` stays unconditional and keeps its full
+content, and the scoped rule reinforces it at the moment somebody has a shard
+open. A scoped rule is a reminder where the work is, never a replacement for a
+standing constraint.
+
+One, not three. The value is the worked example and the fit; a directory of
+conditional rules would make you read scoping decisions that are yours to make.
 
 ## License and origin
 

--- a/scripts/gen-kit-embedded.py
+++ b/scripts/gen-kit-embedded.py
@@ -14,7 +14,6 @@ never edited by hand. Regenerate with:
     python3 scripts/gen-kit-embedded.py
 """
 
-import subprocess
 import sys
 from pathlib import Path
 
@@ -35,6 +34,9 @@ SKIP = {
     # gets the generated one, whose corpus and derived paths match their layout.
     "kit/AGENTS.md",
 }
+# Never part of the kit, whatever the filesystem accumulates.
+IGNORE = {".DS_Store", "__pycache__", ".git"}
+
 # Destination path for a kit file, when it differs from stripping `kit/`.
 REMAP = {
     "kit/govern.yml": ".github/workflows/govern.yml",
@@ -50,14 +52,17 @@ def dest_for(rel: str) -> str:
 
 
 def main() -> int:
-    tracked = subprocess.run(
-        ["git", "-C", str(ROOT), "ls-files", "kit/"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.split()
+    # Walk the tree rather than asking git: a brand-new kit file is untracked
+    # until it is staged, and a generator that silently omitted it would ship a
+    # binary missing the file its own spec had just added. Junk is excluded by
+    # name instead.
+    files = [
+        p.relative_to(ROOT).as_posix()
+        for p in (ROOT / "kit").rglob("*")
+        if p.is_file() and not any(part in IGNORE for part in p.parts)
+    ]
     entries = []
-    for rel in sorted(tracked):
+    for rel in sorted(files):
         if rel in SKIP:
             continue
         text = (ROOT / rel).read_text(encoding="utf-8")

--- a/specs/068-a-path-scoped-rule-example/spec.md
+++ b/specs/068-a-path-scoped-rule-example/spec.md
@@ -4,7 +4,7 @@ title: "A path-scoped rule the kit actually ships"
 status: draft
 kind: "tooling"
 created: "2026-09-07"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:
@@ -14,6 +14,16 @@ depends_on:
 extends:
   - { spec: "029-claude-code-skill-kit", unit: "kit/.claude/rules/", nature: additive }
   - { spec: "029-claude-code-skill-kit", unit: "kit/README.md", nature: additive }
+  # The kit's rule set is embedded for `init --with-kit` (spec 065) and its
+  # agreement with this repository's copy is asserted beside the skills.
+  - { spec: "048-kit-ships-the-governed-loop-skills", unit: "crates/spec-spine-core/tests/kit_skills.rs", nature: additive }
+  - { spec: "065-init-and-the-kit-are-one-adoption", unit: "crates/spec-spine-core/src/kit_embedded.rs", nature: additive }
+  - { spec: "065-init-and-the-kit-are-one-adoption", unit: "scripts/gen-kit-embedded.py", nature: additive }
+  - { spec: "064-the-kit-ships-the-composite-gate", unit: "spec-spine.toml", nature: additive }
+establishes:
+  # Created by this spec (3.1), shipped to adopters and carried here (3.4).
+  - "kit/.claude/rules/derived-artifacts-are-compiler-output.md"
+  - ".claude/rules/derived-artifacts-are-compiler-output.md"
 references:
   - { unit: { kind: file, path: "docs/design/03-adopter-audit-2026-09.md" }, role: context }
   - { unit: { kind: file, path: ".claude/rules/governed-artifact-reads.md" }, role: context }
@@ -163,6 +173,14 @@ regenerates and commits the shards.
 
 **Rewriting the three unconditional rules.** §2. Specs 047 and 048 settled them.
 
+**Decision, 2026-09-07: the kit generator no longer asks git what the kit
+contains.** Spec 065's `scripts/gen-kit-embedded.py` enumerated `kit/` with
+`git ls-files`, so this spec's brand-new rule file was invisible to it until
+staged, and the first regeneration produced a binary whose `--with-kit` would
+not have written the rule the spec exists to ship. §5's assertion that an
+adopter receives it is what caught that. The generator now walks the tree and
+excludes junk by name, so a file that exists is a file that ships.
+
 **Splitting `governed-artifact-reads.md`.** §3.2. It keeps its full content and
 the scoped rule reinforces rather than replaces it.
 
@@ -174,19 +192,35 @@ this spec uses it as one.
 
 ## 5. Verification
 
+Each line is one command (spec 049 §3.2). Every assertion fails against pre-068
+state: the rule did not exist and the README called the pattern excluded.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test kit_skills --locked
-# The kit ships exactly one path-scoped rule, and it is scoped to .derived.
-test "$(grep -rl '^paths:' kit/.claude/rules/ | wc -l | tr -d ' ')" = "1"
-grep -rq '.derived' kit/.claude/rules/
-# The unconditional rule kept its full content, including the 047 clarification.
-grep -q 'typed read' kit/.claude/rules/governed-artifact-reads.md
-# The README describes when to scope instead of excluding the pattern.
-grep -q 'paths:' kit/README.md
-! grep -q 'intentionally excluded.*paths' kit/README.md
-# This repository loads what it ships, and the shards were regenerated.
-test "$(grep -rl '^paths:' .claude/rules/ | wc -l | tr -d ' ')" = "1"
+# 3.1: exactly one rule carries `paths:` frontmatter, scoped to the derived tree.
+grep -q 'paths:' kit/.claude/rules/derived-artifacts-are-compiler-output.md
+grep -q '.derived/\*\*' kit/.claude/rules/derived-artifacts-are-compiler-output.md
+# 3.1: and it carries the clarification adopters most needed.
+grep -q 'Parsing the output of a subcommand is fine' kit/.claude/rules/derived-artifacts-are-compiler-output.md
+# 3.2: it says it does not replace the unconditional rule, and cannot.
+grep -q 'does not replace' kit/.claude/rules/derived-artifacts-are-compiler-output.md
+# 3.2: which keeps its full content and stays unconditional.
+grep -q 'jq' kit/.claude/rules/governed-artifact-reads.md
+! grep -q 'paths:' kit/.claude/rules/governed-artifact-reads.md
+# 3.3: the README says when to scope rather than calling the pattern excluded.
+grep -q 'When to scope a rule to paths' kit/README.md
+! grep -q 'invariant rules: the generic' kit/README.md
+# 3.4: this repository carries the same rule, so it is exercised here rather
+# than only shipped. Spec 046 found three hooks that wrote because this
+# repository never ran them.
+test -f .claude/rules/derived-artifacts-are-compiler-output.md
+diff kit/.claude/rules/derived-artifacts-are-compiler-output.md .claude/rules/derived-artifacts-are-compiler-output.md
+# 3.4: and an adopter installing the kit receives it.
+rm -rf "${TMPDIR:-/tmp}/ss068" && mkdir -p "${TMPDIR:-/tmp}/ss068" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss068" init --with-kit >/dev/null && test -f "${TMPDIR:-/tmp}/ss068/.claude/rules/derived-artifacts-are-compiler-output.md"
+rm -rf "${TMPDIR:-/tmp}/ss068"
+# 3.5: the shards were regenerated and committed with the new claimed paths.
+target/release/spec-spine compile --check
 target/release/spec-spine index check
 ```


### PR DESCRIPTION
Implements spec 068 (adopter-audit kit item 14). **The last of the 25-item
backlog.**

## What changed

The kit's README listed `paths:` frontmatter as an *intentionally excluded*
pattern, and adopters used it anyway — hqgit carries three scoped rules, one of
them scoped to a single file. A pattern the field adopted and the kit called
excluded is a gap in the kit, not a decision.

**One rule ships as the worked example**, scoped to `.derived/**`, carrying the
artifact-specific half of the governed-reads rule and the clarification spec 047
added and adopters most needed: **parsing the OUTPUT of a subcommand is a typed
read and is allowed.**

**The unconditional rule keeps its full content**, and the scoped rule says so
in its own text. This is the part worth getting right: a scoped rule **cannot**
prevent a mistake whose whole shape is *not* touching the path. The mistake here
is reaching for `jq` **instead of** the subcommand, by an agent that may never
open a shard — so a rule scoped to `.derived/**` would never load. If the two
files look redundant, the redundant-looking one is the one doing the work, and
saying that in the file is required rather than optional.

**One, not three.** The value is the worked example and the fit; a directory of
conditional rules would make adopters read scoping decisions that are theirs.
The README now says *when* to scope rather than calling the pattern excluded,
names the shipped rule as the example, cites hqgit as the field evidence, and
carries the caveat.

**This repository carries the same rule**, so it is exercised here rather than
only shipped, with a test asserting the kit's rule set and this repository's
agree. Spec 046 found three kit hooks that wrote when they should have read,
because this repository never ran them; a rule shipped to adopters and never
loaded here would be the third instance of that mistake.

## A defect in spec 065's generator, found and fixed here

`scripts/gen-kit-embedded.py` enumerated `kit/` with **`git ls-files`**, so this
spec's brand-new rule file was invisible to it until staged — and the first
regeneration produced a binary whose `--with-kit` **would not have written the
rule this spec exists to ship**.

§5's assertion that an adopter actually *receives* it is what caught that. The
generator now walks the tree and excludes junk by name, so a file that exists is
a file that ships. Recorded as a decision in §4.

## Verification

`spec-spine verify 068` passes, 16 commands — including scaffolding a fresh
adopter with `--with-kit` and checking the rule arrived. Full gate green: 69
shards fresh, index fresh, 0 unresolved, 0 lint warnings, 74/74 coverage,
`couple` clean over 7 paths. Workspace tests, clippy `-D warnings`,
`fmt --check` pass. No waiver.