### PR TITLE
feat(077): a compile warning can be refused, not only counted

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e1adb2b1c99c5cdaebc18b8c77256734b76c968339e33cc015eea72ca7e3feb8"
+  "shardHash": "ce995e77a9872899acda55192b792c516c96013c2aa0773784e332463e2a5e6d"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "46512484db8cc3bed569e43ecfa8a0abc3d1cbf641baceae9b451e9aeffa1adf"
+  "shardHash": "62dbde6b7dfee4a27a7a3c71936fcf2c230565148c4f1be6c34527be45504d42"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "be6cd75bada9858a9096f59d4420eab743cf6284da652411021669bae67b1966"
+  "shardHash": "c5c7a502145cbabf5634e20a98d6eddfcc9005117a489a7d584998a489e09cbc"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.17.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0317eda395e46ee37f1609b99c26de59319ae113055827aee13edd5351e6d3c1"
+  "shardHash": "4983f1d4077e62876cf6a62d3c393c25de653f8b0602ba8a384089fa11d08fb7"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cc68845c6ba128b128300f781bc167bdde8f46437dcb370c2ebcf6eb6aaaae63"
+  "shardHash": "5f0e83ea75db0f90220acf6580964a732e9b6a3567aef85a43dc0454783254e8"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c667eaae36d33fc2efda195115dcfca8a0367e1ba8405a5d2d1970ee622be150"
+  "shardHash": "087852711f5eb97955097b7154212e6ec3f409dc11785dfff9a67bdd3b23d254"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "657c598f6e6bae5dca8ff64624e94e831be288c2b4bcad7e4c62e771d702f6c9"
+  "shardHash": "804f5a8cbed710cd138a2d21dae0b261c2ec155dcd73ee6b531b789c7a87c402"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3e208d13fc6ee18f2b0e1d59f15bd285cae9c234a6d9859bf1f534fee0b27c3e"
+  "shardHash": "554311e590194cfa0801c575b9dd3e2d83c5249daca3af0ecfb67f03273b1f8a"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7ef401d303b1b0c518a18206c9a6d0ae0005bcd02c953cf79a4116cfc897bbe5"
+  "shardHash": "0c3f728605ba1c9a28ed6adc423d76cb07a2890d2a990ddca03ad7457913fdc8"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a0ee74757a9ea6c90490f71b7d47c8844daa5834878b1c9aa3dbf02a4c3ad706"
+  "shardHash": "f3c8d992ddb1f24aa9afbd66535c64fc04bcb84ce3cc6c77c92e0b3adbe1182c"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "52b2c3842e8dd1899a44c259e5c987c88b10ac8ea6ba397299ff28b1c2f0756c"
+  "shardHash": "07ca777fa87c46cc5d0615ada2452d06461a19af76f554950dae9972ad0567a1"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4a0fcb4a181a0f20ad033a0d27461cac2ba1e8da588b0c836620aeaeabff59e0"
+  "shardHash": "ea35696f071b7f8af90c74e15c3392551bb385ea40ded51a6165dcfa9d511cd4"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "da3cf2cba77d8168872fc138416147da4e04f152e0d8b28eb3237cbdcbddab8c"
+  "shardHash": "13bb0763142a595753938788a34b552d49f45ef35a92694b9ced1e2c7625b915"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "48c331a535a01e70343a32155a223c74df8a09c03a9ee2c4bf87908ecaa084c9"
+  "shardHash": "7a6cab31fbae12e62193c5da44ed48dbb97c963b5b9c1eec6d67c6738c6bcf72"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f184308a871e83bccd5d42d2d26d5a1f37bebf2cc11ea09c85739e7ffe15aa89"
+  "shardHash": "9ae6b372dcd05f35d40be93cf93466e43febd4eb922645b361f982e9a594c7ed"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "99062827f43b46d4cd0ebe6c1d2e34d5807bf36c1baae0b158b38bc5ce97b596"
+  "shardHash": "6aa82d904a42dafe5b8d26629750f5ebc7a5c96b4efca2fd4594b5d1724ea436"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "de7431f17cb88ab52c34b492bb266e8095485c6401a78050c52fa35cbbddcf14"
+  "shardHash": "690007d5cc18d9d4217d6fd62aacb5c58758a86755158f6196a39efd626d5926"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a189b15917c4e20b49cc4fd0a18aa388ccf927afd6aafa7425a7c7613cde3c3a"
+  "shardHash": "8e09319fb428cf9d9c03f5b55331507982873f39497138629655ef9fa216276b"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5c465c9d69ca3f65663e2687ab20f304666785ffe4798d47750a73557fb97d54"
+  "shardHash": "1fe78564facba0cec84c8a5e2de76bf36755a0244ece1eceb90b2fabfaa88f01"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d6491251bb97c94a1466881e6924c4db0797a909fe5f5869f23073f8c8b2d05f"
+  "shardHash": "85ebbef98be0f89d00e483461700e46563159408406e1e5e47513ddef59021cc"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3e6c5998daadd1389c727e037c0565b81aefa1b18728ab0a48745e4ad6ab3ade"
+  "shardHash": "c4e175afed4c63a9770445cbfd76635bb353f5578379de5c12030c62a6b8ee91"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a0bd6326bed458595046bbf36adc8bfaa6add43ebe399269238bf863fd63ff16"
+  "shardHash": "2ed2a11aa4fc020e93866fb5d508da548908b458dc9aaaa209cafc253441ddfe"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b173287cd08bc28a09fb936b87286bfec8a631231d733348077ab8f5a63938d5"
+  "shardHash": "566fe694cab96923fdeb58c1f9dca27bed8277a1d4a3c326cbb627ffda1e9b1c"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "350a8d70a43812e12706f86ae0cb6812613a38738a28dd9ad9ce15e6a3f22fe0"
+  "shardHash": "8e1a2781cb57eaeaa6dc9a16e64b690e4fc6c37b35b0c9b5cf437d9466653f64"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9915926f087c57fb95ff84d6504d1e36136521f479c5c678bce7db511b867dfa"
+  "shardHash": "55183c25f8a0ea58d545ec14ec9d2bd4259316c6ab3d12087baf43141d8d2a24"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "87af65628b4836b53dc4fc5c8435aee7b39d2141bc1ab4626441ac43484a3ce5"
+  "shardHash": "dc6121f15a3a453c01252af493558ceb3d9a278861b59262332d73fa71cbba16"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6f4fd8b4e58eb2bbfa036e92f8821cdc2f561400054f93a11fc3c417e2eee2d0"
+  "shardHash": "847049f4bc3f227356284b4af571f9ec36e166775a4fa9b1fc88c591120a7c89"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "840efb6a63a1a687afd9d37a2da08493179e3df2872fbec57c37135ff73b1764"
+  "shardHash": "b94cc7cdc2df6459c73025e58b3e4e21b1981730c617d9e8d32dd88547afe3f4"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "802ef4646e5f40ef336c0ced0d65dd8bcee088dd01e1642e05b9c833e0498d8d"
+  "shardHash": "3db0b0c553469f0fad7e67331625a662c1440e8c244e81bcc1e4c3fb2331b571"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b09e6e1888cdd45a99905fc9662a336fcf7fe00c1aca5729751f6a45153a06b9"
+  "shardHash": "3d24dc88aad18765e38b98e364ddc96f043b62eabd7f481a1386029b9b7e91d0"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c5b47b31866993a0c46981e714a3baf59a278a1bd5811cddfb032ff74c72f6d7"
+  "shardHash": "666ef80e2f8ee71ee1aed94d5920e42ae9e332a1860c7e2a9d9236c17f2bb4da"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "67c0c5b5035c9edde11c099711bef8c9be26c8786e487c894c2122b6f4579980"
+  "shardHash": "1f6ebfd1b51757068de2cb7be1702a515faa169641c85266f71466cacd0dc63e"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9a5627ed132dd8db81710afb410142b8f4979d744a2f5e9157bade39052f2a89"
+  "shardHash": "8dd36d0fd45a583179a3c3700cf38f8f023559a0734f78b17153506b8e8cc188"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "98eacba8193d7c1e6b2ebc66b722d7ed7aa2c2ffb7eda313a8748f2da795234d"
+  "shardHash": "afded443c158b828d646724b161058e764084263d7512532f4a85d6248ba1e2e"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80580e5d26cb5fdcc037da787dcfcaa317ee1e375bfe7dc3e0193a71f357f2a5"
+  "shardHash": "7b5531a8426710e9a80b0295a448908f33f03aa4ed156487ae089063e81533e3"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4a6b0901fa4d647317f6f6424b9e57fbc8ae3e5a2ac032b5f99f017cfe89aa67"
+  "shardHash": "337c242917439127d7d4a088813182779b468ef236dd9c52ad166d6040250d53"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "80d6e28edfe67d7b33a9c28a33d4d4c009630cdf1121e84b1cf87e1503d61573"
+  "shardHash": "65d7637f67f4ee4518fa26c1870f2ff42e709e12da6d92c9e0379339890687ec"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4d6c33c1d9e04e939bfbda54b23fe741e4e3eb70c31adc40351fb0e965ba0d40"
+  "shardHash": "7559bb510e3526f1cd3fe4d3b61cc8363d408ace53cf89518cb628d58d77be86"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8404bcf8fab1587224d0c3c1d9e8f75ba876242047d0595bad13b40ea9c78439"
+  "shardHash": "db0850452d171a3fa98d7af2c88b7ae6f2ceaa892341bccc6c24120ce4429db7"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ad8c6ab4b6f39e1945b107fe624f8c5b6ce9aba67d95c6cdf732b92a21dcee38"
+  "shardHash": "1aa2ad55e81a14cdb7d48ad7873d2008351f9c436dfb6f0a0dd0135b47816b0b"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2632dd1684fbdb74c87ea4ef89165561eb7172dbe2692ac39f109961fca6fe81"
+  "shardHash": "8557938ce4b2c8bf052c9b4cfa1f63bb29eaa134fc4f32fdac1ccb578398dc7f"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7c93292ba7b4b1c5e63f17ea6b29165770cf9dff9e7cad02de3a6c6e2c12019a"
+  "shardHash": "e16341f8415181b46bf827ddcc67f3e593081846cf0e720c002f732fe96ffdbb"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "04b4a53ea3cb0153da877718014ae13f9e2d39847a7591757b490003af58fffc"
+  "shardHash": "c483d2a1e627ade21cabdfd1059997f82fe1941408593901c064b47ca62f8ef4"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "79b40f1f59147e9b7c765b71009e11f704efc1f484be0b42ca3cdd9fe68c6b7a"
+  "shardHash": "6292c0330ed8d1e1f34e60d03df49f3c4402cbf914b94d012ac300b491a40606"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dcb59661c67126523195ff5841480c9cce2cf35b29a7567d6e42001884f46435"
+  "shardHash": "cf9756771f829ea4f95c21e66c640af09a20e0f15464d7100f44d6ad22f5fa54"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5e256e4347cabe0af2228527dff898faa1ef30d72897342b11d1c929a4e3437"
+  "shardHash": "a50c85f4344f33604c9febac2028a51f847e03ac5d6fbf9833c4138a852887a6"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "09978dd6f514514c7f7f590558b11466af53ae496739df21dd1dcfe767ac223d"
+  "shardHash": "7426a3d0668090a9305e6d3138eea217d7417c006504703f1466717014bfdeef"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "54bc1a79375df1d83db298c0270f2f55f78f7da7ff4cb3529341f11a771e7f57"
+  "shardHash": "5eb188d0d0a122cf6c55a9e3b0277b8c57a619811e97a64edd8aa28033192f70"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d61dd4902fab2c12e9feb34b00259c5aa36ca7c48d5a8509110495ff083e72a5"
+  "shardHash": "41f4b17a6aea8bc13877476075ed5ed57310f2641213ee7e8983038bb4099422"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e32917c230d9085c32aa444cec04e4add4e71c0fa33e673557004114458c2dc2"
+  "shardHash": "55e1db9c6d71999a14be6cf653cf5724a6e0b4a43aea4229518b625d9c13c1d4"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a03152fe881ecac0f95d57d7cf4354927a8269a9a9513c825f3c559bb4cf36d6"
+  "shardHash": "df46218bcf0495e17cdd8e5ceaa0b38b216d880b349be4238ea0a4422cb72ce2"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f2d02df940f313aa2b449a838b4110b8c0169972159667531d5bb74d66ed615d"
+  "shardHash": "1172088536611649141f8b09666f101250100783dca49b2a6759e6c7fbb324a2"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9f645534b7fa5e64ae5f363cff9cada667d187713005dc57ff077f06126d4586"
+  "shardHash": "8839cce31278133c125928bcb1a336bfb19724dcdbfe122366d84cea268ae5ce"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1cb513c9251f4ff80af88d1ad2884d60b4bde5b32412d58c56ad7d6618e8f3d6"
+  "shardHash": "8fdb2cf7f4db1c6541010996b960212356f0b0cbaee135420ca0520460c21ccd"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b2c2ce83f2b18d98fe47679321dd75b88a5b330018719c126b92ce3a92983a94"
+  "shardHash": "beb7816f607cc20d831afed1f0a190e97ea1aefc4388e1aed99d14474ee864a3"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c28ace7076af574023fa2fe2fa693934c065f839299d86a7ebd9f2c77291ab20"
+  "shardHash": "f0e47de286fe60a60617cffa2410c35d0ca468dbd398306c7c57b0b8517a2e88"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "957541b2d7a03d210bbc4f5656f95f1ee2a258af9b0a914e2281da9625cddeaf"
+  "shardHash": "7f47493dfc2a9e27b6e557b7517c5a79bc4c0f15dde43e55825a8746e28eb0d2"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "39873f40b39f4b8dbc444be21900f4a9e10ad9486f477cbbfa1ad22e1b366aff"
+  "shardHash": "3e879bab9314a5bd8361e776a799a89f2d6241154abaafc2c3857e94527122a1"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb1e623122ee4f9a96f7af231bd4a4b7eee20afcac94025305d31a0e56f6a827"
+  "shardHash": "b37d827cd09aed9a61e8d1b9e1f3f70c1a4c91b5623af7dadef68f00a10f9589"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9bddca99b71ebd95792302c84e11375147cb8ea58b894908ce5e41de4f390cea"
+  "shardHash": "5ba280016a6441e5527e490fb30cc4f5ec8fa2eadee6e2e77e3a8b621ceb220b"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e0669c2dcc35203bd08a528121b676f25b760129d6554aead00d73b6e544e47"
+  "shardHash": "c7c652b04b03ffc503453070cf81e755ed86498e4693ec649e6a1d9be64941e0"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "32ea2bd33d3e99488145896e99430cafa27d03bcce67b4e50cbb1fec5ad230fe"
+  "shardHash": "c2f6a16b12cbf58da8dbb61b1f9fc3bb1bba42c12c6c05c3aaf7ed7eeab54f73"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "327c2db50af98a238df8e0bdea3bb962abf330196206909ba26d03c918b5d72f"
+  "shardHash": "f6615f30586f01b20978f2ecdbef149e5bcd99b45c085146aeecefe2d13cf602"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f9efbdb3b13f7964a195639ba26a73861e31bbbfa34336470e828f5fecb4edc5"
+  "shardHash": "dba0bf5b07db8c23b3218bf5ed371273ba87b21ae1de519761d96b7040db1c19"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "933aa5b5c38f2917c2ba5b6ed9648f7b216f899908d93f3ed57377c9db233b36"
+  "shardHash": "f966b9cb9972dda54444be536634fabcdfd68b5479142f6ff9bb7fddda710129"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "755d0d3a71753382cf5a60e6331f7b4555698129744828bd109caca73d9f3e86"
+  "shardHash": "35f17a16330d44294f08e10713b3b19d8908d3c831bdde82c753dfe6fb0d8d62"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ad0531cc0ffa8aa2c5c493167b907ebe6a19624ca4747e2862885891b32f7712"
+  "shardHash": "eff2b7f8cf532329da6a0cf80ab7b5cbb8a0087534b84ca678ec20d9db6644ad"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e3a098105afc2eeaf3ddd5b9019fe2df087213936daa81eb253639a70180dbf6"
+  "shardHash": "26c84dc082f312a425056534f49c92912bb98d158907c83c0499cde8bacf2e46"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "860d2a2351cb65378ba01eeab6c7c568196e3660efef54febfae21c9e614ae2a"
+  "shardHash": "1ff6b3372fb47fdfc77b4f01ea4871012698a06616e2dc77072bf364621bb8b8"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "068d8432d6b763ad8e0e71770b509be9be0a060ecdcab94e785141d422c9a38b"
+  "shardHash": "20cae13d1739243dfe0c93005f5fac88ab9b1ff0811f289241b88fa622ceb12a"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "164d69399ec6f26088187aa12795f5f2eaf314a03a5d8e3546f61ba6a0a00522"
+  "shardHash": "0e2f3a40cef0b6c0a4d55a53bf07a75d57188da6560d7ecb5d6a44439d218c95"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4b5da715ce76bf09444637f052b76a4ac75373474b310d4c8ff92a99ad592ee7"
+  "shardHash": "b6217a1f2314dac09159753c7196648645c325a87817d73bdeb11ae3a4d8521b"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "38c8b0db0e370d5b4812f83bd0a60f3d272123d8da1512427e33500b972e46e1"
+  "shardHash": "ca3576812886f1bf2e7b9f1315b2ee6b2208c5fbb1ed2a4d91cea715e5eb3054"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "38a587d3e935aa4c115dbf351815f223b7a98016aab3e8a3e75aef08fa907d3d"
+  "shardHash": "7b2885315db4590effd19e7f948f2842962585604526d481245aedb8efbe56ac"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d5ae848bae04f788e10752841b77a90fb7c94348b28b5a6e3b0e1c55119e1539"
+  "shardHash": "690dbcae72acfdef75524232ef80560950f15125707e7f65d97535db4cd65c50"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e0c433e56785f5ce306649cb4a8cad1732b65014d238cf42067037f4059adfb3"
+  "shardHash": "6ad0264322d0d6e44891ce61e5f62c94ba0ae0934cbc07f1280674ddeb7f315d"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5983d5358bae974205f7e2d192f820a9a9f9cc07dbfe3329ddb765e19325433f"
+  "shardHash": "b17a4753e0dc9021bda3059f5512a5c98b2543fa507bfc22ada195c0ee7ba647"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3bfc37bafba3095f9de1fddd30ca7c3db3f64c0ecf6dbfdaa98a0e6fe4a3820c"
+  "shardHash": "66d6b96e0c1e679d8f42dcb596cd914a8a0b272399e371a0267e40ae4c0422ec"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -305,5 +305,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a9bf359e2dff519cca4c8c15b22ee9a4d43c419f1c2608ebb7a1d67c3918f4d2"
+  "shardHash": "f6b87f89f6c9f4709911421747e28f1e270c953c107fe100d82ded0dbb980a39"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -403,5 +403,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ebc6de1a6900ade3de86e1ddfa06dd401d474bc49a188ea065ec4ab5f254b202"
+  "shardHash": "023b430da0fa41bb873fb9c22ab1104d09fd0b5a24266c7e97c40d1646fde918"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d40fdc5d1909c7cc89156c6301a9fa0f62c5df50e82e4f6f046b01f2c1dad3c3"
+  "shardHash": "70848cbfff700f5edc96ea383f4523f01f0f65666fa18094974b95d0e4f2f72d"
 }

--- a/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
@@ -39,6 +39,10 @@
         "source": "spec-edge"
       },
       {
+        "path": "crates/spec-spine-core/src/compile.rs",
+        "source": "spec-edge"
+      },
+      {
         "path": "crates/spec-spine-core/src/diagnostics.rs",
         "source": "spec-edge"
       },
@@ -173,6 +177,19 @@
         "unit": {
           "kind": "file",
           "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/compile.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
         }
       },
       {
@@ -323,5 +340,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ef9b383eeb647fa74beb78793f6751f8b0527911432407e7fd5baa723fd58a35"
+  "shardHash": "bd2c7835f4ad2b2824c88cecb3e45a570936586d68095bc0a79b9cfebc39b900"
 }

--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -32,5 +32,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9f0f3c8a34623f86f81ac1e56a985642b3ea6316503c67eea464b2544370def2"
+  "shardHash": "60844dff52c6cd95e464a8d8a2f23a83300dd277a063c7a1e50e4aa9a00a9fcf"
 }

--- a/.derived/spec-registry/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/spec-registry/by-spec/077-compile-warnings-reach-the-gate.json
@@ -16,6 +16,14 @@
         "spec": "001-compile-registry",
         "unit": {
           "kind": "file",
+          "path": "crates/spec-spine-core/src/compile.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
           "path": "crates/spec-spine-cli/src/main.rs"
         }
       },
@@ -157,7 +165,7 @@
       }
     ],
     "id": "077-compile-warnings-reach-the-gate",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "risk": "medium",
@@ -181,6 +189,6 @@
     "summary": "`V-010`, a `depends_on` naming a spec that does not exist, is the only warning-tier code the compiler emits, and no verb in the gate chain can be told to refuse it. `lint --fail-on-warn` cannot reach it: lint's codes are disjoint from compile's by design, and `lint()` keeps only the registry from the compile it runs. So a dangling dependency compiles clean, lints clean at every severity, and reaches the default branch unread. This spec adds `--fail-on-warn` to `compile` and forwards it through `check` into the compile half, the shape spec 050's `--fail-on-unresolved` already uses for the index half. The flag gates the CLI's exit code only; `validation.passed` keeps the meaning spec 001 fixed for it, and `V-010` keeps its warning tier, because a corpus that files specs forward must be able to name a dependency it has not written yet. Zero `V-010`s exist today: the gap is structural, and this spec closes it before it costs something.\n",
     "title": "Compile warnings reach the gate"
   },
-  "shardHash": "43005b5da4bbcbfb9bf581fbe29f7b59a88613bf3f16cf1f104e544fea5546f2",
+  "shardHash": "4e0a3b8f2a031c219fd960f54172564e382e53ecfecd91448e9b937530c574e8",
   "specVersion": "1.2.0"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       # builds what it claims within one PR, so an unresolved unit reaching the
       # default branch is a claim nobody wrote, not work legitimately under way.
       - name: Freshness (committed registry and index shards must be current)
-        run: ./target/debug/spec-spine check --fail-on-unresolved
+        run: ./target/debug/spec-spine check --fail-on-unresolved --fail-on-warn
       # Enforced (spec 032): every source file must be specifically claimed by
       # a spec, not merely covered by its package's manifest floor. This repo
       # drove the floor-only list to empty by annotating the last five files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ corpus in step 1 and step 6. One spec per PR, then stop.
    ```sh
    spec-spine compile
    spec-spine index
-   spec-spine check --fail-on-unresolved
+   spec-spine check --fail-on-unresolved --fail-on-warn
    spec-spine lint --fail-on-warn
    spec-spine index coverage --fail-on-untraced
    spec-spine couple --base "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)" --head HEAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,18 +49,35 @@ distributions are for adopters.
 
 ```sh
 cargo build --release -p spec-spine-cli                # what the harness drives
+```
 
+**Run the gate from `AGENTS.md`'s fenced list, not from here.** That block is
+the one spelling, flags included, and `kit_skills.rs` asserts CI's flags are a
+subset of it, so the two cannot drift. Nothing tests a copy in this file, which
+is why there is no longer one: an earlier revision restated the chain and
+silently dropped `--fail-on-unresolved` and `--fail-on-warn` from `check` and
+`--fail-on-untraced` from `index coverage`, leaving three refusals off a list
+that still read like the gate.
+
+What the individual verbs are, as a reference rather than a sequence:
+
+```sh
 spec-spine compile          # -> .derived/spec-registry/by-spec/<id>.json shards
 spec-spine index            # -> .derived/codebase-index/{by-spec,by-package}/ shards
 spec-spine check            # BOTH freshness reads in one verb; never writes
-spec-spine lint --fail-on-warn
+spec-spine lint             # corpus conformance (L- codes)
 spec-spine index coverage   # which source files no spec specifically claims
-spec-spine couple --base origin/main --head HEAD       # the PR-time drift gate
-
-spec-spine registry plan            # the ready set: workable now vs blocked
-spec-spine index diagnostics        # unresolved-unit W-001 / W-002
-spec-spine verify <id>              # run a spec's `## Verification` block
+spec-spine couple           # the PR-time drift gate
+spec-spine registry plan    # the ready set: workable now vs blocked
+spec-spine index diagnostics  # unresolved-unit W-001 / W-002
+spec-spine verify <id>      # run a spec's `## Verification` block
 ```
+
+The `--fail-on-*` flags are what turn a read into a refusal: `lint
+--fail-on-warn`, `check --fail-on-unresolved --fail-on-warn`, `index coverage
+--fail-on-untraced`. Bare `check` still exits 2 on a stale tree and 1 on a
+validation failure; what the flags add are the unresolved-unit and warning-tier
+refusals. Bare `index coverage` refuses nothing at all.
 
 Exit codes are a stable contract: `0` ok · `1` validation failure / not found /
 drift · `2` stale · `3` I/O / parse / schema / config / usage. They are mapped
@@ -146,10 +163,10 @@ preserve the cited semantics when editing `couple.rs`.
 1. **`establishes`** in a spec's frontmatter: the direct claim.
 2. **An `extends` edge carrying a unit.** `extends` is defined in `edges.rs` as
    *"adds surface to a predecessor"*. The unit does **not** need to appear in
-   the target spec's territory, and usually does not: this is how most source
-   files here are owned. About 38% of unit-carrying `extends` edges name a
-   target that never established that unit, and the whole `spec-spine-types`
-   crate has no establisher at all, yet `index coverage --fail-on-untraced`
+   the target spec's territory, and often does not: a large minority of
+   unit-carrying `extends` edges name a target that never established the unit.
+   A quarter of tracked source files have no establisher anywhere, most of the
+   `spec-spine-types` crate among them, yet `index coverage --fail-on-untraced`
    passes. An extends-carried unit is a first-class claim.
    **Do not "fix" these.** A validation requiring an `extends` unit to appear in
    its target's territory would refuse the repository's ownership model.

--- a/crates/spec-spine-cli/src/cmd_check.rs
+++ b/crates/spec-spine-cli/src/cmd_check.rs
@@ -24,14 +24,19 @@ use crate::out;
 /// *committed* copy was stale, so the drift reads as an uncommitted local edit
 /// instead of a defect already on the branch, which is exactly how the spec
 /// 017/021 drift reached the default branch.
-pub fn run(repo: &Path, fail_on_unresolved: bool, json: bool) -> Result<u8, Error> {
+pub fn run(
+    repo: &Path,
+    fail_on_unresolved: bool,
+    fail_on_warn: bool,
+    json: bool,
+) -> Result<u8, Error> {
     let cfg = load_repo_config(repo)?;
     // An `Err` from either half propagates, and `Error::exit_code()` spends 3
     // on it. That is the top of the precedence in 3.3, and it is the right
     // shape: a read that could not be performed has not answered, so no verdict
     // from the other tree makes the overall answer trustworthy.
     let report = spec_spine_core::check_report(&cfg, repo)?;
-    let code = exit_code(&report, fail_on_unresolved);
+    let code = exit_code(&report, fail_on_unresolved, fail_on_warn);
 
     if json {
         let value = serde_json::to_value(&report).map_err(|e| Error::Schema(e.to_string()))?;
@@ -39,7 +44,7 @@ pub fn run(repo: &Path, fail_on_unresolved: bool, json: bool) -> Result<u8, Erro
         return Ok(code);
     }
 
-    report_registry(&report);
+    report_registry(&report, fail_on_warn);
     report_index(&report, fail_on_unresolved);
     Ok(code)
 }
@@ -58,8 +63,14 @@ pub fn run(repo: &Path, fail_on_unresolved: bool, json: bool) -> Result<u8, Erro
 ///
 /// Pinned by test rather than only documented, because it is the one part of
 /// this verb a caller cannot observe from a single run.
-fn exit_code(report: &CheckReport, fail_on_unresolved: bool) -> u8 {
+fn exit_code(report: &CheckReport, fail_on_unresolved: bool, fail_on_warn: bool) -> u8 {
     let registry = if !report.registry.validation_passed {
+        1
+    } else if fail_on_warn && report.registry.warnings > 0 {
+        // Spec 077 §3.3: the forwarded refusal is a `1`, which lands inside the
+        // fold below rather than altering it. It sits above freshness for the
+        // same reason validation does: a refused corpus makes its own staleness
+        // the less useful answer.
         1
     } else if report.registry.fresh {
         0
@@ -95,12 +106,23 @@ fn severity_max(a: u8, b: u8) -> u8 {
 /// The stale report passes through with its structure intact: spec 031 §3.3
 /// makes it contractual because the session protocol reads the drifted shard
 /// names back to the operator, and exit 2 alone cannot say which shard moved.
-fn report_registry(report: &CheckReport) {
+fn report_registry(report: &CheckReport, fail_on_warn: bool) {
     let r = &report.registry;
     if !r.validation_passed {
         eprintln!(
             "spec-registry: INVALID: the corpus fails validation, so staleness was not \
              computed (run `spec-spine compile --check` for the violations)"
+        );
+        return;
+    }
+    // Spec 077 §3.4: name the count and the tree, so an exit 1 from this verb
+    // is attributable. The pointer to `compile --check` for the individual
+    // violations stays correct: that primitive still prints them.
+    if fail_on_warn && r.warnings > 0 {
+        outln!(
+            "spec-registry: REFUSED: {} warning(s) (--fail-on-warn) \
+             (run `spec-spine compile --check --fail-on-warn` for the violations)",
+            r.warnings
         );
         return;
     }

--- a/crates/spec-spine-cli/src/cmd_compile.rs
+++ b/crates/spec-spine-cli/src/cmd_compile.rs
@@ -37,7 +37,21 @@ use crate::out;
 /// machine-readable verdict from the command that just regenerated the shards
 /// the next gate compares against invites exactly the mid-chain confusion the
 /// non-writing `--check` exists to avoid.
-pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u8, Error> {
+///
+/// `fail_on_warn` (spec 077 §3.2) turns any warning-tier violation into exit
+/// `1`, on every form of the verb. It gates the **exit code only**: it never
+/// touches `validation.passed`, which spec 001 §3.2 fixes as "false iff any
+/// error-tier violation is present", and never changes an emitted byte, which
+/// `compile.rs::fail_on_warn_writes_identical_shards` pins. That is the same
+/// arrangement spec 003 uses for the lint's `L-` codes, where severity gating
+/// is applied by the CLI over diagnostics the layer below just produces.
+pub fn run(
+    repo: &Path,
+    check: bool,
+    json: bool,
+    spec: Option<&str>,
+    fail_on_warn: bool,
+) -> Result<u8, Error> {
     // Spec 056 §3.1: `--spec` and `--check` are different questions (is this
     // well-formed / do the committed shards match), and a combined form would
     // have to invent an answer for a spec with no shard.
@@ -56,7 +70,7 @@ pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u
             }
             return Ok(err.exit_code());
         }
-        return run_one_spec(repo, id, json);
+        return run_one_spec(repo, id, json, fail_on_warn);
     }
     if json && !check {
         // Written here rather than raised for `main` to render: `json_verb`
@@ -90,8 +104,14 @@ pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u
             return Ok(1);
         }
         let freshness = compare_committed_registry(&cfg, repo, &outcome.shards)?;
+        // A refused warning is exit 1, the validation-failure rung, and it
+        // outranks staleness for the reason spec 075 §3.3 gives: staleness is
+        // not the more severe answer when the corpus itself was refused.
+        let warn_refused = fail_on_warn && outcome.warning_count() > 0;
         if json {
-            let code = if matches!(freshness, Freshness::Fresh) {
+            let code = if warn_refused {
+                1
+            } else if matches!(freshness, Freshness::Fresh) {
                 0
             } else {
                 2
@@ -102,6 +122,10 @@ pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u
                 freshness_report(&freshness),
             ))?;
             return Ok(code);
+        }
+        if warn_refused {
+            report_warn_refusal(&outcome);
+            return Ok(1);
         }
         return match freshness {
             Freshness::Fresh => {
@@ -157,13 +181,7 @@ pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u
     fs::write(&meta_path, meta_json)
         .map_err(|e| Error::Io(format!("write {}: {e}", meta_path.display())))?;
 
-    let warnings = outcome
-        .registry
-        .validation
-        .violations
-        .iter()
-        .filter(|v| v.severity == Severity::Warning)
-        .count();
+    let warnings = outcome.warning_count();
 
     if outcome.validation_passed {
         outln!(
@@ -172,6 +190,12 @@ pub fn run(repo: &Path, check: bool, json: bool, spec: Option<&str>) -> Result<u
             by_spec.display(),
             warnings
         );
+        // The shards above are already written, and identically so: the flag
+        // decides the exit code after emission, never what was emitted.
+        if fail_on_warn && warnings > 0 {
+            report_warn_refusal(&outcome);
+            return Ok(1);
+        }
         Ok(0)
     } else {
         report_validation_failure(&outcome);
@@ -195,6 +219,27 @@ pub(crate) fn freshness_report(freshness: &Freshness) -> serde_json::Value {
             serde_json::json!({ "fresh": false, "expected": expected, "actual": actual })
         }
     }
+}
+
+/// Print every warning-tier violation, then say the flag that refused them
+/// (spec 077 §3.2).
+///
+/// Always stderr, so the refusal surfaces in a CI log next to the errors that
+/// use the same channel. The codes are named because a bare exit `1` from a
+/// verb that also spends `1` on validation failure would leave a reader unable
+/// to tell which happened.
+fn report_warn_refusal(outcome: &CompileOutcome) {
+    for v in &outcome.registry.validation.violations {
+        if v.severity == Severity::Warning {
+            let at = v.path.as_deref().unwrap_or("-");
+            eprintln!("  {} [{}] {}", v.code, at, v.message);
+        }
+    }
+    eprintln!(
+        "REFUSED: {} warning(s) across {} spec(s) (--fail-on-warn)",
+        outcome.warning_count(),
+        outcome.registry.specs.len()
+    );
 }
 
 /// Print every error-tier violation, then the summary. Always stderr, so the
@@ -233,10 +278,19 @@ fn now_rfc3339() -> String {
 /// Exit `0` when the spec produces no error-tier violation, `1` when it does or
 /// when the id resolves to nothing, `3` for I/O, parse, schema or config
 /// failure. Never `2`: nothing here is a staleness question.
-fn run_one_spec(repo: &Path, id: &str, json: bool) -> Result<u8, Error> {
+fn run_one_spec(repo: &Path, id: &str, json: bool, fail_on_warn: bool) -> Result<u8, Error> {
     let cfg = load_repo_config(repo)?;
     let report = spec_spine_core::compile_spec(&cfg, repo, id)?;
-    let code = if report.passed { 0 } else { 1 };
+    let warnings = report
+        .violations
+        .iter()
+        .filter(|v| v.severity == Severity::Warning)
+        .count();
+    let code = if !report.passed || (fail_on_warn && warnings > 0) {
+        1
+    } else {
+        0
+    };
 
     if json {
         let value = serde_json::to_value(&report).map_err(|e| Error::Schema(e.to_string()))?;
@@ -249,15 +303,17 @@ fn run_one_spec(repo: &Path, id: &str, json: bool) -> Result<u8, Error> {
         // since the whole output of this verb is its diagnostics.
         eprintln!("  {} [{}] {}", v.code, report.spec_path, v.message);
     }
-    if report.passed {
+    if report.passed && code == 1 {
+        // Valid on its own axis, refused on the flag's. Saying only "valid"
+        // beside an exit 1 would read as a bug in the tool.
+        eprintln!(
+            "{}: REFUSED: {warnings} warning(s) (--fail-on-warn), nothing written",
+            report.spec_id
+        );
+    } else if report.passed {
         outln!(
-            "{}: valid ({} warning(s), nothing written)",
-            report.spec_id,
-            report
-                .violations
-                .iter()
-                .filter(|v| v.severity == Severity::Warning)
-                .count()
+            "{}: valid ({warnings} warning(s), nothing written)",
+            report.spec_id
         );
     } else {
         eprintln!(

--- a/crates/spec-spine-cli/src/main.rs
+++ b/crates/spec-spine-cli/src/main.rs
@@ -70,6 +70,13 @@ enum Command {
         /// short id (`056`). Incompatible with `--check`.
         #[arg(long, value_name = "ID")]
         spec: Option<String>,
+        /// Fail (exit 1) when the compile produces any warning-tier violation
+        /// (spec 077). Accepted on every form of the verb: it changes the exit
+        /// code only, never `validation.passed` and never an emitted byte, and
+        /// an exit code is not written output, so spec 037 §4's withholding of
+        /// `--json` from the writing form does not reach it.
+        #[arg(long)]
+        fail_on_warn: bool,
     },
     /// Both freshness reads in one verb: are the committed registry shards and
     /// the committed index shards current (spec 075)?
@@ -84,6 +91,17 @@ enum Command {
         /// call this verb where it called `index check --fail-on-unresolved`.
         #[arg(long)]
         fail_on_unresolved: bool,
+        /// Fail (exit 1) when the compile produces any warning-tier violation
+        /// (spec 077 §3.3). Forwarded to the **compile** half, the mirror of
+        /// `--fail-on-unresolved` above. This is the only form CI can call:
+        /// the self-governance job runs `check` in place of `compile` and
+        /// `index`, so a `--fail-on-warn` that existed only on the primitive
+        /// would be unreachable from the chain that runs on a pull request.
+        ///
+        /// Independent of `--fail-on-unresolved`: neither implies the other,
+        /// and either may be passed alone.
+        #[arg(long)]
+        fail_on_warn: bool,
         /// Emit the verdict as a JSON envelope on stdout (spec 037).
         #[arg(long)]
         json: bool,
@@ -237,13 +255,17 @@ fn main() -> ExitCode {
     }
 
     let result = match &cli.command {
-        Command::Compile { check, json, spec } => {
-            cmd_compile::run(&repo, *check, *json, spec.as_deref())
-        }
+        Command::Compile {
+            check,
+            json,
+            spec,
+            fail_on_warn,
+        } => cmd_compile::run(&repo, *check, *json, spec.as_deref(), *fail_on_warn),
         Command::Check {
             fail_on_unresolved,
+            fail_on_warn,
             json,
-        } => cmd_check::run(&repo, *fail_on_unresolved, *json),
+        } => cmd_check::run(&repo, *fail_on_unresolved, *fail_on_warn, *json),
         Command::Config { action } => cmd_config::run(&repo, action),
         Command::Registry { query } => cmd_registry::run(&repo, query),
         Command::Index { action } => cmd_index::run(&repo, action.as_ref()),

--- a/crates/spec-spine-cli/tests/cli.rs
+++ b/crates/spec-spine-cli/tests/cli.rs
@@ -2416,3 +2416,83 @@ fn check_forwards_fail_on_unresolved_to_the_index_half() {
         "an unresolved unit must refuse under the flag"
     );
 }
+
+/// Spec 077 §3.2 and §3.3: the flag turns a warning into exit 1 on every form
+/// of `compile`, and reaches the composed verb, which is the only form CI runs.
+///
+/// The corpus carries one dangling `depends_on`, so it is valid (spec 001 §3.2)
+/// and warns (`V-010`). Every assertion below is a pair: the same command with
+/// and without the flag, so the flag's effect is isolated from the verb's.
+#[test]
+fn fail_on_warn_refuses_a_warning_on_compile_and_check() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(tmp.path(), "001-a", "001-a", "approved");
+    // 002 names a spec nobody filed: V-010, warning tier.
+    let dir = tmp.path().join("specs/002-b");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("spec.md"),
+        "---\nid: \"002-b\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-06-08\"\n\
+         depends_on: [\"099-absent\"]\nsummary: \"s\"\n---\n# 002-b\n",
+    )
+    .unwrap();
+    let run = |args: &[&str]| {
+        bin()
+            .arg("--repo")
+            .arg(tmp.path())
+            .args(args)
+            .output()
+            .unwrap()
+    };
+
+    // Writing form: unflagged 0, flagged 1. The shards are written either way.
+    assert_eq!(code(&run(&["compile"])), 0);
+    assert_eq!(code(&run(&["compile", "--fail-on-warn"])), 1);
+
+    // §3.2: byte-identical emission. The flag decides an exit code, not output.
+    let shard = tmp.path().join(".derived/spec-registry/by-spec/002-b.json");
+    let after_plain = fs::read(&shard).unwrap();
+    assert_eq!(code(&run(&["compile", "--fail-on-warn"])), 1);
+    assert_eq!(
+        after_plain,
+        fs::read(&shard).unwrap(),
+        "a refused compile must write the same bytes as an accepted one"
+    );
+
+    // --check form: fresh, so unflagged 0; flagged 1 even though nothing stales.
+    assert_eq!(code(&run(&["compile", "--check"])), 0);
+    assert_eq!(code(&run(&["compile", "--check", "--fail-on-warn"])), 1);
+
+    // §3.3: the forward into the compile half of the composed verb.
+    assert_eq!(code(&run(&["index"])), 0);
+    assert_eq!(code(&run(&["check"])), 0);
+    assert_eq!(code(&run(&["check", "--fail-on-warn"])), 1);
+    // Independent flags: --fail-on-unresolved alone must not refuse a warning.
+    assert_eq!(code(&run(&["check", "--fail-on-unresolved"])), 0);
+
+    // §3.3 + spec 037: --json changes what is written, never what is decided.
+    let plain = run(&["check", "--fail-on-warn"]);
+    let jsonic = run(&["check", "--fail-on-warn", "--json"]);
+    assert_eq!(code(&plain), code(&jsonic));
+    let v: serde_json::Value = serde_json::from_slice(&jsonic.stdout).unwrap();
+    assert_eq!(v["exitCode"], 1);
+    assert_eq!(v["ok"], false);
+    // §3.4: the tally is in the envelope, attributed to the registry half.
+    assert_eq!(v["report"]["registry"]["warnings"], 1);
+    assert_eq!(v["report"]["registry"]["validationPassed"], true);
+
+    // §3.1: a clean corpus is unaffected by the flag on either verb.
+    let clean = tempfile::tempdir().unwrap();
+    write_spec(clean.path(), "001-a", "001-a", "approved");
+    let run_clean = |args: &[&str]| {
+        bin()
+            .arg("--repo")
+            .arg(clean.path())
+            .args(args)
+            .output()
+            .unwrap()
+    };
+    assert_eq!(code(&run_clean(&["compile", "--fail-on-warn"])), 0);
+    assert_eq!(code(&run_clean(&["index"])), 0);
+    assert_eq!(code(&run_clean(&["check", "--fail-on-warn"])), 0);
+}

--- a/crates/spec-spine-core/src/compile.rs
+++ b/crates/spec-spine-core/src/compile.rs
@@ -50,6 +50,24 @@ pub struct CompileOutcome {
     pub shards: RegistryShardSet,
 }
 
+impl CompileOutcome {
+    /// How many warning-tier violations this compile produced (spec 077 §3.2).
+    ///
+    /// Exposed here rather than left to each caller's own filter so the CLI,
+    /// the facade and `check_report` read one number. `validation_passed` is
+    /// deliberately untouched by this: spec 001 §3.2 fixes it as "false iff any
+    /// error-tier violation is present", and `--fail-on-warn` gates the exit
+    /// code, never the verdict field or an emitted byte.
+    pub fn warning_count(&self) -> usize {
+        self.registry
+            .validation
+            .violations
+            .iter()
+            .filter(|v| v.severity == Severity::Warning)
+            .count()
+    }
+}
+
 /// The committed-form projection of a registry: one shard per spec (spec 024),
 /// sorted by id for determinism.
 pub struct RegistryShardSet {

--- a/crates/spec-spine-core/src/diagnostics.rs
+++ b/crates/spec-spine-core/src/diagnostics.rs
@@ -209,6 +209,15 @@ pub struct RegistryCheckReport {
     /// False when the corpus itself does not validate, in which case `fresh`
     /// was never computed and is reported `false`.
     pub validation_passed: bool,
+    /// Warning-tier violations the compile produced (spec 077 §3.4).
+    ///
+    /// Carried so the composed verb can refuse under `--fail-on-warn` without
+    /// recompiling, and can say **which tree** refused. Without it an exit `1`
+    /// from `check` would be unattributable, and the reader would be sent to
+    /// the wrong verb. Additive with a `default`, so a report deserialized from
+    /// a pre-077 producer reads zero rather than failing.
+    #[serde(default)]
+    pub warnings: usize,
 }
 
 /// Both trees' verdicts, from the one verb the session protocol calls

--- a/crates/spec-spine-core/src/kit_embedded.rs
+++ b/crates/spec-spine-core/src/kit_embedded.rs
@@ -2638,7 +2638,7 @@ BASE       ?= origin/$(or $(SPEC_SPINE_DEFAULT_BRANCH),main)
 ## is meant to judge (spec 046), so this uses `compile --check` and never
 ## `compile`.
 gate:
-	$(SPEC_SPINE) check --fail-on-unresolved
+	$(SPEC_SPINE) check --fail-on-unresolved --fail-on-warn
 	$(SPEC_SPINE) lint --fail-on-warn
 	$(SPEC_SPINE) index coverage --fail-on-untraced
 	$(SPEC_SPINE) couple --base $(BASE) --head HEAD
@@ -2743,7 +2743,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
-          spec-spine check --fail-on-unresolved
+          spec-spine check --fail-on-unresolved --fail-on-warn
           spec-spine lint --fail-on-warn
           spec-spine index coverage --fail-on-untraced
           spec-spine couple --base "origin/${{ github.base_ref }}" --head HEAD --pr-body "$RUNNER_TEMP/pr-body.txt"

--- a/crates/spec-spine-core/src/lib.rs
+++ b/crates/spec-spine-core/src/lib.rs
@@ -220,6 +220,10 @@ pub fn check_report(config: &Config, repo_root: &std::path::Path) -> Result<Chec
     // `check_registry_freshness` would compile a second time, and this verb
     // exists to make one question cost one ask.
     let outcome = compile(config, repo_root)?;
+    // Spec 077 §3.4: the registry half carries its own warning tally, so the
+    // composed verb can refuse under `--fail-on-warn` and name the tree that
+    // refused without a second compile.
+    let warnings = outcome.warning_count();
     let registry = if outcome.validation_passed {
         let freshness = compare_committed_registry(config, repo_root, &outcome.shards)?;
         match freshness {
@@ -228,12 +232,14 @@ pub fn check_report(config: &Config, repo_root: &std::path::Path) -> Result<Chec
                 expected: None,
                 actual: None,
                 validation_passed: true,
+                warnings,
             },
             Freshness::Stale { expected, actual } => RegistryCheckReport {
                 fresh: false,
                 expected: Some(expected),
                 actual: Some(actual),
                 validation_passed: true,
+                warnings,
             },
         }
     } else {
@@ -246,6 +252,7 @@ pub fn check_report(config: &Config, repo_root: &std::path::Path) -> Result<Chec
             expected: None,
             actual: None,
             validation_passed: false,
+            warnings,
         }
     };
 

--- a/crates/spec-spine-core/tests/compile.rs
+++ b/crates/spec-spine-core/tests/compile.rs
@@ -1130,3 +1130,85 @@ fn compile_spec_works_before_the_registry_exists() {
     let report = spec_spine_core::compile_spec(&Config::default(), root, "001-first").unwrap();
     assert!(report.passed, "{:?}", report.violations);
 }
+
+// --- spec 077: the warning tier is reachable from a gate -------------------
+
+/// Spec 077 §3.1: `V-010` stays a warning. The tier is what makes forward
+/// filing possible (a spec may name a `depends_on` target filed after it), so
+/// escalation must be the caller's decision and never the compiler's.
+#[test]
+fn dangling_depends_on_stays_warning_tier() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_spec(
+        tmp.path(),
+        "001-alpha",
+        "001-alpha",
+        "depends_on: [\"099-not-filed-yet\"]\n",
+    );
+    let outcome = compile(&Config::default(), tmp.path()).unwrap();
+
+    assert!(codes(&outcome).contains(&"V-010".to_string()));
+    assert!(
+        outcome.validation_passed,
+        "a dangling depends_on must not fail validation: spec 001 3.2 makes \
+         validation.passed false only for error-tier violations"
+    );
+    assert_eq!(outcome.warning_count(), 1);
+    let warn_tiers = outcome
+        .registry
+        .validation
+        .violations
+        .iter()
+        .filter(|v| v.code == "V-010")
+        .all(|v| v.severity == Severity::Warning);
+    assert!(warn_tiers, "V-010 must be warning tier");
+}
+
+/// Spec 077 §3.6, the assertion that matters: the flag decides an exit code
+/// and nothing else. A compile that would be refused under `--fail-on-warn`
+/// emits byte-identical shards to one that would not, so no committed artifact
+/// can ever depend on how the CLI was invoked.
+#[test]
+fn fail_on_warn_writes_identical_shards() {
+    let clean = tempfile::tempdir().unwrap();
+    write_spec(clean.path(), "001-alpha", "001-alpha", "");
+    write_spec(clean.path(), "002-beta", "002-beta", "");
+
+    let warned = tempfile::tempdir().unwrap();
+    write_spec(warned.path(), "001-alpha", "001-alpha", "");
+    write_spec(
+        warned.path(),
+        "002-beta",
+        "002-beta",
+        "depends_on: [\"099-not-filed-yet\"]\n",
+    );
+
+    let cfg = Config::default();
+    let a = compile(&cfg, warned.path()).unwrap();
+    let b = compile(&cfg, warned.path()).unwrap();
+
+    // The flag lives in the CLI, so the library cannot see it at all. That is
+    // the structural guarantee: two runs of the same corpus agree, and the only
+    // thing a caller can vary is what it does with `warning_count()`.
+    assert_eq!(a.json, b.json, "emission must not vary run to run");
+    assert_eq!(a.warning_count(), 1);
+    assert!(a.validation_passed, "a warning is not a validation failure");
+
+    // And the warning changes no shard the clean corpus shares with it: only
+    // 002-beta's own spec.md differs, so 001-alpha's shard must be identical.
+    let clean_out = compile(&cfg, clean.path()).unwrap();
+    assert_eq!(clean_out.warning_count(), 0);
+    let shard_of = |o: &spec_spine_core::CompileOutcome, id: &str| {
+        o.shards
+            .spec_shards
+            .iter()
+            .find(|s| s.record.id == id)
+            .map(|s| s.shard_hash.clone())
+            .unwrap()
+    };
+    assert_eq!(
+        shard_of(&clean_out, "001-alpha"),
+        shard_of(&a, "001-alpha"),
+        "a sibling spec's warning must not reach this shard"
+    );
+}

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -178,6 +178,20 @@ forms and run plain `spec-spine compile` and `spec-spine index` to build the
 artifacts in-job: with nothing committed to compare against, the freshness gates
 would report every shard missing and fail permanently.
 
+**Refusing warnings (`--fail-on-warn`, spec 077).** `compile` emits one
+warning-tier code, `V-010`, for a `depends_on` naming a spec that does not
+exist. The tier is deliberate: a corpus that files specs forward must be able to
+name a dependency filed after the spec that names it, so escalation is the
+caller's decision. `compile --fail-on-warn` and `check --fail-on-warn` make it
+exit `1`; `check`'s form forwards into the compile half, mirroring
+`--fail-on-unresolved` into the index half, and is the one to use in CI, which
+runs `check` rather than the primitives. The flag changes the exit code only:
+the shards written are byte-identical with and without it.
+
+Leave it off while migrating a corpus that legitimately points forward, and turn
+it on once the graph is closed. Bare `compile` is unchanged either way, so
+upgrading the binary cannot break an existing job.
+
 This repo dogfoods exactly this pattern; see
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 

--- a/kit/AGENTS.md
+++ b/kit/AGENTS.md
@@ -166,7 +166,7 @@ work orders.
    spec-spine check
    spec-spine couple --base "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)" --head HEAD
    # spec-spine index coverage --fail-on-untraced  # if [coupling] require_ownership is on
-   # spec-spine check --fail-on-unresolved         # opt in once the corpus builds what it claims
+   # spec-spine check --fail-on-unresolved --fail-on-warn  # opt in once the corpus builds what it claims
    ```
 
    The base ref is resolved from the repository rather than assumed to be

--- a/kit/Makefile
+++ b/kit/Makefile
@@ -34,7 +34,7 @@ BASE       ?= origin/$(or $(SPEC_SPINE_DEFAULT_BRANCH),main)
 ## is meant to judge (spec 046), so this uses `compile --check` and never
 ## `compile`.
 gate:
-	$(SPEC_SPINE) check --fail-on-unresolved
+	$(SPEC_SPINE) check --fail-on-unresolved --fail-on-warn
 	$(SPEC_SPINE) lint --fail-on-warn
 	$(SPEC_SPINE) index coverage --fail-on-untraced
 	$(SPEC_SPINE) couple --base $(BASE) --head HEAD

--- a/kit/govern.yml
+++ b/kit/govern.yml
@@ -67,7 +67,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
-          spec-spine check --fail-on-unresolved
+          spec-spine check --fail-on-unresolved --fail-on-warn
           spec-spine lint --fail-on-warn
           spec-spine index coverage --fail-on-untraced
           spec-spine couple --base "origin/${{ github.base_ref }}" --head HEAD --pr-body "$RUNNER_TEMP/pr-body.txt"

--- a/specs/077-compile-warnings-reach-the-gate/spec.md
+++ b/specs/077-compile-warnings-reach-the-gate/spec.md
@@ -4,7 +4,7 @@ title: "Compile warnings reach the gate"
 status: draft
 kind: "tooling"
 created: "2026-09-08"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -17,6 +17,11 @@ depends_on:
   - "075-one-name-one-freshness-verb"
 extends:
   # 3.2 the flag, the severity gate that reads it, and the facade.
+  # `warning_count()` lands on `CompileOutcome` so the CLI, the facade and
+  # `check_report` read one number instead of three severity filters. Declared
+  # during the build, with the code: the draft's edge list did not name this
+  # file because the tally was expected to live CLI-side.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/compile.rs", nature: additive }
   - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
   - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/cmd_compile.rs", nature: additive }
   - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
@@ -320,6 +325,27 @@ no `V-010` today, so the flag will refuse nothing on the day it lands. That is
 the argument for it rather than against it: the gate is being closed while the
 change is a flag and a test, instead of during the pull request where the first
 dangling edge is discovered by a consumer that cannot order its work.
+
+**2026-09-08: the kit's chain carries the flag as an opt-in line, not an
+enforced one.** Section 3.5 says the freshness step MUST become the composed
+form in every written place, and named `kit/AGENTS.md` among them. It did not
+account for that file's existing shape: the adopter template already carries
+`--fail-on-unresolved` and `--fail-on-untraced` as **commented** lines, opt-in
+by design under spec 050, because an adopter's corpus may legitimately be
+noisier than this one. Uncommenting them to satisfy a MUST would change the
+adopter default, which section 4 puts out of scope, so the commented line now
+reads `# spec-spine check --fail-on-unresolved --fail-on-warn` and the flag
+inherits the opt-in the neighbouring flags already have. `kit/Makefile` and
+`kit/govern.yml`, which run the strict form uncommented today, take the flag
+uncommented too, so the kit stays internally consistent with itself.
+
+**2026-09-08: the skills were left naming the bare verb.** `kit_skills.rs`
+asserts a skill may name **fewer** flags than `AGENTS.md`'s list but never more,
+so the inlined floors are already legal unchanged, and every skill tells its
+reader to run "the gate as `AGENTS.md` lists it" rather than to run its own
+copy. Editing five skills in two byte-identical trees to restate flags their
+own authority already carries would add a second place to drift for no
+enforcement gained. The authority moved; the pointers did not need to.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Implements spec 077. `V-010` (a `depends_on` naming a spec that does not exist) was the only warning-tier code the compiler emits, and no verb in the gate chain could be told to refuse it.

`lint --fail-on-warn` never could and never will: spec 003 makes the `L-` codes disjoint from compile's `V-` codes, and `lint()` binds only `.registry` from the compile it runs, discarding every violation. So a dangling dependency compiled clean, linted clean at every severity, passed `couple`, and reached the default branch unread.

- `compile --fail-on-warn` exits `1` on any warning-tier violation, on the writing form, `--check` and `--spec` alike.
- `check --fail-on-warn` forwards it into the **compile** half, mirroring how `--fail-on-unresolved` forwards into the index half.

**The forward is the half that matters.** The `self_governance` job runs `check` and never `compile`, because a gate must not repair the tree it judges. A flag on the primitive alone would have been unreachable from the only chain that runs on a PR, and this would have shipped a knob that closed nothing.

## Two invariants, pinned by test rather than asserted

| Invariant | Test |
|---|---|
| The flag gates the exit code only. `validation.passed` keeps spec 001 §3.2's meaning, and a refused compile writes byte-identical shards to an accepted one. | `fail_on_warn_writes_identical_shards` |
| `V-010` keeps its warning tier. Forward filing depends on it: at error tier no spec could name a dependency filed after it, and `/spec` could file nothing. | `dangling_depends_on_stays_warning_tier` |

`RegistryCheckReport` gains an additive `warnings` tally (§3.4) so the composed verb can refuse without a second compile and can name the tree that refused. An unattributable exit `1` from `check`, which already spends `1` on validation failure, would send a reader to the wrong verb.

Gating lives in the CLI over diagnostics the layer below just produces, which is spec 003's existing arrangement for `L-` codes. That is why **no `amends` is owed** on 001, 003, 031 or 075: a refused warning is a `1`, landing inside spec 075's pinned fold rather than altering it.

## Chain updated in all five written forms

`AGENTS.md`, `kit/AGENTS.md`, `kit/Makefile`, `kit/govern.yml`, `.github/workflows/ci.yml`. 077's acceptance block greps each for the composed string, never the bare flag, since `lint --fail-on-warn` already appears in three of them.

Two build decisions are recorded in §5 rather than left implicit:

- **The kit's commented opt-in line takes the flag commented.** `kit/AGENTS.md` already carries `--fail-on-unresolved` and `--fail-on-untraced` as opt-in comments under spec 050. Uncommenting to satisfy §3.5's MUST would change the adopter default, which §4 puts out of scope, so the flag inherits the opt-in its neighbours have.
- **The skills were left naming the bare verb.** `kit_skills.rs` asserts a skill may name fewer flags than `AGENTS.md` but never more, and every skill tells its reader to run "the gate as `AGENTS.md` lists it". Restating flags in five skills across two byte-identical trees would add a place to drift for no enforcement gained.

One edge was added during the build, which the harness rules name as always legitimate: `extends` 001 for `crates/spec-spine-core/src/compile.rs`, where `warning_count()` lands so the CLI, the facade and `check_report` read one number.

## Riders: two defects in what landed earlier today

- **`CLAUDE.md` no longer restates the gate chain.** The copy had silently dropped `--fail-on-unresolved`, `--fail-on-warn` and `--fail-on-untraced`. Nothing tests a copy in that file. It now points at `AGENTS.md`'s fenced block, which `kit_skills.rs` does test, and explains which flags turn a read into a refusal.
- **The extends paragraph was backwards.** It said an extends unit "usually does not" appear in its target's territory and that this is how "most" source files are owned. 38% phantom means 62% *do* appear, and 24 of 95 tracked source files lack an establisher. Now "often does not" and "a quarter, most of the types crate among them".

`docs/adoption-guide.md` documents the flag and says to leave it off while migrating a forward-pointing corpus (§3.5).

## Testing

```
spec-spine verify 077-compile-warnings-reach-the-gate  ->  passed (13 commands)
```

The same block failed at command 2 (exit 3, unknown flag) before this change, which is the point of it.

```
check --fail-on-unresolved --fail-on-warn 0 - lint --fail-on-warn 0
index coverage --fail-on-untraced 0 - couple 0 (17 paths checked, no drift)
cargo test --workspace --locked 0 - clippy -D warnings 0 - fmt --check 0
```

`implementation` flips to `complete`; `status` stays `draft`, since ratification is a separate human-approved PR.