### PR TITLE
chore(052-069): ratify the adopter-audit burn-down (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -223,8 +223,8 @@
       }
     ],
     "specId": "052-couple-names-the-crossing",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9cd9297aab51929cd3279221dcf66f5dd6c562c488021eae36b84509b2943da2"
+  "shardHash": "5125912f7b3cc07e810b999b122016d8136ba0706eda2157a76940f917fc43f1"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -91,8 +91,8 @@
       }
     ],
     "specId": "053-depends-on-ordinal-monotonicity",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5c80299d44da175129191cc5ec2a37748afff6857f02a74b318de692eb924fcb"
+  "shardHash": "fade4223fa8b6a77cb896158ae30ee2646b28319c0499ffff3c25a9200d0926b"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -155,8 +155,8 @@
       }
     ],
     "specId": "054-effective-config-is-a-governed-read",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "07fba44ba42d9f41e6a6e504a1b6cb4b3c5c630d94b190024ea2ab36ad60cb48"
+  "shardHash": "77ebd23e9962ef7f33ee67c79b3fee3d3e2f3b62370101b3cce9b1dbe83d6de6"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -160,8 +160,8 @@
       }
     ],
     "specId": "055-the-ledger-answers-what-consumers-rebuild",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b725770dd825044ec71d52a3fb54b10102c885cadcd5fe5b9c82c1ffeb06672e"
+  "shardHash": "25a33cf556b9154104079268a6a96466f83aaeff96a58a2f468ce5e0631b9900"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -193,8 +193,8 @@
       }
     ],
     "specId": "056-compile-one-spec",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6bcadb6a324102a86b61807c6e3596625072d02418b925fdd1e9b4ce95ce4084"
+  "shardHash": "812a614288f91ec84fdce533c9ce098b54c555dc26d1200d11626f00c15ce283"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -173,8 +173,8 @@
       }
     ],
     "specId": "057-claimed-but-unwitnessed",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f0a3ef7be72c71f03163bc2afab9d096ce878564f9b0c6be416831fd842f48ef"
+  "shardHash": "f9c3fa13041591c0f8be154e7932c9cbb4d35bcb66886fb9ccc7c82f9730cff1"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -96,8 +96,8 @@
       }
     ],
     "specId": "058-retroactive-adoption-shape",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "eba36aa32fb8e4ee07bd8bdbb7a2ba89ea5f6f1d36434e43ccca5658c0d04865"
+  "shardHash": "797beec76a048e7242bd25a0fa2c213f0bc2ac28318847ecd67fd67ed2d66b9b"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -142,8 +142,8 @@
       }
     ],
     "specId": "059-read-verbs-on-a-code-free-corpus",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f5347819528610b9af79f56be1cd9da44f48b597bd1e2fbeb0d75c8b2a2731ac"
+  "shardHash": "dd754abe458402101795c9c152dece8e2ccd62e75ee2eec1b1cdc86ecf5fa79e"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -121,8 +121,8 @@
       }
     ],
     "specId": "060-plan-answers-the-whole-question",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dfff9ff4fea5ec13e32301899a01c9f1d66719803124a6b36c116fce06d30cab"
+  "shardHash": "0bc35b4c5443e0358054319aca411b97e7d3f8860c88d91bb080dca4b327f071"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -83,8 +83,8 @@
       }
     ],
     "specId": "061-the-scaffold-ships-what-adopters-wrote",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "79f5400586ca3164695522bf4d76edc6f993259c42837b660b0b01f54012b9f9"
+  "shardHash": "0b794bcfc7712d140c2cb3cf5b608c5e947671ee349fb42d91b9ecf37887cf26"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -155,8 +155,8 @@
       }
     ],
     "specId": "062-a-version-pin-the-cli-can-check",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d0b2eef2db81f04e4326f25b66dd8a06b046e20aebf5eda968db76f0cd37e0cb"
+  "shardHash": "ff196fa2a79c3764a772c83b0c5b0de2695a2eb2ec679b56e827b79213e4cc3c"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -142,8 +142,8 @@
       }
     ],
     "specId": "063-a-stale-binary-is-not-a-stale-ledger",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d9ff0281653e353742394b41ffe6d8680ed63cfa88fbe956450d08c3c03dde8f"
+  "shardHash": "9dbb9aec229700c502149d11755d43faef56fd330cd1879c5a632f3491a0dd75"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -224,8 +224,8 @@
       }
     ],
     "specId": "064-the-kit-ships-the-composite-gate",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d71219e1238a3a47eeee5cc1f98303cb530af07e58b7f4edacb91420e8808aac"
+  "shardHash": "0498cd521654c87a9d74c41d2dc7f07a9df12552a1af30f2db45b824ec7473cf"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -207,8 +207,8 @@
       }
     ],
     "specId": "065-init-and-the-kit-are-one-adoption",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5686e0b4b7440f41db31b74f752b48bf7e0b8ca8ff60781d4c2db68c14b94944"
+  "shardHash": "6c827c928ee2a3a1263268edf0093cce06e7fe02be5eefaba82050ffde33d12e"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -88,8 +88,8 @@
       }
     ],
     "specId": "066-the-contract-records-the-lifecycle-table",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4bc110a85e8ff09b44e1dc339057ab8518111e6f3dfd692e6ff293c203699717"
+  "shardHash": "467f8231151559ec0a87966d40d43d6fa7bb2215aba756cc8c01557c96e5c098"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -105,8 +105,8 @@
       }
     ],
     "specId": "067-the-docs-name-what-adopters-derived",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "770df10ec5dd030dfcc6e2be180851547b5a6030ba7a61809dda204f9404a469"
+  "shardHash": "e767c976768b8d8ef8572ee90f9a3f5beee2eafb2fcdb979ce6af9173eb85bc8"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -172,8 +172,8 @@
       }
     ],
     "specId": "068-a-path-scoped-rule-example",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d260e4e4229888c79c01a3e6a10c12e31fef1578d1f77e8c5cbc69267495d7da"
+  "shardHash": "03315d5685bb5098dcb32c5a4fd5dd6368b61f826b860981591d34bb8218917b"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -129,8 +129,8 @@
       }
     ],
     "specId": "069-the-shipped-default-hashes-what-it-names",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1addbb9b1106506d036eee8971a088c2741e8b0302cf93bcac007bef64f50dd9"
+  "shardHash": "3c42e361c1c2f8a631ebf7d8de271ae7b864f0bb5b116822f10f4d36cfb9380c"
 }

--- a/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
@@ -132,10 +132,10 @@
       "5. Verification"
     ],
     "specPath": "specs/052-couple-names-the-crossing/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The coupling gate has always named the specs that own a drifted path, and has never named the mechanism for crossing into their territory. Its resolution footer offers two doors: edit an owning spec, or waive. For an author who has legitimately touched a unit somebody else owns, both are shut. Editing another spec to clear a refusal is the illegitimate edit the corpus rules forbid, and the waiver is a human instrument that no adopter has ever used and that an unattended session is forbidden on every path. The third door, an `extends` edge declared in the author's own spec, is the corpus's actual answer and the gate never mentions it. This spec makes the refusal name it: three doors in author order, and when the diff edits exactly one spec.md, the concrete `extends` block to paste into that file. It also promotes the owner set from prose into an optional `owners` field on the violation, so an orchestrator reading `couple --json` learns the owner as data instead of by regexing English. No committed artifact and no schema version moves.\n",
     "title": "The coupling gate names the crossing"
   },
-  "shardHash": "681252329fc036ed34c243f5c75e2f79ca6658630656c4e373482f318072d4cc",
+  "shardHash": "607f83fa5b909120dc04258e633fd49334842a3363b12fd57dca6a9cb8d5806d",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -66,10 +66,10 @@
       "5. Verification"
     ],
     "specPath": "specs/053-depends-on-ordinal-monotonicity/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Three adopters independently wrote the same ninety-line `scripts/spec-dag.sh` to assert one thing the tool does not: that a `depends_on` entry names a lower ordinal than the spec declaring it. Spec 033 already ships the harder half of that graph check, refusing a cycle at compile time, and ordinal monotonicity is the cheap total order that makes a cycle impossible by construction rather than detectable after the fact. This spec adds `L-007`, an opt-in conformance lint gated on a new `[lint] require_ordinal_monotonic_depends_on` knob, defaulting off so no existing corpus changes verdict. It is deliberately a lint and not a `V-` code: a forward dependency is a corpus convention an adopter may reasonably not hold, not a structural defect that makes the registry unreadable.\n",
     "title": "A dependency points backward, and the corpus can say so"
   },
-  "shardHash": "e3a14fac12e75cea1cbd364992f4307fe54007fe915404a84a653f88ee9671ec",
+  "shardHash": "a36bd7fb798b1adae5baaee2b1aa53b24d3fdf7caf10aa129cc0a66d151126c8",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
@@ -94,10 +94,10 @@
       "5. Verification"
     ],
     "specPath": "specs/054-effective-config-is-a-governed-read/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`spec-spine.toml` is only half the configuration a coupling decision is made from. The other half is `DEFAULT_BYPASS_PREFIXES`, a thirteen-entry constant compiled into the binary, additive to the adopter's list and impossible to read from outside the process. claude-observatory, which judges other repositories, hand-parses each target's TOML and documents in its spec 016 D-3 that the built-in floor is simply unknowable to it. That is a consumer reimplementing half a contract and knowing it has the other half wrong. This spec adds `spec-spine config show [--json]`: the effective configuration, every default resolved, with the bypass floor rendered as the merged list the gate actually matches against and each entry attributed to the built-in floor or to the adopter's file. It reads and reports; it decides nothing.\n",
     "title": "The effective configuration is a governed read"
   },
-  "shardHash": "f41fb08286152e147adbac03f332ba0c06114f7934d09dd3375ebc879ae071f7",
+  "shardHash": "8e4d7528fd2adae7a67dbb0628f39494ae9aaecf7ccade1959cceb964b11ab69",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -100,10 +100,10 @@
       "5. Verification"
     ],
     "specPath": "specs/055-the-ledger-answers-what-consumers-rebuild/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Two facts the ledger computes and then keeps to itself, each of which an adopter has reimplemented. Ownership of a path is resolved inside `couple.rs::owners_for_path`, a private function, so a consumer that wants to know which spec governs a file rebuilds a path-to-spec map from raw edges and gets the subtree, supersession and comment-header rules wrong. A spec's content hash is written into every registry shard as `shardHash` and is absent from every read verb, so claude-observatory reimplemented `hash.rs` normalization in TypeScript in order to pin against it. This spec adds `spec-spine index owner <path>` and puts `contentHash` on `registry show --json`'s output object. Neither touches a committed artifact, a DTO, or a schema version: both facts already exist and are merely unreachable.\n",
     "title": "The ledger answers what consumers rebuild by hand"
   },
-  "shardHash": "f7fc386bd2a03618429387dd3068303680eff123631d5f051743482d0f06c0a7",
+  "shardHash": "da3e89fe7c83cc6ecc7f5a7102c44c5eba9accb6501e393a25b93b88741b5a59",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/056-compile-one-spec.json
+++ b/.derived/spec-registry/by-spec/056-compile-one-spec.json
@@ -117,10 +117,10 @@
       "5. Verification"
     ],
     "specPath": "specs/056-compile-one-spec/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Writing a spec means validating it before it lands, and the tool offers no way to do that. `compile` writes the whole shard tree, which an author with an unfinished draft must not do; `compile --check` refuses the whole corpus because the draft has no committed shard, reporting the author's work in progress as staleness. So two adopters wrote down a `mktemp -d` ritual: copy the corpus, copy the draft in, compile there, read the violations, delete the copy. It has a documented gotcha, because a `references` edge into `docs/` does not resolve in a corpus copy that has no `docs/`. This spec adds `compile --spec <id>`: validate one spec against the committed registry, report only that spec's violations, and write nothing.\n",
     "title": "Validate one draft without a temporary repository"
   },
-  "shardHash": "485d798d076e8e3449ac206ce93c84778ccc78e2d126336123e495e4fa0213ec",
+  "shardHash": "02c87e7dfeacabc3f0e3abf38b7cfcdf05466452c81bc594b1efd9e486bb6e9c",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
@@ -108,10 +108,10 @@
       "5. Verification"
     ],
     "specPath": "specs/057-claimed-but-unwitnessed/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "A `file` unit carries no span, and only span-backing source files are folded into a per-spec index shard hash. So a spec can claim a file, `index check` can report fresh, `index coverage` can report it claimed, and the file's contents can be rewritten from end to end with no gate noticing. This is not hypothetical in this repository: `AGENTS.md` is claimed by three specs, and appending a line to it leaves both `index check` and `compile --check` reporting fresh. Twenty-four claimed paths here are in that state, and spec 023 signs an attestation over a ledger that never hashed any of them. This spec adds `L-008`, a warning naming each claimed path that contributes to no content hash, and one line of `index check` output reporting the count. It does not fold claimed files into the hash: that would change what staleness means, and the honest first move is to say how large the gap is.\n",
     "title": "A claim no hash witnesses"
   },
-  "shardHash": "c7a91dcf535017b75965273346286a29aecd744363d0fd162c1f7e095bfc9d5d",
+  "shardHash": "abdb08f3d469a89193d770349cb0b9f02b0478c955aa47164c6cc61dc27fe4ac",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
@@ -69,10 +69,10 @@
       "5. Verification"
     ],
     "specPath": "specs/058-retroactive-adoption-shape/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Constitution V requires code adopted from outside the corpus to be specced as found, with the behavior the adopting spec would not have chosen recorded under a `## Known defects` heading. It does not say what counts as that heading, and the first consumer to check mechanically got it wrong: claude-observatory's `defects.ts` matches the string `## Known defects` exactly and therefore rejects the numbered headings of the very specs it cites as precedent. This spec settles the spelling as an anchor rather than a string: any heading whose computed slug is or ends with `known-defects`, at any level, under the same slug rule the indexer already uses for section units. It adds `L-009`, an info-tier lint for a near-miss spelling, and it declines to lint `origin.retroactive` into implying the heading, because spec 043 established that the two are orthogonal.\n",
     "title": "The defects heading has one spelling"
   },
-  "shardHash": "a3078d3df925986851c71c6017da101d6a50e59b30b10502535282d988e86c2b",
+  "shardHash": "5d6a45ca1ab2b9ee62dea542cbbe87124abe10418a747528a63e1636a81d1d53",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -91,10 +91,10 @@
       "5. Verification"
     ],
     "specPath": "specs/059-read-verbs-on-a-code-free-corpus/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Three of the four governed repositories are specify-first: the whole corpus is ratified before a line of code exists, and specs live at approved plus pending for months. Two read verbs give that corpus an answer that is technically correct and practically a lie. `index orphans` reports sixty-four of hqgit's sixty-eight specs, because an orphan is a spec claiming nothing that resolves, and a spec whose code is not written yet claims nothing that resolves; the list is the corpus, so it says nothing. `index coverage --fail-on-untraced` on a tree with no discovered package enumerates zero source files, computes zero untraced, and exits 0 from inside a CI step named \"the whole-tree ownership assertion\". This spec makes the first partition by the in-flight predicate the index already computes, and makes the second refuse an empty universe instead of passing it.\n",
     "title": "Two read verbs that mislead a specify-first corpus"
   },
-  "shardHash": "bab68eecd9f5c7415fac7011203eff309ced25be49da3b11501be7f75762d967",
+  "shardHash": "c8c269b61db919647a806114a477e080a4412e7f4e97cb3a141b501238a7d1f2",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
@@ -82,10 +82,10 @@
       "5. Verification"
     ],
     "specPath": "specs/060-plan-answers-the-whole-question/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`registry plan` prints spec ids and a count. Every consumer needs more than that, so every consumer adds it back: adopters kept about forty lines of Python to join the ready ids against titles and to explain why each blocked spec is blocked, and the corpus's own `/next` skill has to make a second call to turn an id into something a human can read. The data is all there. `Plan` already carries each blocked spec's blockers with the state of each, and the registry it was computed from carries every title. This spec makes the prose form render what the structure already holds, and adds `--next`, the single pick that the one-spec-per-session loop actually asks for. The JSON shape gains title fields and is otherwise unchanged.\n",
     "title": "The plan answers the whole question, and names one pick"
   },
-  "shardHash": "ff916a920c8ec5a92bfbcefc2d9fb59e9f5aaba250bbcf9955d1fc56354a1457",
+  "shardHash": "0067400846a08e50b01dbe3014bcc802baaf46f72c4ddb8fd957f940ddf87ddd",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -65,10 +65,10 @@
       "5. Verification"
     ],
     "specPath": "specs/061-the-scaffold-ships-what-adopters-wrote/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Four scaffold defects the audit measured, all in one generator. `init` writes no `.gitignore`, so every adopter independently learns that `.derived/**/build-meta.json` carries a wall clock and dirties the tree, and spec 039's `state_dir` has the same missing half: the live failure it fixed was a permanently dirty tree, not a classification. The scaffolded `spec-spine.toml` emits five knobs; adopters needed thirteen, and aicortex annotated each of its own with the diagnostic code that knob drives, which is the template to copy. And `CONSTITUTION_TEMPLATE` in `scaffold.rs` is still the two-bullet stub spec 043 complained about, while the real thirty-four-line document sits in `standards/spec/templates/constitution-template.md`: adopters get the stub, and two of them deleted it. This spec fixes all four in `scaffold_init`, which stays a pure function of `Config` performing no IO.\n",
     "title": "The scaffold ships what every adopter wrote by hand"
   },
-  "shardHash": "f6b27334ec9221d05cde708e4c9bc8a8cde23de9843861741de284a84b4a72fd",
+  "shardHash": "3214ed61cc2acb4d10f5c25a724680a1d7002b31b77dc08c4d48f36fecee0ce1",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -99,10 +99,10 @@
       "5. Verification"
     ],
     "specPath": "specs/062-a-version-pin-the-cli-can-check/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "A repository is governed by whichever spec-spine binary happens to be on the path, and nothing anywhere says which one it should be. rahi states 0.11.0 in three files that must agree by hand. All four governed repositories are two to four releases behind the fixes their own experience motivated, and rahi cannot see spec 044, which was written for rahi's exact state, because it is pinned below it. This spec adds `[meta] required_version`, a semver requirement the CLI checks on every run, refusing with a message that names both the requirement and the running version. The schema versions already tell a loader whether it can read an artifact; this tells an operator whether they are running the tool the corpus was governed by, which is a different question and currently has no answer at all.\n",
     "title": "A version pin the CLI can check"
   },
-  "shardHash": "fe2ca3f48246293bd20b298b638cbaa76eb82e0f65b5e80b9bef97f2d241e3bb",
+  "shardHash": "f943dccbb99a31818db8fbd07be3f290461759892080749985e4060e1ce3fa9c",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/spec-registry/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -91,10 +91,10 @@
       "5. Verification"
     ],
     "specPath": "specs/063-a-stale-binary-is-not-a-stale-ledger/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`spec-spine compile --check` exits 2 when the committed registry is stale. A binary predating `--check` rejects the unknown flag and clap exits 2 as well. Two unrelated conditions, one code, distinguishable only by matching English on stderr, and two adopters plus the kit plus this repository's own AGENTS.md carry that matching ritual. This spec maps every command-line usage error to exit 3, so a new binary can never report a usage failure as staleness, and replaces the stderr ritual with the precondition that actually settles it: ask the binary its version first, which every binary ever released answers. The ritual's real defect was that it made the caller parse prose to recover a fact the process had already destroyed by choosing the wrong exit code.\n",
     "title": "A stale binary is not a stale ledger"
   },
-  "shardHash": "920adae51ef3452fc397ccc290c2455bab93d088412cc07c8391cdb73094c41f",
+  "shardHash": "7cbe621fe3b3d1dc3c673848d71f690198e7dc17d5a9d866949caa2be3cab398",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -109,10 +109,10 @@
       "5. Verification"
     ],
     "specPath": "specs/064-the-kit-ships-the-composite-gate/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The kit ships a session harness and no build. Every adopter therefore wrote the same two things by hand. First a composite gate: a Makefile whose language targets are guarded on a manifest probe so the whole thing is green on a code-free tree, and a CI workflow carrying the `has_cargo` job-output pattern that three adopters each rediscovered after GitHub rejected `hashFiles` in a job-level `if`. Second, nothing at all for the committed shard trees: rahi runs one spec per PR with committed shards and has no merge driver, and the kit's README never says the words. This spec ships `kit/Makefile`, `kit/govern.yml`, `kit/.githooks/` and the `.gitattributes` stanza, and holds them to the rule spec 046 and 051 established for everything else in the kit: what the kit ships, this repository runs.\n",
     "title": "The kit ships the composite gate and the merge driver"
   },
-  "shardHash": "30038697c551f963ae5b211861d1a83bf141ea47081fdfca63ba7cc3a7bc204f",
+  "shardHash": "c518342791ade3df14f49542c376e59a8aca5818e3dac3b8b2f795577069c072",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/spec-registry/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -118,10 +118,10 @@
       "5. Verification"
     ],
     "specPath": "specs/065-init-and-the-kit-are-one-adoption/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Adoption is two halves that nothing joins. `spec-spine init` writes a corpus, a constitution, a contract, templates and three agent rules. `kit/` adds the session protocol, the hooks, the agents and fifteen skills. The scaffold does not mention the kit, the kit is not installable by any verb, and `AGENTS.md`, which every skill in the kit reads first and which the three rewriting adopters each wrote from nothing, is written by neither. Spec 043 named this gap G5 and did not close it. This spec adds `spec-spine init --with-kit`, emitting the kit's files through the same `Scaffold` data path as everything else, and makes plain `init` write an `AGENTS.md` naming the governed loop, because a repository with rules and no protocol is the configuration three adopters had to repair by hand.\n",
     "title": "Init and the kit are one adoption"
   },
-  "shardHash": "3c5517dae590c4f2cb9a5498a01b298406b6bf08c7615dbb6b19d052c3d00aaf",
+  "shardHash": "05e7b375daf2eb018b17cc9b81d5bb4554132dfa8e68570dab2fdebafa8a79d1",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -68,10 +68,10 @@
       "5. Verification"
     ],
     "specPath": "specs/066-the-contract-records-the-lifecycle-table/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`status` and `implementation` are the two keys every adopter reasons about daily, and the contract mentions `status` once, in a list of required frontmatter, and `implementation` not at all. The mechanical consequences are spread across four specs: 041 makes a `complete` claim checkable, 044 defines the in-flight window, 045 says an absent key takes its answer from `status`, and 038 reads both to build the ready set. Every specify-first adopter wrote the resulting table into its own contract by hand, and hqgit had to invent a section called \"Lifecycle as scheduling\" because ours has none. This spec adds that section and an \"Extra keys\" section telling adopters to document their `extra_known_keys`, and claims both as section units of the contract.\n",
     "title": "The contract records the lifecycle table and the extra keys"
   },
-  "shardHash": "aef7458271bd8e9124ce57f3b51767444092d882e0283609be7c53f9433a3907",
+  "shardHash": "21a758523487e407f071c40d6880e3e21f28038421b784240a67a98ee2f20cb1",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -65,10 +65,10 @@
       "5. Verification"
     ],
     "specPath": "specs/067-the-docs-name-what-adopters-derived/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Three documentation gaps the audit measured, each with a named victim. There is no page for specify-first adoption, which is how three of the four governed repositories work, so each of them independently derived the guarded Makefile, the CI manifest probe, `implementation: n-a` for record specs, and the fact that two hundred and forty-eight W-001 warnings is the defined state rather than a backlog. Two interactions are documented nowhere and were found by experiment: a path can be on the coupling bypass floor and simultaneously a hashed input, and a trailing-slash directory unit in `establishes` satisfies ownership recursively. And spec 037 changed `attest`'s stdout, which claude-observatory regexes in two places, with no migration note. This spec writes the page and the three paragraphs.\n",
     "title": "The docs name what adopters derived by experiment"
   },
-  "shardHash": "df0cdb5263c776fa8fe1d0e4ed063dd31e48afd387c10602be59a967021f2b1f",
+  "shardHash": "05dcf3c453e5ee703f17dc8121baa00fdf1cd28f6b01040463909863c14bdccb",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
@@ -101,10 +101,10 @@
       "5. Verification"
     ],
     "specPath": "specs/068-a-path-scoped-rule-example/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The kit's three rules are unconditional: every one loads in every session regardless of what the session touches. Claude Code supports `paths:` frontmatter that loads a rule only when a matching file is touched, and the kit's README lists that pattern under \"intentionally excluded\" while hqgit carries three good ones, including per-file scoping. The exclusion was a judgement made before any adopter had tried it, and an adopter has now tried it and kept it. This spec ships one path-scoped rule, scoped to the derived artifact tree, whose content is the one instruction that is only ever relevant when someone has a compiled artifact open: do not hand-edit it. One rule, as a worked example of the mechanism, with the README's exclusion replaced by a description of when to reach for it.\n",
     "title": "A path-scoped rule the kit actually ships"
   },
-  "shardHash": "c2b3fe382b1681601e596460bac14ea424b0dc264f7013489a3a1ac9360590c3",
+  "shardHash": "6f1ebd1ed8ce8de7be2dfe1816713625f4d76154b2303e71ec81f18fc9ad1d6e",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/spec-registry/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -90,10 +90,10 @@
       "Verification"
     ],
     "specPath": "specs/069-the-shipped-default-hashes-what-it-names/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`IndexConfig::default().extra_hashed_inputs` ships as `[\"standards/**\", \".github/workflows/**\"]`. In the glob crate `dir/**` enumerates directories, and the hasher keeps only entries that are files, so the shipped default matches nothing: every adopter who has not overridden it folds zero extra files into the content hash and is told nothing. Spec 057 found the form in this repository's own config and fixed it there; spec 061 found it in the default behind it, emitted the key at its real value with a comment naming the trap, and deferred the fix to its own spec on the grounds that changing it restales every adopter's committed index. This is that spec. The default becomes `[\"standards/**/*\", \".github/workflows/**/*\"]`, the working form 061's comment already tells adopters to write, so an adopter who followed that advice sees no change and one who did not gets a one-time restale and a governance surface that is finally in the ledger. A regression test pins the property that was never asserted: that the shipped default matches files.\n",
     "title": "The shipped default hashes what it names"
   },
-  "shardHash": "1a5fd67f78a71d95e1ebdf5482fa581be6606a19ee975b046010fe6f60687d23",
+  "shardHash": "e18947a62ffb9f6323412da1dcf30ffeb6c3f0a7a956223353a4b61b954ee8f8",
   "specVersion": "1.1.0"
 }

--- a/specs/052-couple-names-the-crossing/spec.md
+++ b/specs/052-couple-names-the-crossing/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "052-couple-names-the-crossing"
 title: "The coupling gate names the crossing"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/053-depends-on-ordinal-monotonicity/spec.md
+++ b/specs/053-depends-on-ordinal-monotonicity/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "053-depends-on-ordinal-monotonicity"
 title: "A dependency points backward, and the corpus can say so"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/054-effective-config-is-a-governed-read/spec.md
+++ b/specs/054-effective-config-is-a-governed-read/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "054-effective-config-is-a-governed-read"
 title: "The effective configuration is a governed read"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/055-the-ledger-answers-what-consumers-rebuild/spec.md
+++ b/specs/055-the-ledger-answers-what-consumers-rebuild/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "055-the-ledger-answers-what-consumers-rebuild"
 title: "The ledger answers what consumers rebuild by hand"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/056-compile-one-spec/spec.md
+++ b/specs/056-compile-one-spec/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "056-compile-one-spec"
 title: "Validate one draft without a temporary repository"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/057-claimed-but-unwitnessed/spec.md
+++ b/specs/057-claimed-but-unwitnessed/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "057-claimed-but-unwitnessed"
 title: "A claim no hash witnesses"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/058-retroactive-adoption-shape/spec.md
+++ b/specs/058-retroactive-adoption-shape/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "058-retroactive-adoption-shape"
 title: "The defects heading has one spelling"
-status: draft
+status: approved
 kind: "governance"
 created: "2026-09-07"
 implementation: complete

--- a/specs/059-read-verbs-on-a-code-free-corpus/spec.md
+++ b/specs/059-read-verbs-on-a-code-free-corpus/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "059-read-verbs-on-a-code-free-corpus"
 title: "Two read verbs that mislead a specify-first corpus"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/060-plan-answers-the-whole-question/spec.md
+++ b/specs/060-plan-answers-the-whole-question/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "060-plan-answers-the-whole-question"
 title: "The plan answers the whole question, and names one pick"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/061-the-scaffold-ships-what-adopters-wrote/spec.md
+++ b/specs/061-the-scaffold-ships-what-adopters-wrote/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "061-the-scaffold-ships-what-adopters-wrote"
 title: "The scaffold ships what every adopter wrote by hand"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/062-a-version-pin-the-cli-can-check/spec.md
+++ b/specs/062-a-version-pin-the-cli-can-check/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "062-a-version-pin-the-cli-can-check"
 title: "A version pin the CLI can check"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/063-a-stale-binary-is-not-a-stale-ledger/spec.md
+++ b/specs/063-a-stale-binary-is-not-a-stale-ledger/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "063-a-stale-binary-is-not-a-stale-ledger"
 title: "A stale binary is not a stale ledger"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/064-the-kit-ships-the-composite-gate/spec.md
+++ b/specs/064-the-kit-ships-the-composite-gate/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "064-the-kit-ships-the-composite-gate"
 title: "The kit ships the composite gate and the merge driver"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/065-init-and-the-kit-are-one-adoption/spec.md
+++ b/specs/065-init-and-the-kit-are-one-adoption/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "065-init-and-the-kit-are-one-adoption"
 title: "Init and the kit are one adoption"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/066-the-contract-records-the-lifecycle-table/spec.md
+++ b/specs/066-the-contract-records-the-lifecycle-table/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "066-the-contract-records-the-lifecycle-table"
 title: "The contract records the lifecycle table and the extra keys"
-status: draft
+status: approved
 kind: "governance"
 created: "2026-09-07"
 implementation: complete

--- a/specs/067-the-docs-name-what-adopters-derived/spec.md
+++ b/specs/067-the-docs-name-what-adopters-derived/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "067-the-docs-name-what-adopters-derived"
 title: "The docs name what adopters derived by experiment"
-status: draft
+status: approved
 kind: "documentation"
 created: "2026-09-07"
 implementation: complete

--- a/specs/068-a-path-scoped-rule-example/spec.md
+++ b/specs/068-a-path-scoped-rule-example/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "068-a-path-scoped-rule-example"
 title: "A path-scoped rule the kit actually ships"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete

--- a/specs/069-the-shipped-default-hashes-what-it-names/spec.md
+++ b/specs/069-the-shipped-default-hashes-what-it-names/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "069-the-shipped-default-hashes-what-it-names"
 title: "The shipped default hashes what it names"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-07"
 implementation: complete


### PR DESCRIPTION
## Summary

Flips eighteen specs from `status: draft` to `approved` now that each has
shipped and merged. This is the ratify half of the repository's
file-build-ratify loop; no behavior changes, no code touched. The diff is
18 one-line frontmatter edits plus the 36 shards the compiler and indexer
regenerate from them.

The batch is the 2026-09 adopter audit worked to the end, plus the defects
that burn-down surfaced in the tool itself:

- **052-055**: `couple` names the extends crossing; `depends_on` ordinal
  monotonicity; effective config becomes a governed read; the ledger
  answers what consumers were rebuilding by hand.
- **056-060**: validate one draft without a temporary repository; a claim
  no hash witnesses; one spelling for the defects heading; the two read
  verbs that misled a specify-first corpus; the plan answers the whole
  question.
- **061-065**: the scaffold ships what every adopter wrote by hand; a
  version pin the CLI can check; a stale binary is not a stale ledger; the
  kit ships the composite gate and the merge driver; init and the kit are
  one adoption.
- **066-069**: the contract records the lifecycle table and the extra
  keys; the docs name what adopters derived by experiment; a path-scoped
  rule the kit actually ships; the shipped default hashes what it names.

Corpus moves to **70/70 approved**, and `registry plan` reports nothing
ready with nothing blocked: the backlog that opened with the adopter audit
is closed.

## Testing

- `compile` 70 specs, 0 warnings; `index` 4 packages / 70 mappings, 0 error diagnostics
- `lint --fail-on-warn`: 0 errors, 0 warnings, 0 info
- `index check --fail-on-unresolved`: fresh, 71 unwitnessed claims (71 allowed)
- `index coverage --fail-on-untraced`: 79/79 specifically claimed (100%), 0 floor-only, 0 unclaimed
- `couple --base origin/main --head HEAD`: 18 paths checked, no drift, no waiver required
- `cargo test --workspace --locked`: 30 suites, 0 failures
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo fmt --all --check`: clean
- `registry status-report`: 70 total, 70 approved