### PR TITLE
chore(release): bump package version to 0.17.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c5d9b07857cf8263b42a31dca9ac1397bd725fe936d3670614adfe30d54f5b2a"
+  "shardHash": "b01fa7e8951dc8a889044776f5fd45943c94964d601897a08b80ea7581987785"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "3"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.16.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.16.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.17.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.17.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.16.0",
-    "@spec-spine/cli-darwin-x64": "0.16.0",
-    "@spec-spine/cli-linux-x64": "0.16.0",
-    "@spec-spine/cli-linux-arm64": "0.16.0",
-    "@spec-spine/cli-win32-x64": "0.16.0"
+    "@spec-spine/cli-darwin-arm64": "0.17.0",
+    "@spec-spine/cli-darwin-x64": "0.17.0",
+    "@spec-spine/cli-linux-x64": "0.17.0",
+    "@spec-spine/cli-linux-arm64": "0.17.0",
+    "@spec-spine/cli-win32-x64": "0.17.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.16.0"
+version = "0.17.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares **v0.17.0**. Version-bump only; the tag is pushed after this merges.

## What ships

Two specs, **070 and 071**, both fixes, both ratified in #141 (corpus 72/72 approved).

- **070** · `detect_duplicates` read the V-004 numeric prefix as a byte slice at a fixed offset, so a spec id whose byte 3 fell inside a multi-byte character aborted the process at **exit 101**, outside the stable 0/1/2/3 contract, and preempted the `V-012` violation that names the real malformation. The prefix is now the leading run of ASCII decimal digits, read by character: the `NNN` spec 001 §3.2 always described, and the rule `lint.rs::ordinal` has applied since spec 053. An id with no leading digit no longer participates in V-004 at all, which also removes a nonsense diagnostic reporting `aut` as a numeric prefix shared by `auth-login` and `auth-logout`.
- **071** · the kit's push gate refused **every** push made from the default branch, tag pushes included, so the shipped harness made the shipped release procedure unexecutable. It did exactly that to v0.16.0. The branch refusal now fires only on a push that would actually update the branch. Its outer match is anchored on the command that invokes the verb rather than substring-matching the whole command, which had been refusing any grep or heredoc that merely mentioned the gate.

## Upgrade notes

**Adopters who copied the kit should re-copy `settings.json`.** The push-gate fix lives in the hook body, so an adopter running the old copy still cannot push a release tag from their default branch. Nothing else about the hook changed.

Spec 070 is a pure correctness fix with no configuration surface: a corpus whose ids all match `^[0-9]{3}-` sees no behavior change whatsoever.

## Schema axis

No change. `REGISTRY`, `INDEX`, `BUILD_META`, `CONFIG` and `VERDICT` schema versions are all untouched since v0.16.0; `crates/spec-spine-types/src/version.rs` has an empty diff against the tag. This is a release that ships without a schema change, which the two axes are decoupled to allow.

## Waiver

The gate reports the two violations every version-bump PR reports. Spec 030's auto-waiver correctly does **not** fire here: a package's own `version` field is not a dependency edit, so this needs the standing manual waiver. Approved by the maintainer for this release.

Spec-Drift-Waiver: A release version bump. `npm/package.json` and `py/pyproject.toml` change only their `version` field and the version-locked `optionalDependencies` pins, which specs 007 and 008 require to track the tag; neither spec's behavior changes, so there is nothing to author in them. This is the standing waiver every version-bump PR carries (cf. #57, #80, #88, #103, #109, #138).

## Testing

- `scripts/bump_version.py --check 0.17.0`: all five locations agree
- `cargo test --workspace --locked`, `clippy -D warnings`, `fmt --check`: clean
- `compile --check`, `lint --fail-on-warn`, `index check --fail-on-unresolved`, `index coverage --fail-on-untraced`: green, 72 shards fresh, 79/79 files claimed
- `couple`: the two C-001 violations above, cleared by the waiver