### PR TITLE
docs: refresh CLAUDE.md to the corpus as it stands

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6aa58ca7b3fb1cfe16e4f6f1e1812ba22f129276a01319f1b9e5a69d5f95f280"
+  "shardHash": "e1adb2b1c99c5cdaebc18b8c77256734b76c968339e33cc015eea72ca7e3feb8"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "60f0bc522d5db8d5bb2c16ec9566539ade2a5f71b3bcce617e346ee70ff73d56"
+  "shardHash": "46512484db8cc3bed569e43ecfa8a0abc3d1cbf641baceae9b451e9aeffa1adf"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1ee2b798a62c43db30babbad000048ca5b41ce31de0191ac67974006d40f0a41"
+  "shardHash": "be6cd75bada9858a9096f59d4420eab743cf6284da652411021669bae67b1966"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.17.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "27143859b0ae80ca92bab6432d8e83e3d560e799bb837b6bb956637fdd628a33"
+  "shardHash": "0317eda395e46ee37f1609b99c26de59319ae113055827aee13edd5351e6d3c1"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "528021a123ee303a16b40d4d73693e94c2140f09a74fcde6392711aef2847439"
+  "shardHash": "cc68845c6ba128b128300f781bc167bdde8f46437dcb370c2ebcf6eb6aaaae63"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a2c02daec7c70a5027d42b970a3e849fa159bc45025e80ef0a0555f145b1d042"
+  "shardHash": "c667eaae36d33fc2efda195115dcfca8a0367e1ba8405a5d2d1970ee622be150"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "63cb7657b8466092649da45702b1d0940f3299d4838fc60dca793afd7177547d"
+  "shardHash": "657c598f6e6bae5dca8ff64624e94e831be288c2b4bcad7e4c62e771d702f6c9"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2c5ed46f1e0d27afb70c5581f5d592afb2dd95cbd766111f763996b5e6ad8ba0"
+  "shardHash": "3e208d13fc6ee18f2b0e1d59f15bd285cae9c234a6d9859bf1f534fee0b27c3e"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c4c5dad1d83d6b969c24cd304cdc6cfc8610c9656769605ca3bd341ef1607a20"
+  "shardHash": "7ef401d303b1b0c518a18206c9a6d0ae0005bcd02c953cf79a4116cfc897bbe5"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "abe7fe89df8efdd9442f4896e04ece37b90fe6c7ef67638d1ed4b125807c8023"
+  "shardHash": "a0ee74757a9ea6c90490f71b7d47c8844daa5834878b1c9aa3dbf02a4c3ad706"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e3370cd11c35e1406419f35b4c5e1823ce0f4f644977502ba8c7341dedfc877a"
+  "shardHash": "52b2c3842e8dd1899a44c259e5c987c88b10ac8ea6ba397299ff28b1c2f0756c"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ecd5ba73f9ac30bad1ef026352863cbbb0b7ef62fa90226170a5faea70431b2f"
+  "shardHash": "4a0fcb4a181a0f20ad033a0d27461cac2ba1e8da588b0c836620aeaeabff59e0"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e6130900b098c1ac1cd489a075a7f4eb13ef68a9240a95c40beeba13e28327a2"
+  "shardHash": "da3cf2cba77d8168872fc138416147da4e04f152e0d8b28eb3237cbdcbddab8c"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "475efe75c1c1ae305136c680579f983f92c31c2d60c9a55a5f3db1eacd334863"
+  "shardHash": "48c331a535a01e70343a32155a223c74df8a09c03a9ee2c4bf87908ecaa084c9"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ed4737fdfddfaeab201e060c4f6b39892cb8ecedc462b07a48c6969e6f31236e"
+  "shardHash": "f184308a871e83bccd5d42d2d26d5a1f37bebf2cc11ea09c85739e7ffe15aa89"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "10202b02d8273e0fc5d5a5acd55a52a77129d81bf5d26cf04a2be9dac30e197b"
+  "shardHash": "99062827f43b46d4cd0ebe6c1d2e34d5807bf36c1baae0b158b38bc5ce97b596"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6d08a791ff6723dd50caf809a2246a6f2a33c58b5772d87e96ccf58dc15a4bf3"
+  "shardHash": "de7431f17cb88ab52c34b492bb266e8095485c6401a78050c52fa35cbbddcf14"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7c64abbd34159e142dcec8751eaa2554010ba0569f1c4561f0c1a17233cb399f"
+  "shardHash": "a189b15917c4e20b49cc4fd0a18aa388ccf927afd6aafa7425a7c7613cde3c3a"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7a597b404685377f97e9710f615609a65df87ab29260f6cc26e0edf50d285eee"
+  "shardHash": "5c465c9d69ca3f65663e2687ab20f304666785ffe4798d47750a73557fb97d54"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "02588cdd27473a6f8152a157010f93b18af92b3c8b758ed5e7760d175bc6f469"
+  "shardHash": "d6491251bb97c94a1466881e6924c4db0797a909fe5f5869f23073f8c8b2d05f"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e0241fdadc387ef8ae16848bbe15783e60cca026bc4b806cc28264b4192b47cd"
+  "shardHash": "3e6c5998daadd1389c727e037c0565b81aefa1b18728ab0a48745e4ad6ab3ade"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "88b3e77905f022ebb26aff89861ad80676af4fd2ca0eb3a7d8c718ffc938782a"
+  "shardHash": "a0bd6326bed458595046bbf36adc8bfaa6add43ebe399269238bf863fd63ff16"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1a4978eb0db446b6d92b95811cc8d6557c43e40a5b6fb525ef7152973b72f1d3"
+  "shardHash": "b173287cd08bc28a09fb936b87286bfec8a631231d733348077ab8f5a63938d5"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5c72bfcecc755668ec5d7c1c1b917e872ba986a5d33280ad7c1e104de7ab6c1e"
+  "shardHash": "350a8d70a43812e12706f86ae0cb6812613a38738a28dd9ad9ce15e6a3f22fe0"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f707dbb05d5b61f1067cd5a63ec9af9db845ab354cadda2cab106c0f815ea2ce"
+  "shardHash": "9915926f087c57fb95ff84d6504d1e36136521f479c5c678bce7db511b867dfa"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fc05e09fa1d1acf694fd933e5e0a924c987a96461c14d07e95971cc4da4fb73e"
+  "shardHash": "87af65628b4836b53dc4fc5c8435aee7b39d2141bc1ab4626441ac43484a3ce5"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dace99b95119186cbda83091fe2c057f0e0d6b62312abf1993d5ae26725f024d"
+  "shardHash": "6f4fd8b4e58eb2bbfa036e92f8821cdc2f561400054f93a11fc3c417e2eee2d0"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "039001d241e7b3fac9ba509739b9b70a4a500e48417c8f400c29ffeb7ab20592"
+  "shardHash": "840efb6a63a1a687afd9d37a2da08493179e3df2872fbec57c37135ff73b1764"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "96519c368f02a6d906bf4f60d45b8ca1ba7cc2eb072b0b14cdf0c616ddd876b0"
+  "shardHash": "802ef4646e5f40ef336c0ced0d65dd8bcee088dd01e1642e05b9c833e0498d8d"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ff622736b1db492b2e9c85d2177ebba8d142b144081bb6f4ca171ce3c1c62458"
+  "shardHash": "b09e6e1888cdd45a99905fc9662a336fcf7fe00c1aca5729751f6a45153a06b9"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8ef453e9a2063d03fb75e42bc1d7f61ad09d715211b70244ae03368dd78cea92"
+  "shardHash": "c5b47b31866993a0c46981e714a3baf59a278a1bd5811cddfb032ff74c72f6d7"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f48b194f02867b7fef091a358788bd2f1599e878f28494ec4059607b89713a96"
+  "shardHash": "67c0c5b5035c9edde11c099711bef8c9be26c8786e487c894c2122b6f4579980"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e4166f7b788f06426fa04d7019c847372f0d73d0c3dc31622c4e28bb5cd9d57f"
+  "shardHash": "9a5627ed132dd8db81710afb410142b8f4979d744a2f5e9157bade39052f2a89"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d6a91f88cd8438642631b7f125bf6c3bfdb4ca866c466d34984853939e4b72e1"
+  "shardHash": "98eacba8193d7c1e6b2ebc66b722d7ed7aa2c2ffb7eda313a8748f2da795234d"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "92813d70e16a73b746d98c5fcec1836cc4082a123ee8b6fe263abed18e1f5b0f"
+  "shardHash": "80580e5d26cb5fdcc037da787dcfcaa317ee1e375bfe7dc3e0193a71f357f2a5"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0ce85a83056ae5aadc5494528e4ee6be46b83ce603ce6ba37bec1f007e4e4324"
+  "shardHash": "4a6b0901fa4d647317f6f6424b9e57fbc8ae3e5a2ac032b5f99f017cfe89aa67"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "14785c0bb4d8ec2dc65b8fdf9b26c4b3f98a7480af94bf4d0ba4f1b6fe199493"
+  "shardHash": "80d6e28edfe67d7b33a9c28a33d4d4c009630cdf1121e84b1cf87e1503d61573"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c0e6e275e9c321ec1fa0593c0f5565bdf383c85a61b39bf1c068a73d6497cc96"
+  "shardHash": "4d6c33c1d9e04e939bfbda54b23fe741e4e3eb70c31adc40351fb0e965ba0d40"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b9b3999a30ecee3669e1f0333fe430ed83ef5002b395e8bbb8fe75ac48afcd42"
+  "shardHash": "8404bcf8fab1587224d0c3c1d9e8f75ba876242047d0595bad13b40ea9c78439"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a6e7fd47701392297199d75d4c4747b148b030d7098d0a7fd4d4905e9cdabdc7"
+  "shardHash": "ad8c6ab4b6f39e1945b107fe624f8c5b6ce9aba67d95c6cdf732b92a21dcee38"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dcb699ad480eaa6839b31acb40355553329580611dce11dac6826f61a1581d4a"
+  "shardHash": "2632dd1684fbdb74c87ea4ef89165561eb7172dbe2692ac39f109961fca6fe81"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4ebf25074934463bf478c3449aa6a1e75c12039bbcc85a55ba629bb97eff4dea"
+  "shardHash": "7c93292ba7b4b1c5e63f17ea6b29165770cf9dff9e7cad02de3a6c6e2c12019a"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1f529b4cae6d3d1e7796f927fa13a51e487469348e827ca5b7f736584ad0c36d"
+  "shardHash": "04b4a53ea3cb0153da877718014ae13f9e2d39847a7591757b490003af58fffc"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a8e1d7fb58679b8601db2bede2c7976d11a4b2e3ab73faf16996026161188af7"
+  "shardHash": "79b40f1f59147e9b7c765b71009e11f704efc1f484be0b42ca3cdd9fe68c6b7a"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "97ebd442fc1f05a5b16373301452a648f50b60afba906e616f7ca1c6c07913da"
+  "shardHash": "dcb59661c67126523195ff5841480c9cce2cf35b29a7567d6e42001884f46435"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "da69a2980579057533a39c4c13a12c0f4c0f0f9e6d82a267dfcd25ef64500808"
+  "shardHash": "a5e256e4347cabe0af2228527dff898faa1ef30d72897342b11d1c929a4e3437"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3f44634e5a6bfdd47bd74bcfccdd83fd6fe0e3ecd47b2e45a14ed4e2c9adc1d9"
+  "shardHash": "09978dd6f514514c7f7f590558b11466af53ae496739df21dd1dcfe767ac223d"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8191ec2a29905f2711cbc1346959a87b011ca6b6cc303d1187e43169408000b8"
+  "shardHash": "54bc1a79375df1d83db298c0270f2f55f78f7da7ff4cb3529341f11a771e7f57"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f6fc289064462ca96ef888a352209bcdf93fd467d0008ceda7e20c9bfe420da4"
+  "shardHash": "d61dd4902fab2c12e9feb34b00259c5aa36ca7c48d5a8509110495ff083e72a5"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "87eee095b1aa959f265bfe8016bd724b8af6c78209cfbcd11cab6167862d19f7"
+  "shardHash": "e32917c230d9085c32aa444cec04e4add4e71c0fa33e673557004114458c2dc2"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e8a809e34081b5a03d400a88794516c0cfda406b54f8eb126d92bfd651538e0"
+  "shardHash": "a03152fe881ecac0f95d57d7cf4354927a8269a9a9513c825f3c559bb4cf36d6"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "659fa2266a93772d3b3090d77eb4a72ab4cedb9638849c01cff6705d24252fb8"
+  "shardHash": "f2d02df940f313aa2b449a838b4110b8c0169972159667531d5bb74d66ed615d"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1bc848815cf2b7e5756d48a6ac9151f22c49d8266ce7316a12c100faead09e72"
+  "shardHash": "9f645534b7fa5e64ae5f363cff9cada667d187713005dc57ff077f06126d4586"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5bdce1e17af226c7cb51324426ec39ad3179ecf864df189efe6a77f7dc3d3b7"
+  "shardHash": "1cb513c9251f4ff80af88d1ad2884d60b4bde5b32412d58c56ad7d6618e8f3d6"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9ce248876483773294f0ec91d7eb221ffb62863fdeea6b562912f46b74f18a2e"
+  "shardHash": "b2c2ce83f2b18d98fe47679321dd75b88a5b330018719c126b92ce3a92983a94"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b1dcbc76462d0d0264eed0863d869b8bcbecbc211e5aac9af56b436800c7750b"
+  "shardHash": "c28ace7076af574023fa2fe2fa693934c065f839299d86a7ebd9f2c77291ab20"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "69d37109e39adabdbe42285a53dd07598ae3edad017fd00de6b08e07296c76b5"
+  "shardHash": "957541b2d7a03d210bbc4f5656f95f1ee2a258af9b0a914e2281da9625cddeaf"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c71e043f494a977ddbbc517710374f0c473823e0fa37d2819f7013c65bda820f"
+  "shardHash": "39873f40b39f4b8dbc444be21900f4a9e10ad9486f477cbbfa1ad22e1b366aff"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5b518464b003aefffdb3fa2dd3488ce2947ee670e644db3d9359a416f8e616d4"
+  "shardHash": "bb1e623122ee4f9a96f7af231bd4a4b7eee20afcac94025305d31a0e56f6a827"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "27b448c67904fa9fc137556fa6bd6881325f3478fed9eba6dbe5214549df4ef8"
+  "shardHash": "9bddca99b71ebd95792302c84e11375147cb8ea58b894908ce5e41de4f390cea"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0677908ad778e2a02cbcb4ce99d97a030e883ac6690cd3679a5143a087d6f942"
+  "shardHash": "5e0669c2dcc35203bd08a528121b676f25b760129d6554aead00d73b6e544e47"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "91d32dca91835c9612fc556060d09b05dfab44bab60be961710aa071a1cd1c95"
+  "shardHash": "32ea2bd33d3e99488145896e99430cafa27d03bcce67b4e50cbb1fec5ad230fe"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2edd8f7d8b91252dfddb330e371f6c30fab650f1218d78bf1df3511e5edcad7e"
+  "shardHash": "327c2db50af98a238df8e0bdea3bb962abf330196206909ba26d03c918b5d72f"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "56007d72430c8e804fc5b4f84173a746ad3d80e5d502254335ee6625a7df357b"
+  "shardHash": "f9efbdb3b13f7964a195639ba26a73861e31bbbfa34336470e828f5fecb4edc5"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a017ff080d87b7e81c266a7cdfe7fa6b2aa6ec75aa7643c4aeb674afe270db20"
+  "shardHash": "933aa5b5c38f2917c2ba5b6ed9648f7b216f899908d93f3ed57377c9db233b36"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c1a1d594976caa5bae8ff64a34f48888efede2bf85fb06afe3655eae207c4641"
+  "shardHash": "755d0d3a71753382cf5a60e6331f7b4555698129744828bd109caca73d9f3e86"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "792766d7d3670c0a1799f6a2596888a77e4c5d03972361e6ff70ae70c07d3b80"
+  "shardHash": "ad0531cc0ffa8aa2c5c493167b907ebe6a19624ca4747e2862885891b32f7712"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5074c91cdf119d1d7ea83dc693fdbaa08d5883afae773c1514c33cf51f3438ac"
+  "shardHash": "e3a098105afc2eeaf3ddd5b9019fe2df087213936daa81eb253639a70180dbf6"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8bcd21588de9c39264769ab648a3013378a47bbd8be2b5822e7fc1a99a316194"
+  "shardHash": "860d2a2351cb65378ba01eeab6c7c568196e3660efef54febfae21c9e614ae2a"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0a3b10d051abac4dbc33d076218f92fc31f8aee16c03e9ba1159e6f57a2e645b"
+  "shardHash": "068d8432d6b763ad8e0e71770b509be9be0a060ecdcab94e785141d422c9a38b"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9385ecd9f1aa226d8500f8c11924d86926bd5b7a578814e559562ca072fc4b3b"
+  "shardHash": "164d69399ec6f26088187aa12795f5f2eaf314a03a5d8e3546f61ba6a0a00522"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "356eb575cfa72456f348aa0ffe1fcac7696f8400efcd3f41b0228dc26f46945f"
+  "shardHash": "4b5da715ce76bf09444637f052b76a4ac75373474b310d4c8ff92a99ad592ee7"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f9903952ed21f66679321718269682291aa04c1cf5acf760d4fe776230b90914"
+  "shardHash": "38c8b0db0e370d5b4812f83bd0a60f3d272123d8da1512427e33500b972e46e1"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bc9e251797b26050dcec39d51a55697de732277c76eabf8db6122d2523ea2219"
+  "shardHash": "38a587d3e935aa4c115dbf351815f223b7a98016aab3e8a3e75aef08fa907d3d"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "eadd17aab0c06cccc8b5a1b1b3df592cccfacb8f4a20b166d600a4eae7dc5ad7"
+  "shardHash": "d5ae848bae04f788e10752841b77a90fb7c94348b28b5a6e3b0e1c55119e1539"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4a0ed2528207639e4b979d86952a3ed98668d47eb3718bfee9100f07deef8f1a"
+  "shardHash": "e0c433e56785f5ce306649cb4a8cad1732b65014d238cf42067037f4059adfb3"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "df7b2b998fc019160fc0a673ec5301baab21774837d77bbc52815801e74aa1c6"
+  "shardHash": "5983d5358bae974205f7e2d192f820a9a9f9cc07dbfe3329ddb765e19325433f"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22b4b23efa2277c14a5297d6d7edc35958cf2c4fec2e4dfebf248feb4648b4bf"
+  "shardHash": "3bfc37bafba3095f9de1fddd30ca7c3db3f64c0ecf6dbfdaa98a0e6fe4a3820c"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -305,5 +305,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "868e36edebf6f3529e8ac3214b14f67f6ed6d47ee8d56440467bafa405cd5752"
+  "shardHash": "a9bf359e2dff519cca4c8c15b22ee9a4d43c419f1c2608ebb7a1d67c3918f4d2"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -403,5 +403,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0836fdcea734dc239441f6613c8a22783b5070d4ec046f2a1b826ddfd8d54aa0"
+  "shardHash": "ebc6de1a6900ade3de86e1ddfa06dd401d474bc49a188ea065ec4ab5f254b202"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e6c6ed94040f27210969f8cc46bbec2cb7824f1f602e5f2eeaa4c88c00e18623"
+  "shardHash": "d40fdc5d1909c7cc89156c6301a9fa0f62c5df50e82e4f6f046b01f2c1dad3c3"
 }

--- a/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
@@ -323,5 +323,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ff0b9fb2d888a49bc3a8e541d7717b48871487427da18151d820432a190f5b07"
+  "shardHash": "ef9b383eeb647fa74beb78793f6751f8b0527911432407e7fd5baa723fd58a35"
 }

--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -32,5 +32,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2efe9ef552e091f92b54d9eeed0dd32376b21546d0935367985fc9405a30f0da"
+  "shardHash": "9f0f3c8a34623f86f81ac1e56a985642b3ea6316503c67eea464b2544370def2"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 spec-spine turns a markdown spec corpus into a typed, hash-verifiable authority
 ledger and **refuses code that drifts from its owning spec** at PR time. It is a
 three-crate Rust workspace publishing an installable library + CLI, plus npm and
-PyPI shims that ship the prebuilt binary. Read `docs/design/00-architecture.md`
-first: it is the load-bearing design doc (crate layout, full `Config`, public
-API, exit codes, schema plan, and the provenance of every ported algorithm).
+PyPI shims that ship the prebuilt binary.
+
+Two documents outrank this one for their subjects. Read
+`docs/design/00-architecture.md` for the design (crate layout, full `Config`,
+public API, exit codes, schema plan, and the provenance of every ported
+algorithm). Read **`AGENTS.md`** for how work is actually done here: it is the
+cross-agent authority (Claude Code, Codex CLI, Cursor, Copilot, via the
+AGENTS.md standard), it holds the session protocol `/prime` executes, and its
+"Working the backlog" section is the operating loop. **The gate chain is
+defined there, not here**, and `kit_skills.rs` asserts every skill's inlined
+gate floor is a subset of that list, so a step added to `AGENTS.md` reaches
+every skill.
 
 ## Commands
 
@@ -29,17 +38,41 @@ cargo test -p spec-spine-core --test couple            # one integration test fi
 cargo test -p spec-spine-core compile::                # tests matching a path
 cargo test --workspace emitted_registry_conforms       # one test by name
 
-# Run the CLI from the checkout (the dogfood gate chain):
-cargo run -p spec-spine-cli -- compile                 # writes .derived/spec-registry/by-spec/<id>.json shards
-cargo run -p spec-spine-cli -- index check             # staleness gate (exit 2 if stale)
-cargo run -p spec-spine-cli -- lint --fail-on-warn
-cargo run -p spec-spine-cli -- couple --base origin/main --head HEAD
-cargo run -p spec-spine-cli -- index coverage            # which source files no spec specifically claims (spec 032)
+# tree-sitter sits behind the default-on `symbol-resolution` feature (spec 027).
+# CI builds and tests without it, and asserts the grammars are absent:
+cargo test -p spec-spine-core --no-default-features --locked
+```
+
+The governed loop runs through the **in-tree binary** (`target/release/spec-spine`,
+or `cargo run -p spec-spine-cli --`), never `npx spec-spine`: the npm and PyPI
+distributions are for adopters.
+
+```sh
+cargo build --release -p spec-spine-cli                # what the harness drives
+
+spec-spine compile          # -> .derived/spec-registry/by-spec/<id>.json shards
+spec-spine index            # -> .derived/codebase-index/{by-spec,by-package}/ shards
+spec-spine check            # BOTH freshness reads in one verb; never writes
+spec-spine lint --fail-on-warn
+spec-spine index coverage   # which source files no spec specifically claims
+spec-spine couple --base origin/main --head HEAD       # the PR-time drift gate
+
+spec-spine registry plan            # the ready set: workable now vs blocked
+spec-spine index diagnostics        # unresolved-unit W-001 / W-002
+spec-spine verify <id>              # run a spec's `## Verification` block
 ```
 
 Exit codes are a stable contract: `0` ok · `1` validation failure / not found /
-drift · `2` stale · `3` I/O / parse / schema / config. They are mapped in
-exactly one place (`crates/spec-spine-cli/src/main.rs` via `Error::exit_code()`).
+drift · `2` stale · `3` I/O / parse / schema / config / usage. They are mapped
+in exactly one place (`crates/spec-spine-cli/src/main.rs` via
+`Error::exit_code()`). Verdict-rendering verbs take `--json` (spec 037), which
+changes what is written and never what is decided.
+
+**Ask `spec-spine --version` before believing any exit code.** The binary in
+`target/release/` is whatever was last built, not necessarily this checkout, and
+a binary predating a flag cannot report on it. `spec-spine.toml` sets
+`[meta] required_version = ">=0.17.0"` as a floor for exactly this failure;
+`scripts/bump_version.py` deliberately does not touch that key.
 
 ## Architecture
 
@@ -47,15 +80,17 @@ Three crates, strict one-directional dependency `types → core → cli`:
 
 - **`spec-spine-types`**, the plain-data substrate: `Config` (the
   `spec-spine.toml` model), the frontmatter grammar, the typed-edge and
-  authority-unit vocabulary, registry/index DTOs, schema-version `const`s, the
-  embedded JSON Schemas (`schemas/*.schema.json`, `include_str!`'d so the crate
-  is self-contained), and the `Error` enum. Everything is owned, serde, with
-  no lifetimes/generics/trait-objects at the boundary, so the same types back
-  both the engine and future FFI bindings.
+  authority-unit vocabulary, registry/index/verdict/attestation DTOs,
+  schema-version `const`s, the embedded JSON Schemas (`schemas/*.schema.json`,
+  `include_str!`'d so the crate is self-contained), and the `Error` enum.
+  Everything is owned, serde, with no lifetimes/generics/trait-objects at the
+  boundary, so the same types back both the engine and future FFI bindings.
 - **`spec-spine-core`**, the engine. One module per capability (`compile`,
-  `index`, `query`, `lint`, `couple`, `scaffold`) plus internal
-  `canonical_json` / `hash` / `markdown` / `sections` / `symbols`. **The library
-  API is the stable surface bindings wrap, not the CLI.**
+  `index`, `query`, `lint`, `couple`, `coverage`, `verify`, `attest`,
+  `diagnostics`, `render`, `scaffold`) plus internal `canonical_json` / `hash` /
+  `markdown` / `sections` / `symbols` / `shard` / `manifest` / `pathutil` /
+  `dep_only`. **The library API is the stable surface bindings wrap, not the
+  CLI.**
 - **`spec-spine-cli`**, a thin clap wrapper. One `cmd_*.rs` per subcommand.
 
 **Invariants that shape every change to core (do not violate without updating
@@ -73,33 +108,56 @@ the design doc):**
 - The **JSON-in/JSON-out facade** in `core/src/lib.rs` (`compile_json`,
   `query_json`, `couple_json`, …) is the FFI seam. Keep it `&str → Result<String,
   Error>` and additive.
+- **`verify` is the one verb that executes** rather than reads, so it is
+  deliberately outside the gate chain: the chain runs against PR branches whose
+  contents are, in the general case, a stranger's.
 
 ### The authority model
 
 Each `specs/NNN-slug/spec.md` declares, in YAML frontmatter, **typed edges** to
-other specs and the **authority units** it owns. Eight edges; `references` is the
-only non-owning one (the coupling gate ignores it): `establishes`, `extends`,
-`refines`, `supersedes`, `amends`, `co_authority`, `constrains`, `references`.
-`origin.retroactive` is a bootstrap marker, not an edge. Units resolve to
-code as `file` (bare string = file shorthand; trailing `/` = subtree), `section`
-(`{file, anchor}`), or `symbol` (`{id}`, resolved by tree-sitter, Rust + TS in
-v1; Python deferred). `directory`/`crate`/`module` kinds shipped in spec 017 (an
-additive minor).
+other specs and the **authority units** it owns. Eight edges; `references` is
+the only non-owning one (the coupling gate ignores it): `establishes`,
+`extends`, `refines`, `supersedes`, `amends`, `co_authority`, `constrains`,
+`references`. `origin.retroactive` is a bootstrap marker, not an edge. Units
+resolve to code as `file` (bare string = file shorthand; trailing `/` =
+subtree), `section` (`{file, anchor}`), or `symbol` (`{id}`, resolved by
+tree-sitter, Rust + TS in v1; Python deferred). `directory`/`crate`/`module`
+kinds shipped in spec 017. A unit may carry `planned: true` (spec 076) to
+declare territory before it is written.
+
+Two lifecycle axes, independent: `status` (draft / approved / superseded /
+retired) and `implementation` (pending / in-progress / complete / n-a /
+deferred). The ratify PR flips only the first.
 
 Two views, joined by the gate: `compile` emits the spec-as-source registry;
-`index` emits the code-as-source index (with a per-shard staleness mechanism).
-Since spec 024 both are stored **sharded** (one committed file per authority unit:
-`spec-registry/by-spec/<id>.json`, `codebase-index/by-spec/<id>.json`,
-`codebase-index/by-package/<slug>.json`); the aggregate view is recomputed from
-the shard set on read, never committed. The **gate chain is `compile → index →
-lint → couple`**. `index coverage` (spec 032) is the read verb beside it: it
-reports, per source file, whether a spec specifically claims it, only a
-manifest floor covers it, or nothing does; `[coupling] require_ownership`
-turns that into a `C-002` refusal on the gate (off in this repo, by decision,
-with the five floor-only files named in `spec-spine.toml`). The
-coupling clearance algorithm (amends-awareness, the strict-expansion guard,
-waiver parsing, bypass matching) is ported behaviorally intact from OAP. Modules
-cite their source; preserve the cited semantics when editing `couple.rs`.
+`index` emits the code-as-source index. Since spec 024 both are stored
+**sharded** (one committed file per authority unit); the aggregate view is
+recomputed from the shard set on read, never committed. `index coverage`
+(spec 032) reports, per source file, whether a spec specifically claims it, only
+a manifest floor covers it, or nothing does; `[coupling] require_ownership` is
+**on** in this repo, so an unclaimed changed source file is a `C-002` refusal,
+and CI runs `index coverage --fail-on-untraced`. The coupling clearance
+algorithm (amends-awareness, the strict-expansion guard, waiver parsing, bypass
+matching) is ported behaviorally intact from OAP. Modules cite their source;
+preserve the cited semantics when editing `couple.rs`.
+
+### How a file gets claimed (three ways, and a common misreading)
+
+1. **`establishes`** in a spec's frontmatter: the direct claim.
+2. **An `extends` edge carrying a unit.** `extends` is defined in `edges.rs` as
+   *"adds surface to a predecessor"*. The unit does **not** need to appear in
+   the target spec's territory, and usually does not: this is how most source
+   files here are owned. About 38% of unit-carrying `extends` edges name a
+   target that never established that unit, and the whole `spec-spine-types`
+   crate has no establisher at all, yet `index coverage --fail-on-untraced`
+   passes. An extends-carried unit is a first-class claim.
+   **Do not "fix" these.** A validation requiring an `extends` unit to appear in
+   its target's territory would refuse the repository's ownership model.
+3. **A `// Spec: specs/<id>/spec.md` comment header** in the first lines of the
+   file (`//`, not `//!`), for the extensions in `coverage.rs::SOURCE_EXTS` (rs,
+   ts, tsx, js, jsx, go, py, sh). It claims exactly the file it sits in, never a
+   subtree, and needs no frontmatter edit anywhere. This is how spec 032's
+   coverage debt was retired without touching the tier-1 bootstrap spec.
 
 ## Determinism is the central claim
 
@@ -120,36 +178,65 @@ This repo runs its own gates against its own corpus in CI (`.github/workflows/ci
 
 - The `.derived/spec-registry/by-spec/` and `.derived/codebase-index/{by-spec,by-package}/`
   shard trees are **committed** (only `build-meta.json` is gitignored). After any
-  change that affects them, regenerate and commit: `cargo run -p spec-spine-cli -- compile`
-  then `... index`. The `index check` step fails CI (exit 2) if any committed
-  shard is stale or the shard set changed; the coupling gate (PR-only) fails if
-  code drifts from its spec.
+  change that affects them, regenerate and commit: `spec-spine compile` then
+  `spec-spine index`. CI runs `check` rather than `compile`/`index`, because a
+  gate must never repair the tree it is judging; it fails (exit 2) if any
+  committed shard is stale.
+- **Editing a governance file restales every shard.** `[index] extra_hashed_inputs`
+  in `spec-spine.toml` folds `AGENTS.md`, `CLAUDE.md`, `spec-spine.toml` itself,
+  `.claude/rules/*`, `kit/**`, the workflows and the embedded schemas into one
+  global scalar. A one-line edit to any of them means regenerating and committing
+  the whole index. Adding a pattern there is expensive and deliberate; the
+  patterns are narrow on purpose (a bare `.claude/**/*` would fold in
+  `.DS_Store` and make shard hashes machine-dependent).
 - Editing code under a path owned by a spec generally requires also editing that
-  spec's `spec.md` (or adding a `Spec-Drift-Waiver:` line to the PR body). The
-  bypass floor (docs, lockfiles, `.derived/`, per `couple.rs::DEFAULT_BYPASS_PREFIXES`,
-  extended by `spec-spine.toml [coupling] bypass_prefixes`) exempts non-code paths.
-- **Merge conflicts on the committed artifacts (spec 020, narrowed by spec 024).**
-  Sharding (spec 024) removes the common conflict: two PRs touching different
-  specs/packages now write disjoint shard files. The opt-in per-clone git merge
-  driver remains for the rare same-shard conflict (two PRs editing the same unit),
-  regenerating from the merged tree. Enable it once per clone:
-  `./.githooks/enable-merge-driver.sh` (build the binary first; the driver shells
-  out to `spec-spine compile && index`). It is
-  inert until registered, and never replaces the `index check` staleness gate.
+  spec's `spec.md` (or adding a `Spec-Drift-Waiver:` line to the PR body, which
+  is a human instrument an agent never self-approves). The bypass floor (docs,
+  lockfiles, `.derived/`, per `couple.rs::DEFAULT_BYPASS_PREFIXES`, extended by
+  `spec-spine.toml [coupling] bypass_prefixes`) exempts non-code paths. A
+  dependency-only manifest bump self-clears via `auto_waive_dependency_only`
+  (specs 005/030), which is why Dependabot PRs are mergeable.
+- **Merge conflicts on the committed artifacts** are rare since sharding (spec
+  024): two PRs touching different specs write disjoint files. The opt-in
+  per-clone merge driver handles the same-shard case:
+  `./.githooks/enable-merge-driver.sh` (build the binary first). It is inert
+  until registered and never replaces the staleness gate.
 
 When working on a feature, add or amend the governing spec under `specs/` in the
 same change. `standards/spec/` holds the constitution + contract + templates;
 `specs/000-spec-spine-bootstrap` is tier-1 (its `unamendable` anchors are
-non-overridable). New specs are filed as the next `NNN-slug` directory.
+non-overridable). New specs are filed as the next `NNN-slug` directory, born
+`status: draft`.
+
+**Never edit an approved spec to make your code pass.** The sanctioned move is
+an `amends` edge declared in the *new* spec's frontmatter, which records the
+change without touching the amended file (spec 040). See
+`.claude/rules/adversarial-prompt-refusal.md`. Two edits are always legitimate
+for the spec you are implementing: claiming a file you created, and recording a
+dated decision the spec was silent on.
+
+## The kit (`kit/`)
+
+`kit/` is the copy-ready Claude Code kit adopters install (specs 029/048/064/065):
+the fifteen skills, the agents, the rules, the hooks, `Makefile` and `govern.yml`.
+`crates/spec-spine-core/src/kit_embedded.rs` is **generated** from that tree by
+`scripts/gen-kit-embedded.py` so `init --with-kit` can write files the binary
+carries; `tests/scaffold.rs` asserts the two agree. Edit `kit/`, then regenerate.
+Never hand-edit `kit_embedded.rs`. This repo's own `.claude/skills/` is
+byte-identical to `kit/.claude/skills/` (spec 048 pins this); the project layer
+lives in `AGENTS.md`, not in the skills.
 
 ## Schema & release versioning (two decoupled axes)
 
-- **Schema versions** (`registry`/`index`/`build-meta`/`config`) are compile-time
-  `const`s in `spec-spine-types/src/version.rs`. The conformance test
+- **Schema versions** (`registry` 1.2.0, `index` 1.1.0, `verdict` 0.3.0,
+  `build-meta`, `config`) are compile-time `const`s in
+  `spec-spine-types/src/version.rs`. The conformance test
   (`core/tests/conformance.rs`) asserts emitted JSON validates against the
   embedded schema of that version: a DTO/schema drift fails the **build**.
-  MINOR = additive only; MAJOR = breaking (loaders reject an unknown MAJOR). See
-  `docs/schema-versioning.md`.
+  MINOR = additive only; MAJOR = breaking (loaders reject an unknown MAJOR). An
+  additive registry field is a MINOR bump that restamps every shard's
+  `specVersion` while leaving `shardHash` alone (the hash is over `spec.md`
+  source bytes). See `docs/schema-versioning.md`.
 - **Package version** lives in three files (`Cargo.toml`, `npm/package.json`,
   `py/pyproject.toml`) and must agree at release time. Bump them in lockstep with
   `scripts/bump_version.py <x.y.z>` (`--check` verifies agreement). This is


### PR DESCRIPTION
## Summary

`CLAUDE.md` was last substantively edited at spec 032 (`d20682f`, 2026-08-28). Forty-six specs have landed since. Its shape was right; its facts had drifted.

**Three statements had become actively wrong**, which is worse than the omissions:

| Said | Actually |
|---|---|
| `require_ownership` is off, five floor-only files named | On (`spec-spine.toml`), debt retired via `// Spec:` headers, CI runs `index coverage --fail-on-untraced` |
| Gate chain is `compile -> index -> lint -> couple` | Six steps, and defined in `AGENTS.md`, not here: `kit_skills.rs` asserts every skill's inlined floor is a subset of that list |
| Core has 11 modules | 22 |

`AGENTS.md` was not mentioned once, despite being the cross-agent authority, the protocol `/prime` executes, and the home of the operating loop.

## Added

Roughly ordered by how much time each would have saved a session:

- **A pointer to `AGENTS.md`** as the authority for how work is done here, rather than duplicating it.
- **How a file gets claimed, in three ways**, including that an **`extends`-carried unit is a first-class claim**. `edges.rs` defines the edge as *"adds surface to a predecessor"*: the unit need not appear in the target's territory, about 38% do not, and the entire `spec-spine-types` crate has no establisher while `index coverage --fail-on-untraced` still passes. Written down with an explicit **"do not fix these"**, because reading those edges as a defect is exactly the mistake that cost this session three artifacts before anyone measured the prevalence.
- **That editing a governance file restales every shard.** This PR is the worked example: one markdown edit restaled 83 index shards (79 by-spec, 4 by-package). That is 84 of the 85 changed files here.
- **The stale-binary trap** and `[meta] required_version` as a floor rather than a pin, plus why `bump_version.py` leaves it alone.
- **The verbs added since 032**: `check`, `verify`, `attest`, `registry plan`, `index diagnostics|render|orphans|coverage`, `config`, and the `--json` verdict envelope.
- **`kit/` and the generated `kit_embedded.rs`**, which was entirely invisible in this file. Edit `kit/`, regenerate, never hand-edit the generated module.
- The two independent lifecycle axes (`status` vs `implementation`), `planned` units, the `symbol-resolution` feature gate, and the current schema versions.
- That an approved spec is amended by an `amends` edge declared in the **new** spec, never by editing the approved file.

## Kept unchanged

The authority model, the purity invariant (no clock, no env, no `git` in core), the determinism and hashing contract, the sharding rationale, and the two-axes versioning section were already correct.

## Testing

```
check --fail-on-unresolved 0 - lint --fail-on-warn 0
index coverage --fail-on-untraced 0 - couple 0
cargo test --workspace --locked 0 (30 suites) - cargo clippy -D warnings 0 - cargo fmt --check 0
```

`CLAUDE.md` is claimed by no spec's frontmatter and is not in `SOURCE_EXTS`, so neither `C-001` nor `C-002` applies and no waiver is involved. The regenerated shards are committed with the change that staled them.