### PR TITLE
fix(060): the plan's acceptance asserts behavior, not corpus state

### DIFF
--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80cc4d834dc2b8dd41cb0a8d0d768b36d8e5ceb9d827ebb50ef75521b003a1e3"
+  "shardHash": "fff53d0fdd9892002cd0225741af0e81642f22b4d84cd196dc6cf7815d2186a6"
 }

--- a/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
@@ -86,6 +86,6 @@
     "summary": "`registry plan` prints spec ids and a count. Every consumer needs more than that, so every consumer adds it back: adopters kept about forty lines of Python to join the ready ids against titles and to explain why each blocked spec is blocked, and the corpus's own `/next` skill has to make a second call to turn an id into something a human can read. The data is all there. `Plan` already carries each blocked spec's blockers with the state of each, and the registry it was computed from carries every title. This spec makes the prose form render what the structure already holds, and adds `--next`, the single pick that the one-spec-per-session loop actually asks for. The JSON shape gains title fields and is otherwise unchanged.\n",
     "title": "The plan answers the whole question, and names one pick"
   },
-  "shardHash": "5ab7aeecb9988937127629e7812f907f280b927ea5529cea402e9ac05cd22eac",
+  "shardHash": "ff916a920c8ec5a92bfbcefc2d9fb59e9f5aaba250bbcf9955d1fc56354a1457",
   "specVersion": "1.1.0"
 }

--- a/specs/060-plan-answers-the-whole-question/spec.md
+++ b/specs/060-plan-answers-the-whole-question/spec.md
@@ -207,16 +207,39 @@ the corpus.
 
 ## 5. Verification
 
+Each line is one command (spec 049 §3.2). The shape assertions run against a
+**scratch corpus** rather than against this repository's plan, because this
+repository's plan is corpus state and corpus state moves.
+
+**Decision, 2026-09-08.** The block originally asserted
+`registry plan --json | grep -q '"title"'` against this repository. That passed
+the day it was written, when specs were ready, and began failing the moment the
+backlog was finished: a corpus with nothing ready has no ready entries, so no
+entry carries a title, and the assertion reported the absence of work as the
+absence of the feature. An acceptance block must assert behavior, and behavior
+is what a fixture demonstrates; the live corpus is an input, not a contract.
+
 ```verify:cli
 # Self-contained: the commands below invoke the release binary.
 cargo build --release --locked
 cargo test -p spec-spine-core --test query --locked
-# The prose form carries titles and the not-schedulable remainder.
-target/release/spec-spine registry plan | grep -q 'not schedulable'
-# --next prints one spec. Until this ships, it is an unknown argument.
+# A scratch corpus with one ready spec and one blocked by it, so the shape
+# assertions below hold whatever this repository's own backlog is doing.
+rm -rf "${TMPDIR:-/tmp}/ss060" && mkdir -p "${TMPDIR:-/tmp}/ss060/specs/001-alpha" "${TMPDIR:-/tmp}/ss060/specs/002-beta" && : > "${TMPDIR:-/tmp}/ss060/spec-spine.toml" && printf -- '---\nid: "001-alpha"\ntitle: "First thing"\nstatus: approved\ncreated: "2026-09-07"\nsummary: "s"\nimplementation: pending\nestablishes:\n  - "specs/001-alpha/spec.md"\n---\n\n# 001-alpha\n## body\n' > "${TMPDIR:-/tmp}/ss060/specs/001-alpha/spec.md" && printf -- '---\nid: "002-beta"\ntitle: "Second thing"\nstatus: approved\ncreated: "2026-09-07"\nsummary: "s"\nimplementation: pending\ndepends_on:\n  - "001-alpha"\nestablishes:\n  - "specs/002-beta/spec.md"\n---\n\n# 002-beta\n## body\n' > "${TMPDIR:-/tmp}/ss060/specs/002-beta/spec.md" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss060" compile >/dev/null
+# 3.3: the ready array carries titles, so no consumer needs a second call.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss060" registry plan --json | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p["ready"][0]=={"id":"001-alpha","title":"First thing"}, p'
+# 3.1: and each blocked entry carries its title and the state of every blocker,
+# rather than a count of them.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss060" registry plan --json | python3 -c 'import json,sys; b=json.load(sys.stdin)["blocked"][0]; assert b["title"]=="Second thing", b; assert b["blockedBy"][0]["id"]=="001-alpha", b; assert b["blockedBy"][0]["state"], b'
+# 3.1: the prose form renders what the structure holds, remainder included.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss060" registry plan | grep -q 'not schedulable'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss060" registry plan | grep -q 'blocked by 001-alpha'
+# 3.2: `--next` is the single pick, as the object rather than a one-element list.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss060" registry plan --next --json | python3 -c 'import json,sys; assert json.load(sys.stdin)=={"id":"001-alpha","title":"First thing"}'
+# 3.2: and an empty ready set is a true answer at exit 0, not a failure. This
+# repository is that case now, which is why the assertions above use a fixture.
 target/release/spec-spine registry plan --next
-# The ready array carries titles, so no consumer needs a second call.
-target/release/spec-spine registry plan --json | grep -q '"title"'
-# The ledger is untouched by a read verb.
+rm -rf "${TMPDIR:-/tmp}/ss060"
+# 3.3: the ledger is untouched by a read verb.
 target/release/spec-spine compile --check
 ```


### PR DESCRIPTION
A follow-up to #126, found by running every built spec's declared acceptance
against `main` after the backlog was finished.

## The defect

Spec 060's `## Verification` asserted:

```sh
target/release/spec-spine registry plan --json | grep -q '"title"'
```

That passed the day it was written, when specs were ready. It **began failing
the moment the backlog was finished**: a corpus with nothing ready has no ready
entries, so no entry carries a title, and the assertion reported *the absence of
work* as *the absence of the feature*.

## The fix

The shape assertions now run against a **scratch corpus** — one ready spec and
one blocked by it — so they hold whatever this repository's backlog is doing.
They got stronger in the process: instead of grepping for the string `"title"`,
they now assert the exact ready object, the blocked entry's title, and its
blocker's id and state.

The live corpus keeps exactly one assertion, the one it is genuinely evidence
for: **an empty ready set is a true answer at exit 0**, not a failure. This
repository is that case now, which is why everything else uses a fixture.

Recorded as a dated decision in §5: an acceptance block must assert behavior,
and behavior is what a fixture demonstrates. The live corpus is an input, not a
contract.

## Verification

`spec-spine verify 060` passes, 11 commands. Full gate green via
`make -f kit/Makefile gate`: 69 shards fresh, index fresh, 0 unresolved, 0 lint
warnings, 79/79 coverage, `couple` clean. No waiver.