### PR TITLE
chore(078): ratify (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -29,8 +29,8 @@
       }
     ],
     "specId": "078-the-protocol-has-an-owner",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e5bec6bde99721ab367e5e13c2f1b0c72b1e1849ff9a0f78bd8f45b5a6d0bbba"
+  "shardHash": "ca5fa364a59c95abe1602edbe166d2991b6047bababe7c36aeb9733edcc640fd"
 }

--- a/.derived/spec-registry/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/spec-registry/by-spec/078-the-protocol-has-an-owner.json
@@ -32,10 +32,10 @@
       "Verification"
     ],
     "specPath": "specs/078-the-protocol-has-an-owner/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Root `AGENTS.md` is the cross-agent authority: the protocol `/prime` executes, the gate list every skill inlines a subset of, and the document spec 051's parity test compares this repository's CI against. No spec in the corpus establishes it. Seven approved specs reach it with an `extends` edge naming spec 029, but 029 establishes exactly one unit, `kit/`, and root `AGENTS.md` is outside that subtree, so the ledger records an owner that never established the file. That is not a defect: `extends` means \"adds surface to a predecessor\", so those edges are the corpus's ordinary convention, and measurement confirms it. What is genuinely missing is narrower. The protocol file has no `establishes` claim at all, so the ledger has no direct answer to who owns it. This spec supplies one, and requires the file to name the spec that governs it, the same \"a file naming its own spec\" move the comment headers make for source. It clarifies the ledger only; it changes no behavior and amends nobody.\n",
     "title": "The protocol has an owner"
   },
-  "shardHash": "a1137a896fe3666a98c6b714c818b3627ca5a50ebadfa08e19d875606377904e",
+  "shardHash": "91889c82fe8492fd37d6dfdc1e087a7a8a236aa19f773b1e7b0d4d00beb6848c",
   "specVersion": "1.2.0"
 }

--- a/specs/078-the-protocol-has-an-owner/spec.md
+++ b/specs/078-the-protocol-has-an-owner/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "078-the-protocol-has-an-owner"
 title: "The protocol has an owner"
-status: draft
+status: approved
 kind: "governance"
 created: "2026-09-08"
 implementation: complete
@@ -52,8 +52,8 @@ Seven approved specs (047, 048, 051, 063, 072, 074 and 075) declare an
 correct**. `extends` is defined in `edges.rs` as "adds surface to a
 predecessor": the unit is surface the extending spec adds, and it need not
 already sit in the target's territory. That is the corpus's ordinary
-convention, measured rather than assumed, and it is the sole claim about a
-fifth of this repository's source files have.
+convention, measured rather than assumed, and it is the sole claim that about
+a fifth of this repository's source files have.
 
 **What is missing is narrower, and it is a gap in the ledger rather than a
 defect in anyone's frontmatter.** Every one of those seven edges says "I add


### PR DESCRIPTION
## Summary

Flips spec 078 from `draft` to `approved`. The evidence is complete on main:

| Check | State |
|---|---|
| Built and merged | `12dbc6e`, `implementation: complete` |
| Claim live in the ledger | typed owner read lists 078 as establishing `AGENTS.md` |
| File names its spec | `> Governed by specs/078-the-protocol-has-an-owner/spec.md.` |
| Acceptance on main | **6 of 6**, having failed at command 3 before the build |
| Gate | `check --fail-on-unresolved --fail-on-warn` 0, lint 0, coverage 0 |

Every text correction landed in the build PR (#159), so this is the flip plus one grammar fix.

## The one edit

§1 read "the sole claim about a fifth of this repository's source files have", which drops a "that". Now:

> and it is the sole claim **that** about a fifth of this repository's source files have.

The construction came from both drafting and review, so the fault is shared.

## What is deliberately not fixed

077 carries the same construction at `specs/077-compile-warnings-reach-the-gate/spec.md:138`, and 077 is already `approved`. Editing an approved spec is a human's decision, not an agent's, and the meaning is clear as it stands, so it is left alone. It can ride a later PR on request.

## Scope

Three files: the spec and its two shards. `spec.md` is not in `[index] extra_hashed_inputs`, so nothing else restales. `couple` clears at 1 path.

After this lands the corpus reads **78 approved, 1 draft**, with 074 the only draft remaining.