### PR TITLE
chore(070-071): ratify the push-gate and id-panic fixes (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -56,8 +56,8 @@
       }
     ],
     "specId": "070-a-malformed-id-is-refused-not-a-panic",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c5bf14aa42135ac8ac136174985b2f2cd4cdc56806d637c0409295b00cab1c6a"
+  "shardHash": "a4b99a059fd085e5a7632b13d34df4657ec4e76070a5930bb2de431a93b1abeb"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -94,8 +94,8 @@
       }
     ],
     "specId": "071-a-tag-push-is-not-a-push-to-main",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9c41a5d9fba5e6ce09a92a25476c587da085ebeb576704685a3eb7ea0576323e"
+  "shardHash": "5db38bb19a09c54c3e5b57f351b184df3e1e14e388f3607960a06fbb52e89389"
 }

--- a/.derived/spec-registry/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/spec-registry/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -50,10 +50,10 @@
       "Verification"
     ],
     "specPath": "specs/070-a-malformed-id-is-refused-not-a-panic/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`detect_duplicates` reads a spec id's V-004 prefix as `&id[..id.len().min(3)]`, a byte slice. An id whose fourth byte falls inside a multi-byte character panics the process instead of diagnosing it, so `a日本-spec` exits 101 with a backtrace where the corpus should have been refused at exit 1 by V-012, the code that exists to name exactly that malformation. Spec 053 §4 found the defect, declined to fix it from inside a lint change, and asked for this spec. The fix reads the prefix the way spec 001 §3.2 already describes it, as a numeric prefix (`NNN`), using the character-safe leading-digit-run rule spec 053 established in `lint.rs`.\n",
     "title": "A malformed id is refused, not a panic"
   },
-  "shardHash": "0eb00521f60e41355ae50291eca3a56dbfea6a2f565f9901faaaeeee9e44191e",
+  "shardHash": "9a606a88854954ef3098e3793088f5e016c259d34954caa7cb178c0ebcd5c69e",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/spec-registry/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -70,10 +70,10 @@
       "Verification"
     ],
     "specPath": "specs/071-a-tag-push-is-not-a-push-to-main/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The kit's push gate refuses a push two ways: by refspec, and by current branch. The branch half is unconditional, so it refuses a tag push made from main, which is exactly what docs/releasing.md tells a maintainer to run the moment the release PR merges. The shipped harness makes the shipped release procedure unexecutable, and it did that to v0.16.0. The outer match is a substring test over the whole command, so it also refuses a grep or a heredoc that merely mentions the gate. This spec narrows the branch refusal to a push that would actually update main, anchors the outer match on the push verb, and replaces the substring assertion that could not see either defect with a guard that runs the gate.\n",
     "title": "A tag push is not a push to main"
   },
-  "shardHash": "75d29b45145622af23ad877004e9647b9ea33617eefd77535e740ff239b35f43",
+  "shardHash": "4899cb5f0db01c311f3a54df3055fde6dc0f218fc0fcce978c319338b5548fa8",
   "specVersion": "1.1.0"
 }

--- a/specs/070-a-malformed-id-is-refused-not-a-panic/spec.md
+++ b/specs/070-a-malformed-id-is-refused-not-a-panic/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "070-a-malformed-id-is-refused-not-a-panic"
 title: "A malformed id is refused, not a panic"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete

--- a/specs/071-a-tag-push-is-not-a-push-to-main/spec.md
+++ b/specs/071-a-tag-push-is-not-a-push-to-main/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "071-a-tag-push-is-not-a-push-to-main"
 title: "A tag push is not a push to main"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete


### PR DESCRIPTION
Ratifies the two specs that landed today, completing the repository's file-then-build-then-ratify loop for both.

## What flips

| Spec | What it fixed |
|---|---|
| `070-a-malformed-id-is-refused-not-a-panic` | The V-004 numeric prefix is read by character, so an id whose byte 3 falls inside a multi-byte character is refused by V-012 at exit 1 rather than aborting the process at 101, outside the stable exit-code contract. |
| `071-a-tag-push-is-not-a-push-to-main` | The kit's push gate refuses only a push that would actually update the default branch, so the release runbook's tag push is executable again, and the gate is asserted by a guard that runs it. |

Both shipped with `implementation: complete` and their `## Verification` blocks passing, so `status: draft -> approved` is the remaining half of the loop.

## Result

Corpus is **72 total, 72 approved**. `registry plan` reports `(nothing ready), blocked: 0`.

## Note on the diff

Two one-line frontmatter changes plus regenerated shards. The substitution was anchored to the start of a line deliberately: spec 070's verification block embeds five `status: draft` strings inside `printf` fixtures that build throwaway corpora, and a blind replace would have corrupted its acceptance. Only the frontmatter line changed; the fixtures are untouched.

`couple --base origin/main --head HEAD` reports 2 paths checked, no drift. No waiver needed.
