### PR TITLE
fix(070): a malformed id is refused, not a panic

### DIFF
--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -1,0 +1,63 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "001-compile-registry",
+      "053-depends-on-ordinal-monotonicity"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/compile.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/00-architecture.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "specId": "070-a-malformed-id-is-refused-not-a-panic",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "0c79e96c92f5ed5389e4a3ac26bcd18080a141ac09de7026e318854abd37c3ae"
+}

--- a/.derived/spec-registry/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/spec-registry/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -1,0 +1,59 @@
+{
+  "record": {
+    "created": "2026-09-08",
+    "dependsOn": [
+      "001-compile-registry",
+      "053-depends-on-ordinal-monotonicity"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/compile.rs"
+        }
+      }
+    ],
+    "id": "070-a-malformed-id-is-refused-not-a-panic",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "070: A malformed id is refused, not a panic",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The numeric prefix is read by character, and only when numeric",
+      "3.2 An id with no numeric prefix is not a V-004 candidate",
+      "3.3 What must keep working",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/070-a-malformed-id-is-refused-not-a-panic/spec.md",
+    "status": "draft",
+    "summary": "`detect_duplicates` reads a spec id's V-004 prefix as `&id[..id.len().min(3)]`, a byte slice. An id whose fourth byte falls inside a multi-byte character panics the process instead of diagnosing it, so `a日本-spec` exits 101 with a backtrace where the corpus should have been refused at exit 1 by V-012, the code that exists to name exactly that malformation. Spec 053 §4 found the defect, declined to fix it from inside a lint change, and asked for this spec. The fix reads the prefix the way spec 001 §3.2 already describes it, as a numeric prefix (`NNN`), using the character-safe leading-digit-run rule spec 053 established in `lint.rs`.\n",
+    "title": "A malformed id is refused, not a panic"
+  },
+  "shardHash": "0eb00521f60e41355ae50291eca3a56dbfea6a2f565f9901faaaeeee9e44191e",
+  "specVersion": "1.1.0"
+}

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -343,6 +343,20 @@ fn validate_spec(
     }
 }
 
+/// The leading run of ASCII decimal digits of `id`, as a sub-slice of it.
+///
+/// This is the `NNN` of spec 001 §3.2, read by character. Slicing `&id[..3]`
+/// outright panics when byte 3 falls inside a multi-byte character, which is
+/// the defect spec 070 fixes; counting ASCII digits can only ever stop on a
+/// character boundary, because every byte it accepts is a one-byte character.
+/// An id with no leading digit yields `""`, which spec 070 §3.2 defines as
+/// having no numeric prefix at all. `lint.rs::ordinal` reads the same run and
+/// parses it, because ordering is a different question about these characters.
+fn numeric_prefix(id: &str) -> &str {
+    let end = id.bytes().take_while(u8::is_ascii_digit).count();
+    &id[..end]
+}
+
 /// V-003 (duplicate id) and V-004 (duplicate numeric prefix). `specs` is
 /// `(id, spec_path)` pairs in discovery order.
 fn detect_duplicates(specs: &[(String, String)], out: &mut Vec<Violation>) {
@@ -350,7 +364,12 @@ fn detect_duplicates(specs: &[(String, String)], out: &mut Vec<Violation>) {
     let mut prefix_owner: BTreeMap<&str, &str> = BTreeMap::new();
     for (id, spec_path) in specs {
         *id_counts.entry(id.as_str()).or_insert(0) += 1;
-        let prefix = &id[..id.len().min(3)];
+        // Spec 070 §3.2: an id with no numeric prefix shares one with nothing,
+        // so it is not a V-004 candidate. V-012 is what refuses it.
+        let prefix = numeric_prefix(id);
+        if prefix.is_empty() {
+            continue;
+        }
         match prefix_owner.get(prefix) {
             Some(other) if *other != id.as_str() => out.push(error(
                 "V-004",

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -131,6 +131,58 @@ fn v004_duplicate_prefix() {
 }
 
 #[test]
+fn v004_reads_a_non_ascii_id_without_panicking() {
+    // Spec 070 §3.1: `a日本-spec` puts a three-byte character across byte 3, the
+    // offset the old byte slice indexed at unconditionally. Reading the prefix
+    // must diagnose the id, not abort the process on its way to doing so.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "a日本-spec", "a日本-spec", "");
+    let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
+    assert!(
+        c.contains(&"V-012".to_string()),
+        "id pattern is the finding: {c:?}"
+    );
+    assert!(
+        !c.contains(&"V-004".to_string()),
+        "no numeric prefix: {c:?}"
+    );
+}
+
+#[test]
+fn v004_ignores_ids_with_no_numeric_prefix() {
+    // Spec 070 §3.2: these share three leading letters and no ordinal, so they
+    // collide on nothing. `aut` was never a numeric prefix. V-012 is the
+    // finding, and V-004 used to be noise printed beside it.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "auth-login", "auth-login", "");
+    write_spec(tmp.path(), "auth-logout", "auth-logout", "");
+    let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
+    assert!(
+        !c.contains(&"V-004".to_string()),
+        "no numeric prefix: {c:?}"
+    );
+    assert!(
+        c.contains(&"V-012".to_string()),
+        "id pattern is the finding: {c:?}"
+    );
+}
+
+#[test]
+fn v004_ignores_a_multibyte_prefix_that_lands_on_a_boundary() {
+    // Spec 070 §3.2: `日本-x` is the case the old slice did not panic on, and
+    // got wrong anyway: three bytes is one character, so it reported the
+    // "numeric prefix" `日` as shared. A non-ordinal is still not an ordinal.
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "日本-x", "日本-x", "");
+    write_spec(tmp.path(), "日本-y", "日本-y", "");
+    let c = codes(&compile(&Config::default(), tmp.path()).unwrap());
+    assert!(
+        !c.contains(&"V-004".to_string()),
+        "no numeric prefix: {c:?}"
+    );
+}
+
+#[test]
 fn supersedes_full_emits_bare_string_partial_emits_object() {
     // Spec 019: a full supersedes (bare id or `{ scope: full }`) serializes as a
     // bare predecessor id, byte-stable wire; a partial item serializes as an

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -180,6 +180,12 @@ fn v004_ignores_a_multibyte_prefix_that_lands_on_a_boundary() {
         !c.contains(&"V-004".to_string()),
         "no numeric prefix: {c:?}"
     );
+    // Assert the finding that must remain, not only the one that must go:
+    // without this the test would still pass if V-012 were suppressed here.
+    assert!(
+        c.contains(&"V-012".to_string()),
+        "id pattern is the finding: {c:?}"
+    );
 }
 
 #[test]

--- a/specs/070-a-malformed-id-is-refused-not-a-panic/spec.md
+++ b/specs/070-a-malformed-id-is-refused-not-a-panic/spec.md
@@ -1,0 +1,197 @@
+---
+id: "070-a-malformed-id-is-refused-not-a-panic"
+title: "A malformed id is refused, not a panic"
+status: draft
+kind: "tooling"
+created: "2026-09-08"
+implementation: complete
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "001-compile-registry"
+  - "053-depends-on-ordinal-monotonicity"
+extends:
+  # 3.1 and 3.2: the V-004 prefix, computed by character and only when numeric.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
+  # 3.3: the regression guards.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/tests/compile.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  `detect_duplicates` reads a spec id's V-004 prefix as `&id[..id.len().min(3)]`,
+  a byte slice. An id whose fourth byte falls inside a multi-byte character
+  panics the process instead of diagnosing it, so `a日本-spec` exits 101 with a
+  backtrace where the corpus should have been refused at exit 1 by V-012, the
+  code that exists to name exactly that malformation. Spec 053 §4 found the
+  defect, declined to fix it from inside a lint change, and asked for this spec.
+  The fix reads the prefix the way spec 001 §3.2 already describes it, as a
+  numeric prefix (`NNN`), using the character-safe leading-digit-run rule spec
+  053 established in `lint.rs`.
+---
+
+# 070: A malformed id is refused, not a panic
+
+## 1. Purpose
+
+Restore the panic-free-on-user-input invariant to `compile`, and with it the
+stable exit-code contract, for the one input that currently breaks both.
+
+`crates/spec-spine-core/src/compile.rs` computes the V-004 duplicate-prefix key
+as:
+
+```rust
+let prefix = &id[..id.len().min(3)];
+```
+
+That is a byte slice at a fixed offset. Rust's `str` indexing panics when the
+offset is not a character boundary, so any id whose byte 3 falls inside a
+multi-byte character aborts the process:
+
+```
+thread 'main' panicked at crates/spec-spine-core/src/compile.rs:353:25:
+byte index 3 is not a char boundary; it is inside '日' (bytes 1..4) of `a日本-spec`
+```
+
+Two contracts break at once. `CLAUDE.md` states that core is "panic-free on user
+input: malformed config/frontmatter yields a clean `Error`, never a panic", and
+the corpus publishes `0` / `1` / `2` / `3` as a stable exit-code contract. A
+panic spends 101, which is not in that set, and it preempts the diagnosis: the
+directory name is already a `V-012` violation, and `V-012` is the code whose
+whole job is to say so. The tool crashes on its way to telling the truth.
+
+The trigger is narrow (an id is authored, not attacker-supplied) which is why
+this is `risk: medium` rather than higher. It is still the only known input that
+makes a governed read abort instead of answering, and a gate that can crash is a
+gate an adopter cannot put in CI with confidence.
+
+## 2. Territory
+
+No new files. Two units, both owned by spec 001 and both `extends`-ed here:
+
+| Unit | Owner | What changes |
+|---|---|---|
+| `crates/spec-spine-core/src/compile.rs` | 001 | `detect_duplicates` reads a character-safe numeric prefix |
+| `crates/spec-spine-core/tests/compile.rs` | 001 | the regression guards for §3.1 to §3.3 |
+
+This spec changes no stated requirement of spec 001, so it declares no `amends`
+edge. Spec 001 §3.2 already defines the code as "`V-004` duplicate numeric
+prefix (`NNN`) across different slugs"; the implementation simply never matched
+that sentence. What lands here is conformance to the owning spec, which is the
+one kind of change an implementing spec may make inside another's territory
+without amending it.
+
+## 3. Behavior
+
+### 3.1 The numeric prefix is read by character, and only when numeric
+
+`detect_duplicates` MUST compute a spec id's numeric prefix as its **leading run
+of ASCII decimal digits**, iterating characters, never by byte index. This is
+the rule spec 053 already established for `lint.rs::ordinal`, whose doc comment
+names this very defect as the thing it does not inherit. The two readings of an
+ordinal in this codebase are now the same reading.
+
+For a conformant id the run is exactly the `NNN` that `V-012` requires, so
+nothing about a well-formed corpus changes.
+
+### 3.2 An id with no numeric prefix is not a V-004 candidate
+
+An id whose leading digit run is empty MUST NOT participate in V-004 at all: it
+has no numeric prefix, so it can share one with nothing.
+
+This is what spec 001 §3.2 says, and the byte-slice implementation contradicted
+it in a second, quieter way. Given the legal-on-disk ids `auth-login` and
+`auth-logout`, the old code reported:
+
+```
+V-004 numeric prefix 'aut' is shared by 'auth-login' and 'auth-logout'
+```
+
+`aut` is not a numeric prefix, and the two specs do not collide. The diagnostic
+was noise printed beside the `V-012` violations that were the real finding.
+Silence is the honest answer when there is no ordinal, which is the same
+argument spec 053 made for `ordinal` returning `None`.
+
+### 3.3 What must keep working
+
+V-004 MUST still fire for two distinct slugs sharing a numeric prefix
+(`007-alpha` and `007-beta`), which is the check's entire purpose, and V-003
+MUST still fire for a genuinely duplicated id. The regression guards in
+`tests/compile.rs` cover the panic input, both shapes of id that carry no
+ordinal (the one that straddles byte 3 and the one that lands exactly on it),
+and the two pre-existing true positives, so a future refactor cannot quietly
+reintroduce either half of the defect.
+
+## 4. Out of scope
+
+**Widening the id grammar.** `V-012` continues to require
+`^[0-9]{3}-[a-z0-9]+(-[a-z0-9]+)*$`. This spec changes what happens on the way
+to that refusal, never the refusal itself: a non-ASCII id is still an invalid
+id, it is simply now *reported* as one. Whether the corpus should accept
+non-numeric ids is a real question and a different spec's.
+
+**Ordinals wider than three digits.** `lint.rs::ordinal` parses an arbitrary
+digit run so that `1001-foo` sorts above `999-bar`, while `V-012` caps the id at
+three. That inconsistency is real and predates this spec. Aligning them is a
+grammar decision, and §4's first paragraph defers it for the same reason.
+
+**Auditing the rest of the codebase for byte slicing.** This spec's change came
+with a sweep of `&str` slicing across `spec-spine-core` and
+`spec-spine-types`. Every other site indexes at an offset returned by `find`, or
+behind `valid_id`'s guard that byte 3 is `-`, and is a character boundary by
+construction. The sweep found one defect and it is fixed here; standing
+enforcement (a lint, a clippy rule) is not proposed, because a rule that fires
+on every safe `find`-derived slice would cost more than it catches.
+
+## 5. Resolved decisions
+
+**2026-09-08: compare digit runs as strings, not as parsed integers.**
+`detect_duplicates` reports the prefix in its message, so it needs the text.
+Parsing to `u64` and formatting back would turn `007` into `7` in the
+diagnostic, and would make `07` and `007` collide as the same prefix when they
+are different (malformed) directory names. The check is about a shared textual
+`NNN`; the string is the right key. `lint.rs::ordinal` parses because it needs
+to *order*, which is a different question about the same characters.
+
+**2026-09-08: no `amends` edge on spec 001.** Considered and rejected: an
+`amends` edge says the amending spec changes what the amended spec requires
+(spec 040). Spec 001 §3.2 requires a numeric prefix check and is unchanged by
+this work. Declaring `amends` here would record a contradiction that does not
+exist and would make the ledger's amendment history less trustworthy, not more.
+
+## Verification
+
+Each line below is one command: spec 049 §3.2 makes a fence's body line a
+command, so no line may depend on a variable another line set. The scratch
+corpora are materialized at fixed paths for that reason.
+
+Every assertion fails against pre-070 code. The first repro aborts at exit 101
+with a char-boundary panic instead of exiting 1, and the second prints the
+`V-004` line that §3.2 removes.
+
+```verify:cli
+# Self-contained: the assertions below drive the release binary.
+cargo build --release --locked
+# 3.3 the regression guards, which panic rather than fail against pre-070 code.
+cargo test -p spec-spine-core --test compile --locked
+# A corpus whose id puts a multi-byte character across byte 3.
+rm -rf "${TMPDIR:-/tmp}/ss070a" && mkdir -p "${TMPDIR:-/tmp}/ss070a/specs/a日本-spec"
+printf -- '---\nid: "a日本-spec"\ntitle: "t"\nstatus: draft\ncreated: "2026-09-08"\nsummary: "s"\n---\n\n# t\n' > "${TMPDIR:-/tmp}/ss070a/specs/a日本-spec/spec.md"
+# 3.1 it is refused by the code that names the real malformation...
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss070a" compile 2>&1 | grep -q 'V-012'
+# ...at exit 1, inside the stable contract, never the 101 a panic spends.
+sh -c 'target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss070a" compile >/dev/null 2>&1; test $? -eq 1'
+# A corpus of two legal-on-disk ids that share three leading letters.
+rm -rf "${TMPDIR:-/tmp}/ss070b" && mkdir -p "${TMPDIR:-/tmp}/ss070b/specs/auth-login" "${TMPDIR:-/tmp}/ss070b/specs/auth-logout"
+printf -- '---\nid: "auth-login"\ntitle: "t"\nstatus: draft\ncreated: "2026-09-08"\nsummary: "s"\n---\n\n# t\n' > "${TMPDIR:-/tmp}/ss070b/specs/auth-login/spec.md"
+printf -- '---\nid: "auth-logout"\ntitle: "t"\nstatus: draft\ncreated: "2026-09-08"\nsummary: "s"\n---\n\n# t\n' > "${TMPDIR:-/tmp}/ss070b/specs/auth-logout/spec.md"
+# 3.2 no ordinal means no V-004, and V-012 remains the finding.
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss070b" compile 2>&1 | grep -q 'V-004'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss070b" compile 2>&1 | grep -q 'V-012'
+# A corpus of two conformant ids that genuinely share NNN.
+rm -rf "${TMPDIR:-/tmp}/ss070c" && mkdir -p "${TMPDIR:-/tmp}/ss070c/specs/007-alpha" "${TMPDIR:-/tmp}/ss070c/specs/007-beta"
+printf -- '---\nid: "007-alpha"\ntitle: "t"\nstatus: draft\ncreated: "2026-09-08"\nsummary: "s"\n---\n\n# t\n' > "${TMPDIR:-/tmp}/ss070c/specs/007-alpha/spec.md"
+printf -- '---\nid: "007-beta"\ntitle: "t"\nstatus: draft\ncreated: "2026-09-08"\nsummary: "s"\n---\n\n# t\n' > "${TMPDIR:-/tmp}/ss070c/specs/007-beta/spec.md"
+# 3.3 the true positive still fires, naming the shared numeric prefix.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss070c" compile 2>&1 | grep -q "numeric prefix '007' is shared"
+rm -rf "${TMPDIR:-/tmp}/ss070a" "${TMPDIR:-/tmp}/ss070b" "${TMPDIR:-/tmp}/ss070c"
+```


### PR DESCRIPTION
Spec 070 fixes the one input that makes a governed read abort instead of answering.

## The defect

`detect_duplicates` computed the V-004 duplicate-prefix key as a byte slice at a fixed offset:

```rust
let prefix = &id[..id.len().min(3)];
```

Rust's `str` indexing panics when the offset is not a character boundary, so any id whose byte 3 falls inside a multi-byte character aborted the process:

```
thread 'main' panicked at crates/spec-spine-core/src/compile.rs:353:25:
byte index 3 is not a char boundary; it is inside '日' (bytes 1..4) of `a日本-spec`
```

Two contracts broke at once. `CLAUDE.md` states that core is "panic-free on user input: malformed config/frontmatter yields a clean `Error`, never a panic", and the corpus publishes `0` / `1` / `2` / `3` as a stable exit-code contract. A panic spends 101, which is not in that set, and it preempted the diagnosis: the id is already a `V-012` violation, and `V-012` is the code whose whole job is to say so. The tool crashed on its way to telling the truth.

A second, quieter defect rode along. Given the ids `auth-login` and `auth-logout`, the old code reported `V-004 numeric prefix 'aut' is shared`. `aut` is not a numeric prefix and those two specs collide on nothing.

Spec 053 §4 found the panic, declined to fix it from inside a lint change, and asked for this spec by name.

## The fix

The prefix is now the leading run of ASCII decimal digits, read by character: the `NNN` that spec 001 §3.2 already describes, and the same rule `lint.rs::ordinal` has applied since spec 053. Counting ASCII digits can only ever stop on a character boundary, so the panic is unreachable by construction rather than guarded against. An id with no leading digit has no numeric prefix and no longer participates in V-004 at all.

**No `amends` edge.** Spec 001 §3.2 has always specified a numeric prefix (`NNN`); the implementation simply never matched that sentence. What lands here is conformance to the owning spec, declared as two `extends` edges on 001's `src/compile.rs` and `tests/compile.rs`.

## Verification

Three regression guards, each failing against pre-070 code for its own reason: the panic input, an id carrying no ordinal, and a multi-byte prefix landing exactly on byte 3 (the case that did not panic and was wrong anyway). Confirmed by reverting `src/compile.rs` and re-running them:

```
v004_reads_a_non_ascii_id_without_panicking          panicked: byte index 3 is not a char boundary
v004_ignores_ids_with_no_numeric_prefix              no numeric prefix: ["V-004", "V-012", "V-012"]
v004_ignores_a_multibyte_prefix_that_lands_on_a_boundary  no numeric prefix: ["V-004", "V-012", "V-012"]
```

`spec-spine verify 070` passes all 16 commands. The gate as `AGENTS.md` lists it is green end to end, and `couple --base origin/main --head HEAD` reports 3 paths checked, no drift: **no waiver needed**.

Filed `status: draft`, `implementation: complete`. The draft to approved flip is the follow-up ratify PR.

## Out of scope

Widening the id grammar (`V-012` still requires `^[0-9]{3}-...`), reconciling `ordinal`'s arbitrary-width digit run with that three-digit cap, and any standing lint against byte slicing. A sweep of `&str` slicing across `spec-spine-core` and `spec-spine-types` found this one defect; every other site indexes at an offset returned by `find` or behind `valid_id`'s guard that byte 3 is `-`.
