### PR TITLE
feat(076): planned territory is declared, not inferred

### DIFF
--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -15,6 +15,18 @@
     ],
     "implementingPaths": [
       {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_registry.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/coverage.rs",
         "source": "spec-edge"
       },
@@ -31,11 +43,27 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/tests/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/tests/index.rs",
         "source": "spec-edge"
       },
       {
         "path": "crates/spec-spine-core/tests/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/query.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/coverage.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/edges.rs",
         "source": "spec-edge"
       },
       {
@@ -56,6 +84,45 @@
       }
     ],
     "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_registry.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
       {
         "locations": [
           {
@@ -111,6 +178,19 @@
       {
         "locations": [
           {
+            "file": "crates/spec-spine-core/tests/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
             "file": "crates/spec-spine-core/tests/index.rs"
           }
         ],
@@ -132,6 +212,45 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/query.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/query.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/coverage.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/coverage.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/edges.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/edges.rs"
         }
       },
       {
@@ -204,5 +323,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f69fbeccf70d6180e98d3adcf20206a63df6f955034819bdc8666768f0d7c7b2"
+  "shardHash": "5b4c5ac4a3ad04380e97ddbf14177fd930bf40fabde9c2064490a8891ae768d4"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5b4c5ac4a3ad04380e97ddbf14177fd930bf40fabde9c2064490a8891ae768d4"
+  "shardHash": "c69412721a1703bfb425774dd629a1ec5dd5cf834590e35aca93748d34f9ee4d"
 }

--- a/.derived/spec-registry/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/spec-registry/by-spec/000-spec-spine-bootstrap.json
@@ -40,5 +40,5 @@
     ]
   },
   "shardHash": "46f7dde94b700dd3376c3392cc0fd5ed66c5508b0e2ef9fb9bb6f5911c0429df",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/001-compile-registry.json
+++ b/.derived/spec-registry/by-spec/001-compile-registry.json
@@ -56,5 +56,5 @@
     "title": "Compile the spec corpus into a deterministic registry"
   },
   "shardHash": "58803b08fdf779e5843f33e636689e1f29f677e49494300adc25d1cb42fef5fb",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/002-registry-query.json
+++ b/.derived/spec-registry/by-spec/002-registry-query.json
@@ -41,5 +41,5 @@
     "title": "Typed read-only query over the registry"
   },
   "shardHash": "e075b2ad750b46d7fa9b2a29b6a1b5583d32c61861e3e874c47a6568aa8ce0de",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/003-conformance-lint.json
+++ b/.derived/spec-registry/by-spec/003-conformance-lint.json
@@ -32,5 +32,5 @@
     "title": "Corpus conformance lint"
   },
   "shardHash": "be02284a66e38f359de7ac79a51d03d21ed5a9f66eb6fbb933dd9d66129f3a26",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/004-codebase-index.json
+++ b/.derived/spec-registry/by-spec/004-codebase-index.json
@@ -59,5 +59,5 @@
     "title": "Codebase index and the file/section/symbol unit grammar"
   },
   "shardHash": "61a32ded0a0b85b3402157ad886ec058b3c596c908f72f9651c87104b13e23bb",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/005-coupling-gate.json
+++ b/.derived/spec-registry/by-spec/005-coupling-gate.json
@@ -71,5 +71,5 @@
     "title": "The coupling gate: join the two views and refuse drift"
   },
   "shardHash": "30e189c73064b85c7749a819b5d0323a3e18f3ec7bb38f9134946c1b670cb2af",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/006-init-scaffold.json
+++ b/.derived/spec-registry/by-spec/006-init-scaffold.json
@@ -61,5 +61,5 @@
     "title": "init: scaffold a new adopter"
   },
   "shardHash": "2a90e685c63337303451b94eed70100a33e049f30f9f180e3091bd7d213668ca",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/007-distribution.json
+++ b/.derived/spec-registry/by-spec/007-distribution.json
@@ -46,5 +46,5 @@
     "title": "Distribution: npm binary shim + the release pipeline"
   },
   "shardHash": "94fa8ee4358e9f6c07f7dec2d23976b7a03ee3fa2e3ed5f7a066ba41f26e62eb",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/008-python-distribution.json
+++ b/.derived/spec-registry/by-spec/008-python-distribution.json
@@ -48,5 +48,5 @@
     "title": "Distribution: uvx/PyPI wheel shim"
   },
   "shardHash": "5ed99bc4931788962a6f03cb1ca3063d6e7ac0fc813747a18bc6ed401dccb0e7",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/spec-registry/by-spec/009-coupling-floor-claim-precedence.json
@@ -64,5 +64,5 @@
     "title": "Coupling gate: explicit unit claims take precedence over the bypass floor"
   },
   "shardHash": "fafe4b8775e6cffee0338ce5f7facbefbc9bce0b681a6cfcecdd167bb085b2c8",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/spec-registry/by-spec/010-registry-query-projection-flags.json
@@ -59,5 +59,5 @@
     "title": "Registry query: --ids-only and --nonzero-only projection flags"
   },
   "shardHash": "7c052714a9855c12a3fa56438af2c744611b6c86880ca92d6b9c0ccdbb556c01",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/011-index-render-orphans.json
+++ b/.derived/spec-registry/by-spec/011-index-render-orphans.json
@@ -61,5 +61,5 @@
     "title": "Index: implement the reserved render and orphans subcommands"
   },
   "shardHash": "6d8ae06d93216cdeb1367f2476b2a9754c73a6aebb9ec57f9c6f350d877fd0be",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/012-index-hash-slices.json
+++ b/.derived/spec-registry/by-spec/012-index-hash-slices.json
@@ -100,5 +100,5 @@
     "title": "Index: named hash slices and `index check --slice <name>`"
   },
   "shardHash": "6f32352ebc96b9dc307fa10d466d416eb5885ea87e27e9b0e65944c1b8205f9c",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/spec-registry/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -108,5 +108,5 @@
     "title": "Frontmatter: declared extra keys carry arbitrary YAML, verbatim"
   },
   "shardHash": "28a565c9fc06090cfd714cce3d0e952cda85479819639a38eacfd3acd6859385",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/spec-registry/by-spec/014-edge-paths-grammar-sugar.json
@@ -67,5 +67,5 @@
     "title": "Edge grammar: `paths:` list sugar on extends/refines items"
   },
   "shardHash": "1b4b94a2fa4356c421601553521fdd8ec9ef8f26268169d75c524f1093cdd61c",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/spec-registry/by-spec/015-establishes-wrapper-na-alias.json
@@ -59,5 +59,5 @@
     "title": "Frontmatter sugar: `unit:`-wrapped establishes items and the `n/a` implementation alias"
   },
   "shardHash": "c49bb5976c14cfc6af0568ab731c22ed80339d22e2a9950add91dfcec1063b3d",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/016-short-id-resolution.json
+++ b/.derived/spec-registry/by-spec/016-short-id-resolution.json
@@ -43,5 +43,5 @@
     "title": "Compile: resolve short spec ids on `depends_on` and `superseded_by`"
   },
   "shardHash": "8afee33f14bdd0f970e5d52d642260afb7e15e97cdf1229da98d406d57cdf6ad",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/017-directory-crate-module-units.json
+++ b/.derived/spec-registry/by-spec/017-directory-crate-module-units.json
@@ -84,5 +84,5 @@
     "title": "Authority units: resolve the reserved directory / crate / module kinds"
   },
   "shardHash": "66b30cc522e37d801ff5adb7848e579afe16a8dd051fbff18797f996cbd8b08a",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/spec-registry/by-spec/018-constrains-discriminator-optional-unit.json
@@ -76,5 +76,5 @@
     "title": "Constrains grammar: classification discriminator and optional unit"
   },
   "shardHash": "245f184e4d47adc3dc2d9193cd9049eab928f2d44aea33c5d0cb2b0a4077e35b",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/spec-registry/by-spec/019-structured-partial-supersedes.json
@@ -141,5 +141,5 @@
     "title": "Supersedes grammar: structured items and partial (unit-scoped) transfer"
   },
   "shardHash": "60e1fc1e10a19cb2865cbdabdcd6acec3216048e97251d503f71fb4cc8903206",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/spec-registry/by-spec/020-derived-artifact-merge-driver.json
@@ -32,5 +32,5 @@
     "title": "Derived-artifact merge driver and merge-queue serialization"
   },
   "shardHash": "f451c26d859ab652c9455b462c6667701c863533fa1e47b01f6a7e846c15c9fd",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/spec-registry/by-spec/021-release-supply-chain-artifacts.json
@@ -39,5 +39,5 @@
     "title": "Release supply-chain artifacts: per-target SBOM and build provenance"
   },
   "shardHash": "956b2805db21b3aca1bbc335f848304a0db0584aa98ea34bdaea68ff08b6833d",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/022-keypath-section-anchors.json
+++ b/.derived/spec-registry/by-spec/022-keypath-section-anchors.json
@@ -40,5 +40,5 @@
     "title": "Bounded keypath section anchors for first-party structured config"
   },
   "shardHash": "faa3125907663ce2568439efc5c05a8730bf80e85887b45dce56c4c679b79d21",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/023-ledger-seal.json
+++ b/.derived/spec-registry/by-spec/023-ledger-seal.json
@@ -100,5 +100,5 @@
     "title": "Ledger Seal (signed, reproducible attestation over the spec corpus)"
   },
   "shardHash": "0f9f4f3b6aa952f24e5f2ef71adbb4c6cde1a29d2eac307eb1f8c544c9a21f40",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/024-index-sharding.json
+++ b/.derived/spec-registry/by-spec/024-index-sharding.json
@@ -227,5 +227,5 @@
     "title": "Per-unit shard storage (conflict-free committed registry + index)"
   },
   "shardHash": "3ea1d022d7f3cff37f0cb602a8ca5b76157020e27b45388d964fad06ede11c28",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/spec-registry/by-spec/025-unresolved-unit-severity.json
@@ -79,5 +79,5 @@
     "title": "Severity tiers for unresolved units: lifecycle- and edge-aware (warn, count, never skip)"
   },
   "shardHash": "a153f204f3b57921b244fcdf256c934de8a03865e47af200fa4233245ba75f8f",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/spec-registry/by-spec/026-resolution-discovery-fixes.json
@@ -67,5 +67,5 @@
     "title": "Indexer resolution + discovery fixes: foreign-YAML regions, Makefile tags, nested-workspace globs"
   },
   "shardHash": "e2c011b1a493629bba2ae7656d3b8fd9cdc68fbb2cc9d87676f71cb8bbe87ebb",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/spec-registry/by-spec/027-symbol-resolution-feature-gate.json
@@ -67,5 +67,5 @@
     "title": "Feature-gate tree-sitter symbol/module resolution for dependency-free embedding"
   },
   "shardHash": "5e2995ada4bfdc3084df4c0e9576e27d52fbc846951d7e619daa5b755e8ff819",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/spec-registry/by-spec/028-references-provenance-derived-at.json
@@ -71,5 +71,5 @@
     "title": "References provenance: optional derived_at timestamp"
   },
   "shardHash": "85123e46582582bb58f48238fa80313d7a14c4e51efc0a0dca39ca59d6730bea",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/spec-registry/by-spec/029-claude-code-skill-kit.json
@@ -32,5 +32,5 @@
     "title": "Claude Code skill kit: a vendored, governed adoption bundle"
   },
   "shardHash": "2ddd4789254cdb2be6184f6cb728bdc2babb3163977eff61171ddc5c255719ad",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/spec-registry/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -74,5 +74,5 @@
     "title": "Cargo and workflow dependabot bumps self-clear: freshness projection + auto-waiver"
   },
   "shardHash": "8a7d53e4b894e9762ea1401b3c84443c5d2e49e1e55274168de7c487176f7a78",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/031-registry-freshness-check.json
+++ b/.derived/spec-registry/by-spec/031-registry-freshness-check.json
@@ -94,5 +94,5 @@
     "title": "Registry freshness: `spec-spine compile --check`"
   },
   "shardHash": "39995f7666e6d0633aee9b4c039ce8c46023f80c02f031d98b6d58d3c481740f",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/032-ownership-coverage.json
+++ b/.derived/spec-registry/by-spec/032-ownership-coverage.json
@@ -138,5 +138,5 @@
     "title": "Ownership coverage: `spec-spine index coverage` and the `C-002` ratchet"
   },
   "shardHash": "71d23a503adb3411b7ba0f428eb6e1309a797a445b476ec4d80314713c00e4c4",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/spec-registry/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "title": "Dependency cycle refusal: the `V-014` corpus-wide check on `depends_on`"
   },
   "shardHash": "edc8debf7e8ab3ca2314bdba9ee2271f52f069309dbfa8807b969749a3030a4d",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/034-references-non-owning-paths.json
+++ b/.derived/spec-registry/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "title": "`references` seeds no implementing path: closing the C-001 ownership leak"
   },
   "shardHash": "54c4e2be071d742b419ccdc8b70ecadd39892f1a48caeb37901f21565e5eb805",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
+++ b/.derived/spec-registry/by-spec/035-stdout-closed-reader.json
@@ -116,5 +116,5 @@
     "title": "A closed reader is not an error: stdout writes stop panicking the CLI"
   },
   "shardHash": "b006c12e017e714dfbedbb313d4e8e033030efdd0b64760460360fabb296bd1f",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/036-configured-corpus-root.json
+++ b/.derived/spec-registry/by-spec/036-configured-corpus-root.json
@@ -57,5 +57,5 @@
     "title": "The coupling gate honors `layout.specs_dir`"
   },
   "shardHash": "52a6e9b5643c01889caeae5a08946cdcae09e68fa52f69f8175ff57ea0e544a0",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/spec-registry/by-spec/037-machine-readable-verdicts.json
@@ -154,5 +154,5 @@
     "title": "Machine-readable verdicts: `--json` on the adjudicating verbs"
   },
   "shardHash": "5b32027ae3e446ab9e5e0541796dc9f0dea4bd49820fdbeb870a8b2a2787a7d6",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/spec-registry/by-spec/038-registry-plan-ready-set.json
@@ -90,5 +90,5 @@
     "title": "`registry plan`: the ready set in dependency order"
   },
   "shardHash": "82f4d71319b7edb4f07a4a9061fe892a0ca0a0bbd577a6922fdd4fc04cc95415",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/039-declared-state-dir.json
+++ b/.derived/spec-registry/by-spec/039-declared-state-dir.json
@@ -130,5 +130,5 @@
     "title": "`layout.state_dir`: a declared, ungoverned tool-state root"
   },
   "shardHash": "2b44036ac42af89908ce214de94105a2ec512b5c790370b593c96b12dca2a280",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/040-amendment-authoring.json
+++ b/.derived/spec-registry/by-spec/040-amendment-authoring.json
@@ -56,5 +56,5 @@
     "title": "An amendment is declared once, in the amending spec"
   },
   "shardHash": "2d5d4ca1b5b056d7863375cbc5c1699d3462a24cfb4fcbcc7540b5499c9cf3ee",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/041-completion-held-to-claims.json
+++ b/.derived/spec-registry/by-spec/041-completion-held-to-claims.json
@@ -60,5 +60,5 @@
     "title": "`implementation: complete` defeats draft leniency"
   },
   "shardHash": "d5ae7f2c3ac3f47fa23a9f6157a1eaaf76816f06a1cbddb47ba968fedaa17522",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/042-per-spec-attestation.json
+++ b/.derived/spec-registry/by-spec/042-per-spec-attestation.json
@@ -142,5 +142,5 @@
     "title": "`attest --spec <id>`: a signed record scoped to one spec"
   },
   "shardHash": "69a670d14ad15194c36e0f71aa4a04d98338bc4ba4d59951f1f5f7f9148e1718",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/043-governance-document-gaps.json
+++ b/.derived/spec-registry/by-spec/043-governance-document-gaps.json
@@ -96,5 +96,5 @@
     "title": "Three governance statements the first adopter could not act on"
   },
   "shardHash": "08644e08a0280ce6a93b9c6bdbd7ee155b90a5b3fba5ab47f939d3b9a828fe42",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/spec-registry/by-spec/044-in-progress-is-in-flight.json
@@ -66,5 +66,5 @@
     "title": "`implementation: in-progress` is in flight"
   },
   "shardHash": "b2e5db066e1426da641e27f5354629b375c526f41b11f03c5866de77e4c65fed",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/spec-registry/by-spec/045-absent-implementation-defers-to-status.json
@@ -98,5 +98,5 @@
     "title": "An absent `implementation` key takes its answer from `status`"
   },
   "shardHash": "df169dcc67b3b05d4438e063c3a5976e0023b44f92dbd2ae9978caa48f89905a",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/spec-registry/by-spec/046-kit-hooks-read-never-write.json
@@ -70,5 +70,5 @@
     "title": "The kit's hooks observe the tree; they do not repair it"
   },
   "shardHash": "1dae2b9ba8cf627777be59d7ef6492c1396fb47f1d7674343491530503b3a90c",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/spec-registry/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -117,5 +117,5 @@
     "title": "The harness rules name the reads and the edits they permit"
   },
   "shardHash": "0a8ed2a93fbf168c303609b71c134d4ed0e990adbb6913ce737d63c58c4dae84",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/spec-registry/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -117,5 +117,5 @@
     "title": "The kit ships one skill set for the governed loop, and this repository runs it"
   },
   "shardHash": "1acd724352ca7eb7cf03c20876b386448e9cd6c8ef88be07961a2a114cf5f4cc",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/spec-registry/by-spec/049-verify-declared-acceptance.json
@@ -134,5 +134,5 @@
     "title": "`spec-spine verify <id>`: run a spec's declared acceptance"
   },
   "shardHash": "35599376172b5d20ffccfeeed539c29bcd32d8e863096fb3e3b74af0c310aa2c",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/spec-registry/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -94,5 +94,5 @@
     "title": "Index diagnostics reach a gate"
   },
   "shardHash": "e14ee4b3a94c32c6e52014b9e8bfb051e161554526884402914c7c1de19d98f2",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/spec-registry/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -129,5 +129,5 @@
     "title": "The harness runs the verbs it ships"
   },
   "shardHash": "361f37deb9e86cc8e8b09d40cf48f0ccb54915ebaa7f9fe76d3cde724c4f6530",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/spec-registry/by-spec/052-couple-names-the-crossing.json
@@ -137,5 +137,5 @@
     "title": "The coupling gate names the crossing"
   },
   "shardHash": "607f83fa5b909120dc04258e633fd49334842a3363b12fd57dca6a9cb8d5806d",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/spec-registry/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -71,5 +71,5 @@
     "title": "A dependency points backward, and the corpus can say so"
   },
   "shardHash": "a36bd7fb798b1adae5baaee2b1aa53b24d3fdf7caf10aa129cc0a66d151126c8",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/spec-registry/by-spec/054-effective-config-is-a-governed-read.json
@@ -99,5 +99,5 @@
     "title": "The effective configuration is a governed read"
   },
   "shardHash": "8e4d7528fd2adae7a67dbb0628f39494ae9aaecf7ccade1959cceb964b11ab69",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/spec-registry/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -105,5 +105,5 @@
     "title": "The ledger answers what consumers rebuild by hand"
   },
   "shardHash": "da3e89fe7c83cc6ecc7f5a7102c44c5eba9accb6501e393a25b93b88741b5a59",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/056-compile-one-spec.json
+++ b/.derived/spec-registry/by-spec/056-compile-one-spec.json
@@ -122,5 +122,5 @@
     "title": "Validate one draft without a temporary repository"
   },
   "shardHash": "02c87e7dfeacabc3f0e3abf38b7cfcdf05466452c81bc594b1efd9e486bb6e9c",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/spec-registry/by-spec/057-claimed-but-unwitnessed.json
@@ -113,5 +113,5 @@
     "title": "A claim no hash witnesses"
   },
   "shardHash": "abdb08f3d469a89193d770349cb0b9f02b0478c955aa47164c6cc61dc27fe4ac",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/spec-registry/by-spec/058-retroactive-adoption-shape.json
@@ -74,5 +74,5 @@
     "title": "The defects heading has one spelling"
   },
   "shardHash": "5d6a45ca1ab2b9ee62dea542cbbe87124abe10418a747528a63e1636a81d1d53",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/spec-registry/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -96,5 +96,5 @@
     "title": "Two read verbs that mislead a specify-first corpus"
   },
   "shardHash": "c8c269b61db919647a806114a477e080a4412e7f4e97cb3a141b501238a7d1f2",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/spec-registry/by-spec/060-plan-answers-the-whole-question.json
@@ -87,5 +87,5 @@
     "title": "The plan answers the whole question, and names one pick"
   },
   "shardHash": "0067400846a08e50b01dbe3014bcc802baaf46f72c4ddb8fd957f940ddf87ddd",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/spec-registry/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -70,5 +70,5 @@
     "title": "The scaffold ships what every adopter wrote by hand"
   },
   "shardHash": "3214ed61cc2acb4d10f5c25a724680a1d7002b31b77dc08c4d48f36fecee0ce1",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/spec-registry/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -104,5 +104,5 @@
     "title": "A version pin the CLI can check"
   },
   "shardHash": "f943dccbb99a31818db8fbd07be3f290461759892080749985e4060e1ce3fa9c",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/spec-registry/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -96,5 +96,5 @@
     "title": "A stale binary is not a stale ledger"
   },
   "shardHash": "7cbe621fe3b3d1dc3c673848d71f690198e7dc17d5a9d866949caa2be3cab398",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/spec-registry/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -114,5 +114,5 @@
     "title": "The kit ships the composite gate and the merge driver"
   },
   "shardHash": "c518342791ade3df14f49542c376e59a8aca5818e3dac3b8b2f795577069c072",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/spec-registry/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -123,5 +123,5 @@
     "title": "Init and the kit are one adoption"
   },
   "shardHash": "05e7b375daf2eb018b17cc9b81d5bb4554132dfa8e68570dab2fdebafa8a79d1",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/spec-registry/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -73,5 +73,5 @@
     "title": "The contract records the lifecycle table and the extra keys"
   },
   "shardHash": "21a758523487e407f071c40d6880e3e21f28038421b784240a67a98ee2f20cb1",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/spec-registry/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -70,5 +70,5 @@
     "title": "The docs name what adopters derived by experiment"
   },
   "shardHash": "05dcf3c453e5ee703f17dc8121baa00fdf1cd28f6b01040463909863c14bdccb",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/spec-registry/by-spec/068-a-path-scoped-rule-example.json
@@ -106,5 +106,5 @@
     "title": "A path-scoped rule the kit actually ships"
   },
   "shardHash": "6f1ebd1ed8ce8de7be2dfe1816713625f4d76154b2303e71ec81f18fc9ad1d6e",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/spec-registry/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -95,5 +95,5 @@
     "title": "The shipped default hashes what it names"
   },
   "shardHash": "e18947a62ffb9f6323412da1dcf30ffeb6c3f0a7a956223353a4b61b954ee8f8",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/spec-registry/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -55,5 +55,5 @@
     "title": "A malformed id is refused, not a panic"
   },
   "shardHash": "9a606a88854954ef3098e3793088f5e016c259d34954caa7cb178c0ebcd5c69e",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/spec-registry/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -75,5 +75,5 @@
     "title": "A tag push is not a push to main"
   },
   "shardHash": "4899cb5f0db01c311f3a54df3055fde6dc0f218fc0fcce978c319338b5548fa8",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/spec-registry/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -135,5 +135,5 @@
     "title": "The default branch is configured, not assumed"
   },
   "shardHash": "c0172fba27b254e875695e137847808c299610c4ec09c86007f48ad3fe652023",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -103,5 +103,5 @@
     "title": "A workflow bump is not a governed change"
   },
   "shardHash": "65438641e5b5016e59ad1979ba1da95d2c95e5d70e8279ac3ea7cf0aced0f3e0",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/spec-registry/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -182,5 +182,5 @@
     "title": "Shipped is not the same as working"
   },
   "shardHash": "4482ee801f5d9c6d3ce6e2d9bbcdd4a93a51a1c4041c11550b8676434b870e98",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/spec-registry/by-spec/075-one-name-one-freshness-verb.json
@@ -219,5 +219,5 @@
     "title": "One name for the protocol, one verb for freshness"
   },
   "shardHash": "109ad720237ba2351d46d79b0180446c132b7dc82060077823b5dc79cb6436bc",
-  "specVersion": "1.1.0"
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -94,10 +94,66 @@
           "kind": "file",
           "path": "crates/spec-spine-core/src/query.rs"
         }
+      },
+      {
+        "nature": "additive",
+        "spec": "038-registry-plan-ready-set",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/query.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "032-ownership-coverage",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/coverage.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "032-ownership-coverage",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/coverage.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "032-ownership-coverage",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "002-registry-query",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_registry.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "014-edge-paths-grammar-sugar",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/edges.rs"
+        }
       }
     ],
     "id": "076-planned-territory-is-declared-not-inferred",
-    "implementation": "pending",
+    "implementation": "in-progress",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -131,6 +187,6 @@
     "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
     "title": "Planned territory is declared, not inferred"
   },
-  "shardHash": "408044e68f619e16a3309eadaabdeef913eb6f87d2bc5387a1781fa3ed87542d",
-  "specVersion": "1.1.0"
+  "shardHash": "d4ceadefbdd6637d6d11adf7eb51bce250d5d4bae09dc68ceb0adf7be2ab9891",
+  "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -153,7 +153,7 @@
       }
     ],
     "id": "076-planned-territory-is-declared-not-inferred",
-    "implementation": "in-progress",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -187,6 +187,6 @@
     "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
     "title": "Planned territory is declared, not inferred"
   },
-  "shardHash": "d4ceadefbdd6637d6d11adf7eb51bce250d5d4bae09dc68ceb0adf7be2ab9891",
+  "shardHash": "1135e51640c544f6f881163e1f67820ced3d1f8fe9a5f31cf3d500611e1139b5",
   "specVersion": "1.2.0"
 }

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -391,6 +391,21 @@ fn render_coverage(report: &CoverageReport) -> String {
         report.floor_only_files.len(),
         report.unclaimed_files.len()
     );
+    // Spec 076 §3.6: a file nothing claims and a file something has planned are
+    // different states, and the report could not tell them apart before. Listed
+    // beside the counts rather than inside them: these paths are not on disk,
+    // so counting a declared intention as coverage would let a spec satisfy
+    // `--fail-on-untraced` by promising.
+    if !report.planned_territory.is_empty() {
+        let _ = writeln!(
+            out,
+            "  planned (declared, not yet written): {}",
+            report.planned_territory.len()
+        );
+        for entry in &report.planned_territory {
+            let _ = writeln!(out, "    {entry}");
+        }
+    }
     for p in &report.packages {
         let path = if p.path.is_empty() {
             "."

--- a/crates/spec-spine-cli/src/cmd_registry.rs
+++ b/crates/spec-spine-cli/src/cmd_registry.rs
@@ -226,6 +226,25 @@ fn print_plan(plan: &Plan) {
             outln!("       blocked by {}", reasons.join(", "));
         }
     }
+    // Spec 076 §3.6: what the corpus has said it will own and has not written
+    // yet. Reported below both sets rather than folded into either, because a
+    // blocked spec's planned territory is exactly what a reader wants when
+    // weighing what unblocking it would cost.
+    if !plan.planned.is_empty() {
+        outln!();
+        let units: usize = plan.planned.iter().map(|p| p.units.len()).sum();
+        outln!(
+            "planned territory ({units} unit(s) across {} spec(s)):",
+            plan.planned.len()
+        );
+        let w = id_width(plan.planned.iter().map(|p| p.id.as_str()));
+        for entry in &plan.planned {
+            outln!("  {:<w$}  {}", entry.id, entry.title, w = w);
+            for unit in &entry.units {
+                outln!("       {unit}");
+            }
+        }
+    }
     outln!();
     outln!(
         "{} specs: {} ready, {} blocked, {} not schedulable",

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use spec_spine_types::{
     Build, Config, Error, Frontmatter, FrontmatterIssue, REGISTRY_SCHEMA_VERSION, Registry,
-    RegistrySpecShard, Severity, SpecRecord, Status, ValidationReport, Violation,
+    RegistrySpecShard, Severity, SpecRecord, Status, Unit, ValidationReport, Violation,
     parse_frontmatter_with, split_frontmatter,
 };
 
@@ -24,7 +24,13 @@ use crate::{canonical_json, hash, markdown, shard};
 /// cycle. They are NOT stored per registry shard (storing them would let a
 /// sibling spec's PR stale this shard); they are recomputed from the assembled
 /// record set on read.
-const CROSS_SPEC_CODES: &[&str] = &["V-003", "V-004", "V-008", "V-010", "V-014"];
+const CROSS_SPEC_CODES: &[&str] = &[
+    "V-003", "V-004", "V-008", "V-010", "V-014",
+    // Spec 076 §3.5: the three planned-territory collisions. Each needs to know
+    // something about a spec other than the one being validated, so each is
+    // corpus-wide and none belongs on a single spec's shard.
+    "V-015", "V-016", "V-017",
+];
 
 /// The cap on **undeclared** `extra_frontmatter` keys before `V-007` fires.
 /// Keys listed in `frontmatter.extra_known_keys` are intentional and exempt;
@@ -174,6 +180,14 @@ pub fn compile(cfg: &Config, repo_root: &Path) -> Result<CompileOutcome, Error> 
     // V-014 reads the records, not the parsed frontmatter, so it sees the
     // short-id-resolved `depends_on` (spec 016) rather than the authored text.
     detect_dependency_cycle(&records, &mut violations);
+    // Spec 076 §3.5, over DECLARED units at compile time rather than over the
+    // resolved graph. Naming the stage matters, because the obvious reading is
+    // wrong: the existing duplicate-ownership machinery operates on
+    // `TraceMapping`, and §3.2 excludes a planned unit from ever producing one,
+    // so a collision between two planned claims would have nothing to ride on.
+    // A rule that cannot fire is worse than no rule, because the spec would
+    // promise a refusal that never happens.
+    validate_planned_territory(&records, &mut violations);
 
     // --- shard projection + aggregate content hash (spec 024) ---
     // One shard per spec, each carrying its compiled record, its corpus-
@@ -389,6 +403,135 @@ fn detect_duplicates(specs: &[(String, String)], out: &mut Vec<Violation>) {
                 None,
             ));
         }
+    }
+}
+
+/// Spec 076 §3.5: planned territory is subject to the ownership rules that
+/// already exist, and this spec introduces no second set.
+///
+/// All three checks are **corpus-wide**, decided with every spec's frontmatter
+/// loaded, because each needs to know something about a spec other than the one
+/// being validated: whether another spec plans the same unit, already owns it,
+/// or is extending a unit this spec marked planned.
+///
+/// - **`V-015`** two specs plan the same unit, without `co_authority`: the
+///   duplicate-ownership refusal, with the same escape as any shared claim.
+/// - **`V-016`** a spec plans a unit another spec already owns. The correct
+///   declaration there is an `extends` edge naming that spec and unit, which is
+///   what crossing into owned territory has always meant.
+/// - **`V-017`** an `extends` edge names a planned unit. There is nothing to
+///   extend: the unit does not exist and its planner does not yet own it.
+fn validate_planned_territory(specs: &[SpecRecord], out: &mut Vec<Violation>) {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    // Subjects, so the flag is never part of the identity being compared.
+    let key = |u: &Unit| unit_identity(&u.subject());
+
+    // Keyed by unit identity, valued by the specs making the claim. `owners`
+    // holds unplanned claims and carries the claimant, because `extends` is
+    // itself an ownership-bearing edge: without knowing WHO owns a unit, the
+    // V-017 check below would be defeated by the very edge it is examining.
+    let mut planners: BTreeMap<String, Vec<&SpecRecord>> = BTreeMap::new();
+    let mut owners: BTreeMap<String, Vec<&SpecRecord>> = BTreeMap::new();
+    let mut shared: BTreeSet<String> = BTreeSet::new();
+    for spec in specs {
+        for c in &spec.co_authority {
+            shared.insert(key(&c.unit));
+        }
+        for unit in owning_units(spec) {
+            let k = key(&unit);
+            if unit.is_planned() {
+                planners.entry(k).or_default().push(spec);
+            } else {
+                owners.entry(k).or_default().push(spec);
+            }
+        }
+    }
+
+    for (unit_key, plans) in &planners {
+        let at = |s: &SpecRecord| Some(s.spec_path.clone());
+        if plans.len() > 1 && !shared.contains(unit_key) {
+            let ids: Vec<&str> = plans.iter().map(|s| s.id.as_str()).collect();
+            out.push(error(
+                "V-015",
+                format!(
+                    "unit '{unit_key}' is planned by more than one spec ({}): declare \
+                     co_authority if the claim is genuinely shared",
+                    ids.join(", ")
+                ),
+                at(plans[0]),
+            ));
+        }
+        if let Some(existing) = owners.get(unit_key)
+            && !shared.contains(unit_key)
+        {
+            let owner_ids: Vec<&str> = existing.iter().map(|s| s.id.as_str()).collect();
+            out.push(error(
+                "V-016",
+                format!(
+                    "spec '{}' plans unit '{unit_key}', which spec(s) {} already own: \
+                     declare an extends edge naming the owning spec and unit instead",
+                    plans[0].id,
+                    owner_ids.join(", ")
+                ),
+                at(plans[0]),
+            ));
+        }
+    }
+
+    // V-017 reads `extends` alone: it is the edge whose meaning is "cross into
+    // territory another spec owns", and a planned unit is territory nobody owns
+    // yet.
+    for spec in specs {
+        for item in &spec.extends {
+            let Some(unit) = &item.unit else { continue };
+            let k = key(unit);
+            // "Owned by someone else": the extending spec's own edge is what
+            // put it in `owners`, so counting it would make this rule silent
+            // in exactly the case it exists for.
+            let owned_elsewhere = owners
+                .get(&k)
+                .is_some_and(|os| os.iter().any(|o| o.id != spec.id));
+            if planners.contains_key(&k) && !owned_elsewhere {
+                out.push(error(
+                    "V-017",
+                    format!(
+                        "spec '{}' extends unit '{k}', which spec '{}' has only planned: \
+                         there is nothing to extend until it is written",
+                        spec.id, planners[&k][0].id
+                    ),
+                    Some(spec.spec_path.clone()),
+                ));
+            }
+        }
+    }
+}
+
+/// Every unit a spec claims through an ownership-bearing edge, for the §3.5
+/// collision checks. `references` is excluded (spec 034: a cited file is not a
+/// claimed one), and so is `amends`, whose subject is a spec rather than a unit.
+fn owning_units(spec: &SpecRecord) -> Vec<Unit> {
+    let mut units: Vec<Unit> = spec.establishes.clone();
+    units.extend(spec.extends.iter().filter_map(|i| i.unit.clone()));
+    units.extend(spec.refines.iter().filter_map(|i| i.unit.clone()));
+    units.extend(spec.supersedes.iter().filter_map(|i| match i {
+        spec_spine_types::SupersedeItem::Scoped(s) => s.unit.clone(),
+        _ => None,
+    }));
+    units.extend(spec.co_authority.iter().map(|i| i.unit.clone()));
+    units.extend(spec.constrains.iter().filter_map(|i| i.unit.clone()));
+    units
+}
+
+/// A unit's identity as a comparable, human-readable key.
+fn unit_identity(unit: &Unit) -> String {
+    match unit {
+        Unit::File { path, .. } => format!("file:{path}"),
+        Unit::Section { file, anchor, .. } => format!("section:{file}#{anchor}"),
+        Unit::Symbol { id, .. } => format!("symbol:{id}"),
+        Unit::Directory { path, .. } => format!("directory:{path}"),
+        Unit::Crate { id, .. } => format!("crate:{id}"),
+        Unit::Module { id, .. } => format!("module:{id}"),
     }
 }
 

--- a/crates/spec-spine-core/src/coverage.rs
+++ b/crates/spec-spine-core/src/coverage.rs
@@ -181,6 +181,7 @@ pub fn coverage_with(cfg: &Config, index: &CodebaseIndex, files: &[String]) -> C
         floor_only_files: Vec::new(),
         unclaimed_files: Vec::new(),
         packages: Vec::new(),
+        planned_territory: Vec::new(),
     };
     for file in universe {
         let Some(entry) =
@@ -219,7 +220,20 @@ pub fn coverage(cfg: &Config, repo_root: &Path) -> Result<CoverageReport, Error>
     }
     let index = load_committed_index(cfg, repo_root)?;
     let files = enumerate_source_files(cfg, repo_root, &index);
-    Ok(coverage_with(cfg, &index, &files))
+    let mut report = coverage_with(cfg, &index, &files);
+    // Spec 076 §3.6: planned territory is a DECLARED state, so it is read from
+    // the spec-as-source view. It cannot come from the index: a planned unit
+    // that has not resolved contributes no `ResolvedUnit` and no location, by
+    // §3.2, which is exactly why the report was blind to it.
+    //
+    // A registry that will not load leaves the list empty rather than failing
+    // the report: this member is additive information beside a coverage verdict
+    // that has already been reached, and `compile --check` is where a broken
+    // registry is the operator's problem.
+    if let Ok(registry) = crate::compile::load_committed_registry(cfg, repo_root) {
+        report.planned_territory = crate::query::planned_territory(&registry);
+    }
+    Ok(report)
 }
 
 /// Why a coverage universe is empty, when it is (spec 059 §3.2, §3.3).

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -218,7 +218,13 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
                 &spec.id,
                 &mut unit_diags,
             );
-            classify_unresolved(&mut spec_diags, unit_diags, *ownership, in_flight);
+            classify_unresolved(
+                &mut spec_diags,
+                unit_diags,
+                *ownership,
+                in_flight,
+                unit.is_planned(),
+            );
             // Only an owning edge contributes an implementing path (spec 034).
             // `references` is non-owning by definition, so a file a spec merely
             // cites is not a file it implements. Every consumer of
@@ -238,7 +244,13 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
                 }
             }
             resolved_units.push(ResolvedUnit {
-                unit: unit.clone(),
+                // Spec 076 §3.4: the **subject**, with the flag cleared.
+                // `planned` annotates a claim's resolution state, not which
+                // territory it names, so a planned claim that has resolved
+                // answers an `authorities` lookup exactly as an unplanned one
+                // does, and the index emits byte-identical shards for a corpus
+                // that uses no planned units.
+                unit: unit.subject(),
                 source_field: *field,
                 ownership: *ownership,
                 locations,
@@ -513,7 +525,7 @@ pub fn authorities(index: &CodebaseIndex, unit: &Unit) -> Vec<String> {
                 owners.insert(mapping.spec_id.clone());
             }
         }
-        if let Unit::File { path } = unit {
+        if let Unit::File { path, .. } = unit {
             if mapping.implementing_paths.iter().any(|p| &p.path == path) {
                 owners.insert(mapping.spec_id.clone());
             }
@@ -819,8 +831,19 @@ fn classify_unresolved(
     produced: Diagnostics,
     owning: bool,
     in_flight: bool,
+    planned: bool,
 ) {
     for d in produced.errors {
+        // Spec 076 §3.2: an unresolved unit marked `planned` is not an
+        // unresolved claim; it is a claim whose subject is openly not yet
+        // written, so it produces no diagnostic at all rather than a
+        // suppressed one. Everything else classifies exactly as spec 025
+        // requires, so a path that is simply wrong is still caught and still
+        // refused by `--fail-on-unresolved`. That asymmetry is the whole
+        // safety argument: nobody marks a typo planned.
+        if planned {
+            continue;
+        }
         if !owning {
             dst.warnings.push(Diagnostic {
                 code: "W-002".to_string(),
@@ -849,7 +872,7 @@ fn resolve_unit(
     diagnostics: &mut Diagnostics,
 ) -> Vec<ResolvedLocation> {
     match unit {
-        Unit::File { path } => {
+        Unit::File { path, .. } => {
             let abs = repo_root.join(path);
             if abs.exists() {
                 vec![ResolvedLocation {
@@ -868,7 +891,7 @@ fn resolve_unit(
         // A directory subtree: resolve to the directory path itself (the gate
         // prefix-matches it against changed paths), requiring the directory to
         // exist (spec 017; I-007 mirrors OAP's missing-directory hard error).
-        Unit::Directory { path } => {
+        Unit::Directory { path, .. } => {
             if repo_root.join(path).is_dir() {
                 vec![ResolvedLocation {
                     file: path.clone(),
@@ -886,7 +909,7 @@ fn resolve_unit(
         // A compilation unit by manifest name: resolve to the discovered
         // package's directory subtree (spec 017; I-003 = unknown crate). Hyphen
         // and underscore are interchangeable in the name (Rust crate convention).
-        Unit::Crate { id } => {
+        Unit::Crate { id, .. } => {
             let norm = id.replace('-', "_");
             match packages
                 .iter()
@@ -910,7 +933,7 @@ fn resolve_unit(
         }
         // A Rust module by `::`-qualified path (spec 017; I-008 = unresolved,
         // distinct from the symbol band's I-005).
-        Unit::Module { id } => {
+        Unit::Module { id, .. } => {
             let locations = modules.resolve(id);
             if locations.is_empty() {
                 diagnostics.errors.push(Diagnostic {
@@ -921,7 +944,7 @@ fn resolve_unit(
             }
             locations
         }
-        Unit::Section { file, anchor } => {
+        Unit::Section { file, anchor, .. } => {
             let abs = repo_root.join(file);
             let span = fs::read_to_string(&abs)
                 .ok()
@@ -943,7 +966,7 @@ fn resolve_unit(
                 }
             }
         }
-        Unit::Symbol { id } => {
+        Unit::Symbol { id, .. } => {
             let locations = symbols.resolve(id);
             if locations.is_empty() {
                 diagnostics.errors.push(Diagnostic {
@@ -1205,12 +1228,12 @@ fn resolve_id(short: &str, all_ids: &BTreeSet<String>) -> String {
 /// A stable canonical string for a unit, for deterministic sorting.
 fn canonical_unit(unit: &Unit) -> String {
     match unit {
-        Unit::File { path } => format!("file:{path}"),
-        Unit::Section { file, anchor } => format!("section:{file}#{anchor}"),
-        Unit::Symbol { id } => format!("symbol:{id}"),
-        Unit::Directory { path } => format!("directory:{path}"),
-        Unit::Crate { id } => format!("crate:{id}"),
-        Unit::Module { id } => format!("module:{id}"),
+        Unit::File { path, .. } => format!("file:{path}"),
+        Unit::Section { file, anchor, .. } => format!("section:{file}#{anchor}"),
+        Unit::Symbol { id, .. } => format!("symbol:{id}"),
+        Unit::Directory { path, .. } => format!("directory:{path}"),
+        Unit::Crate { id, .. } => format!("crate:{id}"),
+        Unit::Module { id, .. } => format!("module:{id}"),
     }
 }
 

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -203,6 +203,71 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
         }
     }
 
+    // L-011 / L-012 (spec 076 3.3, 3.4): the `planned` flag cannot outlive the
+    // work, in either direction.
+    //
+    // Read from the **committed** index for the resolved half, by the same
+    // rule `L-008` follows: `lint` is a read verb, and indexing here would make
+    // it write-shaped and slow. A corpus with no committed index is silent
+    // about `L-012`, which is right: there is no ledger yet to say a claim has
+    // landed. `L-011` needs no ledger at all, being a contradiction inside one
+    // file's frontmatter.
+    let resolved_paths: std::collections::BTreeSet<String> =
+        match crate::index::load_committed_index(cfg, repo_root) {
+            Ok(index) => index
+                .traceability
+                .mappings
+                .iter()
+                .flat_map(|t| t.resolved_units.iter())
+                .filter(|ru| !ru.locations.is_empty())
+                .map(|ru| unit_key(&ru.unit))
+                .collect(),
+            Err(_) => Default::default(),
+        };
+    for spec in &registry.specs {
+        let at = || Some(spec.spec_path.clone());
+        for unit in owned_units(spec).into_iter().filter(|u| u.is_planned()) {
+            // L-011: completion asserts the work is done and a planned unit
+            // asserts it is not. Error tier, not warning: the two together are
+            // a contradiction inside the spec's own frontmatter rather than a
+            // gap someone might hold deliberately. Spec 041 established that
+            // `complete` ends the in-flight window; this extends the same
+            // principle to the new field, which is what keeps `planned` from
+            // becoming a state nobody owns the exit from.
+            if spec.implementation == Some(spec_spine_types::Implementation::Complete) {
+                violations.push(error(
+                    "L-011",
+                    format!(
+                        "spec '{}' is implementation: complete while unit '{}' is still \
+                         marked planned: completion asserts the work is done and a planned \
+                         unit asserts it is not. Drop the flag, or the completion",
+                        spec.id,
+                        unit_label(&unit)
+                    ),
+                    at(),
+                ));
+            }
+            // L-012: the other direction. The file landed, the claim is
+            // satisfied, and without this nothing notices that the spec still
+            // describes it as future work. Warning tier, so `--fail-on-warn`
+            // refuses it in a corpus running the gate and a corpus that does
+            // not is merely told.
+            if resolved_paths.contains(&unit_key(&unit.subject())) {
+                violations.push(warn(
+                    "L-012",
+                    format!(
+                        "spec '{}' marks unit '{}' planned, and it now resolves: drop the \
+                         flag. The claim is unaffected either way, this is a signal about \
+                         the frontmatter",
+                        spec.id,
+                        unit_label(&unit)
+                    ),
+                    at(),
+                ));
+            }
+        }
+    }
+
     // L-010 (spec 074 3.1): an `[index] extra_hashed_inputs` pattern ending in
     // `/**`. In the `glob` crate `dir/**` enumerates DIRECTORIES and the hasher
     // keeps only entries that are files, so such a pattern can never contribute
@@ -345,7 +410,7 @@ fn claimed_paths(spec: &SpecRecord) -> Vec<String> {
 /// The repo-relative path a unit names, for the unit kinds that carry one.
 fn unit_path(unit: &Unit) -> Option<String> {
     match unit {
-        Unit::File { path } | Unit::Directory { path } => Some(path.clone()),
+        Unit::File { path, .. } | Unit::Directory { path, .. } => Some(path.clone()),
         Unit::Section { file, .. } => Some(file.clone()),
         Unit::Symbol { .. } | Unit::Crate { .. } | Unit::Module { .. } => None,
     }
@@ -361,4 +426,46 @@ fn warn(code: &str, message: String, path: Option<String>) -> Violation {
 
 fn info(code: &str, message: String, path: Option<String>) -> Violation {
     Violation::new(code, Severity::Info, message).at_opt(path)
+}
+
+/// A unit's identity as a comparable key, ignoring the `planned` flag (spec
+/// 076 §3.4: the flag is not part of a unit's identity).
+fn unit_key(unit: &Unit) -> String {
+    match unit.subject() {
+        Unit::File { path, .. } => format!("file:{path}"),
+        Unit::Section { file, anchor, .. } => format!("section:{file}#{anchor}"),
+        Unit::Symbol { id, .. } => format!("symbol:{id}"),
+        Unit::Directory { path, .. } => format!("directory:{path}"),
+        Unit::Crate { id, .. } => format!("crate:{id}"),
+        Unit::Module { id, .. } => format!("module:{id}"),
+    }
+}
+
+/// A unit as a reader sees it in a diagnostic: the path or id it names.
+fn unit_label(unit: &Unit) -> String {
+    match unit {
+        Unit::File { path, .. } | Unit::Directory { path, .. } => path.clone(),
+        Unit::Section { file, anchor, .. } => format!("{file}#{anchor}"),
+        Unit::Symbol { id, .. } | Unit::Crate { id, .. } | Unit::Module { id, .. } => id.clone(),
+    }
+}
+
+/// Every unit a spec claims through an ownership-bearing edge.
+///
+/// The same six edges `claimed_paths` walks, returning the units rather than
+/// their paths, because spec 076's checks are about the unit (a symbol or crate
+/// unit has no path and can be planned exactly as a file can). `references` is
+/// excluded for the reason spec 034 gave: a cited file is not a claimed one, so
+/// a spec cannot plan territory by citing it.
+fn owned_units(spec: &SpecRecord) -> Vec<Unit> {
+    let mut units: Vec<Unit> = spec.establishes.clone();
+    units.extend(spec.extends.iter().filter_map(|i| i.unit.clone()));
+    units.extend(spec.refines.iter().filter_map(|i| i.unit.clone()));
+    units.extend(spec.supersedes.iter().filter_map(|i| match i {
+        spec_spine_types::SupersedeItem::Scoped(s) => s.unit.clone(),
+        _ => None,
+    }));
+    units.extend(spec.co_authority.iter().map(|i| i.unit.clone()));
+    units.extend(spec.constrains.iter().filter_map(|i| i.unit.clone()));
+    units
 }

--- a/crates/spec-spine-core/src/query.rs
+++ b/crates/spec-spine-core/src/query.rs
@@ -289,6 +289,30 @@ pub struct Plan {
     /// and a reader cannot tell whether the missing specs were excluded or
     /// lost (spec 060 §3.1).
     pub not_schedulable: usize,
+    /// Territory specs have declared they intend to own and have not written
+    /// yet (spec 076 §3.6).
+    ///
+    /// Reported as a **declared state** rather than derived from a suppressed
+    /// diagnostic: §3.2 removes the `W-001` a planned unit used to produce, so
+    /// a consumer that read the diagnostics band would now see nothing at all.
+    /// This is the read the flag exists to unblind: before it, `plan` could
+    /// only see the past.
+    ///
+    /// Omitted when empty, so a corpus using no planned units emits exactly
+    /// what it did before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub planned: Vec<PlannedTerritory>,
+}
+
+/// One spec's planned territory: what it has said it will own (spec 076).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlannedTerritory {
+    pub id: String,
+    pub title: String,
+    /// The planned units, as the identity strings a reader recognizes
+    /// (`file:src/a.rs`), in the spec's own declaration order.
+    pub units: Vec<String>,
 }
 
 impl Plan {
@@ -397,7 +421,94 @@ pub fn plan(registry: &Registry) -> Result<Plan, Error> {
             .collect(),
         blocked,
         not_schedulable,
+        // Spec 076 §3.6, over every spec rather than the ready set alone: a
+        // blocked spec's planned territory is exactly what a reader wants when
+        // deciding what unblocking it would cost.
+        planned: registry
+            .specs
+            .iter()
+            .filter_map(|spec| {
+                let units: Vec<String> = planned_units(spec);
+                (!units.is_empty()).then(|| PlannedTerritory {
+                    id: spec.id.clone(),
+                    title: spec.title.clone(),
+                    units,
+                })
+            })
+            .collect(),
     })
+}
+
+/// Every spec's planned territory as `<spec id>: <unit identity>` lines,
+/// sorted (spec 076 §3.6).
+///
+/// Shared by `registry plan` and `index coverage` so the two reads cannot
+/// disagree about what the corpus has declared.
+pub fn planned_territory(registry: &Registry) -> Vec<String> {
+    let mut out: Vec<String> = registry
+        .specs
+        .iter()
+        .flat_map(|spec| {
+            planned_units(spec)
+                .into_iter()
+                .map(move |u| format!("{}: {u}", spec.id))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// The identity strings of every unit a spec has marked planned, in its own
+/// declaration order across the ownership-bearing edges.
+fn planned_units(spec: &SpecRecord) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut push = |u: &spec_spine_types::Unit| {
+        if u.is_planned() {
+            out.push(unit_identity(u));
+        }
+    };
+    for u in &spec.establishes {
+        push(u);
+    }
+    for i in &spec.extends {
+        if let Some(u) = &i.unit {
+            push(u);
+        }
+    }
+    for i in &spec.refines {
+        if let Some(u) = &i.unit {
+            push(u);
+        }
+    }
+    for i in &spec.supersedes {
+        if let spec_spine_types::SupersedeItem::Scoped(sc) = i
+            && let Some(u) = &sc.unit
+        {
+            push(u);
+        }
+    }
+    for i in &spec.co_authority {
+        push(&i.unit);
+    }
+    for i in &spec.constrains {
+        if let Some(u) = &i.unit {
+            push(u);
+        }
+    }
+    out
+}
+
+/// A unit as the identity string a reader recognizes.
+fn unit_identity(unit: &spec_spine_types::Unit) -> String {
+    use spec_spine_types::Unit;
+    match unit {
+        Unit::File { path, .. } => format!("file:{path}"),
+        Unit::Section { file, anchor, .. } => format!("section:{file}#{anchor}"),
+        Unit::Symbol { id, .. } => format!("symbol:{id}"),
+        Unit::Directory { path, .. } => format!("directory:{path}"),
+        Unit::Crate { id, .. } => format!("crate:{id}"),
+        Unit::Module { id, .. } => format!("module:{id}"),
+    }
 }
 
 /// Whether this spec should be offered to a scheduler at all.

--- a/crates/spec-spine-core/tests/coverage.rs
+++ b/crates/spec-spine-core/tests/coverage.rs
@@ -758,3 +758,56 @@ fn packages_without_source_files_point_at_resolver_exclusions() {
         reason.explain()
     );
 }
+
+// ── spec 076 §3.6: coverage can see planned territory ───────────────────────
+
+/// §3.6: a file nothing claims and a file something has planned are different
+/// states, and the report could not tell them apart. It reads the DECLARED
+/// state from the registry, because a planned unit that has not resolved
+/// contributes no `ResolvedUnit` at all (§3.2), which is exactly why coverage
+/// was blind to it.
+#[test]
+fn coverage_reports_planned_territory_separately_from_the_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = [\"a\"]\n");
+    write(
+        tmp.path(),
+        "a/Cargo.toml",
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\n",
+    );
+    write(tmp.path(), "a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        tmp.path(),
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: approved\ncreated: \"2026-09-08\"\n\
+         implementation: pending\nsummary: \"s\"\nestablishes:\n  - \"a/src/lib.rs\"\n\
+         \x20 - { kind: file, path: \"a/src/future.rs\", planned: true }\n---\n# 001-a\n## body\n",
+    );
+
+    let cfg = Config::default();
+    let out = index(&cfg, tmp.path()).unwrap();
+    let dir = index_dir(&cfg, tmp.path());
+    let (by_spec, by_package) = index_shard_files(&out.shards).unwrap();
+    shard::sync_dir(&dir.join(BY_SPEC_DIR), &by_spec).unwrap();
+    shard::sync_dir(&dir.join(BY_PACKAGE_DIR), &by_package).unwrap();
+    let compiled = spec_spine_core::compile(&cfg, tmp.path()).unwrap();
+    let reg_dir = spec_spine_core::registry_dir(&cfg, tmp.path());
+    shard::sync_dir(
+        &reg_dir.join(spec_spine_core::shard::BY_SPEC_DIR),
+        &spec_spine_core::registry_shard_files(&compiled.shards).unwrap(),
+    )
+    .unwrap();
+
+    let report = coverage(&cfg, tmp.path()).unwrap();
+    assert_eq!(
+        report.planned_territory,
+        vec!["001-a: file:a/src/future.rs".to_string()],
+        "the declared intention must be visible"
+    );
+    // And it is NOT counted: these paths are not on disk, so counting a
+    // declared intention as coverage would let a spec satisfy
+    // `--fail-on-untraced` by promising rather than by writing.
+    assert_eq!(report.source_files, 1, "only the file that exists");
+    assert_eq!(report.claimed_files, 1);
+    assert!(report.is_fully_claimed());
+}

--- a/crates/spec-spine-core/tests/index.rs
+++ b/crates/spec-spine-core/tests/index.rs
@@ -116,7 +116,7 @@ fn mapping<'a>(
 fn symbol_span(m: &spec_spine_types::TraceMapping, sym_id: &str) -> Option<LineSpan> {
     m.resolved_units
         .iter()
-        .find(|u| matches!(&u.unit, Unit::Symbol { id } if id == sym_id))
+        .find(|u| matches!(&u.unit, Unit::Symbol { id, .. } if id == sym_id))
         .and_then(|u| u.locations.first())
         .and_then(|loc| loc.span)
 }
@@ -658,7 +658,8 @@ fn crate_unit_resolves_to_package_subtree() {
         authorities(
             &idx,
             &Unit::Crate {
-                id: "rs-thing".into()
+                id: "rs-thing".into(),
+                planned: false
             }
         )
         .contains(&"001-c".into())
@@ -731,7 +732,7 @@ fn module_unit_resolves_inline_and_file_modules() {
     let tests_unit = m
         .resolved_units
         .iter()
-        .find(|u| matches!(&u.unit, Unit::Module { id } if id == "rs_thing::tests"))
+        .find(|u| matches!(&u.unit, Unit::Module { id, .. } if id == "rs_thing::tests"))
         .unwrap();
     assert_eq!(tests_unit.locations[0].file, "rs-thing/src/lib.rs");
     assert!(
@@ -741,7 +742,7 @@ fn module_unit_resolves_inline_and_file_modules() {
     let helper_unit = m
         .resolved_units
         .iter()
-        .find(|u| matches!(&u.unit, Unit::Module { id } if id == "rs_thing::helper"))
+        .find(|u| matches!(&u.unit, Unit::Module { id, .. } if id == "rs_thing::helper"))
         .unwrap();
     assert_eq!(helper_unit.locations[0].file, "rs-thing/src/helper.rs");
     assert_eq!(
@@ -846,7 +847,7 @@ fn references_unit_survives_in_resolved_units() {
     let cited = m
         .resolved_units
         .iter()
-        .find(|u| matches!(&u.unit, Unit::File { path } if path == "src/cited.rs"))
+        .find(|u| matches!(&u.unit, Unit::File { path, .. } if path == "src/cited.rs"))
         .expect("the reference is still recorded");
     assert!(!cited.ownership, "a `references` unit is non-owning");
     assert_eq!(cited.locations.len(), 1, "and it still resolves");
@@ -1473,5 +1474,108 @@ fn a_workflow_bump_leaves_every_shard_hash_alone_and_a_run_edit_does_not() {
         before,
         shard::global_inputs_hash(&cfg, root),
         "a `run:` edit is a governed change and must still stale the ledger"
+    );
+}
+
+// ── spec 076: planned territory is declared, not inferred ───────────────────
+
+/// A corpus with one spec claiming `unit_yaml` (a frontmatter fragment).
+fn planned_fixture(unit_yaml: &str, status: &str, implementation: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    write(
+        tmp.path(),
+        "specs/001-a/spec.md",
+        &format!(
+            "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: {status}\ncreated: \"2026-09-08\"\n\
+             implementation: {implementation}\nsummary: \"s\"\nestablishes:\n{unit_yaml}\
+             ---\n# 001-a\n## body\n"
+        ),
+    );
+    tmp
+}
+
+fn diag_codes(tmp: &tempfile::TempDir) -> Vec<String> {
+    let idx = index(&Config::default(), tmp.path()).unwrap().index;
+    idx.diagnostics
+        .warnings
+        .iter()
+        .chain(idx.diagnostics.errors.iter())
+        .map(|d| d.code.clone())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Spec 076 §3.2, and the case the spec was filed for: a draft that declares
+/// territory it has not written passes, while a draft with a path that is
+/// simply wrong still does not. That asymmetry is the whole safety argument.
+#[test]
+fn a_planned_unit_produces_no_diagnostic_and_an_unmarked_one_still_does() {
+    let planned = planned_fixture(
+        "  - { kind: file, path: \"src/not-written-yet.rs\", planned: true }\n",
+        "draft",
+        "pending",
+    );
+    assert!(
+        !diag_codes(&planned).iter().any(|c| c.starts_with("W-00")),
+        "a planned unit is a declared state, not a suppressed diagnostic: {:?}",
+        diag_codes(&planned)
+    );
+
+    let unmarked = planned_fixture("  - \"src/typo.rs\"\n", "draft", "pending");
+    assert!(
+        diag_codes(&unmarked).iter().any(|c| c == "W-001"),
+        "a path that is simply wrong must still be caught: {:?}",
+        diag_codes(&unmarked)
+    );
+}
+
+/// Spec 076 §3.2: every other classification is unchanged. A settled spec's
+/// unresolved unit is still a hard error, and marking it planned is the only
+/// thing that changes that.
+#[test]
+fn planned_does_not_soften_any_other_classification() {
+    let settled = planned_fixture("  - \"src/gone.rs\"\n", "approved", "complete");
+    let codes = diag_codes(&settled);
+    assert!(
+        codes.iter().any(|c| c.starts_with("I-0")),
+        "a settled spec's unresolved unit is still a hard error: {codes:?}"
+    );
+}
+
+/// Spec 076 §3.2 and §3.4: a planned unit contributes nothing while it does not
+/// resolve, and everything once it does. `authorities` must answer for it
+/// exactly as for an unplanned claim, which is why the index stores subjects.
+#[test]
+fn a_planned_unit_that_resolves_is_owned_like_any_other() {
+    let tmp = planned_fixture(
+        "  - { kind: file, path: \"src/a.rs\", planned: true }\n",
+        "draft",
+        "pending",
+    );
+    // Not written yet: no location, no implementing path.
+    let before = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        before.traceability.mappings[0]
+            .implementing_paths
+            .is_empty(),
+        "a declaration of intent is not a declaration of ownership"
+    );
+
+    // Now it lands, and the flag is still on the claim.
+    write(tmp.path(), "src/a.rs", "pub fn a() {}\n");
+    let after = index(&Config::default(), tmp.path()).unwrap().index;
+    assert!(
+        after.traceability.mappings[0]
+            .implementing_paths
+            .iter()
+            .any(|p| p.path == "src/a.rs"),
+        "a resolved planned unit participates in ownership"
+    );
+    assert_eq!(
+        authorities(&after, &Unit::file("src/a.rs")),
+        vec!["001-a".to_string()],
+        "the lookup must not have to know the claim was planned"
     );
 }

--- a/crates/spec-spine-core/tests/lint.rs
+++ b/crates/spec-spine-core/tests/lint.rs
@@ -631,3 +631,230 @@ fn the_l010_message_names_the_working_form() {
         .message;
     assert!(msg.contains("standards/**/*"), "{msg}");
 }
+
+// ── spec 076 §3.3 and §3.4: the flag cannot outlive the work ────────────────
+
+/// A corpus whose one spec claims `unit_yaml` at the given lifecycle.
+fn planned_corpus(unit_yaml: &str, status: &str, implementation: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "specs/001-a/spec.md",
+        &format!(
+            "---\nid: \"001-a\"\ntitle: \"A\"\nstatus: {status}\ncreated: \"2026-09-08\"\n\
+             implementation: {implementation}\nsummary: \"s\"\nestablishes:\n{unit_yaml}\
+             ---\n# 001-a\n## body\n"
+        ),
+    );
+    tmp
+}
+
+fn lint_codes(tmp: &tempfile::TempDir) -> Vec<(String, Severity)> {
+    spec_spine_core::lint::lint(&Config::default(), tmp.path())
+        .unwrap()
+        .violations
+        .into_iter()
+        .map(|v| (v.code, v.severity))
+        .collect()
+}
+
+/// §3.3: completion asserts the work is done and a planned unit asserts it is
+/// not, so the two together are a contradiction inside one file's frontmatter.
+/// Error tier, not warning: it is not a state a corpus holds deliberately.
+#[test]
+fn l011_refuses_a_completed_spec_that_still_plans_territory() {
+    let tmp = planned_corpus(
+        "  - { kind: file, path: \"src/later.rs\", planned: true }\n",
+        "approved",
+        "complete",
+    );
+    let found = lint_codes(&tmp);
+    assert!(
+        found.contains(&("L-011".to_string(), Severity::Error)),
+        "L-011 must fire at error tier: {found:?}"
+    );
+}
+
+/// §3.3: `complete` is the only bound, deliberately. An `approved` spec at
+/// `pending` may carry planned units for as long as that state is honest, which
+/// on a specify-first corpus is months. An intermediate deadline would mean
+/// inventing a clock.
+#[test]
+fn l011_is_silent_while_the_work_is_genuinely_in_flight() {
+    for implementation in ["pending", "in-progress"] {
+        let tmp = planned_corpus(
+            "  - { kind: file, path: \"src/later.rs\", planned: true }\n",
+            "approved",
+            implementation,
+        );
+        assert!(
+            !lint_codes(&tmp).iter().any(|(c, _)| c == "L-011"),
+            "{implementation}: a spec still doing the work may plan territory"
+        );
+    }
+}
+
+/// §3.4: the other direction. Without it the flag rots: the file lands, the
+/// claim is satisfied, and nothing notices that the spec still calls it future
+/// work. Warning tier, so `--fail-on-warn` refuses it in a corpus running the
+/// gate without imposing it on one that does not.
+#[test]
+fn l012_reports_a_planned_unit_that_has_resolved() {
+    let tmp = planned_corpus(
+        "  - { kind: file, path: \"src/landed.rs\", planned: true }\n",
+        "draft",
+        "pending",
+    );
+    write(tmp.path(), "src/landed.rs", "pub fn a() {}\n");
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    // `L-012` reads the COMMITTED index, by the same rule `L-008` follows: lint
+    // is a read verb, and indexing inside it would make it write-shaped.
+    let out = spec_spine_core::index(&Config::default(), tmp.path()).unwrap();
+    let dir = spec_spine_core::index_dir(&Config::default(), tmp.path());
+    let (by_spec, by_package) = spec_spine_core::index_shard_files(&out.shards).unwrap();
+    spec_spine_core::shard::sync_dir(&dir.join(spec_spine_core::shard::BY_SPEC_DIR), &by_spec)
+        .unwrap();
+    spec_spine_core::shard::sync_dir(
+        &dir.join(spec_spine_core::shard::BY_PACKAGE_DIR),
+        &by_package,
+    )
+    .unwrap();
+
+    let found = lint_codes(&tmp);
+    assert!(
+        found.contains(&("L-012".to_string(), Severity::Warning)),
+        "L-012 must fire at warning tier once the claim lands: {found:?}"
+    );
+}
+
+/// §3.4: and it must not fire while the claim is honestly unwritten, or the
+/// diagnostic would just be a second name for "planned".
+#[test]
+fn l012_is_silent_while_the_planned_unit_is_still_unwritten() {
+    let tmp = planned_corpus(
+        "  - { kind: file, path: \"src/never.rs\", planned: true }\n",
+        "draft",
+        "pending",
+    );
+    assert!(!lint_codes(&tmp).iter().any(|(c, _)| c == "L-012"));
+}
+
+// ── spec 076 §3.5: collisions reuse the ownership rules ─────────────────────
+
+/// Write one spec with arbitrary extra frontmatter lines.
+fn spec_with(tmp: &tempfile::TempDir, id: &str, extra: &str) {
+    write(
+        tmp.path(),
+        &format!("specs/{id}/spec.md"),
+        &format!(
+            "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-08\"\n\
+             implementation: pending\nsummary: \"s\"\n{extra}---\n# {id}\n## body\n"
+        ),
+    );
+}
+
+fn compile_codes(tmp: &tempfile::TempDir) -> Vec<String> {
+    spec_spine_core::compile(&Config::default(), tmp.path())
+        .unwrap()
+        .registry
+        .validation
+        .violations
+        .into_iter()
+        .map(|v| v.code)
+        .collect()
+}
+
+/// §3.5: two specs planning the same unit is the duplicate-ownership refusal.
+/// Decided over DECLARED units at compile time, because the existing machinery
+/// runs on `TraceMapping` and §3.2 keeps a planned unit from ever producing
+/// one: a rule that cannot fire is worse than no rule.
+#[test]
+fn v015_refuses_two_specs_planning_the_same_unit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let unit = "establishes:\n  - { kind: file, path: \"src/x.rs\", planned: true }\n";
+    spec_with(&tmp, "001-a", unit);
+    spec_with(&tmp, "002-b", unit);
+    assert!(
+        compile_codes(&tmp).iter().any(|c| c == "V-015"),
+        "{:?}",
+        compile_codes(&tmp)
+    );
+}
+
+/// §3.5: with the same `co_authority` escape as any other shared claim, so the
+/// new rule introduces no second ownership vocabulary.
+#[test]
+fn v015_allows_a_shared_plan_declared_as_co_authority() {
+    let tmp = tempfile::tempdir().unwrap();
+    let unit = "establishes:\n  - { kind: file, path: \"src/x.rs\", planned: true }\n\
+                co_authority:\n  - { unit: { kind: file, path: \"src/x.rs\" }, with_specs: [\"002-b\"] }\n";
+    spec_with(&tmp, "001-a", unit);
+    spec_with(
+        &tmp,
+        "002-b",
+        "establishes:\n  - { kind: file, path: \"src/x.rs\", planned: true }\n",
+    );
+    assert!(
+        !compile_codes(&tmp).iter().any(|c| c == "V-015"),
+        "a genuinely shared claim has an escape: {:?}",
+        compile_codes(&tmp)
+    );
+}
+
+/// §3.5: planning a unit another spec already owns is refused. The correct
+/// declaration is an `extends` edge naming that spec and unit, which is what
+/// crossing into owned territory has always meant.
+#[test]
+fn v016_refuses_planning_territory_another_spec_already_owns() {
+    let tmp = tempfile::tempdir().unwrap();
+    spec_with(&tmp, "001-a", "establishes:\n  - \"src/x.rs\"\n");
+    spec_with(
+        &tmp,
+        "002-b",
+        "establishes:\n  - { kind: file, path: \"src/x.rs\", planned: true }\n",
+    );
+    assert!(
+        compile_codes(&tmp).iter().any(|c| c == "V-016"),
+        "{:?}",
+        compile_codes(&tmp)
+    );
+}
+
+/// §3.5: a planned unit must not be the target of an `extends` edge. There is
+/// nothing to extend: the unit does not exist and its planner does not own it.
+#[test]
+fn v017_refuses_extending_a_unit_that_is_only_planned() {
+    let tmp = tempfile::tempdir().unwrap();
+    spec_with(
+        &tmp,
+        "001-a",
+        "establishes:\n  - { kind: file, path: \"src/x.rs\", planned: true }\n",
+    );
+    spec_with(
+        &tmp,
+        "002-b",
+        "extends:\n  - { spec: \"001-a\", unit: { kind: file, path: \"src/x.rs\" }, nature: additive }\n",
+    );
+    assert!(
+        compile_codes(&tmp).iter().any(|c| c == "V-017"),
+        "{:?}",
+        compile_codes(&tmp)
+    );
+}
+
+/// The corpus this repository actually has must stay clean, or the three new
+/// refusals would be a change of behaviour dressed as a new rule.
+#[test]
+fn the_planned_refusals_are_silent_on_a_corpus_that_plans_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    spec_with(&tmp, "001-a", "establishes:\n  - \"src/x.rs\"\n");
+    spec_with(
+        &tmp,
+        "002-b",
+        "extends:\n  - { spec: \"001-a\", unit: \"src/x.rs\", nature: additive }\n",
+    );
+    let codes = compile_codes(&tmp);
+    for code in ["V-015", "V-016", "V-017"] {
+        assert!(!codes.iter().any(|c| c == code), "{code} fired: {codes:?}");
+    }
+}

--- a/crates/spec-spine-core/tests/query.rs
+++ b/crates/spec-spine-core/tests/query.rs
@@ -820,3 +820,56 @@ fn the_ordering_contract_survives_the_titles() {
     let ids: Vec<&str> = p.ready.iter().map(|r| r.id.as_str()).collect();
     assert_eq!(ids, ["001-alpha", "002-beta", "003-gamma"]);
 }
+
+// ── spec 076 §3.6: the ledger records planned territory as a state ──────────
+
+/// §3.6: `registry plan` can report planned territory. Before the flag, the
+/// read that exists to answer "what is being worked on and who will own it"
+/// could only see the past.
+#[test]
+fn the_plan_reports_planned_territory() {
+    let tmp = tempfile::tempdir().unwrap();
+    plan_spec(
+        &tmp,
+        "001-a",
+        "establishes:\n  - { kind: file, path: \"src/x.rs\", planned: true }\n\
+         \x20 - { kind: symbol, id: \"m::f\", planned: true }\n  - \"src/here.rs\"\n",
+    );
+    let registry = spec_spine_core::compile(&Config::default(), tmp.path())
+        .unwrap()
+        .registry;
+    let plan = spec_spine_core::query::plan(&registry).unwrap();
+    assert_eq!(plan.planned.len(), 1, "{:?}", plan.planned);
+    assert_eq!(plan.planned[0].id, "001-a");
+    assert_eq!(
+        plan.planned[0].units,
+        vec!["file:src/x.rs".to_string(), "symbol:m::f".to_string()],
+        "only the planned units, in declaration order"
+    );
+
+    // And a corpus that plans nothing reports nothing, so the member is absent
+    // from existing output rather than an empty array in it.
+    let bare = tempfile::tempdir().unwrap();
+    plan_spec(&bare, "001-a", "establishes:\n  - \"src/x.rs\"\n");
+    let registry = spec_spine_core::compile(&Config::default(), bare.path())
+        .unwrap()
+        .registry;
+    let plan = spec_spine_core::query::plan(&registry).unwrap();
+    assert!(plan.planned.is_empty());
+    let json = serde_json::to_string(&plan).unwrap();
+    assert!(!json.contains("planned"), "{json}");
+}
+
+/// One spec with arbitrary extra frontmatter, for the planned-territory read.
+fn plan_spec(tmp: &tempfile::TempDir, id: &str, extra: &str) {
+    let dir = tmp.path().join("specs").join(id);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("spec.md"),
+        format!(
+            "---\nid: \"{id}\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-08\"\n\
+             implementation: pending\nsummary: \"s\"\n{extra}---\n# {id}\n## body\n"
+        ),
+    )
+    .unwrap();
+}

--- a/crates/spec-spine-types/src/coverage.rs
+++ b/crates/spec-spine-types/src/coverage.rs
@@ -26,6 +26,20 @@ pub struct CoverageReport {
     pub unclaimed_files: Vec<String>,
     /// Per-package breakdown, sorted by package path.
     pub packages: Vec<PackageCoverage>,
+    /// Territory a spec has declared it will own and has not written yet
+    /// (spec 076 §3.6), as `<spec id>: <unit identity>` entries, sorted.
+    ///
+    /// **Not** part of the numerator or the denominator, and deliberately so.
+    /// These paths are not on disk, so they are not source files; counting a
+    /// planned claim as coverage would let a spec satisfy `--fail-on-untraced`
+    /// by declaring an intention. What this answers is the question the report
+    /// could not answer before: a file nothing claims and a file something has
+    /// planned now look different to a reader.
+    ///
+    /// Omitted when empty, so a corpus using no planned units emits exactly
+    /// what it did before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub planned_territory: Vec<String>,
 }
 
 impl CoverageReport {

--- a/crates/spec-spine-types/src/edges.rs
+++ b/crates/spec-spine-types/src/edges.rs
@@ -76,7 +76,7 @@ pub(crate) fn expand_extend_paths(items: Vec<ExtendItem>) -> Result<Vec<ExtendIt
         for path in paths {
             out.push(ExtendItem {
                 spec: item.spec.clone(),
-                unit: Some(Unit::File { path }),
+                unit: Some(Unit::file(path)),
                 paths: None,
                 nature: item.nature.clone(),
             });
@@ -109,7 +109,7 @@ pub(crate) fn expand_refine_paths(items: Vec<RefineItem>) -> Result<Vec<RefineIt
         for path in paths {
             out.push(RefineItem {
                 aspect: item.aspect.clone(),
-                unit: Some(Unit::File { path }),
+                unit: Some(Unit::file(path)),
                 paths: None,
                 refines_specs: item.refines_specs.clone(),
             });

--- a/crates/spec-spine-types/src/unit.rs
+++ b/crates/spec-spine-types/src/unit.rs
@@ -25,39 +25,173 @@ use serde::{Deserialize, Serialize};
 pub enum Unit {
     /// A file path (bare string shorthand resolves here). A trailing `/` denotes
     /// the directory subtree rooted at `path`.
-    File { path: String },
+    File {
+        path: String,
+        /// Spec 076: the spec claims this territory and has not written it
+        /// yet. A declared state, not a diagnostic: an unresolved unit marked
+        /// `planned` produces no `W-001`, while one that is merely wrong still
+        /// does, which is the distinction that makes the flag safe to add to a
+        /// corpus gating on `--fail-on-unresolved`.
+        ///
+        /// Serialized only when true, so a corpus that uses no planned units
+        /// emits byte-identical shards across this change. A written
+        /// `planned: false` therefore normalizes to absent: it means exactly
+        /// what omitting it means, and one canonical form per meaning is what
+        /// keeps the four-triple determinism gate from seeing a round-trip as
+        /// drift.
+        #[serde(default, skip_serializing_if = "is_false")]
+        planned: bool,
+    },
     /// A named section within a file: a Makefile target, a Markdown heading slug,
     /// a `region:` marker, or a CI `jobs.<name>`.
-    Section { file: String, anchor: String },
+    Section {
+        file: String,
+        anchor: String,
+        /// Spec 076: the spec claims this territory and has not written it
+        /// yet. A declared state, not a diagnostic: an unresolved unit marked
+        /// `planned` produces no `W-001`, while one that is merely wrong still
+        /// does, which is the distinction that makes the flag safe to add to a
+        /// corpus gating on `--fail-on-unresolved`.
+        ///
+        /// Serialized only when true, so a corpus that uses no planned units
+        /// emits byte-identical shards across this change. A written
+        /// `planned: false` therefore normalizes to absent: it means exactly
+        /// what omitting it means, and one canonical form per meaning is what
+        /// keeps the four-triple determinism gate from seeing a round-trip as
+        /// drift.
+        #[serde(default, skip_serializing_if = "is_false")]
+        planned: bool,
+    },
     /// A symbol (function / type / export), resolved by the indexer via
     /// tree-sitter (Rust `.rs` and TypeScript `.ts`/`.tsx`).
-    Symbol { id: String },
+    Symbol {
+        id: String,
+        /// Spec 076: the spec claims this territory and has not written it
+        /// yet. A declared state, not a diagnostic: an unresolved unit marked
+        /// `planned` produces no `W-001`, while one that is merely wrong still
+        /// does, which is the distinction that makes the flag safe to add to a
+        /// corpus gating on `--fail-on-unresolved`.
+        ///
+        /// Serialized only when true, so a corpus that uses no planned units
+        /// emits byte-identical shards across this change. A written
+        /// `planned: false` therefore normalizes to absent: it means exactly
+        /// what omitting it means, and one canonical form per meaning is what
+        /// keeps the four-triple determinism gate from seeing a round-trip as
+        /// drift.
+        #[serde(default, skip_serializing_if = "is_false")]
+        planned: bool,
+    },
     /// A directory subtree, named explicitly (`{ kind: directory, path }`). The
     /// subtree-prefix resolution is identical to a trailing-slash file unit; the
     /// distinct kind preserves the author's intent across the round-trip (spec
     /// 017). Resolves to the directory path; the gate prefix-matches it.
-    Directory { path: String },
+    Directory {
+        path: String,
+        /// Spec 076: the spec claims this territory and has not written it
+        /// yet. A declared state, not a diagnostic: an unresolved unit marked
+        /// `planned` produces no `W-001`, while one that is merely wrong still
+        /// does, which is the distinction that makes the flag safe to add to a
+        /// corpus gating on `--fail-on-unresolved`.
+        ///
+        /// Serialized only when true, so a corpus that uses no planned units
+        /// emits byte-identical shards across this change. A written
+        /// `planned: false` therefore normalizes to absent: it means exactly
+        /// what omitting it means, and one canonical form per meaning is what
+        /// keeps the four-triple determinism gate from seeing a round-trip as
+        /// drift.
+        #[serde(default, skip_serializing_if = "is_false")]
+        planned: bool,
+    },
     /// A compilation unit by its manifest name (Cargo `[package].name` or npm
     /// `package.json:name`), resolved against the discovered package inventory to
     /// the package directory subtree (spec 017).
-    Crate { id: String },
+    Crate {
+        id: String,
+        /// Spec 076: the spec claims this territory and has not written it
+        /// yet. A declared state, not a diagnostic: an unresolved unit marked
+        /// `planned` produces no `W-001`, while one that is merely wrong still
+        /// does, which is the distinction that makes the flag safe to add to a
+        /// corpus gating on `--fail-on-unresolved`.
+        ///
+        /// Serialized only when true, so a corpus that uses no planned units
+        /// emits byte-identical shards across this change. A written
+        /// `planned: false` therefore normalizes to absent: it means exactly
+        /// what omitting it means, and one canonical form per meaning is what
+        /// keeps the four-triple determinism gate from seeing a round-trip as
+        /// drift.
+        #[serde(default, skip_serializing_if = "is_false")]
+        planned: bool,
+    },
     /// A module by its `::`-qualified path (e.g. `my_crate::serialization`),
     /// resolved by the indexer's Rust module index: file-modules (whole file)
     /// and top-level inline `mod` blocks (line-span) (spec 017).
-    Module { id: String },
+    Module {
+        id: String,
+        /// Spec 076: the spec claims this territory and has not written it
+        /// yet. A declared state, not a diagnostic: an unresolved unit marked
+        /// `planned` produces no `W-001`, while one that is merely wrong still
+        /// does, which is the distinction that makes the flag safe to add to a
+        /// corpus gating on `--fail-on-unresolved`.
+        ///
+        /// Serialized only when true, so a corpus that uses no planned units
+        /// emits byte-identical shards across this change. A written
+        /// `planned: false` therefore normalizes to absent: it means exactly
+        /// what omitting it means, and one canonical form per meaning is what
+        /// keeps the four-triple determinism gate from seeing a round-trip as
+        /// drift.
+        #[serde(default, skip_serializing_if = "is_false")]
+        planned: bool,
+    },
 }
 
 impl Unit {
     /// A file unit from a path (the bare-string shorthand target).
     pub fn file(path: impl Into<String>) -> Self {
-        Unit::File { path: path.into() }
+        Unit::File {
+            path: path.into(),
+            planned: false,
+        }
+    }
+
+    /// Spec 076 §3.1: whether the claiming spec has declared this territory
+    /// planned but not yet written.
+    pub fn is_planned(&self) -> bool {
+        match self {
+            Unit::File { planned, .. }
+            | Unit::Section { planned, .. }
+            | Unit::Symbol { planned, .. }
+            | Unit::Directory { planned, .. }
+            | Unit::Crate { planned, .. }
+            | Unit::Module { planned, .. } => *planned,
+        }
+    }
+
+    /// The same unit with the flag cleared: its **subject**, which is what
+    /// identity is about.
+    ///
+    /// `planned` annotates a claim's resolution state, not which territory the
+    /// claim names, so two units differing only in the flag name one unit. The
+    /// index stores subjects, so a planned claim that has resolved answers an
+    /// `authorities` lookup exactly as an unplanned one does (spec 076 §3.4),
+    /// and the collision checks in §3.5 compare subjects rather than payloads.
+    pub fn subject(&self) -> Self {
+        let mut out = self.clone();
+        match &mut out {
+            Unit::File { planned, .. }
+            | Unit::Section { planned, .. }
+            | Unit::Symbol { planned, .. }
+            | Unit::Directory { planned, .. }
+            | Unit::Crate { planned, .. }
+            | Unit::Module { planned, .. } => *planned = false,
+        }
+        out
     }
 
     /// True if this unit resolves to a directory subtree: a file unit whose path
     /// ends `/`, or an explicit [`Unit::Directory`] (spec 017).
     pub fn is_directory_subtree(&self) -> bool {
         match self {
-            Unit::File { path } => path.ends_with('/'),
+            Unit::File { path, .. } => path.ends_with('/'),
             Unit::Directory { .. } => true,
             _ => false,
         }
@@ -87,12 +221,37 @@ impl<'de> Deserialize<'de> for Unit {
         #[derive(Deserialize)]
         #[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
         enum Tagged {
-            File { path: String },
-            Section { file: String, anchor: String },
-            Symbol { id: String },
-            Directory { path: String },
-            Crate { id: String },
-            Module { id: String },
+            File {
+                path: String,
+                #[serde(default)]
+                planned: bool,
+            },
+            Section {
+                file: String,
+                anchor: String,
+                #[serde(default)]
+                planned: bool,
+            },
+            Symbol {
+                id: String,
+                #[serde(default)]
+                planned: bool,
+            },
+            Directory {
+                path: String,
+                #[serde(default)]
+                planned: bool,
+            },
+            Crate {
+                id: String,
+                #[serde(default)]
+                planned: bool,
+            },
+            Module {
+                id: String,
+                #[serde(default)]
+                planned: bool,
+            },
         }
 
         match Repr::deserialize(deserializer)? {
@@ -100,15 +259,37 @@ impl<'de> Deserialize<'de> for Unit {
                 if path.trim().is_empty() {
                     return Err(de::Error::custom("unit path must not be empty"));
                 }
-                Ok(Unit::File { path })
+                // Spec 076 §3.1: the bare-string shorthand cannot carry the
+                // flag, and the grammar is deliberately not extended to let it.
+                // A second string grammar would be parsed in a second place,
+                // where a misspelling degrades silently into a path.
+                Ok(Unit::File {
+                    path,
+                    planned: false,
+                })
             }
-            Repr::Tagged(Tagged::File { path }) => Ok(Unit::File { path }),
-            Repr::Tagged(Tagged::Section { file, anchor }) => Ok(Unit::Section { file, anchor }),
-            Repr::Tagged(Tagged::Symbol { id }) => Ok(Unit::Symbol { id }),
-            Repr::Tagged(Tagged::Directory { path }) => Ok(Unit::Directory { path }),
-            Repr::Tagged(Tagged::Crate { id }) => Ok(Unit::Crate { id }),
-            Repr::Tagged(Tagged::Module { id }) => Ok(Unit::Module { id }),
+            Repr::Tagged(Tagged::File { path, planned }) => Ok(Unit::File { path, planned }),
+            Repr::Tagged(Tagged::Section {
+                file,
+                anchor,
+                planned,
+            }) => Ok(Unit::Section {
+                file,
+                anchor,
+                planned,
+            }),
+            Repr::Tagged(Tagged::Symbol { id, planned }) => Ok(Unit::Symbol { id, planned }),
+            Repr::Tagged(Tagged::Directory { path, planned }) => {
+                Ok(Unit::Directory { path, planned })
+            }
+            Repr::Tagged(Tagged::Crate { id, planned }) => Ok(Unit::Crate { id, planned }),
+            Repr::Tagged(Tagged::Module { id, planned }) => Ok(Unit::Module { id, planned }),
             Repr::Wrapped { unit } => Ok(*unit),
         }
     }
+}
+
+/// `skip_serializing_if` for a `bool` that is only meaningful when true.
+fn is_false(b: &bool) -> bool {
+    !*b
 }

--- a/crates/spec-spine-types/src/version.rs
+++ b/crates/spec-spine-types/src/version.rs
@@ -22,7 +22,17 @@
 /// an optional `derived_at` ISO-8601 timestamp; the registry format gains an
 /// emittable field, so the minor bumps. The permissive shard schema is unchanged
 /// and a corpus that declares no `derived_at` emits byte-identical record bodies.
-pub const REGISTRY_SCHEMA_VERSION: &str = "1.1.0";
+/// `1.2.0`: additive MINOR (spec 076). A unit payload may carry an optional
+/// `planned: true`, declaring territory a spec intends to own and has not
+/// written yet. Follows the precedent 028 set: additive, no MAJOR, loaders that
+/// know `1.x` keep working. `planned` is serialized only when true, and a
+/// written `planned: false` normalizes to absent, so a corpus that uses no
+/// planned units emits byte-identical shards across this change and needs no
+/// re-index. `Config` and the DTOs derive `deny_unknown_fields`, so a binary
+/// predating this spec meets the key with a parse error and exits 3 rather than
+/// silently ignoring a claim about territory: the fail-closed direction, and the
+/// reason the flag is a typed field rather than a convention in a comment.
+pub const REGISTRY_SCHEMA_VERSION: &str = "1.2.0";
 
 /// `schemaVersion` emitted in the codebase index, carried by each index shard.
 /// `0.2.0`: additive `build.sliceHashes` (spec 012).

--- a/crates/spec-spine-types/tests/dtos.rs
+++ b/crates/spec-spine-types/tests/dtos.rs
@@ -63,8 +63,10 @@ fn validation_passed_follows_error_tier() {
 #[test]
 fn schema_versions_are_pinned() {
     // 1.0.0: MAJOR, sharded registry (spec 024); 1.1.0: additive MINOR (spec
-    // 028), optional `references` provenance `derived_at` timestamp.
-    assert_eq!(REGISTRY_SCHEMA_VERSION, "1.1.0");
+    // 028), optional `references` provenance `derived_at` timestamp; 1.2.0:
+    // additive MINOR (spec 076), optional `planned` on a unit payload. A
+    // consumer that knows 1.x keeps working, which is the MINOR rule.
+    assert_eq!(REGISTRY_SCHEMA_VERSION, "1.2.0");
     // 1.1.0: additive MINOR (spec 025): unresolved-unit severity tiers (W-001 /
     // W-002 warnings) on top of the spec-024 sharded MAJOR.
     assert_eq!(INDEX_SCHEMA_VERSION, "1.1.0");

--- a/crates/spec-spine-types/tests/grammar.rs
+++ b/crates/spec-spine-types/tests/grammar.rs
@@ -15,7 +15,8 @@ fn bare_string_is_file_unit() {
     assert_eq!(
         u,
         Unit::File {
-            path: "src/lib.rs".into()
+            path: "src/lib.rs".into(),
+            planned: false
         }
     );
 }
@@ -26,7 +27,8 @@ fn tagged_units_parse() {
     assert_eq!(
         file,
         Unit::File {
-            path: "a.rs".into()
+            path: "a.rs".into(),
+            planned: false
         }
     );
 
@@ -36,7 +38,8 @@ fn tagged_units_parse() {
         section,
         Unit::Section {
             file: "Makefile".into(),
-            anchor: "build".into()
+            anchor: "build".into(),
+            planned: false
         }
     );
 
@@ -44,7 +47,8 @@ fn tagged_units_parse() {
     assert_eq!(
         symbol,
         Unit::Symbol {
-            id: "crate::run".into()
+            id: "crate::run".into(),
+            planned: false
         }
     );
 }
@@ -56,21 +60,24 @@ fn directory_crate_module_units_parse() {
     assert_eq!(
         dir,
         Unit::Directory {
-            path: "src/api".into()
+            path: "src/api".into(),
+            planned: false
         }
     );
     let krate: Unit = serde_yaml::from_str("{ kind: crate, id: \"factory-engine\" }").unwrap();
     assert_eq!(
         krate,
         Unit::Crate {
-            id: "factory-engine".into()
+            id: "factory-engine".into(),
+            planned: false
         }
     );
     let module: Unit = serde_yaml::from_str("{ kind: module, id: \"my_crate::tests\" }").unwrap();
     assert_eq!(
         module,
         Unit::Module {
-            id: "my_crate::tests".into()
+            id: "my_crate::tests".into(),
+            planned: false
         }
     );
     // The wrapper form (spec 015) composes with the new kinds.
@@ -79,7 +86,8 @@ fn directory_crate_module_units_parse() {
     assert_eq!(
         wrapped,
         Unit::Directory {
-            path: "crates/x".into()
+            path: "crates/x".into(),
+            planned: false
         }
     );
 }
@@ -92,7 +100,8 @@ fn unit_wrapper_form_unwraps() {
     assert_eq!(
         bare,
         Unit::File {
-            path: "src/lib.rs".into()
+            path: "src/lib.rs".into(),
+            planned: false
         }
     );
     let tagged: Unit =
@@ -100,7 +109,8 @@ fn unit_wrapper_form_unwraps() {
     assert_eq!(
         tagged,
         Unit::Symbol {
-            id: "crate::f".into()
+            id: "crate::f".into(),
+            planned: false
         }
     );
     // The inner unit inherits its own validation (empty path still rejected).
@@ -112,7 +122,13 @@ fn directory_subtree_detection() {
     assert!(Unit::file("src/").is_directory_subtree());
     assert!(!Unit::file("src/lib.rs").is_directory_subtree());
     // An explicit directory unit is always a subtree (spec 017).
-    assert!(Unit::Directory { path: "src".into() }.is_directory_subtree());
+    assert!(
+        Unit::Directory {
+            path: "src".into(),
+            planned: false
+        }
+        .is_directory_subtree()
+    );
 }
 
 #[test]
@@ -134,13 +150,15 @@ fn establishes_accepts_mixed_forms() {
     assert_eq!(
         fm.establishes[0],
         Unit::File {
-            path: "src/whole.rs".into()
+            path: "src/whole.rs".into(),
+            planned: false
         }
     );
     assert_eq!(
         fm.establishes[1],
         Unit::Symbol {
-            id: "crate::f".into()
+            id: "crate::f".into(),
+            planned: false
         }
     );
 }
@@ -157,14 +175,17 @@ fn establishes_accepts_unit_wrapper() {
         fm.establishes,
         vec![
             Unit::File {
-                path: "src/whole.rs".into()
+                path: "src/whole.rs".into(),
+                planned: false
             },
             Unit::File {
-                path: "src/bare.rs".into()
+                path: "src/bare.rs".into(),
+                planned: false
             },
             Unit::Section {
                 file: "Makefile".into(),
-                anchor: "ci".into()
+                anchor: "ci".into(),
+                planned: false
             },
         ]
     );
@@ -205,7 +226,8 @@ fn extends_paths_sugar_expands_to_file_units() {
     assert_eq!(
         fm.extends[0].unit,
         Some(Unit::File {
-            path: "a.rs".into()
+            path: "a.rs".into(),
+            planned: false
         })
     );
     assert_eq!(fm.extends[0].nature.as_deref(), Some("additive"));
@@ -213,7 +235,8 @@ fn extends_paths_sugar_expands_to_file_units() {
     assert_eq!(
         fm.extends[1].unit,
         Some(Unit::File {
-            path: "src/api/".into()
+            path: "src/api/".into(),
+            planned: false
         })
     );
     assert!(
@@ -268,7 +291,8 @@ fn constrains_discriminator_and_optional_unit() {
     assert_eq!(
         fm.constrains[0].unit,
         Some(Unit::File {
-            path: "schema.json".into()
+            path: "schema.json".into(),
+            planned: false
         })
     );
     assert_eq!(fm.constrains[1].kind.as_deref(), Some("sequencing-plan"));
@@ -304,7 +328,8 @@ fn supersedes_full_and_partial_forms_parse() {
     assert_eq!(
         fm.supersedes[2].partial_unit(),
         Some(&Unit::File {
-            path: "src/clone.ts".into()
+            path: "src/clone.ts".into(),
+            planned: false
         })
     );
     // Partial without a unit is documentary: no transfer unit.
@@ -372,4 +397,127 @@ fn references_provenance_unknown_field_is_rejected() {
     let src = "---\nid: x\ntitle: t\nstatus: draft\ncreated: \"2026-06-08\"\nsummary: s\n\
 references:\n  - { provenance: { kind: k, ref: \"r\", bogus: \"x\" } }\n---\n";
     assert!(parse_frontmatter(src).is_err());
+}
+
+// ── spec 076: the `planned` flag on a unit payload ──────────────────────────
+
+/// §3.1: the flag is valid only in the **object form**, on any unit kind. The
+/// bare-string shorthand cannot carry it, and the grammar is deliberately not
+/// extended to let it: a second string grammar parsed in a second place is a
+/// second place for the flag to be misspelled into silence.
+#[test]
+fn planned_round_trips_on_every_unit_kind_in_object_form() {
+    for (src, want) in [
+        (
+            r#"{ "kind": "file", "path": "src/a.rs", "planned": true }"#,
+            Unit::File {
+                path: "src/a.rs".into(),
+                planned: true,
+            },
+        ),
+        (
+            r#"{ "kind": "section", "file": "d.md", "anchor": "a", "planned": true }"#,
+            Unit::Section {
+                file: "d.md".into(),
+                anchor: "a".into(),
+                planned: true,
+            },
+        ),
+        (
+            r#"{ "kind": "symbol", "id": "m::f", "planned": true }"#,
+            Unit::Symbol {
+                id: "m::f".into(),
+                planned: true,
+            },
+        ),
+        (
+            r#"{ "kind": "directory", "path": "src/", "planned": true }"#,
+            Unit::Directory {
+                path: "src/".into(),
+                planned: true,
+            },
+        ),
+        (
+            r#"{ "kind": "crate", "id": "c", "planned": true }"#,
+            Unit::Crate {
+                id: "c".into(),
+                planned: true,
+            },
+        ),
+        (
+            r#"{ "kind": "module", "id": "c::m", "planned": true }"#,
+            Unit::Module {
+                id: "c::m".into(),
+                planned: true,
+            },
+        ),
+    ] {
+        let got: Unit = serde_json::from_str(src).unwrap_or_else(|e| panic!("{src}: {e}"));
+        assert_eq!(got, want, "{src}");
+        assert!(got.is_planned(), "{src}");
+        // And back out, so a consumer that round-trips does not change meaning.
+        let json = serde_json::to_string(&got).unwrap();
+        assert_eq!(serde_json::from_str::<Unit>(&json).unwrap(), want);
+    }
+}
+
+/// §3.1: the bare-string shorthand is never planned, and neither is the spec
+/// 015 `{ unit: ... }` wrapper around one.
+#[test]
+fn the_bare_string_shorthand_cannot_be_planned() {
+    let bare: Unit = serde_json::from_str(r#""src/a.rs""#).unwrap();
+    assert!(!bare.is_planned());
+    let wrapped: Unit = serde_json::from_str(r#"{ "unit": "src/a.rs" }"#).unwrap();
+    assert!(!wrapped.is_planned());
+    assert_eq!(bare, wrapped);
+}
+
+/// §3.1: `planned: false` MUST be accepted and MUST mean exactly what omitting
+/// it means, so a consumer that round-trips a unit does not change its meaning.
+/// §3.7: and it MUST normalize to **absent** on write, or the same corpus would
+/// compile to two different byte sequences depending on how it was spelled,
+/// which the four-triple determinism gate would surface as inexplicable
+/// staleness rather than as a round-trip bug.
+#[test]
+fn planned_false_means_omitted_and_normalizes_to_absent() {
+    let written: Unit =
+        serde_json::from_str(r#"{ "kind": "file", "path": "a", "planned": false }"#)
+            .expect("`planned: false` is accepted");
+    let omitted: Unit = serde_json::from_str(r#"{ "kind": "file", "path": "a" }"#).unwrap();
+    assert_eq!(written, omitted);
+
+    let json = serde_json::to_string(&written).unwrap();
+    assert!(
+        !json.contains("planned"),
+        "false must normalize to absent, got {json}"
+    );
+    assert_eq!(json, serde_json::to_string(&omitted).unwrap());
+}
+
+/// §3.7: emitting a unit that is not planned MUST NOT change existing output,
+/// so no corpus needs a re-index for this change.
+#[test]
+fn an_unplanned_unit_emits_exactly_what_it_did_before() {
+    assert_eq!(
+        serde_json::to_string(&Unit::file("src/lib.rs")).unwrap(),
+        r#"{"kind":"file","path":"src/lib.rs"}"#
+    );
+}
+
+/// §3.4: the flag is not part of a unit's identity. `subject()` is what the
+/// index stores and what the collision checks compare, so a planned claim that
+/// has resolved answers a lookup exactly as an unplanned one does.
+#[test]
+fn subject_clears_the_flag_and_keeps_the_territory() {
+    let planned = Unit::File {
+        path: "src/a.rs".into(),
+        planned: true,
+    };
+    assert_ne!(planned, Unit::file("src/a.rs"), "the payloads differ");
+    assert_eq!(
+        planned.subject(),
+        Unit::file("src/a.rs"),
+        "the territory does not"
+    );
+    assert!(!planned.subject().is_planned());
 }

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -4,7 +4,7 @@ title: "Planned territory is declared, not inferred"
 status: draft
 kind: "tooling"
 created: "2026-09-08"
-implementation: pending
+implementation: in-progress
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -48,6 +48,32 @@ extends:
     nature: additive
     paths:
       - "crates/spec-spine-core/src/query.rs"        # planned territory in the plan
+      - "crates/spec-spine-core/tests/query.rs"      # 3.6 the plan read
+  # 3.6 the report DTO gains the declared-state member, and both read verbs
+  # render it. Declared in the implementing change: 3.6 requires the fact to be
+  # in the artifact and names no file.
+  - spec: "032-ownership-coverage"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/coverage.rs"
+      - "crates/spec-spine-core/tests/coverage.rs"
+      - "crates/spec-spine-cli/src/cmd_index.rs"
+  - spec: "002-registry-query"
+    nature: additive
+    paths:
+      - "crates/spec-spine-cli/src/cmd_registry.rs"
+  # 3.5 the three collision refusals live with the rest of compile's V-band.
+  - spec: "001-compile-registry"
+    nature: additive
+    paths:
+      - "crates/spec-spine-core/src/compile.rs"
+  # 3.1 spec 014's `paths:` sugar expands to file units, and those units now
+  # carry the flag's default. Crossed here rather than amended: the expansion's
+  # meaning is unchanged, since 3.1 keeps the shorthand unable to be planned.
+  - spec: "014-edge-paths-grammar-sugar"
+    nature: additive
+    paths:
+      - "crates/spec-spine-types/src/edges.rs"
 references:
   - { unit: { kind: file, path: "docs/design/00-architecture.md" }, role: context }
 summary: >
@@ -361,6 +387,50 @@ means `--fail-on-warn` still refuses it in a corpus that runs the gate, which
 is the behavior this repository wants without imposing it on one that does not.
 `L-010` is allocated by spec 074, which is why this spec takes the next two and
 depends on it.
+
+**2026-09-08: the flag is a field on every unit variant, and the index stores
+the unit's SUBJECT.** `Unit` is an internally-tagged enum, so "one optional
+boolean on the unit DTO" means a field per variant. That alone would have made
+`planned` part of a unit's identity, and `authorities()` compares units by
+equality: a planned claim that had resolved would then have failed the lookup
+that 3.4 requires it to answer like any other. `Unit::subject()` clears the
+flag, the index stores subjects, and the 3.5 collision checks compare subjects.
+The flag is therefore a declaration-time annotation everywhere except the
+declaration itself, which is what 3.4's "resolved for every other purpose"
+means in practice.
+
+**2026-09-08: `V-017` asks whether a unit is owned by someone *other than* the
+extending spec.** The first implementation asked only whether the unit had any
+unplanned owner, and the rule went silent in exactly the case it exists for:
+`extends` is itself an ownership-bearing edge, so the edge under examination had
+already registered its own spec as an owner. Caught by the test rather than by
+reading, which is the argument for writing the test that fails first.
+
+**2026-09-08: planned territory is reported beside the counts, never inside
+them.** Section 3.6 requires `index coverage` to distinguish an unclaimed file
+from a planned one, and the tempting reading is to count a planned claim as
+coverage. That would let a spec satisfy `--fail-on-untraced` by declaring an
+intention rather than by writing the file, which is the one thing the ratchet
+exists to refuse. A planned unit whose path is not on disk is not a source file
+at all, so it is reported as a separate list; a planned unit whose path IS on
+disk resolves, is already counted as claimed, and draws `L-012` telling the
+author to drop the flag. The two cases together cover the space.
+
+**2026-09-08: `index coverage` reads the committed registry for this, and
+tolerates a registry it cannot load.** Planned territory is a declared state,
+so it cannot come from the index: 3.2 keeps a planned unit from producing a
+`ResolvedUnit`, which is precisely why the report was blind to it. A registry
+that will not load leaves the list empty rather than failing the report, because
+this member is additive information beside a coverage verdict already reached,
+and a broken registry is `compile --check`'s refusal to make, not this one's.
+
+**2026-09-08: the round-trip tests live in `tests/grammar.rs`, where the
+territory table puts them.** They were written into `tests/dtos.rs` first, where
+they passed. The `## Verification` block runs both files, so the mistake would
+not have shown as a failure: it would have made the `grammar.rs` line assert
+nothing, which is the exact defect spec 074 was filed about. Moved, and recorded
+because the block passing is not evidence that each of its lines is carrying its
+own weight.
 
 ## Verification
 

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -4,7 +4,7 @@ title: "Planned territory is declared, not inferred"
 status: draft
 kind: "tooling"
 created: "2026-09-08"
-implementation: in-progress
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:


### PR DESCRIPTION
Implements spec 076, the last of the 072–076 cohort.

## The gap

Ownership was only ever **inferred from resolution**. A corpus that opts into
spec 050's `--fail-on-unresolved` therefore could not declare territory before
writing it at all: filing spec 075 with
`establishes: crates/spec-spine-cli/src/cmd_check.rs` refused the gate on a
`W-001`, and the claim had to be removed and deferred to the implementing
change. Specs 072 to 075 are `extends`-only, and that is not a property of those
changes; it is the gate shaping the corpus.

The obvious fix, making the gate lifecycle-aware, is refused in §1 and §5: it
ties "not written yet" to `status: draft`, which only works in a draft-then-build
repository, and it would gut `--fail-on-unresolved`, whose entire marginal value
is refusing `W-001`.

## What landed

**§3.1 The flag.** A unit may carry `planned: true`, in the **object form only**.
The bare-string shorthand cannot, deliberately: a second string grammar parsed in
a second place is a second place for the flag to be misspelled into silence.
`planned: false` is accepted and means exactly what omitting it means.

**§3.2 A declared state, not a diagnostic.** A planned unresolved unit produces
**no diagnostic at all**. Every other classification is untouched: a wrong path
is still `W-001`, `W-002` from a non-owning edge, a hard error on a settled spec,
and still refused by `--fail-on-unresolved`. That asymmetry is the safety
argument, and nobody marks a typo planned.

**§3.3 / §3.4 It cannot outlive the work.** `L-011` (**error**) refuses
`implementation: complete` beside a planned unit, a contradiction inside one
file's frontmatter. `L-012` (**warning**) reports a planned unit that has
resolved, so the annotation cannot rot while the work quietly lands. `complete`
is the only bound; an intermediate deadline would mean inventing a clock.

**§3.5 Collisions reuse the ownership rules.** `V-015` two specs planning one
unit (with the `co_authority` escape), `V-016` planning territory another spec
owns, `V-017` extending a unit that is only planned. All three are corpus-wide
and run over **declared** units at compile time: the existing duplicate-ownership
machinery operates on `TraceMapping`, which §3.2 keeps a planned unit from ever
producing, so a rule built there could not have fired.

**§3.6 The reads are unblinded.** `registry plan` reports planned territory
alongside ready and blocked; `index coverage` reports it **beside** the counts
and never inside them, because counting a declared intention as coverage would
let a spec satisfy `--fail-on-untraced` by promising rather than by writing.

**§3.7 `REGISTRY_SCHEMA_VERSION` 1.1.0 → 1.2.0**, additive MINOR on spec 028's
precedent. `planned` serializes only when true and a written `planned: false`
normalizes to absent, so **no corpus needs a re-index**.

## Two things worth reviewing

**The index stores each unit's subject.** `Unit` is internally tagged, so the
flag is a field per variant, and that alone would have made `planned` part of a
unit's identity: `authorities()` compares units by equality, so a planned claim
that had resolved would have failed the lookup §3.4 requires it to answer. The
index stores `unit.subject()` with the flag cleared, and the §3.5 checks compare
subjects.

**`V-017` asks whether a unit is owned by someone *other than* the extender.**
The first implementation asked only whether the unit had any unplanned owner, and
went silent in exactly the case it exists for: `extends` is itself
ownership-bearing, so the edge under examination had already registered its own
spec as an owner. Caught by the test, not by reading.

## Gate

lint 0 warnings, coverage 80/80, couple 18 paths no drift, `verify 076` passes
all 8 commands, 30 test suites, clippy and fmt clean. The coupling gate caught an
undeclared crossing into `edges.rs` mid-build and spec 052's footer named it; the
`extends` edge is declared.