### PR TITLE
fix(069): the shipped default hashes what it names (one-time index restale)

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "90a16055d60610092cd0e2683f0866b624e1212b7ac2be35b9d81f75cb12e770"
+  "shardHash": "0186bd696c9804aad935ef16dd13e621d552d776a463ce51fb4cb531a366eaa0"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ccb41bcd7b1a2598b9aebe827e8c1b285bfddb43d00a4634578199e98da8bbca"
+  "shardHash": "d47b8a99358cf2732a0e1898e45107d1f0abff078661dce565e844c23f949a7d"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "69f527b491e2397e745ec89483e8691f580fdc71c568ad021cf72963f15f281f"
+  "shardHash": "31ae396ce43f6a9b2d286af1996ad3a210ab4ba1c59172a52fffac22ff6e1ea0"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.15.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b7c5374fce25606a5bc4505cc6b763ca3f45d032dae31e82124914404fe5b71c"
+  "shardHash": "2d6916493cc757c9e36e8983db03f631e03301b8a49ecc26a945dc8526189d52"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "347c2d2de07f1fc83da8a19ca9c130efee2079dc8f30b51106b487ddfd03090c"
+  "shardHash": "21e704d8343dea6b500f9e66c4c645f6f6e50c006750b1938728159828d2a935"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8b20dbf54236ce8c99f7eceb4f1f869abad0641472d3a7d6b769d470d127febb"
+  "shardHash": "43150ef68835c92863d7cbc0b9379bce142a6c37f2be44c387cf8585388b8a32"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "375213278a72532693461b31bcc44d5e01b83e3a217bcc946abd5bd81aaeea03"
+  "shardHash": "92b47834b663650d08b6b4072f11fecfec6325c0be2a3093c0ec693669052311"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5db45bb21d43c014fa6ac345c33a0e88eee0ad88d9c0680173db2655a1103a08"
+  "shardHash": "8cbb31e5926dc33199e5997b5856c20ac573ec9b8fe18e9ddfcb866546bee279"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "27459c7efeddb47cc4160d3191e50f62ac50cdb04caf80776443f4d82019a1a6"
+  "shardHash": "f3dfa8ecb34b3470e22aa646d77c66238243161621a464649959dfa3bc98091b"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c2abba526419354acbbb347c0a7ef4b5dec4757533563fb904ab7994622559b2"
+  "shardHash": "3273110cbb7038cb8e9efe0d14c2b06062551b6f04f9819a9c6436b2cd361df9"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d02948c84052dd349bc8dff36929f509d9032dade7e2aaae58057420d9dfcf87"
+  "shardHash": "1a8b3b368f7f7538597944c815dab63cc5cd03020c0254f3060a954a8a82dca6"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b7c5470a45bd9cf0abbf44de2d13c5d0420c65dd316c2259dd64a838fa39fca4"
+  "shardHash": "dda1a25a55f9f8a93b887536142fea227093d01ce5c0d54fb1e54451f5c7e81f"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "356fe2ea291f0a17ed9abb044bf492b2a1e12fac3c83ebe99ca79bcece96bb3a"
+  "shardHash": "1adb6b18e0c60ae6c3804e21c20a96111a4a509805610903f30b5a386ce9fa35"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "747f72fd928bcb53a1ffbfe793d7e6cfb826474a861feccbe869b23f3c7fed9d"
+  "shardHash": "39cda91902f5af0f220fb114ed939f65229cfb9f9e5ec89ea8f4795a26d0ca86"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5eac212730fa8f8aeca7045819313b5b482072ef43ef71ecfb70876d701c7a6e"
+  "shardHash": "194de82d171bfd31f49b79d6c67c64d4d57074b9987a088aa82d724c46dd260c"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fefa11918225c4d41bf4a3140afbad1962c82fa88f3d8f952f083d0b11044270"
+  "shardHash": "739455abddf958d813109202ba1c5575e366a51c12848acbf74b6781c688c436"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "62b9430a31c5d1e0c948e6a00851b3640dbbd9b1951b5c1fc5968b5fe188f88c"
+  "shardHash": "ff93b58ab0fc6bccdc68fe074c432bbb5fc9b230297b7e26b933270479fe0b18"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6c96023ab41f6f771ab46e10cf8b4b90a4a8b6549aa02436ca4c5a2216e811b0"
+  "shardHash": "75c715fe3e4494bbde6d0337deca18d621213682cf5b4256bb45520a6668d1ae"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "435d30e4d0f16830096ba0d2a64a3f5891ac34930400fca5b89f4011bee1aed4"
+  "shardHash": "d03403ed6fb983679ccbc54712053371eacdbe41527d1008579344b100072f70"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a48989ce2ff8da8a13d29f56a7d664aa7f28483160a80e3aa3e3aa8aa99f4a66"
+  "shardHash": "e57fee7b222b410d9ac02b7142dcefee58467f4e6a1729dc9bd88fc8c3c16410"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2e0570792ed054f2cc9482285bb06d902e6fb5f2c7218da7af841e541324c790"
+  "shardHash": "342b542919c7ce47608a80a88edff09b14c1e7ea80cf61684e7b6f0d83554e10"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "96836941d14200a4cc1a0aef691149d1447bc1b211f0b21cc59b7cd48bbdbff7"
+  "shardHash": "2ab48bddc212249b74563fa2b1f7ce2f85bd6b92ef9e734f2c9ab3c3d4282401"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fda283a1168ae25af9d0502ea01786d76848d7fb2aa41b5b800c7be13f69e8db"
+  "shardHash": "f497628d855c6fea1171428f5d0d5a6a54944c48f04448d789a538f5959a1679"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a2f13ddbfaa0e647230dc720c157912ec7228b22401c8798cb4bacefd02df6cb"
+  "shardHash": "b36dec61f9707bff1d904011d50a28e647e6759b6be0dd0f47f5534688ef1ca4"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8d8ca4c657c36469c0e436a6e730b45950f2d2ddda587b4e9b1248d7d973dd43"
+  "shardHash": "f8f0c26954659b18542c86ee0ecd889bcb0d5bb5e71049430c6339eb6e93bbce"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5a61eeca94302bdf8883934a3b36dc1e39b104feaed08646a4c41b915bfc005d"
+  "shardHash": "42bd613b33ec189b592dc505e6e028098d739628e10d384a4d5bf7e67c62dc97"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d59ab7bf6350046d45947584d1872d2ab705b1f7c399e91aa57e3945f74c9027"
+  "shardHash": "50568303ca645a719c45d57a49957b3735b0215994606ee6362912e587ff5a82"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4d6c391bb00be33945263664755cbf27e1737d8db2416be6e18426974864e90c"
+  "shardHash": "b84aaab58117314ed0014942d8f11de9fc38937894506e5994c0758f379bd72a"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b714716c9087df4ba9ea0ae3a8ffd222af423ee3449f7548222d578c3ce920b7"
+  "shardHash": "5e01e15cddb4d6d73ffe159c006edb2d5ceea03d2afdf06dee17b21fada3240c"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dbc036e83b3813f8e6c2200c354b87551e8d4cdba9d177f82e6e69c854f8fc24"
+  "shardHash": "4bc1eb9c2e3248215486bf884f66c629707630b70d2bd4c9e60964113cc8ddd6"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b09e2fd6ff37cf60f44c388c059904e3ab3e4b4803faba702e5097ca87f38b33"
+  "shardHash": "055e0ec261954c29400213efbe8cf1794274c0605ef5cf84c537dc1e10e7f8fa"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c361dce6c115c85904efdcfd67066342de08ce1184278994b4f960a9d8eccf3b"
+  "shardHash": "bcb1bef49e63ade15f3f0e0c8f8b5bd951c5d98d60aed3cad5fcb01536727955"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f0025189f00d3861c4407a3179ed63e6f5eb61f14c128319c8c56b435490ea9b"
+  "shardHash": "6a8e93035a5ee9fb864c9590ff7382c0e0b8dc6a80efe98a94be2542d6eb46d8"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "49ca6955275d83d803c8a327a6808192700528831e660fc162a7a499e392ea81"
+  "shardHash": "8ea2e9201f8f80e0ed658c734ef67433f219dfdcab58fda6f6f91eb151dc1a5a"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0efbf8bcba771c94c7f29577daa3890c8b709cb8f0a12bba6e77d4aeea6b3b87"
+  "shardHash": "ae8636ae4dc2416435adbdb10f8be538f67b69d8bc5ab4552b4fd94d16e2a276"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b622d7fc98efad8395e21ae58e0d3ed41a2fc8287f82af010c18fbb4b248ff9d"
+  "shardHash": "3a1f07aebc485ed8f43cc1257e64aae18c3968258dd383a6bcb2a49998bb4f9e"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "852ae7329f949b2785ea6ee11ce2e00aabc35a4d9d4f884fab74614453f7887f"
+  "shardHash": "dce34e75f3b6a544854e2684ddc72596516efae00062dc22f4da8684aaf9b18c"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ca8e026e8c5fff528f30b6112741f572de516190457c7c7f47965feb6a2107f7"
+  "shardHash": "6eb8d8212821014c44beaff9612f9a66342754659c4990c4b64150a2846ed6a3"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2024245a67a797a112547105268ec8a8f94f82992cf7283ab8ffc43a95fe9c4f"
+  "shardHash": "0e349fdca686a6d9ec7e0ad0e8759aa85cd850b538962a641e352f5286663b64"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c6eabc6a5d6bc61f940de0cb50d0136987fcef9e88ee42741193fb765f24dfb9"
+  "shardHash": "8be7a9e77efbcd20a82fcf3c617551ae3404af3227b6806e38d47384f5abbc56"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9dcebc957da80e58064fa423110767c53b0d9c67c82b377a74d9dd90eebd2e0b"
+  "shardHash": "e499fe704565762902f817d9bc7c43def76e44c4fff9db0cc4b4827d1a1db4d5"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ed34e34296f03893cd64dc1c80e16f53fff33511d35690e05ac066c9ca16acda"
+  "shardHash": "a6028cb02972a39082a87a09266a53883de1343df39b5dbea02970286a41dbf1"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "86e717f677c2e43aaeef8ea5644d5b7c0cf4440c76cbf49b3e333e64993a17df"
+  "shardHash": "fdbcfabf9a2f7ba537c6fa58c57606139358ab8488ed4d467a00816283b51411"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2b6d6cea2f8d6a23f838e8aa8485cc094ff79864f715b4c769307ebc82605e37"
+  "shardHash": "d94fe98a9b976e1c11e1d7c1caf6cae37b7aacaf3e18de18132c2e5da6c53d1e"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "230605d58721c347448f8ade97e483782dd61fd914ff93489bf94288d154a631"
+  "shardHash": "b9170ea9f0b75d16c82d70beeaf5fbc68c6fdd6483fc747aa65daedd03195d11"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4d6ab83a20f4ea077c5afd651234ce398bed3b1b77bdea751b090e7adffc94ac"
+  "shardHash": "7577b6dfda074380f2fee72832faab9f1a3d5034a6c69ae1f00061a344f52422"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05867803de5d420fb73ac6f5b0af338677c190c2bea10b58843e704d2ae4e071"
+  "shardHash": "eceb3750057839d9be6ebfc5982ab4916160322c9f50755011df598a1a866ae3"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "79a9aea4282d0c3d123d09b5cd6273dd1e1d92d424f5a1187e2be6dcbd730a81"
+  "shardHash": "e67783a22187d867bfe5c769a7ef1ec4d7a6634ae8ad175bb66294ef83fec9ab"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "999b6056e5cf4b0d44a93a22e7f5e2816c9c5b55b47f71f404de5dc69f173cc2"
+  "shardHash": "357592f22f64533b1345ee835ffeb10d063ce6017cdfb0222607941dee4eef8f"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "207dbf70c21f43b23a7a944dd998ae1cb6690751ac8903313a97496070d83297"
+  "shardHash": "18585145ee7dc3dd91c4ba0e90812e6e4900103b78fcbc2bdcbcd9e12c9178c0"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "76aae3e2c270ef40c1838e0b6adf1ff03eb8739ef339fd7ef69830c8135df3b0"
+  "shardHash": "719c877c273c3da0d49ddb9b9e52c32aba5364f228c6a9666739a4df19cfc57b"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a9dcec263684e0a8671bd87b7e71906c08e9489921fb25bd25a3222b80c084b3"
+  "shardHash": "98918a1979821bfabbf8937f5a9ebdfd8e23d1d781cc1111913aef899574848c"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3024c3fc162c8c3ed1c15b96fc0f48b8114f3649f2df7a32a3f0f510b6b70d1b"
+  "shardHash": "ede2313108a579f64cedc390c98fb7233cd5289a7434b08abbd00601205ffb52"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "261a4cdd6f684abecadab55681aea32bfb4059d30c461afc7e9f806afc4b6d90"
+  "shardHash": "1222675d5bbbf06e8410c44a5c095c8b78663dea6c64eca48dd37c2ad4b15739"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f0db26ae8883f6f93766d1ebf221c8e9c54731a36cdf455810cf393eb9b8d321"
+  "shardHash": "a9a3d6fc6d53bb5df9a141ad27e5aa12b149b6a71c3dc558f07d106fc831b747"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "199ee39096d3d944a213d17d1afe23d94933bcfb4eadaaa4762ca9377e22a626"
+  "shardHash": "9cd9297aab51929cd3279221dcf66f5dd6c562c488021eae36b84509b2943da2"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6610b35b31a4f692215bb4463853a178c6a7e8249206a7e5b4601c74bf777f7a"
+  "shardHash": "5c80299d44da175129191cc5ec2a37748afff6857f02a74b318de692eb924fcb"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "910e4322bdb59a2d2ba1b0d26b100a2313eccf18b44233409522fd8117eb0b1d"
+  "shardHash": "07fba44ba42d9f41e6a6e504a1b6cb4b3c5c630d94b190024ea2ab36ad60cb48"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c1e6c698eb5f3e8a00f459d2646c6cfef9a7bdfdea959aa04d7410949343aa1b"
+  "shardHash": "b725770dd825044ec71d52a3fb54b10102c885cadcd5fe5b9c82c1ffeb06672e"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5ed5622f5fcbf89b25fcec81dd9747696fd1700575fa82a7fe92a2701d90d06b"
+  "shardHash": "6bcadb6a324102a86b61807c6e3596625072d02418b925fdd1e9b4ce95ce4084"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "afb0adaaa6cc017e06162eaf9463c1c5487856ad1eefec663f369fec54516d07"
+  "shardHash": "f0a3ef7be72c71f03163bc2afab9d096ce878564f9b0c6be416831fd842f48ef"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b059890c1e103f49cae6a7506cb09b8901b70a85b7082274975d70d7badf617"
+  "shardHash": "eba36aa32fb8e4ee07bd8bdbb7a2ba89ea5f6f1d36434e43ccca5658c0d04865"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6285ea0e537217b928caa4d7bf80ae0af9b12f045e379953e069fce26ba40eca"
+  "shardHash": "f5347819528610b9af79f56be1cd9da44f48b597bd1e2fbeb0d75c8b2a2731ac"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fff53d0fdd9892002cd0225741af0e81642f22b4d84cd196dc6cf7815d2186a6"
+  "shardHash": "dfff9ff4fea5ec13e32301899a01c9f1d66719803124a6b36c116fce06d30cab"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9f459774e4b9841732aaef90c9f3f3b2a8afab825ac5d39a5f25ab6352a032c9"
+  "shardHash": "79f5400586ca3164695522bf4d76edc6f993259c42837b660b0b01f54012b9f9"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c216cb8e611697eef69e3670f7b5f09dae407311379366a4cd50f3e8cbf4a44a"
+  "shardHash": "d0b2eef2db81f04e4326f25b66dd8a06b046e20aebf5eda968db76f0cd37e0cb"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d9487393f55096bd3aa80e41f1b1b178fe892f8d828f3be0b528af0ba280f28a"
+  "shardHash": "d9ff0281653e353742394b41ffe6d8680ed63cfa88fbe956450d08c3c03dde8f"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dae663de22cb4ac53231976f08fb48b1edbac80714911fbee9f499dea1781ac8"
+  "shardHash": "d71219e1238a3a47eeee5cc1f98303cb530af07e58b7f4edacb91420e8808aac"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bfbca9af821b43c3ab7671d5dae05115fa8fd290430de2888c2489b9cc52927f"
+  "shardHash": "5686e0b4b7440f41db31b74f752b48bf7e0b8ca8ff60781d4c2db68c14b94944"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "57722a3a2a13de4d62507b1dcb71217bcecea8a9615385717883603fac2861a7"
+  "shardHash": "4bc110a85e8ff09b44e1dc339057ab8518111e6f3dfd692e6ff293c203699717"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dba8ab500b27caf23e8e38effeda05949ecaa5eab86a57ce26c01d5fae070bb0"
+  "shardHash": "770df10ec5dd030dfcc6e2be180851547b5a6030ba7a61809dda204f9404a469"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2fddecbf4e4990815c2853661c02de739152bfe5fa991b1cded61eba778d4274"
+  "shardHash": "d260e4e4229888c79c01a3e6a10c12e31fef1578d1f77e8c5cbc69267495d7da"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -1,15 +1,21 @@
 {
   "mapping": {
+    "amends": [
+      "061-the-scaffold-ships-what-adopters-wrote"
+    ],
     "dependsOn": [
-      "004-codebase-index"
+      "004-codebase-index",
+      "057-claimed-but-unwitnessed",
+      "061-the-scaffold-ships-what-adopters-wrote",
+      "067-the-docs-name-what-adopters-derived"
     ],
     "implementingPaths": [
       {
-        "path": "crates/spec-spine-core/src/index.rs",
+        "path": "crates/spec-spine-cli/tests/couple.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-core/src/symbols.rs",
+        "path": "crates/spec-spine-core/src/scaffold.rs",
         "source": "spec-edge"
       },
       {
@@ -17,19 +23,15 @@
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/src/unit.rs",
+        "path": "crates/spec-spine-core/tests/scaffold.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/src/version.rs",
+        "path": "crates/spec-spine-types/src/config.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-types/tests/dtos.rs",
-        "source": "spec-edge"
-      },
-      {
-        "path": "crates/spec-spine-types/tests/grammar.rs",
+        "path": "docs/adoption-guide.md",
         "source": "spec-edge"
       }
     ],
@@ -37,27 +39,27 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/index.rs"
+            "file": "crates/spec-spine-cli/tests/couple.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-core/src/index.rs"
+          "path": "crates/spec-spine-cli/tests/couple.rs"
         }
       },
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/src/symbols.rs"
+            "file": "crates/spec-spine-core/src/scaffold.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-core/src/symbols.rs"
+          "path": "crates/spec-spine-core/src/scaffold.rs"
         }
       },
       {
@@ -76,59 +78,59 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/src/unit.rs"
+            "file": "crates/spec-spine-core/tests/scaffold.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/src/unit.rs"
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
         }
       },
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/src/version.rs"
+            "file": "crates/spec-spine-types/src/config.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/src/version.rs"
+          "path": "crates/spec-spine-types/src/config.rs"
         }
       },
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/tests/dtos.rs"
+            "file": "docs/adoption-guide.md"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/tests/dtos.rs"
+          "path": "docs/adoption-guide.md"
         }
       },
       {
         "locations": [
           {
-            "file": "crates/spec-spine-types/tests/grammar.rs"
+            "file": "docs/design/00-architecture.md"
           }
         ],
-        "ownership": true,
-        "sourceField": "extends",
+        "ownership": false,
+        "sourceField": "references",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-types/tests/grammar.rs"
+          "path": "docs/design/00-architecture.md"
         }
       }
     ],
-    "specId": "017-directory-crate-module-units",
-    "specStatus": "approved"
+    "specId": "069-the-shipped-default-hashes-what-it-names",
+    "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09d157489b827e99b1f419055a7aa4f23d9a338dba2633fdfe40a8c8fce3b200"
+  "shardHash": "1addbb9b1106506d036eee8971a088c2741e8b0302cf93bcac007bef64f50dd9"
 }

--- a/.derived/spec-registry/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/spec-registry/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -1,0 +1,99 @@
+{
+  "record": {
+    "amends": [
+      "061-the-scaffold-ships-what-adopters-wrote"
+    ],
+    "created": "2026-09-07",
+    "dependsOn": [
+      "004-codebase-index",
+      "057-claimed-but-unwitnessed",
+      "061-the-scaffold-ships-what-adopters-wrote",
+      "067-the-docs-name-what-adopters-derived"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "062-a-version-pin-the-cli-can-check",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/config.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "061-the-scaffold-ships-what-adopters-wrote",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "061-the-scaffold-ships-what-adopters-wrote",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/scaffold.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "055-the-ledger-answers-what-consumers-rebuild",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "067-the-docs-name-what-adopters-derived",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "030-cargo-workflow-dependency-waiver",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/couple.rs"
+        }
+      }
+    ],
+    "id": "069-the-shipped-default-hashes-what-it-names",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "069: The shipped default hashes what it names",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The default matches files",
+      "3.2 The scaffold stops describing the default as broken",
+      "3.3 A regression guard that fails on the old default",
+      "3.4 The documentation stops quoting the broken value",
+      "3.5 The migration note",
+      "3.6 A workflow bump stales the ledger, and the test says so",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/069-the-shipped-default-hashes-what-it-names/spec.md",
+    "status": "draft",
+    "summary": "`IndexConfig::default().extra_hashed_inputs` ships as `[\"standards/**\", \".github/workflows/**\"]`. In the glob crate `dir/**` enumerates directories, and the hasher keeps only entries that are files, so the shipped default matches nothing: every adopter who has not overridden it folds zero extra files into the content hash and is told nothing. Spec 057 found the form in this repository's own config and fixed it there; spec 061 found it in the default behind it, emitted the key at its real value with a comment naming the trap, and deferred the fix to its own spec on the grounds that changing it restales every adopter's committed index. This is that spec. The default becomes `[\"standards/**/*\", \".github/workflows/**/*\"]`, the working form 061's comment already tells adopters to write, so an adopter who followed that advice sees no change and one who did not gets a one-time restale and a governance surface that is finally in the ledger. A regression test pins the property that was never asserted: that the shipped default matches files.\n",
+    "title": "The shipped default hashes what it names"
+  },
+  "shardHash": "1a5fd67f78a71d95e1ebdf5482fa581be6606a19ee975b046010fe6f60687d23",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -527,14 +527,29 @@ fn workflow_uses_bump_auto_waives() {
     git_in(root, &["add", "-A"]);
     git_in(root, &["commit", "-q", "-m", "base"]);
 
-    // Dependabot github-actions bump: the action ref only. No re-index (a file
-    // unit carries no span, so it is not a hashed input), no spec edit.
+    // Dependabot github-actions bump: the action ref only, no spec edit.
     write(
         root,
         ".github/workflows/ci.yml",
         "name: CI\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    \
          steps:\n      - uses: actions/checkout@v5\n      - run: cargo test\n",
     );
+
+    // The bump stales the ledger, because `.github/workflows/**/*` is a hashed
+    // input (spec 069 fixed the default that had made it one in name only).
+    // 030 1 reasoned that workflow freshness "is already fine" because a `file`
+    // unit carries no span; that is true of the unit and was never true of the
+    // `extra_hashed_inputs` glob beside it, which is why this repository's own
+    // workflow edits have stale every shard since spec 057. The subject of this
+    // test is the coupling half, so re-index first and then assert it.
+    let stale = index_check(root);
+    assert_eq!(
+        code(&stale),
+        2,
+        "a hashed workflow bump stales the index: {}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    refresh(root);
     git_in(root, &["add", "-A"]);
     git_in(root, &["commit", "-q", "-m", "bump-action"]);
 
@@ -542,7 +557,7 @@ fn workflow_uses_bump_auto_waives() {
     assert_eq!(
         code(&fresh),
         0,
-        "a file-unit workflow bump must not stale the index: {}",
+        "the re-indexed tree is fresh: {}",
         String::from_utf8_lossy(&fresh.stderr)
     );
 

--- a/crates/spec-spine-core/src/scaffold.rs
+++ b/crates/spec-spine-core/src/scaffold.rs
@@ -180,11 +180,12 @@ fn config_toml(cfg: &Config) -> String {
          # stales every shard.\n\
          #\n\
          # WATCH THE GLOB FORM. `dir/**` matches DIRECTORIES and therefore no\n\
-         # files; you want `dir/**/*`. The default below carries the broken form\n\
-         # and so hashes nothing (spec 057 found this in spec-spine\x27s own\n\
-         # config, where it had silently held since the key was added). It is\n\
-         # left as-is here because changing the default would restale every\n\
-         # existing adopter\x27s index; fix it in your own file:\n\
+         # files; you want `dir/**/*`, which is what the default below has.\n\
+         # The bare form is not an error and not empty: it parses, it prints\n\
+         # back through `config show`, and it matches nothing at all. It was\n\
+         # the shipped default until spec 069, and spec 057 found the same\n\
+         # form in spec-spine\x27s own config before that. If you narrow or\n\
+         # extend this list, keep the trailing `/*`:\n\
          #\n\
          #   extra_hashed_inputs = [\"{standards}/**/*\", \".github/workflows/**/*\"]\n\
          extra_hashed_inputs = [{extra_hashed_inputs}]\n\

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -190,6 +190,69 @@ fn missing_file_unit_is_blocking_diagnostic_i004() {
     assert!(idx.diagnostics.errors.iter().any(|d| d.code == "I-004"));
 }
 
+// ===== spec 069: the shipped default hashes what it names =====
+
+/// Spec 069 §3.3: the **shipped default** folds real files into the content
+/// hash. Until 069 it folded none: `extra_hashed_inputs` defaulted to
+/// `["standards/**", ".github/workflows/**"]`, `**` enumerates directories, and
+/// `glob_files` keeps only entries that are files, so the default matched
+/// nothing. Every adopter who had not overridden the key could rewrite their
+/// constitution with `index check` still reporting fresh.
+///
+/// The fixture deliberately uses `Config::default()` rather than a hand-written
+/// `[index]` table. A test that spells its own globs proves the glob engine
+/// works and cannot fail when the default rots, which is exactly how this
+/// survived: `tests/lint.rs` already pinned that `sub/**` matches nothing and
+/// `sub/**/*` matches, and the broken default sat beside it for months.
+#[test]
+fn the_shipped_default_hashes_the_files_it_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(tmp.path(), "specs/001-x/spec.md", &spec("001-x", ""));
+    // The two trees the default names, each one directory deeper than the
+    // pattern's literal prefix: the pre-069 form matched the directories and
+    // discarded them, so a file directly under them is the case that failed.
+    write(
+        tmp.path(),
+        "standards/spec/constitution.md",
+        "# Constitution\n",
+    );
+    write(tmp.path(), ".github/workflows/ci.yml", "name: ci\n");
+
+    let cfg = Config::default();
+    let idx = index(&cfg, tmp.path()).unwrap().index;
+    let hashed = spec_spine_core::witnessed_paths(&cfg, tmp.path(), &idx);
+    for expected in ["standards/spec/constitution.md", ".github/workflows/ci.yml"] {
+        assert!(
+            hashed.contains(expected),
+            "the default did not fold {expected} into the content hash: {hashed:?}"
+        );
+    }
+
+    // ...and the consequence that matters: editing one of them moves the hash.
+    // Membership alone would still pass if the file were collected and then
+    // dropped before hashing, which is the shape of the bug this guards.
+    let before = spec_spine_core::shard::global_inputs_hash(&cfg, tmp.path());
+    write(
+        tmp.path(),
+        "standards/spec/constitution.md",
+        "# Constitution\n\nA governed edit.\n",
+    );
+    let after = spec_spine_core::shard::global_inputs_hash(&cfg, tmp.path());
+    assert_ne!(
+        before, after,
+        "an edit to a standards file must move the global inputs hash"
+    );
+
+    let before_wf = after;
+    write(tmp.path(), ".github/workflows/ci.yml", "name: ci2\n");
+    assert_ne!(
+        before_wf,
+        spec_spine_core::shard::global_inputs_hash(&cfg, tmp.path()),
+        "an edit to a workflow file must move the global inputs hash"
+    );
+}
+
 // ===== spec 026: resolution + discovery fixes =====
 
 /// AC-1 (spec 026 D1): a section unit on a foreign (non-workflow) YAML resolves

--- a/crates/spec-spine-core/tests/scaffold.rs
+++ b/crates/spec-spine-core/tests/scaffold.rs
@@ -271,6 +271,30 @@ fn the_scaffolded_config_round_trips_a_non_default_configuration() {
     assert_eq!(load_config(&toml).unwrap(), cfg);
 }
 
+/// Spec 069 §3.2: the emitted default is the working glob form. The round-trip
+/// assertion above cannot catch this: it compares the emitted file against
+/// `Config::default()`, so it holds just as well when both carry a pattern that
+/// matches nothing. This asserts the value itself, and the negative half is the
+/// one that bites, because `"standards/**/*"` contains `standards/**` as a
+/// substring and a careless `contains` check would pass on the broken form.
+#[test]
+fn the_scaffolded_default_hashes_files_not_directories() {
+    let toml = scaffolded(&Config::default(), "spec-spine.toml");
+    assert!(
+        toml.contains(r#"extra_hashed_inputs = ["standards/**/*", ".github/workflows/**/*"]"#),
+        "{toml}"
+    );
+    for broken in [r#""standards/**""#, r#"".github/workflows/**""#] {
+        assert!(
+            !toml.contains(broken),
+            "the pre-069 directory form is still emitted: {broken}"
+        );
+    }
+    // The trap outlives the default: an adopter narrowing this list can still
+    // write it, so the warning stays (and spec 061's own acceptance greps it).
+    assert!(toml.contains("matches DIRECTORIES"), "{toml}");
+}
+
 /// §3.2: the knobs adopters reached for are named, each with the code it drives
 /// where one exists. These are the thirteen the audit counted, not the five the
 /// scaffold used to emit.

--- a/crates/spec-spine-types/src/config.rs
+++ b/crates/spec-spine-types/src/config.rs
@@ -176,9 +176,15 @@ pub struct IndexConfig {
 impl Default for IndexConfig {
     fn default() -> Self {
         IndexConfig {
+            // Spec 069: the trailing `/*` is load-bearing. In the `glob`
+            // crate `dir/**` enumerates directories, and `glob_files` keeps
+            // only entries that are files, so the bare form these two carried
+            // until 069 matched nothing at all: an adopter on the default
+            // folded no governance file into any content hash and was told
+            // nothing. `dir/**/*` is the same intent, spelled so it matches.
             extra_hashed_inputs: vec![
-                "standards/**".to_string(),
-                ".github/workflows/**".to_string(),
+                "standards/**/*".to_string(),
+                ".github/workflows/**/*".to_string(),
             ],
             slices: BTreeMap::new(),
             resolver_exclusions: vec![

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -240,7 +240,7 @@ divergence observed across the reference repos. Every sub-table is
 | `layout.cargo_workspace` | root Cargo workspace manifest | `Cargo.toml` |
 | `layout.npm_workspaces` | manifests that *declare* npm/pnpm workspace members | `["package.json", "pnpm-workspace.yaml"]` |
 | `layout.standalone_rust_workspaces` / `standalone_npm_packages` | crates/packages outside the root workspace | `[]` |
-| `index.extra_hashed_inputs` | globs folded into the staleness content hash, beyond the always-hashed core | `["standards/**", ".github/workflows/**"]` |
+| `index.extra_hashed_inputs` | globs folded into the staleness content hash, beyond the always-hashed core. **Keep the trailing `/*`**: `dir/**` matches directories and therefore no files | `["standards/**/*", ".github/workflows/**/*"]` |
 | `index.resolver_exclusions` | dir names pruned from symbol/section walks | `["target","node_modules",".derived","dist","build",".next"]` |
 | `index.slices` | named glob groups, each emitted as a `build.sliceHashes` entry and gated by `index check --slice <name>`; names match `[a-z0-9][a-z0-9-]*`, each list non-empty. Independent of the global `contentHash` | `{}` |
 | `branding.compiler_id` / `indexer_id` | ids stamped in emitted `build` metadata | `"spec-spine"` |
@@ -265,7 +265,7 @@ allowed = ["app", "platform", "tooling"]
 standalone_rust_workspaces = ["apps/desktop/src-tauri"]
 
 [index]
-extra_hashed_inputs = ["standards/**", ".github/workflows/**", "schemas/**"]
+extra_hashed_inputs = ["standards/**/*", ".github/workflows/**/*", "schemas/**/*"]
 ```
 
 The bypass floor (always applied, cannot be removed) covers `.github/`, `docs/`,
@@ -323,7 +323,7 @@ A path can be on both, neither, or either, and neither implies the other:
 
 - `docs/` here is **bypassed and not hashed**: a documentation edit raises no
   `C-001`, and stales nothing.
-- `standards/**` here is **bypassed and hashed**: an edit to the constitution
+- `standards/**/*` here is **bypassed and hashed**: an edit to the constitution
   raises no `C-001`, and does stale every shard.
 
 Bypassed answers "will the gate refuse this change"; hashed answers "does this
@@ -333,7 +333,15 @@ the other is how a governance file ends up outside both.
 > **Watch the glob form** in `extra_hashed_inputs`. `dir/**` matches
 > **directories**, so it hashes no files; you want `dir/**/*`. This repository
 > carried `["standards/**", ".github/workflows/**"]` for a long time, matching
-> nothing, until spec 057's predicate found it.
+> nothing, until spec 057's predicate found it. So did the shipped default
+> behind it, until spec 069.
+
+> **Upgrading across spec 069.** `[index] extra_hashed_inputs` shipped a default
+> that matched no files. It is fixed. If you did not override the key, your next
+> `spec-spine index` will rewrite every shard once, because the standards tree
+> and the workflow directory are entering the content hash for the first time.
+> Commit the result. Nothing about what staleness *means* has changed; a surface
+> that was silently outside the ledger is now inside it.
 
 ## Directory units claim recursively
 

--- a/docs/design/00-architecture.md
+++ b/docs/design/00-architecture.md
@@ -249,7 +249,7 @@ standalone_npm_packages    = []     # e.g. ["services/api"]
 # Globs folded into the content-hash beyond the always-hashed core
 # (= all spec.md + all discovered manifests + spec-spine.toml). OAP hashed ~10
 # project-specific paths; adopters declare their own. Documented base set:
-extra_hashed_inputs = ["standards/**", ".github/workflows/**"]
+extra_hashed_inputs = ["standards/**/*", ".github/workflows/**/*"]
 # Directory names pruned from symbol/section resolution walks (OAP RESOLVER_EXCLUSIONS).
 resolver_exclusions = ["target", "node_modules", ".derived", "dist", "build", ".next"]
 
@@ -759,7 +759,7 @@ as recommended unless you redirect.
 | Q5 | Include `directory`/`crate`/`module` unit kinds in v1? | v1 shipped file/section/symbol; ✅ **all three later added (spec 017)** as the planned additive MINOR: `directory` as an explicit kind, `crate`/`module` resolved via the package/module index |
 | Q6 | Registry/index JSON: pretty (diffable) vs compact (OAP)? | **Pretty**, sorted keys, LF, trailing newline |
 | Q7 | Per-archive CycloneDX SBOM in the release workflow? | ✅ **Shipped (spec 021):** per-target CycloneDX SBOM + build provenance, gated to fail closed on a zero-component SBOM |
-| Q8 | `index.extra_hashed_inputs` default base set contents? | `["standards/**", ".github/workflows/**"]` + always-hashed core (specs, manifests, config) |
+| Q8 | `index.extra_hashed_inputs` default base set contents? | `["standards/**/*", ".github/workflows/**/*"]` + always-hashed core (specs, manifests, config). Shipped as `["standards/**", ".github/workflows/**"]`, which matched **directories** and therefore no files; ✅ **corrected (spec 069)** |
 | Q9 | `manifest.metadata_namespace` default `"spec-spine"` ⇒ `[package.metadata.spec-spine]` (hyphenated TOML key, legal but unusual). Prefer `"spec"`? | Keep **`"spec-spine"`** (self-describing; hyphenated bare keys are valid TOML) |
 | Q10 | How much provenance/`references` semantics in v1? | Ship the `references` edge + open `provenance.uri_schemes` config + basic URI well-formedness; defer rich knowledge-graph semantics |
 | Q11 | MSRV / edition: match references (2024/1.85) or lower MSRV for reach? | **Match references (edition 2024)** unless you want broader adopter MSRV |

--- a/specs/069-the-shipped-default-hashes-what-it-names/spec.md
+++ b/specs/069-the-shipped-default-hashes-what-it-names/spec.md
@@ -1,0 +1,367 @@
+---
+id: "069-the-shipped-default-hashes-what-it-names"
+title: "The shipped default hashes what it names"
+status: draft
+kind: "tooling"
+created: "2026-09-07"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "004-codebase-index"
+  - "057-claimed-but-unwitnessed"
+  - "061-the-scaffold-ships-what-adopters-wrote"
+  - "067-the-docs-name-what-adopters-derived"
+amends:
+  # 061 §4 emitted the key at its real (broken) value with a comment saying it
+  # is left as-is because fixing it would restale every adopter. Both halves of
+  # that sentence stop being true here, so the comment it mandates changes.
+  - "061-the-scaffold-ships-what-adopters-wrote"
+extends:
+  # §3.1 The default value itself.
+  - { spec: "062-a-version-pin-the-cli-can-check", unit: "crates/spec-spine-types/src/config.rs", nature: additive }
+  # §3.2 The scaffold comment 061 §3.2 mandates, and the assertion beside it.
+  - { spec: "061-the-scaffold-ships-what-adopters-wrote", unit: "crates/spec-spine-core/src/scaffold.rs", nature: additive }
+  - { spec: "061-the-scaffold-ships-what-adopters-wrote", unit: "crates/spec-spine-core/tests/scaffold.rs", nature: additive }
+  # §3.3 The regression guard: the default must match files, not directories.
+  - { spec: "055-the-ledger-answers-what-consumers-rebuild", unit: "crates/spec-spine-core/tests/index.rs", nature: additive }
+  # §3.4 The adopter-facing default table and the bypassed-vs-hashed example.
+  - { spec: "067-the-docs-name-what-adopters-derived", unit: "docs/adoption-guide.md", nature: additive }
+  # §3.6 030's workflow auto-waive test asserted a freshness premise that the
+  # broken default was the only thing making true.
+  - { spec: "030-cargo-workflow-dependency-waiver", unit: "crates/spec-spine-cli/tests/couple.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  `IndexConfig::default().extra_hashed_inputs` ships as
+  `["standards/**", ".github/workflows/**"]`. In the glob crate `dir/**`
+  enumerates directories, and the hasher keeps only entries that are files, so
+  the shipped default matches nothing: every adopter who has not overridden it
+  folds zero extra files into the content hash and is told nothing. Spec 057
+  found the form in this repository's own config and fixed it there; spec 061
+  found it in the default behind it, emitted the key at its real value with a
+  comment naming the trap, and deferred the fix to its own spec on the grounds
+  that changing it restales every adopter's committed index. This is that spec.
+  The default becomes `["standards/**/*", ".github/workflows/**/*"]`, the
+  working form 061's comment already tells adopters to write, so an adopter who
+  followed that advice sees no change and one who did not gets a one-time
+  restale and a governance surface that is finally in the ledger. A regression
+  test pins the property that was never asserted: that the shipped default
+  matches files.
+---
+
+# 069: The shipped default hashes what it names
+
+## 1. Purpose
+
+A scaffolded adopter can rewrite its entire constitution and the ledger will
+report itself fresh. That is not a hypothetical:
+
+```console
+$ spec-spine --repo /tmp/probe init && spec-spine --repo /tmp/probe compile && spec-spine --repo /tmp/probe index
+$ printf '\nA governed edit.\n' >> /tmp/probe/standards/spec/constitution.md
+$ spec-spine --repo /tmp/probe index check
+index is fresh
+```
+
+The cause is one character short in a shipped default:
+
+```rust
+extra_hashed_inputs: vec![
+    "standards/**".to_string(),
+    ".github/workflows/**".to_string(),
+],
+```
+
+In the `glob` crate `**` matches a sequence of path components, so `standards/**`
+enumerates `standards`, `standards/spec`, `standards/spec/templates`, and nothing
+else: every entry it yields is a directory. Both `glob_files` helpers then apply
+`.filter(|p| p.is_file())`, which discards all of them. The pattern is
+well-formed, the config parses, `config show` prints it back, and it matches zero
+files.
+
+The consequence is not merely a missing hash. `standards/` is on the coupling
+gate's bypass floor, so a change there raises no `C-001` by design: the ledger's
+content hash is the only mechanism that was supposed to notice. Spec 023 signs
+attestations over that hash, which means an adopter's signed attestation has been
+attesting to a corpus whose governing documents it never read. The one surface
+where "nothing detects this" is unacceptable is precisely the one the default
+left uncovered.
+
+Two specs have already walked past this. Spec 057 found the identical form in
+**this repository's** `spec-spine.toml`, fixed it here, and did not look at the
+default behind it. Spec 061, writing out the exhaustive scaffolded config,
+found the default itself and declined to fix it, on the reasoning that changing
+a shipped default restales every adopter's committed index and therefore
+"belongs in its own spec with its own release note". This is that spec, and the
+release note is §3.5.
+
+## 2. Territory
+
+This spec owns no file. Every change lands in a unit another spec already holds,
+declared as an `extends` edge in the frontmatter:
+
+| Unit | Owner crossed | What changes |
+|---|---|---|
+| `crates/spec-spine-types/src/config.rs` | 062 (latest claimant) | the default value (§3.1) |
+| `crates/spec-spine-core/src/scaffold.rs` | 061 | the comment 061 §3.2 mandates (§3.2) |
+| `crates/spec-spine-core/tests/scaffold.rs` | 061 | the assertion that the emitted default works (§3.2) |
+| `crates/spec-spine-core/tests/index.rs` | 055 (latest claimant) | the regression guard (§3.3) |
+| `docs/adoption-guide.md` | 067 | the default column and the worked example (§3.4) |
+
+`docs/design/00-architecture.md` quotes the default in a design narrative and is
+owned by no spec; it is a `references` edge, and §3.4 updates it.
+
+## 3. Behavior
+
+### 3.1 The default matches files
+
+`IndexConfig::default().extra_hashed_inputs` MUST be
+`["standards/**/*", ".github/workflows/**/*"]`.
+
+The value is the working spelling of the intent the broken form already
+declared: every file under the standards tree and every file under
+`.github/workflows`, recursively, of any extension. It MUST NOT be narrowed to
+a set of extensions in this spec (§4), and it MUST be character-for-character
+the form spec 061's scaffold comment already tells adopters to write, so that an
+adopter who followed that advice observes no change at all.
+
+### 3.2 The scaffold stops describing the default as broken
+
+`scaffold.rs`'s comment above the key currently reads, in part, that "the
+default below carries the broken form and so hashes nothing" and that "it is
+left as-is here because changing the default would restale every existing
+adopter's index". Both clauses MUST go: they will be false.
+
+The comment MUST still name the trap, because the trap outlives the default:
+an adopter narrowing or extending this list can still write `dir/**` and get
+silence. It MUST retain the literal phrase `matches DIRECTORIES`, which spec
+061's own `## Verification` block greps for, and it SHOULD name spec 069 as
+where the default was fixed so the history stays readable from the file.
+
+`tests/scaffold.rs` MUST gain an assertion that the emitted config carries the
+working form and does **not** carry the bare `"standards/**"` entry. The
+existing round-trip assertion (the emitted file parses to a `Config` equal to
+`Config::default()`) MUST continue to hold unchanged; it adapts to the new
+default on its own, which is why it is not sufficient as the guard.
+
+### 3.3 A regression guard that fails on the old default
+
+`tests/index.rs` MUST gain a test asserting the property no test held: that the
+**shipped default** folds real files into the content hash.
+
+The test MUST build a fixture repository containing at least one file under
+`standards/` and one under `.github/workflows/`, MUST use `Config::default()`
+rather than a hand-written config (a test that spells its own globs cannot fail
+when the default rots), and MUST assert that both files appear among the hashed
+inputs. It MUST fail against the pre-069 default.
+
+Asserting on the set of hashed paths is preferred to asserting on the hash
+value, which would be a golden test that changes whenever anything else in the
+fixture does.
+
+### 3.4 The documentation stops quoting the broken value
+
+`docs/adoption-guide.md` MUST change in three places:
+
+1. the `index.extra_hashed_inputs` row of the config table, whose default column
+   currently reads `["standards/**", ".github/workflows/**"]`;
+2. the non-default example further down, which copies the broken form into a
+   snippet an adopter is invited to paste;
+3. the bypassed-versus-hashed worked example, whose second bullet claims
+   `standards/**` is "bypassed and hashed". That bullet is the one place the
+   guide asserts the broken form works, and it is the sentence this spec makes
+   true.
+
+The **"Watch the glob form" callout MUST be kept**, and its historical sentence
+MUST remain accurate. The trap it describes is a property of the glob crate, not
+of the old default, and the callout is the only place an adopter writing their
+own pattern is warned.
+
+`docs/design/00-architecture.md` quotes the default in its config narrative and
+MUST be updated to match. It is owned by no spec and sits on the bypass floor,
+so this is a consistency edit, not a governed claim.
+
+### 3.5 The migration note
+
+The change is a one-time restale for an adopter who relies on the default, and
+that adopter MUST be able to find out why before it happens to them. The note
+MUST read, in substance:
+
+> `[index] extra_hashed_inputs` shipped a default that matched no files. It is
+> fixed. If you did not override the key, your next `spec-spine index` will
+> rewrite every shard once, because the standards tree and the workflow
+> directory are entering the content hash for the first time. Commit the result.
+> Nothing about what staleness *means* has changed; a surface that was silently
+> outside the ledger is now inside it.
+
+It MUST live in `docs/adoption-guide.md`, beside the knob it concerns. This
+repository publishes no `CHANGELOG.md`, and `release.yml` sets
+`generate_release_notes: true`, so GitHub composes the release body from merged
+pull request titles: there is no committed release-notes file for a migration
+note to live in, and a note that exists only in a release body is invisible to
+an adopter who upgrades by version number. The pull request title for this spec
+MUST therefore name the restale as well, since that title *is* the generated
+release note.
+
+`spec-spine`'s own corpus is unaffected: its `spec-spine.toml` overrides the key
+with `["standards/**/*.md", ".github/workflows/*.yml"]`, which already matches.
+That MUST NOT be taken as evidence the change is inert, and is the reason §3.3
+requires a test rather than trusting the gate.
+
+### 3.6 A workflow bump stales the ledger, and the test says so
+
+`.github/workflows/**/*` is half the default, so fixing it makes a workflow edit
+stale every shard for an adopter on the default. `crates/spec-spine-cli/tests/couple.rs`
+asserts the opposite today, in spec 030's `workflow_uses_bump_auto_waives`:
+that a Dependabot action-ref bump leaves the index fresh. That assertion MUST be
+corrected rather than preserved, and the test MUST keep its actual subject,
+which is that the bump self-clears the **coupling** gate.
+
+The corrected test MUST assert the real sequence: the bump stales the index
+(exit 2), a re-index restores it, and `couple` then auto-waives. It MUST NOT be
+made to pass by giving the fixture a config that excludes workflows from the
+hash, which would leave the suite asserting a configuration nobody runs.
+
+This is not a behavior spec 069 invents. `spec-spine`'s own `spec-spine.toml`
+has carried `.github/workflows/*.yml` since spec 057, so a workflow edit has
+staled every shard **in this repository** since then, and a probe confirms it
+still does. What changes is that adopters on the default now get the behavior
+this repository already has.
+
+## 4. Out of scope
+
+**Narrowing the default to a set of extensions.** `["standards/**/*.md",
+".github/workflows/*.yml"]`, which this repository uses, hashes less and would
+spare an adopter a restale from an editor swapfile under `standards/`. It is
+also not what the broken default said, and inventing a narrower intent inside a
+bug fix is how a fix becomes a behavior change nobody asked for. An adopter who
+wants the narrower form writes it; the scaffolded comment shows how.
+
+**A lint that refuses `dir/**` in any `extra_hashed_inputs`.** This is the
+generalisation, and it is genuinely attractive: it would catch the trap in an
+adopter's hand-written config, which no mechanism does today. `L-008` catches
+only the case where the unhashed path is also **claimed**, and this repository
+suppresses 71 of those through `[lint] unwitnessed_allowed`. It is a new
+diagnostic code with its own false-positive question (`dir/**` is legitimate in
+a `[index.slices]` entry meant to match nothing yet), and it belongs in its own
+spec.
+
+**Deduplicating the two `glob_files` helpers.** `index.rs` and `shard.rs` carry
+byte-identical private copies, and the `.filter(|p| p.is_file())` line that makes
+this bug bite is duplicated in both. Consolidating them is a refactor across two
+specs' territory with no behavior change, and doing it here would bury the
+one-line fix this spec exists to make.
+
+**A workflow freshness projection.** `Cargo.toml` and `package.json` fold into
+the hash as governance *projections* (spec 004 §3.5, extended by 030 §3.1): the
+manifest with its dependency tables stripped, so a version bump moves no hash.
+No such projection exists for a workflow, so a `uses:` action bump moves the
+global scalar and stales every shard, and a bot that can neither re-index nor
+waive walls on exit 2. Spec 030 did not build one because it read workflow
+freshness as already fine. It was not, and §3.6 records why. Building the
+projection (strip `uses:` refs, hash the rest) is the real fix and is its own
+spec: it is a hashing-semantics change with a migration of its own, and folding
+it into a one-line default correction would hide it.
+
+**Changing what enters the content hash.** The set of hashed inputs is
+`spec-spine.toml`, every `spec.md`, each package manifest, the span-backing
+files of resolved units, and every `extra_hashed_inputs` match. This spec
+changes which files the last of those five resolves to, and touches none of the
+other four. Spec 057 §4's separate question, whether bare `file` units should
+contribute their bytes, stays open.
+
+## 5. Resolved decisions
+
+**Decision, 2026-09-07: the restale is accepted, not mitigated.** The
+alternative considered was a compatibility path: keep the broken default,
+detect it at load, and warn. That preserves every adopter's committed index at
+the cost of shipping a default the tool itself reports as wrong, and it leaves
+the attestation gap open for anyone who does not read warnings. A default that
+does not do what it says is a defect and not a contract, so there is nothing to
+preserve compatibility with. The restale is one commit for an adopter and is
+what a correct ledger costs.
+
+**Decision, 2026-09-07: 067 is extended, not amended.** Spec 067 records, as a
+finding an adopter derived by experiment, that `standards/**` is in the default
+`extra_hashed_inputs` and that editing a standards file therefore stales every
+shard. The second half of that sentence is false today and true after this spec.
+069 is not contradicting 067's stated behavior; it is making 067's description
+of the world accurate. The doc file 067 owns is edited under an `extends` edge,
+and 067's own `spec.md` is not touched (spec 040).
+
+**Decision, 2026-09-07: spec 030 is not amended.** 030 §1 says that for GitHub
+Actions "a `file` unit carries no span and is not a hashed input (004 §3.5), so
+freshness is already fine". The first clause is true and is about the unit; the
+conclusion is false whenever an `extra_hashed_inputs` glob covers the same file,
+which in this repository it has since spec 057. So 069 does not change 030's
+stated behavior: 030 implements a coupling waiver, that waiver is untouched, and
+its test still asserts it. What 069 falsifies is a premise in 030's problem
+statement that was already false when written. A premise is corrected by the
+record, not by an `amends` edge, so this entry is the record and the test is
+edited under an `extends` edge on the file.
+
+**Decision, 2026-09-07: the migration note goes in the adoption guide.** The
+first draft of §3.5 required it "in the release notes", which named no file.
+There is no `CHANGELOG.md` here and the release workflow generates its body from
+pull request titles, so that requirement was unsatisfiable as written. The guide
+is where an adopter reads about the knob, so it is where the note about the knob
+changing belongs. `docs/releasing.md` was considered and rejected: it is the
+maintainer's runbook for cutting a release, not a document adopters read, and it
+is owned by spec 007, a crossing this spec has no other reason to make.
+
+**Decision, 2026-09-07: the edge on `config.rs` names 062.** No spec
+`establishes` `crates/spec-spine-types/src/config.rs`; it is covered by the
+`000` package-manifest floor and claimed by seven `extends` edges. Spec 057 set
+the convention by naming the most recent claimant (053, at the time), and this
+spec follows it by naming 062. The alternative, naming the `000` floor, would
+assert a crossing into the bootstrap spec's territory that the ownership model
+does not actually record.
+
+## Verification
+
+Each line below is one command: spec 049 §3.2 makes a fence's body line a
+command, so a trailing backslash continuation would become its own fragment and
+fail. The adopter is materialized once at a fixed path, because each line is its
+own shell and a `$(mktemp -d)` would not survive to the next assertion.
+
+Every assertion fails against pre-069 code: the default matched no files, so the
+scaffolded adopter's `index check` reported fresh across an edited constitution,
+and the emitted config carried the bare `"standards/**"` entry.
+
+```verify:cli
+# Self-contained: the commands below invoke the release binary.
+cargo build --release --locked
+# 3.3 the regression guard, and 3.2's assertion beside the round-trip.
+cargo test -p spec-spine-core --test index --locked
+cargo test -p spec-spine-core --test scaffold --locked
+# 3.6 030's workflow auto-waive test, corrected to the real sequence.
+cargo test -p spec-spine-cli --test couple --locked
+# 3.4 the guide keeps the trap warning and 3.5 puts the migration note beside it.
+grep -q 'Watch the glob form' docs/adoption-guide.md
+grep -q 'Upgrading across spec 069' docs/adoption-guide.md
+# Materialize a fresh adopter on the shipped default.
+rm -rf "${TMPDIR:-/tmp}/ss069" && mkdir -p "${TMPDIR:-/tmp}/ss069" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" init >/dev/null
+# 3.1: the emitted default is the working form...
+grep -q 'extra_hashed_inputs = \["standards/\*\*/\*", ".github/workflows/\*\*/\*"\]' "${TMPDIR:-/tmp}/ss069/spec-spine.toml"
+# ...and the bare directory form is gone from the file.
+! grep -q '"standards/\*\*"' "${TMPDIR:-/tmp}/ss069/spec-spine.toml"
+# 3.2: the trap is still named, in the phrase 061's own verification greps for.
+grep -q 'matches DIRECTORIES' "${TMPDIR:-/tmp}/ss069/spec-spine.toml"
+# 3.2: the emitted config still round-trips through the real loader.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" config show >/dev/null
+# 3.1: a fresh adopter's ledger starts clean...
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" compile >/dev/null
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" index >/dev/null
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" index check
+# ...and an edit to the constitution now stales it, which is the whole spec.
+printf '\nA governed edit.\n' >> "${TMPDIR:-/tmp}/ss069/standards/spec/constitution.md"
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" index check
+# The same holds for the workflow directory, the default's other half.
+mkdir -p "${TMPDIR:-/tmp}/ss069/.github/workflows" && printf 'name: ci\n' > "${TMPDIR:-/tmp}/ss069/.github/workflows/ci.yml"
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" index >/dev/null
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" index check
+printf 'name: ci2\n' > "${TMPDIR:-/tmp}/ss069/.github/workflows/ci.yml"
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss069" index check
+rm -rf "${TMPDIR:-/tmp}/ss069"
+```


### PR DESCRIPTION
Spec 061 §4 deferred this fix to "its own spec with its own release note". This is that spec.

## The defect

`IndexConfig::default().extra_hashed_inputs` shipped as `["standards/**", ".github/workflows/**"]`. In the `glob` crate `dir/**` enumerates directories, and both `glob_files` helpers keep only entries that are files, so **the shipped default matched nothing**. An adopter who had not overridden the key folded zero governance files into any content hash and was told nothing.

A scaffolded adopter could rewrite its entire constitution and the ledger still reported itself fresh:

```console
$ spec-spine --repo /tmp/probe init && spec-spine --repo /tmp/probe compile && spec-spine --repo /tmp/probe index
$ printf '\nA governed edit.\n' >> /tmp/probe/standards/spec/constitution.md
$ spec-spine --repo /tmp/probe index check
index is fresh
```

`standards/` is on the coupling gate's bypass floor by design, so the content hash was the only mechanism meant to notice a change there. Spec 023 signs attestations over that hash, which means an adopter's signed attestation has been attesting to a corpus whose governing documents it never read.

## The fix

The default becomes `["standards/**/*", ".github/workflows/**/*"]`: the working spelling of the intent the broken form already declared, and character-for-character what spec 061's scaffold comment already tells adopters to write. An adopter who followed that advice sees no change.

## Upgrade note

**This is a one-time restale.** If you did not override `[index] extra_hashed_inputs`, your next `spec-spine index` rewrites every shard once, because the standards tree and the workflow directory are entering the content hash for the first time. Commit the result. Nothing about what staleness *means* has changed; a surface that was silently outside the ledger is now inside it.

`spec-spine`'s own corpus is unaffected: `spec-spine.toml` already overrides the key with a matching form. That is exactly why this needed a test rather than the gate.

## A premise corrected, not just a value

Spec 030 §1 reasoned that a GitHub Actions bump needed only a coupling waiver, because a `file` unit carries no span and so "freshness is already fine". True of the unit; false whenever an `extra_hashed_inputs` glob covers the same file, which in this repository it has since spec 057. A probe confirms a workflow edit already stales every shard here.

`workflow_uses_bump_auto_waives` was asserting the opposite, and passing only because the default matched nothing. It now asserts the real sequence: the bump stales the index, a re-index restores it, and `couple` auto-waives. Spec 030 is **not** amended: its behavior is untouched and its waiver still works. What 069 falsifies is a premise in 030's problem statement that was already false when written, and §5 records that.

§4 names the follow-on: a **workflow freshness projection** (strip `uses:` refs, hash the rest), the analogue of what 030 §3.1 built for `Cargo.toml`. Without it a Dependabot action bump stales the ledger and a bot can neither re-index nor waive. That is a hashing-semantics change with its own migration and does not belong inside a one-line default correction.

## Why the regression guard uses `Config::default()`

`tests/lint.rs` already pinned that `sub/**` matches nothing and `sub/**/*` matches. That test sat beside the broken default for months. A test that spells its own globs proves the glob engine works and cannot fail when the *default* rots, so the new guard in `tests/index.rs` builds its fixture from `Config::default()` and asserts both that the two files land in `witnessed_paths` and that editing either moves the global inputs hash. Both new tests were confirmed to fail against the pre-069 default before the fix was restored.

## Gate

`compile` / `index` / `lint --fail-on-warn` / `index check --fail-on-unresolved` / `index coverage --fail-on-untraced` all green; `couple --base origin/main`: 7 paths checked, no drift. `cargo test --workspace`, `clippy -D warnings`, `fmt --check` green. `spec-spine verify 069`: 22/22 commands pass.

No waiver required: every crossing is declared as an `extends` edge in 069's own frontmatter.

Spec 069 is filed `status: draft`, `implementation: complete`. The ratify flip stays a human call.
