### PR TITLE
chore(072-076): ratify four of the five (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -215,8 +215,8 @@
       }
     ],
     "specId": "072-the-default-branch-is-configured-not-assumed",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0a16e5625ddf200cfef011a6d371f9ef9620e007302ca4b08373b67a85bea285"
+  "shardHash": "df7b2b998fc019160fc0a673ec5301baab21774837d77bbc52815801e74aa1c6"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -144,8 +144,8 @@
       }
     ],
     "specId": "073-a-workflow-bump-is-not-a-governed-change",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fa2b2e44aabdd2aac5d92f9e3d9315b0239fb99bcb5cdecaaede2cba1c9b6f46"
+  "shardHash": "22b4b23efa2277c14a5297d6d7edc35958cf2c4fec2e4dfebf248feb4648b4bf"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -400,8 +400,8 @@
       }
     ],
     "specId": "075-one-name-one-freshness-verb",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b1ad7355653b83ab68ea978777740043824f3cb22d4e5df9106b82eacdc9a04e"
+  "shardHash": "0836fdcea734dc239441f6613c8a22783b5070d4ec046f2a1b826ddfd8d54aa0"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -320,8 +320,8 @@
       }
     ],
     "specId": "076-planned-territory-is-declared-not-inferred",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c69412721a1703bfb425774dd629a1ec5dd5cf834590e35aca93748d34f9ee4d"
+  "shardHash": "e6c6ed94040f27210969f8cc46bbec2cb7824f1f602e5f2eeaa4c88c00e18623"
 }

--- a/.derived/spec-registry/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/spec-registry/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -130,10 +130,10 @@
       "Verification"
     ],
     "specPath": "specs/072-the-default-branch-is-configured-not-assumed/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The kit's push gate protects a branch named main and nothing else. An adopter whose default branch is master or trunk installs a gate that refuses nothing, learns this from no diagnostic, and is told by the same harness to run a coupling gate against an origin/main that does not exist. Spec 071 narrowed what the gate refuses but left the name hardcoded, naming the gap and deferring it for want of a mechanism. This spec supplies one: the branch is resolved per repository from an environment override, then from the remote's own HEAD, then from main as a compatibility floor, with no dependency on the spec-spine binary and no new configuration key. Every branch comparison in the push gate, the coupling base in the PR gate and the Makefile, and the commands the kit documents follow the resolved name.\n",
     "title": "The default branch is configured, not assumed"
   },
-  "shardHash": "c0172fba27b254e875695e137847808c299610c4ec09c86007f48ad3fe652023",
+  "shardHash": "ad560665a35b128dd70d3a8df0cf099d7deca8c8b63e0537dec8f764d05d0099",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/spec-registry/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -98,10 +98,10 @@
       "Verification"
     ],
     "specPath": "specs/073-a-workflow-bump-is-not-a-governed-change/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "A GitHub Actions workflow enters the index content hash as raw bytes, so a Dependabot `uses:` bump moves the global-inputs scalar and stales every shard in the repository. The bot can neither re-index nor add a waiver to its own PR body, so the PR walls on exit 2 and needs a maintainer to push a re-index commit. Spec 030 built the coupling half of this for workflows and read the freshness half as already fine; it was not, and spec 069 made that visible by fixing the default glob, then deferred the real fix as a hashing change with a migration of its own. This is that spec. A workflow folds as its governance projection, the parsed document with the pinned ref of each `uses:` reference removed and the action path kept, so a version or SHA bump is invisible to the ledger while a changed action, a `run:` or `with:` edit, an added step or an unpin all still stale it. The projection and 030's waiver classifier are required to state one rule, and the upgrade restales every workflow-bearing repository once.\n",
     "title": "A workflow bump is not a governed change"
   },
-  "shardHash": "65438641e5b5016e59ad1979ba1da95d2c95e5d70e8279ac3ea7cf0aced0f3e0",
+  "shardHash": "b0d3dfef27296fd7c7313ab3f42d557b48824542de98ad9e298f952370a755f7",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/spec-registry/by-spec/075-one-name-one-freshness-verb.json
@@ -214,10 +214,10 @@
       "Verification"
     ],
     "specPath": "specs/075-one-name-one-freshness-verb/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The session protocol is ambiguous in two places and both are collisions with its own neighbours. Its entry point is named `/init`, which is also a Claude Code built-in meaning the opposite thing (one-time, repository-level, and it writes) and also `spec-spine init`, which means a third thing again. And it asks one question, whether the committed state is current, in two spellings: `compile --check` is a flag and `index check` is a subcommand, so the protocol, the hook, the skills and CI each have to spell both. This spec renames the skill to `/prime` with no alias, and adds `spec-spine check`, an additive top-level verb that runs both freshness reads, reports each tree separately, and composes one exit code. Nothing is removed: both primitives keep their flags, their tests and their contracts, and CI may still call one when it regenerated only one tree.\n",
     "title": "One name for the protocol, one verb for freshness"
   },
-  "shardHash": "109ad720237ba2351d46d79b0180446c132b7dc82060077823b5dc79cb6436bc",
+  "shardHash": "d7165a29b66ac8b5f96240c9fbaceacbdd34470367cc572298ee422a881175f9",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/spec-registry/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -183,10 +183,10 @@
       "Verification"
     ],
     "specPath": "specs/076-planned-territory-is-declared-not-inferred/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "A spec cannot say what it intends to own. Ownership is only ever inferred from a unit resolving on disk, so a corpus that opts into spec 050's `--fail-on-unresolved` gate forecloses declaring territory before writing it: every claim must arrive with its file. The cost is that `registry plan` and `index coverage` are blind to planned ownership, a draft's risk understates the work, and two specs can plan the same file with no edge to collide on until one of them ships. This spec adds an optional `planned` flag to the unit payload. A planned unit is a declared state rather than an unresolved one, so it produces no `W-001` and the gate keeps refusing every claim that is merely broken. The flag is bound to the lifecycle field that ends it: a spec at `implementation: complete` carrying one is refused, and a planned unit that has resolved is reported so the flag cannot be left on.\n",
     "title": "Planned territory is declared, not inferred"
   },
-  "shardHash": "1135e51640c544f6f881163e1f67820ced3d1f8fe9a5f31cf3d500611e1139b5",
+  "shardHash": "63b90297889fd09cc0924bde5ce733289ee65cec41e799cbd75da9f4c6c58051",
   "specVersion": "1.2.0"
 }

--- a/specs/072-the-default-branch-is-configured-not-assumed/spec.md
+++ b/specs/072-the-default-branch-is-configured-not-assumed/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "072-the-default-branch-is-configured-not-assumed"
 title: "The default branch is configured, not assumed"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete

--- a/specs/073-a-workflow-bump-is-not-a-governed-change/spec.md
+++ b/specs/073-a-workflow-bump-is-not-a-governed-change/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "073-a-workflow-bump-is-not-a-governed-change"
 title: "A workflow bump is not a governed change"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete

--- a/specs/075-one-name-one-freshness-verb/spec.md
+++ b/specs/075-one-name-one-freshness-verb/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "075-one-name-one-freshness-verb"
 title: "One name for the protocol, one verb for freshness"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete

--- a/specs/076-planned-territory-is-declared-not-inferred/spec.md
+++ b/specs/076-planned-territory-is-declared-not-inferred/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "076-planned-territory-is-declared-not-inferred"
 title: "Planned territory is declared, not inferred"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete


### PR DESCRIPTION
Specs **072, 073, 075 and 076** are implemented, verified against their own
`## Verification` blocks, and merged. This flips them `draft` → `approved`. The
corpus moves to **76 approved, 1 draft**.

| spec | what it fixed |
|---|---|
| 072 | the kit's push gate protected a branch named `main` and nothing else |
| 073 | a Dependabot action bump staled every shard in the repository |
| 075 | the session skill shadowed a Claude Code built-in and inverted its meaning; freshness was asked two ways |
| 076 | a spec could not declare territory before writing it |

## 074 stays `draft`, deliberately

Its §3.6 requires `kit/scripts/verify-spec.sh` to be removed. **Spec 051 §3.2
says normatively that it MUST NOT be**, names the retirement trigger as *"adopters
upgrading, not this spec merging"*, and warns that deleting it "would leave an
approved spec's declared acceptance unable to pass, and repairing that by editing
048 is the move the coherence guard exists to stop."

Both consequences were confirmed by doing it: `kit/scripts/` empties and settled
spec **048** raises a blocking `I-004` on the directory unit it claims, and two of
048's six acceptance commands run the script. Spec 074 declares no `amends` on
either 051 or 048, and its §2 never considered them.

Approving it would put a requirement that contradicts an approved spec into the
approved set, which is not a call to make on a session's own authority. Its other
**ten** sections are implemented and merged (PR #150). `implementation` stays
`in-progress`, and `spec-spine registry plan` correctly reports 074 as the one
spec with work remaining.

Two clean resolutions, both a human's to pick:

1. Declare `amends` on 051 (and on 048, whose acceptance changes) once adopters
   have upgraded past v0.15.0, which is the trigger 051 named.
2. Move §3.6 to its own spec whose trigger is that same fact, which is what spec
   051 §4 already planned.

Gate green: lint 0 warnings, coverage 80/80, couple 4 paths no drift.