### PR TITLE
docs(076): draft spec 076, planned territory is declared, not inferred

### DIFF
--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -204,5 +204,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b55f1b6747474922080dd031da0a93fb93bd0d03d19ac492e76366031cab4d97"
+  "shardHash": "5aaefb18e22586c6d46672a4f637f6947379d42cf642f81f4c4eaf684d9f34f0"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -204,5 +204,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bf12aa3fba202adda115b01c55c754ef35be7bd3cad6811cdd5ec26fa321a714"
+  "shardHash": "3d6fd1048d6f651a75754a81230533d705befe52fde7117045f225b528b2a38d"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -1,0 +1,208 @@
+{
+  "mapping": {
+    "amends": [
+      "025-unresolved-unit-severity"
+    ],
+    "dependsOn": [
+      "003-conformance-lint",
+      "004-codebase-index",
+      "025-unresolved-unit-severity",
+      "032-ownership-coverage",
+      "038-registry-plan-ready-set",
+      "041-completion-held-to-claims",
+      "050-index-diagnostics-reach-a-gate",
+      "074-shipped-is-not-the-same-as-working"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/query.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/unit.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/version.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/dtos.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/tests/grammar.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/unit.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/unit.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/version.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/dtos.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/tests/grammar.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/grammar.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/00-architecture.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "specId": "076-planned-territory-is-declared-not-inferred",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "bf12aa3fba202adda115b01c55c754ef35be7bd3cad6811cdd5ec26fa321a714"
+}

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -204,5 +204,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3d6fd1048d6f651a75754a81230533d705befe52fde7117045f225b528b2a38d"
+  "shardHash": "b55f1b6747474922080dd031da0a93fb93bd0d03d19ac492e76366031cab4d97"
 }

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -131,6 +131,6 @@
     "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
     "title": "Planned territory is declared, not inferred"
   },
-  "shardHash": "4683f8b37535995f10464fedd2716ae1b46a44a192fc59d8fae9ae39d39515c3",
+  "shardHash": "2b27d110b19e44d7239f1757d9c644f44f5da88734817bcfa340b5ff34936869",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -1,0 +1,136 @@
+{
+  "record": {
+    "amends": [
+      "025-unresolved-unit-severity"
+    ],
+    "created": "2026-09-08",
+    "dependsOn": [
+      "003-conformance-lint",
+      "004-codebase-index",
+      "025-unresolved-unit-severity",
+      "032-ownership-coverage",
+      "038-registry-plan-ready-set",
+      "041-completion-held-to-claims",
+      "050-index-diagnostics-reach-a-gate",
+      "074-shipped-is-not-the-same-as-working"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/unit.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/grammar.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/tests/dtos.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "032-ownership-coverage",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/coverage.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "038-registry-plan-ready-set",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/query.rs"
+        }
+      }
+    ],
+    "id": "076-planned-territory-is-declared-not-inferred",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/00-architecture.md"
+        }
+      }
+    ],
+    "risk": "medium",
+    "sectionHeadings": [
+      "076: Planned territory is declared, not inferred",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The flag",
+      "3.2 A planned unit is a declared state, not a diagnostic (amends 025)",
+      "3.3 The flag cannot outlive the work",
+      "3.4 A planned unit that has resolved is reported",
+      "3.5 Collisions reuse the ownership rules",
+      "3.6 The ledger records planned territory as a state",
+      "3.7 Schema and version",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/076-planned-territory-is-declared-not-inferred/spec.md",
+    "status": "draft",
+    "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
+    "title": "Planned territory is declared, not inferred"
+  },
+  "shardHash": "4683f8b37535995f10464fedd2716ae1b46a44a192fc59d8fae9ae39d39515c3",
+  "specVersion": "1.1.0"
+}

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -131,6 +131,6 @@
     "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
     "title": "Planned territory is declared, not inferred"
   },
-  "shardHash": "9eaa99033d32e5b52a8bdb394810c6d1e4558e53e7ff3797edf389297df5ba07",
+  "shardHash": "408044e68f619e16a3309eadaabdeef913eb6f87d2bc5387a1781fa3ed87542d",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -131,6 +131,6 @@
     "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
     "title": "Planned territory is declared, not inferred"
   },
-  "shardHash": "2b27d110b19e44d7239f1757d9c644f44f5da88734817bcfa340b5ff34936869",
+  "shardHash": "9eaa99033d32e5b52a8bdb394810c6d1e4558e53e7ff3797edf389297df5ba07",
   "specVersion": "1.1.0"
 }

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -1,0 +1,348 @@
+---
+id: "076-planned-territory-is-declared-not-inferred"
+title: "Planned territory is declared, not inferred"
+status: draft
+kind: "tooling"
+created: "2026-09-08"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "003-conformance-lint"
+  - "004-codebase-index"
+  - "025-unresolved-unit-severity"
+  - "032-ownership-coverage"
+  - "038-registry-plan-ready-set"
+  - "041-completion-held-to-claims"
+  - "050-index-diagnostics-reach-a-gate"
+  - "074-shipped-is-not-the-same-as-working"   # allocates L-010; this spec takes the next two
+amends:
+  # 025 FR-002 requires an unresolved unit from an owning edge, whose owning
+  # spec is `draft` or `implementation: pending`, to be emitted as `W-001`.
+  # 3.2 below makes a unit marked `planned` a declared state that produces no
+  # W-001 at all, which changes what FR-002 requires.
+  - "025-unresolved-unit-severity"
+extends:
+  - spec: "004-codebase-index"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/unit.rs"        # the optional flag on the unit payload
+      - "crates/spec-spine-core/src/index.rs"        # classification and the declared state
+      - "crates/spec-spine-types/tests/grammar.rs"   # round-trip and rejection
+      - "crates/spec-spine-core/tests/index.rs"
+  - spec: "001-compile-registry"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/version.rs"     # REGISTRY_SCHEMA_VERSION 1.1.0 -> 1.2.0
+      - "crates/spec-spine-types/tests/dtos.rs"
+  - spec: "003-conformance-lint"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/lint.rs"         # L-011 and L-012
+      - "crates/spec-spine-core/tests/lint.rs"
+  - spec: "032-ownership-coverage"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/coverage.rs"     # planned territory in the report
+  - spec: "038-registry-plan-ready-set"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/query.rs"        # planned territory in the plan
+references:
+  - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
+summary: >
+  A spec cannot say what it intends to own. Ownership is only ever inferred
+  from a unit resolving on disk, so a corpus that opts into spec 050's
+  `--fail-on-unresolved` gate forecloses declaring territory before writing it:
+  every claim must arrive with its file. The cost is that `registry plan` and
+  `index coverage` are blind to planned ownership, a draft's risk understates
+  the work, and two specs can plan the same file with no edge to collide on
+  until one of them ships. This spec adds an optional `planned` flag to the
+  unit payload. A planned unit is a declared state rather than an unresolved
+  one, so it produces no `W-001` and the gate keeps refusing every claim that
+  is merely broken. The flag is bound to the lifecycle field that ends it:
+  a spec at `implementation: complete` carrying one is refused, and a planned
+  unit that has resolved is reported so the flag cannot be left on.
+---
+
+# 076: Planned territory is declared, not inferred
+
+## 1. Purpose
+
+Let a spec say what it intends to own, without weakening the gate that refuses
+a claim which is simply wrong.
+
+Today ownership is inferred from resolution. A unit that does not resolve is an
+unresolved unit, and spec 025 grades it by lifecycle: a warning while the
+owning spec is in flight, an error once it is not. Spec 050 then offers
+`--fail-on-unresolved`, which refuses any `W-001` or `W-002`, for a corpus past
+the specify-first stage. This repository opted in and CI runs it.
+
+The consequence went unnoticed until it bit. **A corpus that sets that flag
+cannot declare territory before writing it at all.** Filing spec 075 with
+`establishes: crates/spec-spine-cli/src/cmd_check.rs` refused the gate on a
+`W-001`, and the claim had to be removed and deferred to the implementing
+change. Specs 072 to 075 are `extends`-only, and that is not a property of
+those changes; it is the gate shaping the corpus.
+
+What is lost is not cosmetic:
+
+- `spec-spine registry plan` and `spec-spine index coverage` say nothing about
+  planned ownership, so the reads that exist to answer "what is being worked
+  on and who will own it" can only see the past.
+- A draft's `risk` understates the work, because the territory it will take is
+  not written down anywhere a tool can read.
+- Two drafts can plan the same file with no edge to collide on. The duplicate
+  ownership surfaces only when the second one ships, which is the latest and
+  most expensive moment to find it.
+
+The obvious fix is to make the gate lifecycle-aware and let a `draft` carry
+unresolved units. That fix is wrong, for a reason specific to this being a
+tool other people adopt: it ties "not written yet" to `status: draft`, which
+only works in a repository that drafts then builds. An adopter who ratifies
+first has `approved` specs planning territory, and the gate would have to
+special-case them. It would also make `--fail-on-unresolved` a near no-op,
+since a settled spec's unresolved unit is already a hard error that plain
+`index check` refuses; refusing `W-001` is the flag's entire marginal value.
+
+A declared field is loop-agnostic and keeps that value. A typo'd path stays a
+`W-001` and stays refused, because nobody marked it planned.
+
+## 2. Territory
+
+No new files. Everything is an additive `extends` except the amendment below.
+
+**This spec `amends` 025.** Its FR-002 requires an unresolved unit from an
+owning edge, on a spec that is `draft` or `implementation: pending`, to be
+emitted as `W-001`. Section 3.2 makes a unit marked `planned` produce no
+diagnostic at all, which changes what FR-002 requires.
+
+**It does not amend 000, and that was the read that decided this spec's shape.**
+The unit vocabulary looked like it might sit under a non-overridable anchor.
+It does not: spec 000 declares `*(anchor: typed-authority-graph)*` explicitly
+on section 4's opening paragraph, which fixes the principle (a spec declares
+typed edges and the authority units it owns; authority is derived by walking
+the graph, never declared directly) and says nothing about the unit payload.
+Section 4.2 records the opposite in spec 000's own words: "The schema is
+permissive on the unit payload, so `directory`/`crate`/`module` were added as
+an additive minor with no schema-file edit." Spec 017, which added those three
+kinds, declared no `amends`. A `planned` flag annotates a claim's resolution
+state; authority still derives from the edge, so the anchored sentence stands.
+
+**It does not amend 050.** Section 3.2 of that spec is phrased over diagnostic
+codes: the flag "MUST exit 1 when the committed index records any `W-001` or
+`W-002`". That rule is unchanged here. What changes is what produces a `W-001`.
+The mechanism composes with the gate rather than carving an exception into it,
+and that is the property that makes it safe.
+
+**It does not amend 041**, which requires that a spec not be treated as in
+flight once `implementation` is `complete`. Section 3.3 extends that principle
+to the new field rather than contradicting it.
+
+**Coupling falls out for free, and the spec relies on it.** Dropping a
+`planned` flag is an edit to `spec.md`, which is exactly the spec-side change
+the coupling gate demands when the claimed file lands. So the implementing PR
+satisfies `couple` by doing the thing this design already requires, with no
+waiver and no special case. That is why this is a mechanism rather than a rule:
+it composes with the gate that was already there.
+
+## 3. Behavior
+
+### 3.1 The flag
+
+A unit MAY carry `planned: true`, meaning the spec claims this territory and
+has not written it yet.
+
+The flag is valid only in the **object form** of a unit. The bare-string file
+shorthand (`"src/thing.rs"`) cannot carry it, and the shorthand grammar MUST
+NOT be extended to allow it: a planned claim is written as
+`{ kind: file, path: "src/thing.rs", planned: true }`. The friction is
+accepted deliberately, because the alternative is a second string grammar to
+parse and a second place for the flag to be misspelled silently.
+
+`planned: false` MUST be accepted and MUST mean exactly what omitting it means,
+so a consumer that round-trips a unit does not change its meaning.
+
+The flag is valid on any unit kind, since a spec may plan a section or a
+symbol as readily as a file.
+
+### 3.2 A planned unit is a declared state, not a diagnostic (amends 025)
+
+An unresolved unit marked `planned` MUST NOT produce `W-001`. It is not an
+unresolved claim; it is a claim whose subject is openly not yet written.
+
+Every other classification is unchanged. An unresolved unit that is **not**
+marked planned still classifies exactly as spec 025 requires: `W-002` from a
+non-owning edge, `W-001` from an owning edge on an in-flight spec, and a hard
+`I-003`..`I-009` error otherwise. A path that is simply wrong is therefore
+still caught, and still refused by `--fail-on-unresolved`, which is the
+property that makes the flag safe to add.
+
+A planned unit MUST NOT contribute a `ResolvedLocation` or a `TraceMapping`
+entry, exactly as an unresolved unit does not. It is a declaration of intent,
+not of ownership, and no authority query may resolve to it.
+
+### 3.3 The flag cannot outlive the work
+
+A spec whose `implementation` is `complete` while any of its units carries
+`planned: true` MUST be refused by the lint, as **`L-011`**, at the **error**
+tier. Not a warning: completion asserts the work is done, and a planned unit
+asserts it is not, so the two together are a contradiction in the spec's own
+frontmatter rather than a gap someone might hold deliberately.
+
+This binds the flag to the lifecycle field that already exists, which is what
+keeps it from becoming a state nobody owns the exit from. Spec 041 established
+that `complete` ends the in-flight window; this extends the same principle to
+the new field.
+
+### 3.4 A planned unit that has resolved is reported
+
+When a unit marked `planned` **does** resolve on disk, the lint MUST emit
+**`L-012`** at the **warning** tier, naming the unit and saying to drop the
+flag.
+
+Without this the flag rots in the other direction: the file lands, the claim is
+satisfied, and nothing notices that the spec still describes it as future work.
+Warning tier means `lint --fail-on-warn` refuses it, so a corpus running the
+gate is told at the first opportunity rather than at completion.
+
+A resolved planned unit MUST still be treated as resolved for every other
+purpose: it contributes its `TraceMapping`, it participates in ownership, and
+it is hashed like any other resolved unit. `L-012` is a signal about the
+frontmatter, not a downgrade of the claim.
+
+### 3.5 Collisions reuse the ownership rules
+
+Planned territory is subject to the ownership rules that already exist; this
+spec introduces no second set.
+
+- Two specs planning the same unit is the **duplicate-ownership refusal**, with
+  the same `co_authority` escape as any other shared claim.
+- A spec planning a unit another spec **already owns** MUST be refused. The
+  correct declaration there is an `extends` edge naming that spec and unit,
+  which is what crossing into owned territory has always meant.
+- A planned unit MUST NOT appear as the target of an `extends` edge. There is
+  nothing to extend: the unit does not exist, and its planner does not yet own
+  it.
+
+### 3.6 The ledger records planned territory as a state
+
+A planned unit MUST be recorded in the emitted artifacts as a **declared
+state**, not as a suppressed diagnostic. A consumer MUST be able to ask what a
+spec plans to own without reading the diagnostics band.
+
+`spec-spine registry plan` MUST be able to report planned territory alongside
+the ready set, and `spec-spine index coverage` MUST be able to distinguish a
+source file that no spec claims from one that a spec has planned. Both are the
+reads this spec exists to unblind, and both become possible only because 3.6
+puts the fact in the artifact rather than in a warning.
+
+### 3.7 Schema and version
+
+The unit DTO gains one optional boolean. `REGISTRY_SCHEMA_VERSION` MUST bump
+**MINOR, `1.1.0` to `1.2.0`**, following the precedent spec 028 set when the
+`Provenance` struct gained an optional field: additive, no MAJOR, loaders that
+know `1.x` keep working.
+
+`Config` and the DTOs derive `deny_unknown_fields`, so a binary predating this
+spec meets a `planned` key with a parse error and exits **3**, rather than
+silently ignoring a claim about territory. That is the fail-closed direction
+and it is the reason the flag is a typed field rather than a convention in a
+comment.
+
+Emitting the field where it is absent MUST NOT change existing output:
+`planned` is serialized only when true, so every shard of a corpus that uses no
+planned units is byte-identical across this change and no re-index is needed.
+
+## 4. Out of scope
+
+**Making `--fail-on-unresolved` lifecycle-aware.** Considered first and
+rejected in section 1: it ties the exemption to `status: draft`, which only
+works in a draft-then-build repository, and it would reduce the flag to a
+near no-op since a settled spec's unresolved unit is already a hard error.
+
+**A `plans:` edge.** A ninth edge type would put the intent in the graph rather
+than on the unit, and the graph's eight types are enumerated in spec 000
+section 4.1 under the tier-1 anchor's own section. A field on the payload
+achieves the same visibility without touching the edge vocabulary, and section
+4.2 already establishes that the payload is the extensible part.
+
+**A config allowlist of planned paths.** `[lint] unresolved_allowed`, mirroring
+`unwitnessed_allowed`, would make the gap explicit but would keep it outside
+the edge graph, so two specs planning one file would still not collide. The
+whole value of putting the flag on the unit is that the existing ownership
+machinery does the collision detection.
+
+**Planning a unit in another repository, or a unit kind that does not exist
+yet.** The flag says a claim's subject is not written; it does not relax any
+other validation. A malformed unit is still malformed.
+
+**Retrofitting the corpus.** Specs 072 to 075 deferred their claims to their
+implementing changes and that remains correct for them. Nothing here requires
+an existing spec to be rewritten to use the flag.
+
+## 5. Resolved decisions
+
+**2026-09-08: a declared field, not a lifecycle-aware gate.** The gate fix was
+proposed first and is the smaller change. It fails on adopters: it works only
+where drafts precede builds, and an adopter who ratifies first has `approved`
+specs planning territory that the rule would have to special-case. It also
+guts the flag it modifies. The field is loop-agnostic, and it preserves the
+distinction that actually matters, which is between a claim that is early and
+a claim that is wrong.
+
+**2026-09-08: no `amends` on 000, checked rather than predicted.** The unit
+vocabulary looked like tier-1 territory. The anchor is declared explicitly on
+section 4's principle and does not reach the payload, section 4.2 says the
+payload is permissive, and spec 017 extended the vocabulary with no amendment.
+This is the fourth consecutive spec where reading the owning spec's words gave
+a different edge than the size of the change suggested, and the second where
+the answer was lighter rather than heavier.
+
+**2026-09-08: no `amends` on 050, because its rule is phrased over codes.**
+The gate refuses any `W-001` or `W-002`. This spec does not exempt anything
+from that rule; it changes what produces a `W-001`. Had 050 been written over
+"unresolved units" in the abstract, this spec would have owed it an amendment,
+and the difference is one sentence of drafting in a spec written months
+earlier.
+
+**2026-09-08: the shorthand stays as it is.** A planned claim must use the
+object form, so `"src/thing.rs"` cannot be marked planned. Extending the bare
+string to carry a flag would mean a second grammar, parsed in a second place,
+where a misspelling degrades silently into a path. The friction is one pair of
+braces and it buys a flag that is either typed correctly or refused.
+
+**2026-09-08: `L-011` is an error and `L-012` a warning.** Completion beside a
+planned unit is a contradiction inside one file's frontmatter and cannot be a
+state a corpus holds deliberately, so it refuses. A planned unit that has
+resolved is a stale annotation on correct work, which is a nudge; warning tier
+means `--fail-on-warn` still refuses it in a corpus that runs the gate, which
+is the behavior this repository wants without imposing it on one that does not.
+`L-010` is allocated by spec 074, which is why this spec takes the next two and
+depends on it.
+
+## Verification
+
+Each line below is one command: spec 049 3.2 makes a fence's body line a
+command, so no line may depend on a variable another line set.
+
+Every assertion fails against pre-076 code. The decisive case is the one that
+motivated the spec: a draft that declares territory it has not written passes
+`index check --fail-on-unresolved`, while a draft with a typo'd path still
+fails it.
+
+```verify:cli
+cargo build --release --locked
+# 3.1 and 3.7 the flag round-trips, and the shorthand still refuses it.
+cargo test -p spec-spine-types --test grammar --locked
+# 3.7 the registry schema bumped MINOR and the DTOs still conform.
+cargo test -p spec-spine-types --test dtos --locked
+cargo test -p spec-spine-core --test conformance --locked
+# 3.2 planned suppresses W-001; an unmarked bad path still produces one.
+cargo test -p spec-spine-core --test index --locked
+# 3.3 and 3.4 the flag cannot outlive the work, in either direction.
+cargo test -p spec-spine-core --test lint --locked
+# 3.6 the plan and the coverage report can see planned territory.
+cargo test -p spec-spine-core --test coverage --locked
+cargo test -p spec-spine-core --test query --locked
+```

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -242,6 +242,13 @@ two planned claims would therefore have nothing to ride on, and a rule that
 cannot fire is worse than no rule, because the spec would promise a refusal
 that never happens.
 
+All three are **corpus-wide** checks, decided with every spec's frontmatter
+loaded, not per-spec ones. Stated explicitly because each rule needs to know
+something about a spec other than the one being validated: whether another spec
+plans the same unit, already owns it, or is extending a unit this spec marked
+planned. An implementer who validates each spec in isolation first MUST defer
+these until the whole corpus is in hand.
+
 `compile` sees every declared edge and unit before any resolution, which is
 exactly the view these three rules need: two specs declaring the same planned
 unit, a planned unit whose path another spec already owns, and an `extends`

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -195,6 +195,15 @@ keeps it from becoming a state nobody owns the exit from. Spec 041 established
 that `complete` ends the in-flight window; this extends the same principle to
 the new field.
 
+**`complete` is the only bound, deliberately.** A spec that is `approved` and
+`implementation: pending` may carry planned units for as long as that state is
+honest, which on a specify-first corpus is months. Adding an intermediate
+deadline would mean inventing a clock, and every clock this corpus has
+considered has been refused for the same reason: it makes an artifact depend on
+when it was built rather than on what it contains. The exit is owned by the
+lifecycle field, and `L-012` covers the other direction by catching a flag that
+has become false in fact.
+
 ### 3.4 A planned unit that has resolved is reported
 
 When a unit marked `planned` **does** resolve on disk, the lint MUST emit
@@ -225,6 +234,21 @@ spec introduces no second set.
   nothing to extend: the unit does not exist, and its planner does not yet own
   it.
 
+**These checks run over declared units at compile time, not over the resolved
+graph.** Naming the pipeline stage matters here, because the obvious reading is
+wrong: the existing duplicate-ownership machinery operates on `TraceMapping`,
+and 3.2 excludes a planned unit from ever producing one. A collision between
+two planned claims would therefore have nothing to ride on, and a rule that
+cannot fire is worse than no rule, because the spec would promise a refusal
+that never happens.
+
+`compile` sees every declared edge and unit before any resolution, which is
+exactly the view these three rules need: two specs declaring the same planned
+unit, a planned unit whose path another spec already owns, and an `extends`
+naming a planned unit are all decidable from the corpus frontmatter alone. The
+refusals are therefore compile-time validation errors in the `V-` band, not
+index diagnostics, and they fire whether or not the path exists on disk.
+
 ### 3.6 The ledger records planned territory as a state
 
 A planned unit MUST be recorded in the emitted artifacts as a **declared
@@ -254,6 +278,15 @@ comment.
 Emitting the field where it is absent MUST NOT change existing output:
 `planned` is serialized only when true, so every shard of a corpus that uses no
 planned units is byte-identical across this change and no re-index is needed.
+
+**A written `planned: false` MUST normalize to absent.** Section 3.1 accepts it
+on input and gives it the meaning of omission, so a tool that read it and wrote
+it back verbatim would emit a shard that differs from the one the same corpus
+compiles to from scratch. That is a determinism break of exactly the kind the
+four-triple gate exists to catch, and it would surface as an inexplicable
+staleness rather than as a bug in the round-trip. Normalizing on write keeps
+one canonical form for one meaning, which is the rule the rest of the emitter
+already follows.
 
 ## 4. Out of scope
 

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -234,8 +234,9 @@ spec plans to own without reading the diagnostics band.
 `spec-spine registry plan` MUST be able to report planned territory alongside
 the ready set, and `spec-spine index coverage` MUST be able to distinguish a
 source file that no spec claims from one that a spec has planned. Both are the
-reads this spec exists to unblind, and both become possible only because 3.6
-puts the fact in the artifact rather than in a warning.
+reads this spec exists to unblind, and both become possible only because this
+section puts the fact in the artifact rather than leaving it in a warning that
+3.2 has already suppressed.
 
 ### 3.7 Schema and version
 


### PR DESCRIPTION
## What

A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` forecloses declaring territory before writing it.

This was found by hitting it, not by reasoning about it: filing spec 075 with `establishes: crates/spec-spine-cli/src/cmd_check.rs` refused the gate on a `W-001`, and the claim had to be removed and deferred to the implementing change. **Specs 072 to 075 being `extends`-only is not a property of those changes; it is the gate shaping the corpus.**

What is lost:

- `registry plan` and `index coverage` say nothing about planned ownership, so the reads that exist to answer "what is being worked on and who will own it" can only see the past.
- A draft's `risk` understates the work, because the territory it will take is written nowhere a tool can read.
- Two drafts can plan the same file with no edge to collide on. The duplicate ownership surfaces when the second one ships, which is the latest and most expensive moment to find it.

## Why not the smaller fix

Making `--fail-on-unresolved` lifecycle-aware was proposed first and is rejected in §1 for two reasons:

- It ties "not written yet" to `status: draft`, which only works in a draft-then-build repository. An adopter who ratifies first has **`approved` specs planning territory**, and the rule would have to special-case them. A declared field is loop-agnostic.
- It would make the flag a near no-op. A settled spec's unresolved unit is already a hard error that plain `index check` refuses, so refusing `W-001` is the flag's entire marginal value.

A declared field also keeps the distinction that matters: **a typo'd path stays a `W-001` and stays refused**, because nobody marked it planned. The flag separates a claim that is *early* from one that is *wrong*.

## The mechanism

`planned: true`, optional, on the unit payload. Object form only: the bare-string shorthand cannot carry it and is deliberately not extended, since a second string grammar is a second place for the flag to be misspelled into silence.

Bound at both ends so it cannot rot:

- **`L-011`, error tier.** `implementation: complete` beside a planned unit is a contradiction inside one file's frontmatter, not a state anyone holds deliberately. This binds the flag to the lifecycle field that already exists, extending spec 041's principle rather than contradicting it.
- **`L-012`, warning tier.** A planned unit that has resolved is a stale annotation on correct work. Warning tier means `lint --fail-on-warn` refuses it in a corpus running the gate, without imposing that on one that does not.

Collisions reuse the ownership rules rather than adding a second set: two specs planning one unit is the duplicate-ownership refusal with the same `co_authority` escape; planning a unit another spec already owns is refused, because that is an `extends` edge; and a planned unit may not be an `extends` target, since there is nothing to extend.

## Edges

**Amends 025**, whose FR-002 requires an unresolved unit from an owning edge, on a `draft` or `implementation: pending` spec, to be emitted as `W-001`.

**Does not amend 000**, which was the read that decided the shape and which I would not have predicted. The unit vocabulary looked like tier-1 territory. It is not: spec 000 declares `*(anchor: typed-authority-graph)*` explicitly on §4's opening paragraph, fixing the principle (typed edges, authority units, authority derived by walking the graph) and saying nothing about the payload. §4.2 records the opposite in spec 000's own words: "The schema is permissive on the unit payload, so `directory`/`crate`/`module` were added as an additive minor with no schema-file edit." Spec 017, which added those kinds, declared no `amends`.

**Does not amend 050**, because its rule is phrased over codes: the flag "MUST exit 1 when the committed index records any `W-001` or `W-002`". That is unchanged; what changes is what produces a `W-001`. The mechanism composes with the gate instead of carving an exception into it. Had 050 been written over "unresolved units" in the abstract, this spec would have owed it an amendment, and the difference is one sentence of drafting in a spec written months earlier.

**Does not amend 041.**

**Coupling falls out for free.** Dropping a `planned` flag is an edit to `spec.md`, which is exactly the spec-side change `couple` demands when the claimed file lands. The implementing PR clears the coupling gate by doing the thing the design already requires, with no waiver and no special case. That is why this is a mechanism rather than a rule.

## Schema

`REGISTRY_SCHEMA_VERSION` `1.1.0` -> `1.2.0`, additive, following the precedent spec 028 set when `Provenance` gained an optional field. `deny_unknown_fields` means a binary predating this spec meets a `planned` key with a parse error and exits **3** rather than silently ignoring a claim about territory, which is the fail-closed direction.

The field serializes only when true, so a corpus using no planned units is byte-identical across this change and needs no re-index.

## Status

`status: draft`, `implementation: pending`. Approval is a human flip, made after review.

`depends_on` includes 074 because that spec allocates `L-010` and this one takes the next two codes.

Gate: `compile`, `index`, `lint --fail-on-warn`, `index check --fail-on-unresolved`, `index coverage --fail-on-untraced` and `couple` all exit 0. Workspace tests green, `cargo fmt --all --check` clean. No `.rs` files changed, so clippy is unaffected.

## Release: 072 to 076 ship as one release, 0.18.0

Recorded here so the release runbook does not discover the schema bump.

The package version and the schema versions are decoupled axes, so a registry MINOR does not force a release of its own. This bump is additive: a loader that accepts `1.x` is unaffected, and the field serializes only when true, so a corpus using no planned units emits byte-identical shards across it. The precedent is v0.16.0, which shipped specs 051 to 069 together, and v0.8.0, which carried spec 028's `REGISTRY_SCHEMA_VERSION` `1.0.0` to `1.1.0` inside an ordinary release.

The real cost of batching is not the schema bump; it is that **0.18.0 carries four adopter-facing migrations**, and the release notes must enumerate all of them rather than letting `generate_release_notes` compose them from PR titles:

1. **073**: every workflow-bearing repository restales once. Re-run `spec-spine index` and commit, then re-attest. A pre-073 attestation reports `versionMismatch` from `verify-attestation --recompute`, which is spec 023 FR-005's named outcome carrying its own remediation, not a content failure.
2. **074 section 3.9**: any adopter scaffolded before v0.16.0 has `standards/**` and `.github/workflows/**` written into their own `spec-spine.toml`, matching no files. Upgrading does not fix it, because the value is theirs and not the default. Rewrite as `dir/**/*` and re-index once.
3. **075**: `/init` becomes `/prime` with no alias. Adopters re-copy the skills and update their `AGENTS.md`; a stale `AGENTS.md` gives "skill not found", which is loud rather than silent.
4. **076**: `REGISTRY_SCHEMA_VERSION` `1.1.0` to `1.2.0`, additive. Action is needed only by a consumer pinning an exact registry schema version.

Two of those four (073 and 074) are re-index migrations and compose without ordering constraints between them. `docs/releasing.md` should gain one step from this: before tagging, check whether any spec merged since the last tag moved a schema constant in `version.rs`, and name it in the release body. That check belongs in the release PR rather than in a spec of its own.
