### PR TITLE
chore(release): bump package version to 0.16.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.15.0"
+    "version": "0.16.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2d6916493cc757c9e36e8983db03f631e03301b8a49ecc26a945dc8526189d52"
+  "shardHash": "63f0859c2d1d1a9dfe41b3c21836caf2e2bae244907e6d75aad76c48782a1476"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "3"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.15.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.15.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.16.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.16.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.15.0",
-    "@spec-spine/cli-darwin-x64": "0.15.0",
-    "@spec-spine/cli-linux-x64": "0.15.0",
-    "@spec-spine/cli-linux-arm64": "0.15.0",
-    "@spec-spine/cli-win32-x64": "0.15.0"
+    "@spec-spine/cli-darwin-arm64": "0.16.0",
+    "@spec-spine/cli-darwin-x64": "0.16.0",
+    "@spec-spine/cli-linux-x64": "0.16.0",
+    "@spec-spine/cli-linux-arm64": "0.16.0",
+    "@spec-spine/cli-win32-x64": "0.16.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.15.0"
+version = "0.16.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares **v0.16.0**. Version-bump only; the tag is pushed after this merges.

## What ships

Nineteen specs, **051 through 069**, none of which has ever been in a release.
Spec 051 landed after the v0.15.0 bump (#109); 052-069 are the 2026-09 adopter
audit worked to the end, ratified 70/70 in #137. The corpus that opened the
audit backlog now reports `(nothing ready)` with nothing blocked.

**The tool.**

- **052** · `couple` names the owning spec on `C-001` and points at `extends`, with structured `owners` on the violation. The refusal that cost an adopter four sessions now answers itself.
- **053** · opt-in ordinal monotonicity on `depends_on`; three adopters retire the same 90-line `spec-dag.sh`.
- **054** · the effective configuration is a governed read, so the built-in bypass floor stops being unknowable to a consumer.
- **055** · owner-of-path queries and a per-spec content hash on `registry show --json`; consumers stop rebuilding path-to-spec maps and reimplementing `hash.rs`.
- **056** · `compile --spec <id>` validates one draft without the `mktemp -d` ritual two adopters documented.
- **057** · a claimed `file` unit outside every hashed input is named and counted (`L-008`, `unwitnessed_allowed`), so a claim no hash witnesses stops being invisible.
- **058** · one spelling for the retroactive-adoption defects heading, by computed anchor rather than literal text.
- **059** · `index orphans` and `coverage --fail-on-untraced` stop misleading a specify-first or package-less corpus.
- **060** · `registry plan` answers the whole question (title, `depends_on` states, why each blocked spec is blocked) and `--next` names one pick.
- **062** · `[meta] required_version`, a version pin the CLI checks on every verb.
- **063** · a usage error maps to exit **3**, so exit 2 from any verb means staleness and nothing else.
- **069** · the shipped `extra_hashed_inputs` default hashes what it names.

**The kit and the scaffold.** 061 (the scaffold ships what every adopter wrote by hand: the annotated config, the real constitution template, the `build-meta.json` and `state_dir` gitignore lines), 064 (the composite gate, `govern.yml`, and the `.derived/` merge driver), 065 (`init --with-kit`, so the corpus and the harness are one adoption), 066-068 (the contract's lifecycle table and extra keys, the interactions adopters derived by experiment, a path-scoped rule the kit actually ships), and 051 (the harness runs the verbs the tool already shipped).

## Upgrade notes

Two changes an adopter will notice:

- **A one-time index restale (069).** The `[index] extra_hashed_inputs` default was `["standards/**", ".github/workflows/**"]`, which in the `glob` crate enumerates directories and therefore matched **no files**: every adopter who never overrode it was folding zero extra files into the content hash and was told nothing. It becomes `["standards/**/*", ".github/workflows/**/*"]`. An adopter who already wrote the working form sees no change; one who did not gets a single restale, then a governance surface that is genuinely in the hash.
- **Exit 3 for usage errors (063).** A wrapper that read exit 2 as "either a stale binary or a stale ledger" and disambiguated on stderr can drop that ritual.

## Schema axis

`VERDICT_SCHEMA_VERSION` moved 0.2.0 to 0.3.0 (spec 056 added `compile.spec`), an additive minor already on main. `REGISTRY`, `INDEX`, `BUILD_META` and `CONFIG` schema versions are unchanged.

## Waiver

The gate reports the two violations every version-bump PR reports. Spec 030's auto-waiver correctly does **not** fire here: a package's own `version` field is not a dependency edit, so this needs the standing manual waiver. Approved by the maintainer for this release.

Spec-Drift-Waiver: A release version bump. `npm/package.json` and `py/pyproject.toml` change only their `version` field and the version-locked `optionalDependencies` pins, which specs 007 and 008 require to track the tag; neither spec's behavior changes, so there is nothing to author in them. This is the standing waiver every version-bump PR carries (cf. #57, #80, #88, #103, #109).

## Testing

- `scripts/bump_version.py --check 0.16.0`: all five locations agree
- `Cargo.lock` regenerated (the documented `--locked` footgun: it fails until the lockfile is rewritten)
- `compile` 70 specs / 0 warnings; `index` 4 packages / 70 mappings / 0 error diagnostics
- `lint --fail-on-warn`: 0/0/0
- `index check --fail-on-unresolved`: fresh, 71 unwitnessed (71 allowed)
- `index coverage --fail-on-untraced`: 79/79 specifically claimed (100%)
- `couple`: 2 violations, both waived by the line above; exit 0
- `cargo test --workspace --locked`: 30 suites, 0 failures
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo fmt --all --check`: clean
- `cargo package --workspace --locked`: all three crates cross-verify from packaged sources