### PR TITLE
feat(078): the protocol names its owner

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce995e77a9872899acda55192b792c516c96013c2aa0773784e332463e2a5e6d"
+  "shardHash": "f983b1a3d44f0370e7dc459598306b6daac53b908a32ee8a9b8fc910cc6cf9ab"
 }

--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f983b1a3d44f0370e7dc459598306b6daac53b908a32ee8a9b8fc910cc6cf9ab"
+  "shardHash": "6af7ba45dbc9a12c4ae233c28cae780c90374558bd509990b0604eabb14066b0"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6d90b80c637279b5f8b7b8f4ee7b84e43bc0792e9bc4cb9dd85882494592980c"
+  "shardHash": "dee5ab000bed42768bd692ecb45ec663f1ac6c503f5a8998d9f79916093e4dc2"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "62dbde6b7dfee4a27a7a3c71936fcf2c230565148c4f1be6c34527be45504d42"
+  "shardHash": "6d90b80c637279b5f8b7b8f4ee7b84e43bc0792e9bc4cb9dd85882494592980c"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a1c4b9bda6e315c4e01c700e995b2f540d96d6973cd7c5ee5443d7e894a4c93e"
+  "shardHash": "509ce5bdc516ac3e1bdd4da17dd366a3f0dd005d8b9a4185f9a3c8ed1d47feec"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c5c7a502145cbabf5634e20a98d6eddfcc9005117a489a7d584998a489e09cbc"
+  "shardHash": "a1c4b9bda6e315c4e01c700e995b2f540d96d6973cd7c5ee5443d7e894a4c93e"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.17.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4983f1d4077e62876cf6a62d3c393c25de653f8b0602ba8a384089fa11d08fb7"
+  "shardHash": "d49cffce2901633ccab535809479016ff006aa0192ca65fb56891bcef1f7c095"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.17.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d49cffce2901633ccab535809479016ff006aa0192ca65fb56891bcef1f7c095"
+  "shardHash": "187e1b877750f95394362c1fa872d2b0287aa86f1b65641685f7e2e17df61085"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "93eb15bc945f4501fe5d0f215a52e09637086a66be2993a8e4c81f773009506a"
+  "shardHash": "547ca5c5e3035e2a99eb0302d3dd70ffb71287d469894b0dfbc2635ff159ffaf"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5f0e83ea75db0f90220acf6580964a732e9b6a3567aef85a43dc0454783254e8"
+  "shardHash": "93eb15bc945f4501fe5d0f215a52e09637086a66be2993a8e4c81f773009506a"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "087852711f5eb97955097b7154212e6ec3f409dc11785dfff9a67bdd3b23d254"
+  "shardHash": "25b21c36e377d9c88d4010781bb5a76db2092086aeb98684d6be00747e2eb56d"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "25b21c36e377d9c88d4010781bb5a76db2092086aeb98684d6be00747e2eb56d"
+  "shardHash": "d954287eb3cfa1bf9392757c2648249efa07c2d81a8cb5913f2469fe3ef99223"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "75f200f8fbec2f5dbbc03dd2743bcb37a5bb54e758202ed30aab46162cf34b9d"
+  "shardHash": "0878fba96786d62687fa8b6ee00732df123f6eb5c2e376ae4f6739985d9a7c89"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "804f5a8cbed710cd138a2d21dae0b261c2ec155dcd73ee6b531b789c7a87c402"
+  "shardHash": "75f200f8fbec2f5dbbc03dd2743bcb37a5bb54e758202ed30aab46162cf34b9d"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "554311e590194cfa0801c575b9dd3e2d83c5249daca3af0ecfb67f03273b1f8a"
+  "shardHash": "2c64681cd6a38442303e571d916d56bfd060caaaf2be4f48889d7ff1e144de8d"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2c64681cd6a38442303e571d916d56bfd060caaaf2be4f48889d7ff1e144de8d"
+  "shardHash": "2619a53d1a2d03fb326bb1c195e1598e6aaea20c610f4d8acdbc0669e76a7b7b"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0c3f728605ba1c9a28ed6adc423d76cb07a2890d2a990ddca03ad7457913fdc8"
+  "shardHash": "d8f5ab36216c72a9bd165dc7733d5b78743390ad6958d62de9d2bc4c3d3e3464"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d8f5ab36216c72a9bd165dc7733d5b78743390ad6958d62de9d2bc4c3d3e3464"
+  "shardHash": "23f80ae0efb654944e7505c8f64aef963fa060d1aa643446a9a6823a6c28bfeb"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f3c8d992ddb1f24aa9afbd66535c64fc04bcb84ce3cc6c77c92e0b3adbe1182c"
+  "shardHash": "5955ef9f3a45137a777f0cb145e11ef841efc5309adbfc4f2fab0b321a0d44ad"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5955ef9f3a45137a777f0cb145e11ef841efc5309adbfc4f2fab0b321a0d44ad"
+  "shardHash": "36c86af3ce57458a3cbc3a6971476afe78635b8a0f9767008074d07d70748a3f"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "07ca777fa87c46cc5d0615ada2452d06461a19af76f554950dae9972ad0567a1"
+  "shardHash": "a4c0aecaf83c99435716c433185e63ee3178c1fec81d1e77252ec1eb94505223"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a4c0aecaf83c99435716c433185e63ee3178c1fec81d1e77252ec1eb94505223"
+  "shardHash": "8c3132025d81d408527f2012ff5b6307350fe69fd08f1fdcd63f3a13def5fffd"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ecb907ff76c6f1122449adca2dfe4ff22960e3991a6f26d7ad11320d6d4c400b"
+  "shardHash": "1627889e5bc85ed919034bb72cbf6d2ed4dfccc3495058df3ced0aa45bdd196d"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ea35696f071b7f8af90c74e15c3392551bb385ea40ded51a6165dcfa9d511cd4"
+  "shardHash": "ecb907ff76c6f1122449adca2dfe4ff22960e3991a6f26d7ad11320d6d4c400b"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "529c419fe2333f8d72cf71abd0b6a3c057e5c1eedca8d2c0b89e3ac60e2c8499"
+  "shardHash": "066ae9bd4ed2b96fe5d74f25a9d724b026ffa8945b494bf4793e2eab60c1deab"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "13bb0763142a595753938788a34b552d49f45ef35a92694b9ced1e2c7625b915"
+  "shardHash": "529c419fe2333f8d72cf71abd0b6a3c057e5c1eedca8d2c0b89e3ac60e2c8499"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7a6cab31fbae12e62193c5da44ed48dbb97c963b5b9c1eec6d67c6738c6bcf72"
+  "shardHash": "d2a0b57db4d1f4548ea386ae24d5cd84a716b3215175f2e3ef2bf24a789e1dc4"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d2a0b57db4d1f4548ea386ae24d5cd84a716b3215175f2e3ef2bf24a789e1dc4"
+  "shardHash": "711532006df3a204121e4d042a90fd36ca60e2a3662d971b0ddddaad3e48f53e"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a8a4ebb0205994067d45a42c0a503998b8f3c8a0eca630ab177ded610d49bc2d"
+  "shardHash": "421c2d18b51653d08806e69ded15040adfb8c54053096e65554e7c1230b4aa84"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9ae6b372dcd05f35d40be93cf93466e43febd4eb922645b361f982e9a594c7ed"
+  "shardHash": "a8a4ebb0205994067d45a42c0a503998b8f3c8a0eca630ab177ded610d49bc2d"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6aa82d904a42dafe5b8d26629750f5ebc7a5c96b4efca2fd4594b5d1724ea436"
+  "shardHash": "eed5b9009bbd75c301f9c5b77a8aaa4d3863930ab0d0e9bdf160f4dd7736da38"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "eed5b9009bbd75c301f9c5b77a8aaa4d3863930ab0d0e9bdf160f4dd7736da38"
+  "shardHash": "cef873531b57fd2f34cd08af70880e61ccae8014dc7d78b0b67ab87186475e3d"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "690007d5cc18d9d4217d6fd62aacb5c58758a86755158f6196a39efd626d5926"
+  "shardHash": "7748f182bcf5f323132e38e56b91a392b4042c58e3cb0ba25f0cc6f13737a40e"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7748f182bcf5f323132e38e56b91a392b4042c58e3cb0ba25f0cc6f13737a40e"
+  "shardHash": "0cb98f239cb57bff3005435f4a64d702592d7017ab0d0c93720ae757d0c008f9"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "79ba5cc11572a57f69348e19efb2cf7e65de5b6ede659e3b63259cea93dda4e5"
+  "shardHash": "dd2a8a0606b7c2797f9402f9bae9d44f38a2a447079768289bc3afacc8078a00"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8e09319fb428cf9d9c03f5b55331507982873f39497138629655ef9fa216276b"
+  "shardHash": "79ba5cc11572a57f69348e19efb2cf7e65de5b6ede659e3b63259cea93dda4e5"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dd5670eb6368f5955f3840d1c72fe2862bfc0149dd4ec22f317dbd58c652ee37"
+  "shardHash": "8841348f1bb30a0c5c84eceb3dc0878bdd88485edfd1fb46805832719d6a8a98"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1fe78564facba0cec84c8a5e2de76bf36755a0244ece1eceb90b2fabfaa88f01"
+  "shardHash": "dd5670eb6368f5955f3840d1c72fe2862bfc0149dd4ec22f317dbd58c652ee37"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "85ebbef98be0f89d00e483461700e46563159408406e1e5e47513ddef59021cc"
+  "shardHash": "0b26d513c373b080ebfc98135a8faa85ad6dd3cf63ccc430bd863a9f7e18bca8"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0b26d513c373b080ebfc98135a8faa85ad6dd3cf63ccc430bd863a9f7e18bca8"
+  "shardHash": "7983663777c7e7f67ce9639f4c73cfb7fad3a421fad1a624c918c062f9c0b11a"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c4e175afed4c63a9770445cbfd76635bb353f5578379de5c12030c62a6b8ee91"
+  "shardHash": "a05e367096d5f3951a098fb6e781efe396dff15cdb323012f8fd36e2eeada4cf"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a05e367096d5f3951a098fb6e781efe396dff15cdb323012f8fd36e2eeada4cf"
+  "shardHash": "e8a5b9e2b04cd659e28544590f82baed4aa307db2c34fee0b9b52b06bdb1267c"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2ed2a11aa4fc020e93866fb5d508da548908b458dc9aaaa209cafc253441ddfe"
+  "shardHash": "55df8aa78c95d0de9c4e644e639b059306c937f2ffe179b43eba8942b48f41bb"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "55df8aa78c95d0de9c4e644e639b059306c937f2ffe179b43eba8942b48f41bb"
+  "shardHash": "c69850f04d927bd3a8d570e8c03a1070d654697129a257ff8710fb0cb5a5b7e3"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "566fe694cab96923fdeb58c1f9dca27bed8277a1d4a3c326cbb627ffda1e9b1c"
+  "shardHash": "b49a05ecf5d18c6e26cf6363b9b46b413e12abd5a49de79bc9bda066d18b489e"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b49a05ecf5d18c6e26cf6363b9b46b413e12abd5a49de79bc9bda066d18b489e"
+  "shardHash": "d80c79713570b12b4c1ebcaa68dda3112f00c90eb49a18baaf026280bed66fca"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "144ff4b2fdde2d10e6616f2072386014cf8cb7bae0160f24ae0b27f98f58bdda"
+  "shardHash": "1f3fb00dd1b66c856f3ae2e2aa24b1015f70958e1474288c612efbdff3d459d8"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8e1a2781cb57eaeaa6dc9a16e64b690e4fc6c37b35b0c9b5cf437d9466653f64"
+  "shardHash": "144ff4b2fdde2d10e6616f2072386014cf8cb7bae0160f24ae0b27f98f58bdda"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0b1cdb7b35cee6fa81c3ebf4d0dbc473574216b96e36617b660df1595b1c146f"
+  "shardHash": "ec91352dbd891edc42e4ca594aa5a6306145af4aecf8e08a90f8347a0069f705"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "55183c25f8a0ea58d545ec14ec9d2bd4259316c6ab3d12087baf43141d8d2a24"
+  "shardHash": "0b1cdb7b35cee6fa81c3ebf4d0dbc473574216b96e36617b660df1595b1c146f"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dc6121f15a3a453c01252af493558ceb3d9a278861b59262332d73fa71cbba16"
+  "shardHash": "bfcec5acc2e8690fea9ba7c6e2033000af099d812fefac461abbd83bb365ebb9"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bfcec5acc2e8690fea9ba7c6e2033000af099d812fefac461abbd83bb365ebb9"
+  "shardHash": "8c397a080bdb7b8f4ee531198ef3806bec6b27d6271607a9ac18b5332857f289"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b48fc12c4ca2cf54aa748b68f626ab30f3c08546d5192d1bc7667442c1c53b1a"
+  "shardHash": "c6486dd1a918cb3c8891b62b27bfb86b8aade65689326b21104dedc64d4b9cf9"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "847049f4bc3f227356284b4af571f9ec36e166775a4fa9b1fc88c591120a7c89"
+  "shardHash": "b48fc12c4ca2cf54aa748b68f626ab30f3c08546d5192d1bc7667442c1c53b1a"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c903d807dfa4601bdd10576b8840f7feef4b3f25b6222794941b1f2cf66f6f33"
+  "shardHash": "50c8571a33e5b3649deacc19b7f36b01a94dfb8e62e2c33a8f0b22e70739d341"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b94cc7cdc2df6459c73025e58b3e4e21b1981730c617d9e8d32dd88547afe3f4"
+  "shardHash": "c903d807dfa4601bdd10576b8840f7feef4b3f25b6222794941b1f2cf66f6f33"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3db0b0c553469f0fad7e67331625a662c1440e8c244e81bcc1e4c3fb2331b571"
+  "shardHash": "9a58f1efd14c08612e350765adb8f9e96d2b729e03dee7848bfa766dd732f452"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9a58f1efd14c08612e350765adb8f9e96d2b729e03dee7848bfa766dd732f452"
+  "shardHash": "64288bbba0d83ea836b8938ed13198ce21a30f647bdeb8db0d4187af1baa4cd2"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "95c1cb6d14286365b868a03a5e1330f43e304144d6237f4e69319c790fe830bc"
+  "shardHash": "7eebec4e24d52cd9f6ea73119873d56987216751cb8b154040821a121707f8b6"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3d24dc88aad18765e38b98e364ddc96f043b62eabd7f481a1386029b9b7e91d0"
+  "shardHash": "95c1cb6d14286365b868a03a5e1330f43e304144d6237f4e69319c790fe830bc"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "991311ccd3303e060a1b11859d239222a524ecd17a0d92a1ebdab9b6ebbbaacf"
+  "shardHash": "7e07c14937532336798fa32b6ef3cc006276f958d98084eb25006e27253b3603"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "666ef80e2f8ee71ee1aed94d5920e42ae9e332a1860c7e2a9d9236c17f2bb4da"
+  "shardHash": "991311ccd3303e060a1b11859d239222a524ecd17a0d92a1ebdab9b6ebbbaacf"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "53020e77005651bc1225d41098c9aa28de22e217f98a2444b76fe60c86e29460"
+  "shardHash": "2a4982d51cd45e22e7277b48772e0db0a25116a376f9beec6f9dbaf6fb535996"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1f6ebfd1b51757068de2cb7be1702a515faa169641c85266f71466cacd0dc63e"
+  "shardHash": "53020e77005651bc1225d41098c9aa28de22e217f98a2444b76fe60c86e29460"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8dd36d0fd45a583179a3c3700cf38f8f023559a0734f78b17153506b8e8cc188"
+  "shardHash": "acb86a4790793c866bdd90562ddba0f5af6f61e720cb870f34db509da7ef6065"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "acb86a4790793c866bdd90562ddba0f5af6f61e720cb870f34db509da7ef6065"
+  "shardHash": "23aa95422a4a98fca72cc19896c9b8439467d5e02d938dff6da4bd39244f77e4"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "abea0a58e6304805a5a2e3e1e1f1d520587701120b91328573aced0c6e961a05"
+  "shardHash": "3bd69595acac94d6ed14771fc9332497a361e8937d12b281bf578c821cc5a8aa"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "afded443c158b828d646724b161058e764084263d7512532f4a85d6248ba1e2e"
+  "shardHash": "abea0a58e6304805a5a2e3e1e1f1d520587701120b91328573aced0c6e961a05"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b5531a8426710e9a80b0295a448908f33f03aa4ed156487ae089063e81533e3"
+  "shardHash": "4723391a3546f45669348e03dd0d7e68b125b26b867fbc42502bfa3f2f4d59fc"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4723391a3546f45669348e03dd0d7e68b125b26b867fbc42502bfa3f2f4d59fc"
+  "shardHash": "28fa129a8bfc9e3307bf06c203dc06f8385dd24f985c21d2585ad104be353a5d"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "337c242917439127d7d4a088813182779b468ef236dd9c52ad166d6040250d53"
+  "shardHash": "c027c084c32ac2e27bd02810a70acc2d983d367d0271cdf33acd8164e626b592"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c027c084c32ac2e27bd02810a70acc2d983d367d0271cdf33acd8164e626b592"
+  "shardHash": "d0b443ff5dea492ba86f4226cbf81d72abae8332509cbd80769ddf48f9d5c89b"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "65d7637f67f4ee4518fa26c1870f2ff42e709e12da6d92c9e0379339890687ec"
+  "shardHash": "a8c5c8bd0e0fa2b99c0006ba04355b0ab6774fe3c84fa97f44d91604f8db2cf9"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a8c5c8bd0e0fa2b99c0006ba04355b0ab6774fe3c84fa97f44d91604f8db2cf9"
+  "shardHash": "94ef905290ad954494df77366796e04c9f3f590e9c9195e499e22fa48110f7fb"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7559bb510e3526f1cd3fe4d3b61cc8363d408ace53cf89518cb628d58d77be86"
+  "shardHash": "1d435d1fd9905c68521248b073024450532260a13e0f5308353c36c7d8e99ee8"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1d435d1fd9905c68521248b073024450532260a13e0f5308353c36c7d8e99ee8"
+  "shardHash": "49e18349a3c0c0ef6e70ff359cb835b6209c1d4c36d2f13c63bf8da15a46a2d7"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "db0850452d171a3fa98d7af2c88b7ae6f2ceaa892341bccc6c24120ce4429db7"
+  "shardHash": "05812346a50ca1bc00422e82a27d058daf3d44cc384d34a69cd607ee3e67a8c8"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "05812346a50ca1bc00422e82a27d058daf3d44cc384d34a69cd607ee3e67a8c8"
+  "shardHash": "35d144a1a206f2ceddbbb94ad98e2b16fe8b926d55c61ee32bf298e6b89aedd9"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1aa2ad55e81a14cdb7d48ad7873d2008351f9c436dfb6f0a0dd0135b47816b0b"
+  "shardHash": "ce11f8f4aef512c90d666fa7c85f5d56e40f200dd9190b7a5782f6fbc7eb1b47"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce11f8f4aef512c90d666fa7c85f5d56e40f200dd9190b7a5782f6fbc7eb1b47"
+  "shardHash": "6c489794642aa1a234a3984db107105d0acb78dab434c5adade8d2e4e7e918f1"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8557938ce4b2c8bf052c9b4cfa1f63bb29eaa134fc4f32fdac1ccb578398dc7f"
+  "shardHash": "0b3224fd40f174d454b7ec015f5cbc8828052f969fd95618e005c6a613220f11"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0b3224fd40f174d454b7ec015f5cbc8828052f969fd95618e005c6a613220f11"
+  "shardHash": "1b351cc1be0c99f6c281bc0241eee16a6eaa9ecaa309f3949641d079beeec5f6"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e16341f8415181b46bf827ddcc67f3e593081846cf0e720c002f732fe96ffdbb"
+  "shardHash": "0e58fa3d94176b75da7f8d6c864e1fbed04409336102c4d07335840017833c87"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0e58fa3d94176b75da7f8d6c864e1fbed04409336102c4d07335840017833c87"
+  "shardHash": "b9566bfbef29d0c54733b71081367562440a62d912dfbbc8c5160e4882d701c7"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "69bbde722f9d99d1b1a4059e5677e65bbc8deddb36e0b07d937c3424bdbedbf7"
+  "shardHash": "add6b464e118606909614ff1c86e2c902c87c8e3fe323f2e3f23fda5f1564689"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c483d2a1e627ade21cabdfd1059997f82fe1941408593901c064b47ca62f8ef4"
+  "shardHash": "69bbde722f9d99d1b1a4059e5677e65bbc8deddb36e0b07d937c3424bdbedbf7"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6292c0330ed8d1e1f34e60d03df49f3c4402cbf914b94d012ac300b491a40606"
+  "shardHash": "98fab27d29fbd562fa36329f2b6b43ef4b7aefb4b8cab6811c3703df6544749b"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "98fab27d29fbd562fa36329f2b6b43ef4b7aefb4b8cab6811c3703df6544749b"
+  "shardHash": "410a2920ab704c46dc716dcb03f7b470a5fad7b057b3334850475985264ac036"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cf9756771f829ea4f95c21e66c640af09a20e0f15464d7100f44d6ad22f5fa54"
+  "shardHash": "625f5a525110bdcdbb5cad593913af206e7fe9085357383dbf8ad92f38d378a3"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "625f5a525110bdcdbb5cad593913af206e7fe9085357383dbf8ad92f38d378a3"
+  "shardHash": "5370782967c6b715216434d66536443ba0097308d4bcfab8b7f8f7034e772b51"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a50c85f4344f33604c9febac2028a51f847e03ac5d6fbf9833c4138a852887a6"
+  "shardHash": "ce514eb55030c4f8f61dec2627e815f154135cc82d630a3891d93ee83c2a8e06"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce514eb55030c4f8f61dec2627e815f154135cc82d630a3891d93ee83c2a8e06"
+  "shardHash": "082103107afb5a697a6527762c04ead707211a691596034b17f460a9ca5727f6"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7426a3d0668090a9305e6d3138eea217d7417c006504703f1466717014bfdeef"
+  "shardHash": "19d232e030dcbb5a00ad3934b7efdf1be226cd02e40a46cadb78226d40d16205"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "19d232e030dcbb5a00ad3934b7efdf1be226cd02e40a46cadb78226d40d16205"
+  "shardHash": "314381b1f855a60b27db9ba817a5746e40a396cfc88504d3abec16070623bdd3"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "492e79b311e7a3a543a8216b04320e960ad6b71ba132c87b66c6060a691134be"
+  "shardHash": "d3233026b9385068adee2f23e1c92c07cc30d5730f1945ec3830d8f4b5f569be"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5eb188d0d0a122cf6c55a9e3b0277b8c57a619811e97a64edd8aa28033192f70"
+  "shardHash": "492e79b311e7a3a543a8216b04320e960ad6b71ba132c87b66c6060a691134be"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "41f4b17a6aea8bc13877476075ed5ed57310f2641213ee7e8983038bb4099422"
+  "shardHash": "7e7acf51a6c4cdf0efc98a3398f484baddfe29167a21b0510cd01e0184a2a425"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7e7acf51a6c4cdf0efc98a3398f484baddfe29167a21b0510cd01e0184a2a425"
+  "shardHash": "0de26b8c7b01ac3dd20ec9fd789b8ced57fcf98a79d37955a3cf7268e5aa9866"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "55e1db9c6d71999a14be6cf653cf5724a6e0b4a43aea4229518b625d9c13c1d4"
+  "shardHash": "4d4ae3f5032766fbde9ede70adc0964ac3e27ce5f6f7d0ed36f29782e86e5b76"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4d4ae3f5032766fbde9ede70adc0964ac3e27ce5f6f7d0ed36f29782e86e5b76"
+  "shardHash": "4d27deceba005c98ffab060c4b378e78fb0b368024c6c3be73d8a236fb10a3dc"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "df46218bcf0495e17cdd8e5ceaa0b38b216d880b349be4238ea0a4422cb72ce2"
+  "shardHash": "1f7701e3d139a901038db0e7cb77c1391df5dbf653d4c8e1259ee0a6f5890564"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1f7701e3d139a901038db0e7cb77c1391df5dbf653d4c8e1259ee0a6f5890564"
+  "shardHash": "0156f495b7a875f45a4a0978e0bd670b7b1b456824f03cfd655ba0fbaf911601"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8245fc9673eb0da5b034daf4ae50d7e0d3656292a43dd1f811a15127b5b13702"
+  "shardHash": "7c09411001753b53cfda11b846896569bd01679bac6518e1f954483cf572d2c1"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1172088536611649141f8b09666f101250100783dca49b2a6759e6c7fbb324a2"
+  "shardHash": "8245fc9673eb0da5b034daf4ae50d7e0d3656292a43dd1f811a15127b5b13702"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6d87f0bb9693703247647245c6a7307be66b73f0e00e3e011551287247aa4446"
+  "shardHash": "4148b80a2fe9f1a474aba51cf1cf3f1d2104b46e518d70a5f8a46d8550b8d122"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -217,5 +217,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8839cce31278133c125928bcb1a336bfb19724dcdbfe122366d84cea268ae5ce"
+  "shardHash": "6d87f0bb9693703247647245c6a7307be66b73f0e00e3e011551287247aa4446"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "64205b1cc165d13836e3cae1daed521775add347851c6bb5e16986b1a54ad0e1"
+  "shardHash": "6cb062e371ba2eff5445346f430e1adf3fdcf3f0ebb5bb8884a25198cf1a9bbe"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8fdb2cf7f4db1c6541010996b960212356f0b0cbaee135420ca0520460c21ccd"
+  "shardHash": "64205b1cc165d13836e3cae1daed521775add347851c6bb5e16986b1a54ad0e1"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b78e601e33a1fcc5aa4517a13bb860d6e81e3835138abf7db92d55acdd7ae415"
+  "shardHash": "fe3de9f04b4bc8e0727694380aa261786ea1c0ad5e46db35332b270fba4705d2"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "beb7816f607cc20d831afed1f0a190e97ea1aefc4388e1aed99d14474ee864a3"
+  "shardHash": "b78e601e33a1fcc5aa4517a13bb860d6e81e3835138abf7db92d55acdd7ae415"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "76028bb13be2e39977d74acdb102078ea0b5890b0f5456ec6e1d1e08db0891f3"
+  "shardHash": "19fe33e885370de51c3edc754b8ed8b4bbfad25faf16ee70c2437fb59f5f2855"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f0e47de286fe60a60617cffa2410c35d0ca468dbd398306c7c57b0b8517a2e88"
+  "shardHash": "76028bb13be2e39977d74acdb102078ea0b5890b0f5456ec6e1d1e08db0891f3"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7f47493dfc2a9e27b6e557b7517c5a79bc4c0f15dde43e55825a8746e28eb0d2"
+  "shardHash": "4666ca803e8a9c73e0a5529996431647d6a2d742b66a133d385eee91bbe32eb0"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4666ca803e8a9c73e0a5529996431647d6a2d742b66a133d385eee91bbe32eb0"
+  "shardHash": "3c30410b87989536162c606a7ebf852f5467e2fa9beb219ec37989eb565f694e"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3e879bab9314a5bd8361e776a799a89f2d6241154abaafc2c3857e94527122a1"
+  "shardHash": "4282ba1acc15372f9b9575fbc751c4690c41be9fa1ecd18930af46fb00caa025"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4282ba1acc15372f9b9575fbc751c4690c41be9fa1ecd18930af46fb00caa025"
+  "shardHash": "89ac0cdd0a2e0e4ee4c8d064beaaaf7882f133b1a9031498fcca85942c4e4000"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b37d827cd09aed9a61e8d1b9e1f3f70c1a4c91b5623af7dadef68f00a10f9589"
+  "shardHash": "b93d780c6096eac17c80c479d83f14d0ca4ca947ec98faaff8fca0cf997abd31"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b93d780c6096eac17c80c479d83f14d0ca4ca947ec98faaff8fca0cf997abd31"
+  "shardHash": "0c72bc2127898c40fbea3f69b666225a4950bf74e70f1eaab5dedaedb688dc31"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fd38ccd3ce5490dece433c60a683ab77e22bd5c5b91307aa1605098d90f24367"
+  "shardHash": "49c8adc4a26305cb04b244b8cb33f3554e1bdbcea1491b4ceeb4a56f13095857"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5ba280016a6441e5527e490fb30cc4f5ec8fa2eadee6e2e77e3a8b621ceb220b"
+  "shardHash": "fd38ccd3ce5490dece433c60a683ab77e22bd5c5b91307aa1605098d90f24367"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "97afe45d1a65fd761c3336088b092b8cd92c6d6ad5b2ab76dea706743ede8c6e"
+  "shardHash": "6a5474e696ae54a5db9df31857d9279aa33277a5288ba441b9c7323c451424be"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c7c652b04b03ffc503453070cf81e755ed86498e4693ec649e6a1d9be64941e0"
+  "shardHash": "97afe45d1a65fd761c3336088b092b8cd92c6d6ad5b2ab76dea706743ede8c6e"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c2f6a16b12cbf58da8dbb61b1f9fc3bb1bba42c12c6c05c3aaf7ed7eeab54f73"
+  "shardHash": "b9726e718637eefcbd64065e0efd2dfa68953e4a56f569c012611891efd2bcac"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b9726e718637eefcbd64065e0efd2dfa68953e4a56f569c012611891efd2bcac"
+  "shardHash": "890c1fb63a49bc563280c010a6ec38605510eeebea45205733a0bef233e60a67"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "69a58638b1e920c6389d42cb04a847060df452562145a8b596826c520ae81482"
+  "shardHash": "3215fcedd0ef3e8bf64aafbd11bb7b8f8bb59b666e41a4294d2a760897429754"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f6615f30586f01b20978f2ecdbef149e5bcd99b45c085146aeecefe2d13cf602"
+  "shardHash": "69a58638b1e920c6389d42cb04a847060df452562145a8b596826c520ae81482"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dba0bf5b07db8c23b3218bf5ed371273ba87b21ae1de519761d96b7040db1c19"
+  "shardHash": "057f7704559c636748bc8a7df51cf613d49e38baabb2302ba3529a533a3108b3"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "057f7704559c636748bc8a7df51cf613d49e38baabb2302ba3529a533a3108b3"
+  "shardHash": "1f55cbe099796eee7c0d476f065288dfaa30f2ce9207c4693e107109ad48ef86"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f966b9cb9972dda54444be536634fabcdfd68b5479142f6ff9bb7fddda710129"
+  "shardHash": "1adc2b340c24d79d5986539ec69ec9b5af78d8ad652f629111557d279aeed324"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1adc2b340c24d79d5986539ec69ec9b5af78d8ad652f629111557d279aeed324"
+  "shardHash": "949a3ae3cc2318ae882ab3ef0803be4c3cb29967a2dd340eefbf4e69f748fa72"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "35f17a16330d44294f08e10713b3b19d8908d3c831bdde82c753dfe6fb0d8d62"
+  "shardHash": "b88bdd49e574b19376301e767ef513076dd52fd726a08343cd2d8bb9924c2442"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b88bdd49e574b19376301e767ef513076dd52fd726a08343cd2d8bb9924c2442"
+  "shardHash": "cc2685493c4abecc92c07342cdeebbda0f5d7ede0dbd61c8b34c8e76c8e5aa7e"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4850c31a1c9c3c11493a06a8ae44d394ee992980654bc9bad95fcb3ffbb28708"
+  "shardHash": "92f8d8c6901feebb9d9b8d89df4fd82f456c7189e6967756d22e270449832247"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "eff2b7f8cf532329da6a0cf80ab7b5cbb8a0087534b84ca678ec20d9db6644ad"
+  "shardHash": "4850c31a1c9c3c11493a06a8ae44d394ee992980654bc9bad95fcb3ffbb28708"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "26c84dc082f312a425056534f49c92912bb98d158907c83c0499cde8bacf2e46"
+  "shardHash": "59da4a554125af247c9213ae27cede81bca480d7b7c033d4e26b9a73be450fb8"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "59da4a554125af247c9213ae27cede81bca480d7b7c033d4e26b9a73be450fb8"
+  "shardHash": "627957f9df2ff584adc69abe3178453ebfc11e0ea96a17262faf8ed0866a1c90"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a7cbb6112631d353f0e4c30cdfc707607f9b80f0f206809a7e4867f5406a4779"
+  "shardHash": "f001ba0bbb87c237be5d6c08d8014176dee59828dd530fc99efe1a7e7fad78bf"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1ff6b3372fb47fdfc77b4f01ea4871012698a06616e2dc77072bf364621bb8b8"
+  "shardHash": "a7cbb6112631d353f0e4c30cdfc707607f9b80f0f206809a7e4867f5406a4779"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "907076ebff41f61263cbe2e71b93e87c0c6cf507050910be6355c67b77683687"
+  "shardHash": "0bbc948e9ac39afad3a2e2320a8b727a4262382bd7fdc102bcb3a570a6046bbb"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "20cae13d1739243dfe0c93005f5fac88ab9b1ff0811f289241b88fa622ceb12a"
+  "shardHash": "907076ebff41f61263cbe2e71b93e87c0c6cf507050910be6355c67b77683687"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0e2f3a40cef0b6c0a4d55a53bf07a75d57188da6560d7ecb5d6a44439d218c95"
+  "shardHash": "e2981f095a4782d01f621147ce8762327f62efef80fa63406967c7a28610de89"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2981f095a4782d01f621147ce8762327f62efef80fa63406967c7a28610de89"
+  "shardHash": "ecb19d818d081b9cada4491c0801d7cdd29e2cc8f39cfefa6ecd6ef0fecb2147"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b6217a1f2314dac09159753c7196648645c325a87817d73bdeb11ae3a4d8521b"
+  "shardHash": "1548d2a9ada168f2e2d64d3c7fbe70fffa71c5eadbd236f9d5f1bd4d85025a4d"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1548d2a9ada168f2e2d64d3c7fbe70fffa71c5eadbd236f9d5f1bd4d85025a4d"
+  "shardHash": "8b71b653092dd0e30ff695ada4e5aa828598e8c524b635bda85b6e10924c44a8"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cf24a974ad9d3ec8cca38e2cb80e3bbb724dab6238e96cb82454985225c357de"
+  "shardHash": "356e404f830d012b3ecbdeebf503fb92170955081adb9f7ce0b1a139c5375f39"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ca3576812886f1bf2e7b9f1315b2ee6b2208c5fbb1ed2a4d91cea715e5eb3054"
+  "shardHash": "cf24a974ad9d3ec8cca38e2cb80e3bbb724dab6238e96cb82454985225c357de"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e4df63513cf3cd335ffa7d4292c891a48e12e4cc01bf62ee0e2f2880c0fbc749"
+  "shardHash": "d3e1c3c1809d1d715f75abc1798a6e3ae5bc9cbbc1dd5c8bcc4ee9262013178e"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b2885315db4590effd19e7f948f2842962585604526d481245aedb8efbe56ac"
+  "shardHash": "e4df63513cf3cd335ffa7d4292c891a48e12e4cc01bf62ee0e2f2880c0fbc749"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "690dbcae72acfdef75524232ef80560950f15125707e7f65d97535db4cd65c50"
+  "shardHash": "7a173bb503e4d7916d88a4f435b661ddae5007f0183289cd41cdc66d1adb0a6a"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7a173bb503e4d7916d88a4f435b661ddae5007f0183289cd41cdc66d1adb0a6a"
+  "shardHash": "6d859ebdc0ec54d1680f545de2515e317521d7c074cd838b73544b1b9a2e6a52"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6ad0264322d0d6e44891ce61e5f62c94ba0ae0934cbc07f1280674ddeb7f315d"
+  "shardHash": "5e9e5ce06d3df0f96d1c8631dc2825563ce8413e5d49805a458bae1ec0ffb928"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e9e5ce06d3df0f96d1c8631dc2825563ce8413e5d49805a458bae1ec0ffb928"
+  "shardHash": "8c550441938591ab093fe03bb2b15187d8959f43a1c57a39c0fa7440d2ab9b7c"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b17a4753e0dc9021bda3059f5512a5c98b2543fa507bfc22ada195c0ee7ba647"
+  "shardHash": "44ae3985eb347fdddb8c91ec9ca70e3aa161e55ef570904aa469cee569fbd0f2"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "44ae3985eb347fdddb8c91ec9ca70e3aa161e55ef570904aa469cee569fbd0f2"
+  "shardHash": "b1906cfc18948921f369b0a14c4d088ada84be56f5def8eadcb7d2f8da989296"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "66d6b96e0c1e679d8f42dcb596cd914a8a0b272399e371a0267e40ae4c0422ec"
+  "shardHash": "0b1c045840a4ffd67b6cf1fd1fdec0058b8d27d6930ece8177aa411cd1505ea7"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0b1c045840a4ffd67b6cf1fd1fdec0058b8d27d6930ece8177aa411cd1505ea7"
+  "shardHash": "ec3bccfffa7e83fa8229d1c18496979e0433b89375b6d1fd154720d4d0ad99f0"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -305,5 +305,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e3b20f462716e01e88a074a12267872f9c5f2f5e3ca4726d82b99e5b1c1da119"
+  "shardHash": "da416b636ba5a413a8d29932de642aa1dc7072f2cd28c98c6a8dbe0b9b1885b6"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -305,5 +305,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f6b87f89f6c9f4709911421747e28f1e270c953c107fe100d82ded0dbb980a39"
+  "shardHash": "e3b20f462716e01e88a074a12267872f9c5f2f5e3ca4726d82b99e5b1c1da119"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -403,5 +403,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4bb16f9daf2409ea135fd66bda920cafcca9dd8b6d7b29f9e4640bad348a6621"
+  "shardHash": "d865f05e692f1faac2abffb47b8a34c0b92d64dd3c441ad3bd795b6a7b4bae24"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -403,5 +403,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "023b430da0fa41bb873fb9c22ab1104d09fd0b5a24266c7e97c40d1646fde918"
+  "shardHash": "4bb16f9daf2409ea135fd66bda920cafcca9dd8b6d7b29f9e4640bad348a6621"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2c2789f1b8e6f4f352aa8be568d8db3d53f1f834943527993bc621b65b53b138"
+  "shardHash": "2928c7583424e8400d43549293770887b0af9e1f55d81e350753040675a90f56"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "70848cbfff700f5edc96ea383f4523f01f0f65666fa18094974b95d0e4f2f72d"
+  "shardHash": "2c2789f1b8e6f4f352aa8be568d8db3d53f1f834943527993bc621b65b53b138"
 }

--- a/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
@@ -340,5 +340,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "30c7eea75e7d0a04c58d1d24c61e101e30cd9a0de43670af16c8dd4145e0cdd4"
+  "shardHash": "bc52c095536124acd2cc9cfdd6e68b16b4b701d42adc54d293ec160b4b94fd7d"
 }

--- a/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
@@ -340,5 +340,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bc52c095536124acd2cc9cfdd6e68b16b4b701d42adc54d293ec160b4b94fd7d"
+  "shardHash": "f02b738be2a75e945709280b8486425865196a6c541c6876c66728ed86db95e0"
 }

--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -32,5 +32,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "60844dff52c6cd95e464a8d8a2f23a83300dd277a063c7a1e50e4aa9a00a9fcf"
+  "shardHash": "35e5244ea7ebf90615d1636ba8ee6fc95584d3fbfc63b4ed06f436fb8cdeb621"
 }

--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -32,5 +32,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "35e5244ea7ebf90615d1636ba8ee6fc95584d3fbfc63b4ed06f436fb8cdeb621"
+  "shardHash": "e5bec6bde99721ab367e5e13c2f1b0c72b1e1849ff9a0f78bd8f45b5a6d0bbba"
 }

--- a/.derived/spec-registry/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/spec-registry/by-spec/078-the-protocol-has-an-owner.json
@@ -36,6 +36,6 @@
     "summary": "Root `AGENTS.md` is the cross-agent authority: the protocol `/prime` executes, the gate list every skill inlines a subset of, and the document spec 051's parity test compares this repository's CI against. No spec in the corpus establishes it. Seven approved specs reach it with an `extends` edge naming spec 029, but 029 establishes exactly one unit, `kit/`, and root `AGENTS.md` is outside that subtree, so the ledger records an owner that never established the file. That is not a defect: `extends` means \"adds surface to a predecessor\", so those edges are the corpus's ordinary convention, and measurement confirms it. What is genuinely missing is narrower. The protocol file has no `establishes` claim at all, so the ledger has no direct answer to who owns it. This spec supplies one, and requires the file to name the spec that governs it, the same \"a file naming its own spec\" move the comment headers make for source. It clarifies the ledger only; it changes no behavior and amends nobody.\n",
     "title": "The protocol has an owner"
   },
-  "shardHash": "9cc6c05dcd84e60fd9a447c1aa3632932fe8c57c05ef5e4f7a17d5a82d8bb8d0",
+  "shardHash": "a1137a896fe3666a98c6b714c818b3627ca5a50ebadfa08e19d875606377904e",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/spec-registry/by-spec/078-the-protocol-has-an-owner.json
@@ -15,7 +15,7 @@
       }
     ],
     "id": "078-the-protocol-has-an-owner",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "governance",
     "owner": "The spec-spine Authors",
     "risk": "medium",
@@ -26,16 +26,16 @@
       "3. Behavior",
       "3.1 The claim",
       "3.2 The file names the spec that governs it",
-      "3.3 The inherited edges are recorded, not rewritten",
+      "3.3 Existing edges are not touched",
       "4. Out of scope",
       "5. Resolved decisions",
       "Verification"
     ],
     "specPath": "specs/078-the-protocol-has-an-owner/spec.md",
     "status": "draft",
-    "summary": "Root `AGENTS.md` is the cross-agent authority: the protocol `/prime` executes, the gate list every skill inlines a subset of, and the document spec 051's parity test compares this repository's CI against. No spec in the corpus establishes it. Seven approved specs reach it with an `extends` edge naming spec 029, but 029 establishes exactly one unit, `kit/`, and root `AGENTS.md` is outside that subtree, so the ledger records an owner that never claimed the file. Nothing catches this: no validation confirms an `extends` unit appears in its target's territory. This spec claims the file where it should have been claimed, and requires the file to name the spec that governs it, which is the same \"a file naming its own spec\" move the comment headers make for source. It corrects the ledger only; it changes no behavior, amends nobody, and deliberately leaves the seven inherited edges alone, because repointing another spec's frontmatter is that spec's business and spec 079 is where the migration is decided.\n",
+    "summary": "Root `AGENTS.md` is the cross-agent authority: the protocol `/prime` executes, the gate list every skill inlines a subset of, and the document spec 051's parity test compares this repository's CI against. No spec in the corpus establishes it. Seven approved specs reach it with an `extends` edge naming spec 029, but 029 establishes exactly one unit, `kit/`, and root `AGENTS.md` is outside that subtree, so the ledger records an owner that never established the file. That is not a defect: `extends` means \"adds surface to a predecessor\", so those edges are the corpus's ordinary convention, and measurement confirms it. What is genuinely missing is narrower. The protocol file has no `establishes` claim at all, so the ledger has no direct answer to who owns it. This spec supplies one, and requires the file to name the spec that governs it, the same \"a file naming its own spec\" move the comment headers make for source. It clarifies the ledger only; it changes no behavior and amends nobody.\n",
     "title": "The protocol has an owner"
   },
-  "shardHash": "fe5c4a5f411eb395902442c14d42bfa679aa25c9def3fe184f15a6978089aabe",
+  "shardHash": "9cc6c05dcd84e60fd9a447c1aa3632932fe8c57c05ef5e4f7a17d5a82d8bb8d0",
   "specVersion": "1.2.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,6 @@
 # AGENTS.md: spec-spine
 
-> **Governed by `specs/078-the-protocol-has-an-owner/spec.md`.** This file is the
-> cross-agent protocol and the canonical spelling of the gate chain, so the spec
-> that claims it is named here: a reader editing this document should not have to
-> compile the registry to learn which spec they are editing under. The claim is
-> prose rather than a `// Spec:` header, because that grammar is defined over the
-> source extensions in `coverage.rs::SOURCE_EXTS` and markdown is not among them.
+> Governed by `specs/078-the-protocol-has-an-owner/spec.md`.
 
 ## New Sessions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS.md: spec-spine
 
+> **Governed by `specs/078-the-protocol-has-an-owner/spec.md`.** This file is the
+> cross-agent protocol and the canonical spelling of the gate chain, so the spec
+> that claims it is named here: a reader editing this document should not have to
+> compile the registry to learn which spec they are editing under. The claim is
+> prose rather than a `// Spec:` header, because that grammar is defined over the
+> source extensions in `coverage.rs::SOURCE_EXTS` and markdown is not among them.
+
 ## New Sessions
 
 Run `/prime` as the mandatory first action of every new session. The command reads this section to derive its execution plan dynamically: any item added here is automatically picked up on the next init. This file is the cross-agent authority (read by Claude Code, Codex CLI, Cursor, Copilot, and any future agent via the AAIF/Linux Foundation AGENTS.md standard).

--- a/specs/078-the-protocol-has-an-owner/spec.md
+++ b/specs/078-the-protocol-has-an-owner/spec.md
@@ -4,7 +4,7 @@ title: "The protocol has an owner"
 status: draft
 kind: "governance"
 created: "2026-09-08"
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: medium
 depends_on:
@@ -25,14 +25,14 @@ summary: >
   corpus establishes it. Seven approved specs reach it with an `extends` edge
   naming spec 029, but 029 establishes exactly one unit, `kit/`, and root
   `AGENTS.md` is outside that subtree, so the ledger records an owner that
-  never claimed the file. Nothing catches this: no validation confirms an
-  `extends` unit appears in its target's territory. This spec claims the file
-  where it should have been claimed, and requires the file to name the spec
-  that governs it, which is the same "a file naming its own spec" move the
-  comment headers make for source. It corrects the ledger only; it changes no
-  behavior, amends nobody, and deliberately leaves the seven inherited edges
-  alone, because repointing another spec's frontmatter is that spec's business
-  and spec 079 is where the migration is decided.
+  never established the file. That is not a defect: `extends` means "adds
+  surface to a predecessor", so those edges are the corpus's ordinary
+  convention, and measurement confirms it. What is genuinely missing is
+  narrower. The protocol file has no `establishes` claim at all, so the ledger
+  has no direct answer to who owns it. This spec supplies one, and requires the
+  file to name the spec that governs it, the same "a file naming its own spec"
+  move the comment headers make for source. It clarifies the ledger only; it
+  changes no behavior and amends nobody.
 ---
 
 # 078: The protocol has an owner
@@ -83,13 +83,13 @@ rare case where the correct edge is no edge at all.
 correctly attributed there. The two files are near-copies and it would be easy
 to sweep both; only one is wrong.
 
-**The seven inherited edges are deliberately not repointed.** Each lives in
-another spec's frontmatter, and six of those seven are approved. Editing them
-would mean editing seven approved specs to correct a record, which is a
-different act from filing a claim, and one an agent does not perform on its own
-authority. Section 3.3 states what the corpus should do about them; spec 079,
-which adds the validation that would refuse them, is where the migration is
-sequenced, because a check and the debt it creates belong in one decision.
+**The seven existing edges are correct and are left alone.** They were first
+read as a misattribution to be migrated. Measurement over the corpus refuted
+that: a large minority of unit-carrying `extends` edges name a target that
+never established the unit, across more than fifty specs, and `extends` is the
+sole claim for about a fifth of this repository's source files. `edges.rs`
+defines the edge as "adds surface to a predecessor", which is what those seven
+do. There is nothing to repoint and no debt to retire.
 
 ## 3. Behavior
 
@@ -125,32 +125,30 @@ the extensions in `SOURCE_EXTS`, markdown is not among them, and inventing a
 markdown dialect of it would create a second claim mechanism the indexer does
 not read.
 
-### 3.3 The inherited edges are recorded, not rewritten
+### 3.3 Existing edges are not touched
 
-This spec MUST NOT edit the frontmatter of specs 047, 048, 051, 063, 072, 074
-or 075.
+This spec MUST NOT edit the frontmatter of any other spec.
 
-New specs SHOULD name `078-the-protocol-has-an-owner` when declaring an
-`extends` edge on root `AGENTS.md`. This is a SHOULD rather than a MUST because
-nothing validates it yet; spec 079 is what makes it enforceable, and a
-requirement no verb can check is a wish.
+An `extends` edge naming root `AGENTS.md` MAY name any spec whose surface it
+adds to, as it always could. Adding an `establishes` claim does not make the
+existing edges wrong, and this spec creates no obligation to repoint them: the
+edge type means "adds surface to a predecessor", and a claim on the file is a
+separate statement from the edges that extend it.
 
-The seven existing edges remain as they are and are hereby **named debt**,
-in the sense spec 032 §3.8 used the term: an explicit, written-down gap with a
-retirement path, rather than an invisible one. Spec 079 decides how it is
-retired, because the check that refuses these edges and the correction of the
-edges it refuses are one decision, and splitting them across two specs would
-put the corpus in a state its own gate rejects.
+There is deliberately no migration, no debt entry and no follow-on. An earlier
+draft of this section prescribed all three, on the belief that the existing
+edges were misattributed; section 5 records why that was withdrawn.
 
 ## 4. Out of scope
 
-**Validating that an `extends` unit appears in its target's territory.** That
-is the mechanism whose absence let this survive seven ratifications, and it is
-spec 079. It is corpus-wide validation with its own blast radius, and it must
-ship together with a decision about the seven edges it would immediately
-refuse.
-
-**Repointing the seven inherited edges.** Section 3.3, and spec 079.
+**Validating that an `extends` unit appears in its target's territory.**
+Proposed while this spec was drafted and since **refuted** rather than
+deferred. Such a check would refuse a large minority of the corpus's edges
+across more than fifty specs, contradict the edge's documented meaning, and
+strip the only claim about a fifth of this repository's source files carry. It
+is named here so it is not proposed again as an obvious missing gate. If
+visibility into the shape is ever wanted, it belongs as a tier on the
+`index coverage` read verb and never as a gate.
 
 **Claiming the other unowned governance files.** This spec fixes the file it
 names and does not go looking. A sweep of every unclaimed root-level document
@@ -181,16 +179,32 @@ ownership would report that as two units without adding a fact anyone needs.
 The one heading that genuinely is a contract, `## New Sessions`, is already
 protected by spec 075 §3.1, which requires it not to change.
 
-**2026-09-08: the seven inherited edges stay, and are called debt rather than
-left unmentioned.** The tempting move is to correct all seven while the subject
-is fresh. It was refused for two reasons. Six of the seven are approved specs,
-and correcting an approved spec's frontmatter is a human's decision, not an
-agent's, even when the correction is factual. And a correction landing before
-spec 079's check exists would be unverifiable: nothing would prove the corpus
-was clean afterwards, so the work would have to be redone as an audit anyway
-once the check landed. Spec 032 shipped its ratchet off with the debt named and
-retired it later with the check in hand; this follows that precedent
-deliberately.
+**2026-09-08: the seven edges were called a misattribution, and the count says
+they are the convention.** This spec was drafted believing that an `extends`
+edge naming a unit outside its target's territory was a defect, that the seven
+specs extending 029 for root `AGENTS.md` had inherited one, and that a
+follow-on spec should add a check and migrate them. Measurement through typed
+reads refuted all three at once:
+
+```
+unit-carrying extends edges                        435
+  target never establishes the unit    a large minority, 50+ specs
+tracked source files                                95
+  established directly                              71
+  claimed only through an extends edge              17
+```
+
+`edges.rs` defines the edge as "adds surface to a predecessor", and that is
+exactly what those edges do. The follow-on spec was dropped, section 3.3's
+migration was withdrawn, and section 4 records the check as refused rather
+than deferred.
+
+Kept as a correction rather than deleted, because the belief reached three
+artifacts before anyone counted, and the transferable lesson is procedural:
+measure how common a pattern is, through a typed read, before filing a spec
+that would validate against it. What survives of this spec is the part the
+measurement never touched, which is that the protocol file had no
+`establishes` claim and now has one.
 
 **2026-09-08: the ownership line is prose, not a `// Spec:` header.** The
 header grammar is defined over `SOURCE_EXTS`, which is rs, ts, tsx, js, jsx, go,

--- a/specs/078-the-protocol-has-an-owner/spec.md
+++ b/specs/078-the-protocol-has-an-owner/spec.md
@@ -48,25 +48,26 @@ parity test compares CI's governance commands against.
 No spec establishes it.
 
 Seven approved specs (047, 048, 051, 063, 072, 074 and 075) declare an
-`extends` edge naming spec 029 with unit `AGENTS.md`. Spec 029's `establishes`
-list has exactly one entry, `kit/`. Root `AGENTS.md` is not inside that
-subtree; `kit/AGENTS.md` is, and that one is correctly attributed. So seven
-specs record a claim about a file that their named target never claimed.
+`extends` edge naming spec 029 with unit `AGENTS.md`, and **those edges are
+correct**. `extends` is defined in `edges.rs` as "adds surface to a
+predecessor": the unit is surface the extending spec adds, and it need not
+already sit in the target's territory. That is the corpus's ordinary
+convention, measured rather than assumed, and it is the sole claim about a
+fifth of this repository's source files have.
 
-**The misattribution is invisible by construction.** `V-004` refuses an edge
-naming a spec that does not exist, and `V-017` refuses an `extends` on a unit
-another spec has only *planned*. Neither asks the obvious question: does the
-target's territory contain the unit at all? Nothing does. The edge therefore
-compiles, lints clean at every severity, passes the coupling gate and survives
-ratification, seven times over.
+**What is missing is narrower, and it is a gap in the ledger rather than a
+defect in anyone's frontmatter.** Every one of those seven edges says "I add
+surface to this file". None says "this file is mine". So the registry can
+answer which specs extend the protocol document and cannot answer who owns it,
+which for a ledger whose product is exactly that answer is a hole in the middle
+of its own house.
 
-**What it costs today is accuracy, not safety.** The coupling gate reads root
-`AGENTS.md` as owned, because an `extends` edge carrying a unit puts the
-extending spec into that unit's owner set, so an edit to the protocol still has
-to arrive with a spec that changed. Coverage ignores it, since markdown is not
-in `SOURCE_EXTS`. Nothing is unguarded. What is wrong is the ledger's answer to
-"who owns this file", and a ledger whose whole product is that answer should
-not be wrong about its own protocol document.
+**Nothing is unguarded in the meantime.** An `extends` edge carrying a unit
+puts the extending spec into that unit's owner set, so the coupling gate reads
+root `AGENTS.md` as owned and an edit still has to arrive with a spec that
+changed. Coverage ignores it, since markdown is not in `SOURCE_EXTS`. This spec
+closes a gap in what the ledger can *say*, not a hole in what the gate can
+catch.
 
 ## 2. Territory
 
@@ -75,13 +76,14 @@ This spec establishes one unit, root `AGENTS.md`, and nothing else.
 **The claim owes no `amends`, and that is a fact about spec 029 rather than a
 convenience.** An amendment is owed to a spec whose stated behavior a later
 spec changes. 029 states nothing about root `AGENTS.md`: it does not claim it,
-require anything of it, or mention it in its territory. Claiming a file its
-alleged owner never claimed contradicts nothing that spec says. This is the
-rare case where the correct edge is no edge at all.
+require anything of it, or mention it in its territory. Establishing a file 029
+never established contradicts nothing that spec says, and takes nothing from
+the specs that extend it. This is the rare case where the correct edge is no
+edge at all.
 
-**`kit/AGENTS.md` is untouched.** It falls inside 029's `kit/` subtree and is
-correctly attributed there. The two files are near-copies and it would be easy
-to sweep both; only one is wrong.
+**`kit/AGENTS.md` is untouched.** It falls inside 029's `kit/` subtree, so it
+already has an establisher and needs nothing from this spec. The two files are
+near-copies and it would be easy to sweep both; only one has the gap.
 
 **The seven existing edges are correct and are left alone.** They were first
 read as a misattribution to be migrated. Measurement over the corpus refuted


### PR DESCRIPTION
## Summary

Builds spec 078, and withdraws the premise it was filed on. The second is the larger change.

**The build.** `AGENTS.md` now carries a prose line naming `specs/078-the-protocol-has-an-owner/spec.md` as its governing spec, satisfying §3.2. A reader editing the protocol should not have to compile the registry to learn which spec they are editing under.

Prose, not a `// Spec:` header: that grammar is defined over `coverage.rs::SOURCE_EXTS` and markdown is not among them, so a markdown dialect would create a second claim mechanism the indexer does not read. §3.2 requires that, and the Verification block asserts it both ways.

**The withdrawal.** 078 was filed believing that an `extends` edge naming a unit outside its target's territory was a defect, that the seven specs extending 029 for root `AGENTS.md` had inherited one, and that a follow-on spec should add a validation and migrate them. Measurement through typed reads refuted all three at once:

```
unit-carrying extends edges                        435
  target never establishes the unit    a large minority, 50+ specs
tracked source files                                95
  established directly                              71
  claimed only through an extends edge              17
```

`edges.rs` defines the edge as *"adds surface to a predecessor"*, which is exactly what those edges do. `extends` is the sole claim for about a fifth of this repository's source files.

| Section | Change |
|---|---|
| Summary, §2 | The seven edges are correct and left alone. Nothing to repoint, no debt to retire. |
| §3.3 | Loses its **normative** migration: the SHOULD directing new specs to name 078, and the "named debt" declaration with a retirement path. Now says only that this spec touches no other frontmatter and creates no obligation. |
| §4 | Records the phantom-`extends` check as **refuted**, with the numbers, rather than deferred. |
| §5 third decision | Rewritten as the correction, keeping the procedural lesson: measure how common a pattern is through a typed read before filing a spec that would validate against it. |

**Every reference to the dropped follow-on spec is gone. There were seven.**

What survives is the part the measurement never touched, and it is the part worth keeping: the protocol file had no `establishes` claim, so the ledger had no direct answer to who owns it. Now it does, and the file says so.

## Testing

```
spec-spine verify 078-the-protocol-has-an-owner  ->  passed (6 commands)
```

It failed at command 3 before this change, for exactly the missing ownership line.

```
check --fail-on-unresolved --fail-on-warn 0 - lint --fail-on-warn 0
index coverage --fail-on-untraced 0 - couple 0 (2 paths, no drift)
cargo test --workspace --locked 0 - clippy -D warnings 0 - fmt --check 0
```

## On the diff size

84 of the 86 changed files are regenerated index shards. `AGENTS.md` is in `[index] extra_hashed_inputs`, so any edit to it folds into the global-inputs scalar and restales every shard. Unavoidable, and the reason this PR should not overlap with another that edits the protocol file.

`status` stays `draft`; ratification is a separate human-approved PR.