### PR TITLE
docs(079): a dead glob is dead in both tables

### DIFF
--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2eb5710ba4c613add93fa1dea847ebf791ff9389cf2d5591b7de014603ff407a"
+  "shardHash": "5df03f856f0ca46d554c57277af2ef9c6e5d59c4a476b29470c97f108624e64a"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e19cbc4e0d9789221ba38f7fbdae728bef034ed8eb80f638cc94068a215cec7"
+  "shardHash": "da221e294ef1cf14ce9f7b749557190537ff2776a353c156d44bbbc6e1ae7f74"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5df03f856f0ca46d554c57277af2ef9c6e5d59c4a476b29470c97f108624e64a"
+  "shardHash": "5a9a6bab7f67f37752a68119f0b78e6ed2ef64e0478c4dbf66b41fc62643bb68"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b02997bf5959d9c8b9a3457164e3b5c5710b9057616e50abab73a90bd853205f"
+  "shardHash": "fadcae0fa0e2e25f086893f19e2fdb36fe5663a860bc0eab720c3f0a68b3b496"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "da221e294ef1cf14ce9f7b749557190537ff2776a353c156d44bbbc6e1ae7f74"
+  "shardHash": "b02997bf5959d9c8b9a3457164e3b5c5710b9057616e50abab73a90bd853205f"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fadcae0fa0e2e25f086893f19e2fdb36fe5663a860bc0eab720c3f0a68b3b496"
+  "shardHash": "af1347fe70448e10d1ed8f8cf61581b7537b689c4ef7eca381a12f87ff0105ed"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -1,0 +1,52 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "003-conformance-lint",
+      "012-index-hash-slices",
+      "053-depends-on-ordinal-monotonicity",
+      "069-the-shipped-default-hashes-what-it-names"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-core/src/lint.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/lint.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/lint.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      }
+    ],
+    "specId": "079-a-dead-glob-is-dead-in-both-tables",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "2eb5710ba4c613add93fa1dea847ebf791ff9389cf2d5591b7de014603ff407a"
+}

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5a9a6bab7f67f37752a68119f0b78e6ed2ef64e0478c4dbf66b41fc62643bb68"
+  "shardHash": "5e19cbc4e0d9789221ba38f7fbdae728bef034ed8eb80f638cc94068a215cec7"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "af1347fe70448e10d1ed8f8cf61581b7537b689c4ef7eca381a12f87ff0105ed"
+  "shardHash": "8576a124905c57b8fa8b07b91dfa2d9d9e903fb73d357b00a5b9a2c16a074ca7"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 carried seventeen dead patterns, nine in the table the lint reads and eight in the table it does not. A fix pass corrected all nine and six of the eight; the two survivors reached an already-reviewed pull request and were caught by a second human reading, since no tool could report them. Both pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "5bcfe8d5bfaebf445c02d5226e40438fd1f4279ffac88dbb5e9b74ed970c772b",
+  "shardHash": "73393c1dfb78ee4b9f46b070c2090220cab3c8ed3be61242fa70635d9d0fdaa9",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -1,0 +1,53 @@
+{
+  "record": {
+    "created": "2026-09-09",
+    "dependsOn": [
+      "003-conformance-lint",
+      "012-index-hash-slices",
+      "053-depends-on-ordinal-monotonicity",
+      "069-the-shipped-default-hashes-what-it-names"
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "003-conformance-lint",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lint.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "053-depends-on-ordinal-monotonicity",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/lint.rs"
+        }
+      }
+    ],
+    "id": "079-a-dead-glob-is-dead-in-both-tables",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "risk": "low",
+    "sectionHeadings": [
+      "079: A dead glob is dead in both tables",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `L-010` reads both pattern tables",
+      "3.2 The message names which table, and which slice",
+      "3.3 The slice message MUST NOT claim a content hash",
+      "3.4 The refusal is proven on a fixture, not on this corpus",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/079-a-dead-glob-is-dead-in-both-tables/spec.md",
+    "status": "draft",
+    "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
+    "title": "A dead glob is dead in both tables"
+  },
+  "shardHash": "5ed53d69ddfdb4d4da9f62b955313ab5d95d29271df552e65624531f3be9d31d",
+  "specVersion": "1.2.0"
+}

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "afe499b6ce82e17cdcbb80229ae04626a58b05f4048743361f4de517a16570b8",
+  "shardHash": "d52fe1fd8cbe46eb9a6f285b686b0f14b7d1da341b24aff3ed5f6640038bae17",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "5ed53d69ddfdb4d4da9f62b955313ab5d95d29271df552e65624531f3be9d31d",
+  "shardHash": "7827dec7a3771293e03cf6d3d2aa5bd4c2487b020de2b81101b3413b7fa67418",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "d52fe1fd8cbe46eb9a6f285b686b0f14b7d1da341b24aff3ed5f6640038bae17",
+  "shardHash": "9cf1b16b99f91d81b77edf3b795d846ea2fc8edc7a7d7dddf35c4238a8b4a3bc",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "4bbc86e9bd0f3b7a271d670e3ae10f0e0b82898e1dfcf0eae12cf42a0b699218",
+  "shardHash": "afe499b6ce82e17cdcbb80229ae04626a58b05f4048743361f4de517a16570b8",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -45,9 +45,9 @@
     ],
     "specPath": "specs/079-a-dead-glob-is-dead-in-both-tables/spec.md",
     "status": "draft",
-    "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
+    "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 carried seventeen dead patterns, nine in the table the lint reads and eight in the table it does not. A fix pass corrected all nine and six of the eight; the two survivors reached an already-reviewed pull request and were caught by a second human reading, since no tool could report them. Both pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "9cf1b16b99f91d81b77edf3b795d846ea2fc8edc7a7d7dddf35c4238a8b4a3bc",
+  "shardHash": "7852ec0c608caa896375c748f30cdafc768e20254ffd0159602fe99144b5633f",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 carried seventeen dead patterns, nine in the table the lint reads and eight in the table it does not. A fix pass corrected all nine and six of the eight; the two survivors reached an already-reviewed pull request and were caught by a second human reading, since no tool could report them. Both pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "7852ec0c608caa896375c748f30cdafc768e20254ffd0159602fe99144b5633f",
+  "shardHash": "5bcfe8d5bfaebf445c02d5226e40438fd1f4279ffac88dbb5e9b74ed970c772b",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 had nine dead patterns across the two tables; the slice half survived a fix pass and a review because nothing named it, and the survivors pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "7827dec7a3771293e03cf6d3d2aa5bd4c2487b020de2b81101b3413b7fa67418",
+  "shardHash": "4bbc86e9bd0f3b7a271d670e3ae10f0e0b82898e1dfcf0eae12cf42a0b699218",
   "specVersion": "1.2.0"
 }

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -108,6 +108,17 @@ reporting, and for a slice it MUST name the slice. A reader who sees `L-010`
 against `workflows` must be able to find the offending line without guessing
 which table it came from.
 
+Each violation MUST occupy **one line**, as every existing `L-` code's message
+already does. This is not a style preference, it is what makes 3.3's prohibition
+checkable. A reader, and the acceptance in 3.4, isolates a slice's violation by
+selecting the line naming the table; if a message were split across a summary
+line and a continuation, a filter that selects the naming line would not see the
+rest of the claim, and a negative assertion over it would pass while the
+forbidden text sat one line below. The alternative, searching the whole output
+for the forbidden phrase, cannot work here either, because the
+`extra_hashed_inputs` form of `L-010` says `content hash` legitimately and would
+trip it. One line per violation is what keeps the two forms separable.
+
 ### 3.3 The slice message MUST NOT claim a content hash
 
 The existing `L-010` text ends "so it can contribute no bytes to any content
@@ -135,6 +146,11 @@ cannot demonstrate the rule and could not regress if the rule were deleted.
 Acceptance MUST construct a config that trips the rule and assert the refusal
 against it, and MUST also assert the corrected form passes, so the test pins
 the boundary rather than the mere presence of a warning.
+
+The negative assertion of 3.3 MUST be scoped to the slice's own line, which
+3.2's one-line rule makes sound, rather than run over the whole output: the
+`extra_hashed_inputs` form of the same code says `content hash` correctly, so an
+unscoped search would refuse a true message.
 
 It MUST additionally assert that a bare `lint` exits 0 on the tripping fixture.
 Asserting only the `--fail-on-warn` refusal leaves the tier half-proven: an
@@ -195,7 +211,13 @@ carries the same two units the same two ways, so this follows the path already
 taken for these exact files. The routing is worth stating because the corpus is
 not consistent about it: specs 057 and 058 carry `tests/lint.rs` through 003,
 which does not own it, and an `extends` unit is a first-class claim either way,
-so nothing refuses them. And 074 is still `status: draft`, held only by its §3.6, which is
+so nothing refuses them.
+
+053 also appears in `depends_on`, where the relationship is ownership routing
+rather than behavioral precedence: 079 needs nothing 053 decided about ordinal
+monotonicity, it needs the file 053 created. The field name implies more than is
+meant, so it is written down here rather than left for a reader auditing the
+dependency graph to find surprising. And 074 is still `status: draft`, held only by its §3.6, which is
 about deleting `kit/scripts/verify-spec.sh` and has nothing to do with this
 rule; making 079 depend on 074 would report 079 as blocked behind a decision it
 does not wait on. 074 is named throughout the prose as the rule's origin, which

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -121,6 +121,13 @@ The slice message MUST therefore speak about the slice's own hash, the one
 hash is affected. Reusing the existing sentence verbatim would ship a false
 statement under a true code.
 
+The prohibition is on the **claim**, in whichever spelling: neither
+`content hash` nor `contentHash` may appear in a slice's `L-010` message. Naming
+both forms is not pedantry. The acceptance in 3.4 asserts the absence of that
+phrase, and an assertion that matches only one spelling passes trivially against
+an implementation that emits the other, which would leave the rule this section
+exists to enforce untested.
+
 ### 3.4 The refusal is proven on a fixture, not on this corpus
 
 This repository declares no `[index.slices]` table, so its own `lint` output
@@ -140,10 +147,22 @@ spec.
 
 As of filing that edit is **not** on `main`: line 62 still reads
 `.github/workflows/**`. Nothing in this spec's acceptance depends on it, and 079
-can be built and ratified with 012 unchanged. It is recorded here because the
-example is the documented source of at least one adopter's dead slice table, so
-shipping the lint without correcting it leaves the tool refusing a form its own
-specification still teaches.
+can be built with 012 unchanged.
+
+What the gap is, precisely. `lint` reads `spec-spine.toml`, not spec markdown,
+so 012's fenced example changes no verdict for anyone and nothing regresses in
+the tool. The cost is entirely on the reading side: an adopter who copies the
+example writes a pattern the tool then refuses, which is how at least one
+adopter's dead slice table got there. That makes it a documentation defect with
+a measured victim, not a behavior defect.
+
+Who does it and when. The edit is a human's, because 012 is approved and a draft
+may not rewrite it. It **should land before 079 is ratified**, so that no window
+exists in which the corpus has ratified a rule its own specification
+contradicts. This spec does not block on it: building 079, and merging the
+build, are fine with 012 unchanged. Ratification is the gate, and it is the
+ratifier's check rather than an acceptance criterion, since 079 cannot assert
+anything about a file it does not claim.
 
 **An `L-008` analogue for slices.** `L-008` flags a claimed path that no content
 hash witnesses. A slice is an opt-in named group, not an ownership claim, so
@@ -160,9 +179,16 @@ the lint tier for the same rule and this spec does not reopen that.
 
 D-1 (2026-09-09, the edge target). The lint unit is claimed through
 `003-conformance-lint`, not through `074-shipped-is-not-the-same-as-working`,
-even though 074 is where `L-010` was established. Two reasons. 074 itself
-carries `lint.rs` through 003, so this follows the path already taken for this
-exact file. And 074 is still `status: draft`, held only by its §3.6, which is
+even though 074 is where `L-010` was established, and the test file is claimed
+through `053-depends-on-ordinal-monotonicity`. Each unit is routed through the
+spec that **establishes** it: 003 establishes `crates/spec-spine-core/src/lint.rs`,
+and 053 establishes `crates/spec-spine-core/tests/lint.rs`, which it created
+because `L-007` was the first rule to need a dedicated lint test file. 074
+carries the same two units the same two ways, so this follows the path already
+taken for these exact files. The routing is worth stating because the corpus is
+not consistent about it: specs 057 and 058 carry `tests/lint.rs` through 003,
+which does not own it, and an `extends` unit is a first-class claim either way,
+so nothing refuses them. And 074 is still `status: draft`, held only by its §3.6, which is
 about deleting `kit/scripts/verify-spec.sh` and has nothing to do with this
 rule; making 079 depend on 074 would report 079 as blocked behind a decision it
 does not wait on. 074 is named throughout the prose as the rule's origin, which
@@ -197,7 +223,7 @@ target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'wo
 # 3.3: no line about a slice claims a content hash is affected. The line above
 # already asserts a slice line exists, so this one only has to be negative, and
 # it runs the binary once.
-! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep 'index.slices' | grep -q 'content hash'
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep 'index.slices' | grep -qiE 'content ?hash'
 # 3.4: the corrected form passes, so the test pins the boundary.
 printf '[index.slices]\nworkflows = [".github/workflows/**/*"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn
 rm -rf "${TMPDIR:-/tmp}/ss079"

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -48,6 +48,14 @@ documented in its own doc comment as carrying "`extra_hashed_inputs` pattern
 semantics", and the slice walk in `index.rs` keeps only files exactly as the
 global one does. So `dir/**` is equally inert there, and nothing says so.
 
+Spec 069 fixed the shipped default to the `**/*` form and, by its own §4,
+deferred the lint: a pattern matching nothing today can be a legitimate
+forward-looking entry, and 069 would not refuse a form on that evidence. 074
+§3.1 took the lint up once the form was shown to be inert under every tree
+rather than merely empty under this one. Neither pass looked at the second
+table, so the value 069 could not reach in an adopter's own file is still
+unreachable there.
+
 This is not hypothetical. An adopter audited on 2026-09-09 carried nine dead
 patterns across the two tables. The six in `extra_hashed_inputs` were found and
 fixed; the two in `[index.slices]` survived the same fix pass and reached a pull
@@ -128,7 +136,14 @@ teaches `workflows = [".github/workflows/**"]`, the dead form, and adopter
 slice tables were copied from it. 012 is approved, and a new spec does not get
 to rewrite an approved spec's text through its own decision entry. That
 correction is a human's direct one-token edit to line 62, taken outside this
-spec and before it.
+spec.
+
+As of filing that edit is **not** on `main`: line 62 still reads
+`.github/workflows/**`. Nothing in this spec's acceptance depends on it, and 079
+can be built and ratified with 012 unchanged. It is recorded here because the
+example is the documented source of at least one adopter's dead slice table, so
+shipping the lint without correcting it leaves the tool refusing a form its own
+specification still teaches.
 
 **An `L-008` analogue for slices.** `L-008` flags a claimed path that no content
 hash witnesses. A slice is an opt-in named group, not an ownership claim, so
@@ -179,8 +194,10 @@ target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn ; t
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'L-010'
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'index.slices'
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'workflows'
-# 3.3: the slice message does not claim a content hash is affected.
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'index.slices' && ! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep 'index.slices' | grep -q 'content hash'
+# 3.3: no line about a slice claims a content hash is affected. The line above
+# already asserts a slice line exists, so this one only has to be negative, and
+# it runs the binary once.
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep 'index.slices' | grep -q 'content hash'
 # 3.4: the corrected form passes, so the test pins the boundary.
 printf '[index.slices]\nworkflows = [".github/workflows/**/*"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn
 rm -rf "${TMPDIR:-/tmp}/ss079"

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -243,12 +243,25 @@ dead form one table over.
 
 ## Verification
 
-Every assertion below fails against pre-079 code: `lint` does not read
-`[index.slices]` at all today, so the fixture that trips the rule exits 0.
+The two assertions that carry the rule fail against pre-079 code, because
+`lint` does not read `[index.slices]` at all today: the co-occurrence chain and
+the `--fail-on-warn` refusal both exit non-zero. The bare-`lint` tier line and
+the corrected-form line are boundary controls and pass both before and after,
+which is what makes them controls.
 
 Each line is one command. Spec 049 §3.2 makes a fence's body line a command, so
 no line may depend on a variable another line set, and the fixture setup is one
 long line rather than a continuation.
+
+Each line is run as its own `sh -c`, a full POSIX shell, with no `set -e`
+(`crates/spec-spine-cli/src/cmd_verify.rs`, the `Command::new("sh").arg("-c")`
+call that executes each planned command and compares its status). That is what
+makes `;`, `!` and `&&` mean what they read as, and in particular what makes
+`<cmd> ; test $? -eq 1` a real assertion rather than a no-op: `$?` is the
+preceding command's status in the same shell. Spec 059's block, approved and
+`implementation: complete`, relies on the same guarantee. Stated here because a
+reader who assumes a restricted line executor would read the tier assertion as
+vacuous, and the tier is the claim this spec most needs to hold.
 
 ```verify:cli
 cargo build --release --locked
@@ -262,7 +275,7 @@ target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn ; t
 # string appears somewhere, which an implementation splitting the message across
 # lines would satisfy while leaving 3.2's one-line rule unverified and 3.3's
 # scoped negative toothless. The chain proves all three share one line.
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -F 'L-010' | grep -F 'index.slices' | grep -q 'workflows'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -F 'L-010' | grep -F 'index.slices' | grep -qF 'workflows'
 # 3.1: the tier. A bare `lint` reports the warning and still exits 0; an
 # implementation that promoted it to an error would pass every other line here.
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -136,6 +136,13 @@ Acceptance MUST construct a config that trips the rule and assert the refusal
 against it, and MUST also assert the corrected form passes, so the test pins
 the boundary rather than the mere presence of a warning.
 
+It MUST additionally assert that a bare `lint` exits 0 on the tripping fixture.
+Asserting only the `--fail-on-warn` refusal leaves the tier half-proven: an
+implementation that emitted `L-010` at error tier would satisfy every other
+assertion here while contradicting 3.1. The tier is the claim most easily lost
+in implementation, because promoting a warning is the natural reflex when a
+rule turns out to have no legitimate counter-example.
+
 ## 4. Out of scope
 
 **Correcting spec 012's own example.** `specs/012-index-hash-slices/spec.md`
@@ -218,12 +225,15 @@ rm -rf "${TMPDIR:-/tmp}/ss079" && mkdir -p "${TMPDIR:-/tmp}/ss079/specs/001-x" &
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn ; test $? -eq 1
 # 3.2: the message names the table and the slice.
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'L-010'
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'index.slices'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -qF 'index.slices'
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'workflows'
+# 3.1: the tier. A bare `lint` reports the warning and still exits 0; an
+# implementation that promoted it to an error would pass every other line here.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint
 # 3.3: no line about a slice claims a content hash is affected. The line above
 # already asserts a slice line exists, so this one only has to be negative, and
 # it runs the binary once.
-! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep 'index.slices' | grep -qiE 'content ?hash'
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -F 'index.slices' | grep -qiE 'content ?hash'
 # 3.4: the corrected form passes, so the test pins the boundary.
 printf '[index.slices]\nworkflows = [".github/workflows/**/*"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn
 rm -rf "${TMPDIR:-/tmp}/ss079"

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -9,8 +9,10 @@ summary: >
   where it enumerates directories and can contribute no bytes. `[index.slices]`
   carries pattern lists with the same documented semantics and the same
   file-only walk, and the lint is silent about it. An adopter audited on
-  2026-09-09 had nine dead patterns across the two tables; the slice half
-  survived a fix pass and a review because nothing named it, and the survivors
+  2026-09-09 carried seventeen dead patterns, nine in the table the lint reads
+  and eight in the table it does not. A fix pass corrected all nine and six of
+  the eight; the two survivors reached an already-reviewed pull request and were
+  caught by a second human reading, since no tool could report them. Both
   pointed at directories that do not exist yet, so they would have stayed
   silently empty on the day those directories arrived. This spec extends the
   rule to the second table, and requires the slice message to speak about the
@@ -56,14 +58,20 @@ rather than merely empty under this one. Neither pass looked at the second
 table, so the value 069 could not reach in an adopter's own file is still
 unreachable there.
 
-This is not hypothetical. An adopter audited on 2026-09-09 carried nine dead
-patterns across the two tables. The six in `extra_hashed_inputs` were found and
-fixed; the two in `[index.slices]` survived the same fix pass and reached a pull
-request that had already been reviewed once, precisely because no lint named
-them and the fix was driven off the lint's output. The remaining dead slice
-patterns pointed at directories that do not exist yet, which is the worse half
-of the defect: they cost nothing on the day they are written and stay silently
-empty on the day the directory arrives.
+This is not hypothetical. An adopter audited on 2026-09-09 carried **seventeen**
+dead patterns: nine in `[index] extra_hashed_inputs` and eight in
+`[index.slices]`. A fix pass corrected all nine in the table the lint reads, and
+six of the eight in the table it does not. The two survivors, `deploy/**` and
+`eval/**`, reached a pull request that had already been reviewed once, and were
+caught by a second human reading rather than by any tool, because no tool can
+report them. A second adopter in the same audit carried six more in
+`extra_hashed_inputs` and declares no slices table at all.
+
+That split is the argument. The table `L-010` reads came out of the pass clean,
+and the table it does not read came out of the same pass still broken, with
+nothing able to say so. Both survivors pointed at directories that do not exist
+yet, which is the worse half of the defect: they cost nothing on the day they
+are written and stay silently empty on the day the directory arrives.
 
 An adopter who upgrades is currently told about one table and not the other.
 That is a worse position than being told about neither, because the silence

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -1,0 +1,190 @@
+---
+id: "079-a-dead-glob-is-dead-in-both-tables"
+title: "A dead glob is dead in both tables"
+status: draft
+kind: "tooling"
+created: "2026-09-09"
+summary: >
+  `L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`,
+  where it enumerates directories and can contribute no bytes. `[index.slices]`
+  carries pattern lists with the same documented semantics and the same
+  file-only walk, and the lint is silent about it. An adopter audited on
+  2026-09-09 had nine dead patterns across the two tables; the slice half
+  survived a fix pass and a review because nothing named it, and the survivors
+  pointed at directories that do not exist yet, so they would have stayed
+  silently empty on the day those directories arrived. This spec extends the
+  rule to the second table, and requires the slice message to speak about the
+  slice's own hash rather than repeating a sentence about `contentHash` that is
+  false for slices.
+implementation: pending
+owner: "The spec-spine Authors"
+risk: low
+depends_on:
+  - "003-conformance-lint"
+  - "012-index-hash-slices"
+  - "053-depends-on-ordinal-monotonicity"
+  - "069-the-shipped-default-hashes-what-it-names"
+extends:
+  # 3.1 to 3.3: the rule, and the message that has to say which table it is
+  # talking about. Claimed the way spec 074 claimed the same file when it
+  # added `L-010` in the first place, through 003 rather than through 074:
+  # see the decision in section 5.
+  - { spec: "003-conformance-lint", unit: "crates/spec-spine-core/src/lint.rs", nature: additive }
+  # 3.4: the rule's own acceptance, on a fixture rather than this corpus.
+  - { spec: "053-depends-on-ordinal-monotonicity", unit: "crates/spec-spine-core/tests/lint.rs", nature: additive }
+---
+
+# 079: A dead glob is dead in both tables
+
+## 1. Purpose
+
+`L-010` (spec 074 §3.1) refuses an `[index] extra_hashed_inputs` pattern ending
+in `/**`, because in the `glob` crate `dir/**` enumerates directories and the
+hasher keeps only files, so such a pattern can never contribute a byte. The
+lint reads that one table and is silent about the other.
+
+`[index.slices]` (spec 012) holds pattern lists too. `IndexConfig::slices` is
+documented in its own doc comment as carrying "`extra_hashed_inputs` pattern
+semantics", and the slice walk in `index.rs` keeps only files exactly as the
+global one does. So `dir/**` is equally inert there, and nothing says so.
+
+This is not hypothetical. An adopter audited on 2026-09-09 carried nine dead
+patterns across the two tables. The six in `extra_hashed_inputs` were found and
+fixed; the two in `[index.slices]` survived the same fix pass and reached a pull
+request that had already been reviewed once, precisely because no lint named
+them and the fix was driven off the lint's output. The remaining dead slice
+patterns pointed at directories that do not exist yet, which is the worse half
+of the defect: they cost nothing on the day they are written and stay silently
+empty on the day the directory arrives.
+
+An adopter who upgrades is currently told about one table and not the other.
+That is a worse position than being told about neither, because the silence
+reads as clearance.
+
+## 2. Territory
+
+This spec claims no new file. It extends two units it shares with the specs
+that own them:
+
+- `crates/spec-spine-core/src/lint.rs`, through `003-conformance-lint`, for the
+  rule and its message. Spec 074 carries the same unit through the same spec.
+- `crates/spec-spine-core/tests/lint.rs`, through
+  `053-depends-on-ordinal-monotonicity`, for the acceptance.
+
+`spec-spine.toml` in this repository declares no `[index.slices]` table and this
+spec does not add one. Section 3.4 says what that costs and how acceptance is
+arranged around it.
+
+## 3. Behavior
+
+### 3.1 `L-010` reads both pattern tables
+
+`lint` MUST apply the `L-010` rule to every pattern in every list under
+`[index.slices]`, under the same test it applies to
+`[index] extra_hashed_inputs`: a pattern ending in `/**` is refused.
+
+The check stays on the **pattern**, not on whether it currently matches, for
+the reason 074 §3.1 already gave: a pattern matching nothing today is a
+legitimate forward-looking entry in a specify-first corpus, while a pattern
+ending `/**` is inert under every tree and so is decidable from the config
+alone. That reasoning is if anything stronger here, since the adopter evidence
+above is exactly a forward-looking slice entry that would never have fired.
+
+It stays at **warning** tier, so `lint --fail-on-warn` refuses it and a bare
+`lint` reports it.
+
+### 3.2 The message names which table, and which slice
+
+One code now covers two tables, so the message MUST say which one it is
+reporting, and for a slice it MUST name the slice. A reader who sees `L-010`
+against `workflows` must be able to find the offending line without guessing
+which table it came from.
+
+### 3.3 The slice message MUST NOT claim a content hash
+
+The existing `L-010` text ends "so it can contribute no bytes to any content
+hash". That is true of `extra_hashed_inputs` and **false of a slice**: spec 012
+makes slices independent of the global hash, and `IndexConfig::slices` says so
+in terms ("listing a file here does NOT fold it into `contentHash`"). A correct
+slice pattern contributes no bytes to `contentHash` either.
+
+The slice message MUST therefore speak about the slice's own hash, the one
+`index check --slice <name>` gates, and MUST NOT tell the reader their content
+hash is affected. Reusing the existing sentence verbatim would ship a false
+statement under a true code.
+
+### 3.4 The refusal is proven on a fixture, not on this corpus
+
+This repository declares no `[index.slices]` table, so its own `lint` output
+cannot demonstrate the rule and could not regress if the rule were deleted.
+Acceptance MUST construct a config that trips the rule and assert the refusal
+against it, and MUST also assert the corrected form passes, so the test pins
+the boundary rather than the mere presence of a warning.
+
+## 4. Out of scope
+
+**Correcting spec 012's own example.** `specs/012-index-hash-slices/spec.md`
+teaches `workflows = [".github/workflows/**"]`, the dead form, and adopter
+slice tables were copied from it. 012 is approved, and a new spec does not get
+to rewrite an approved spec's text through its own decision entry. That
+correction is a human's direct one-token edit to line 62, taken outside this
+spec and before it.
+
+**An `L-008` analogue for slices.** `L-008` flags a claimed path that no content
+hash witnesses. A slice is an opt-in named group, not an ownership claim, so
+"claimed but in no slice" is not a defect and must not become a warning.
+
+**Folding slices into `contentHash`.** Their independence is spec 012's design,
+and 3.3 depends on it rather than changing it.
+
+**Refusing the form at config load.** `deny_unknown_fields` style refusal would
+make this exit 3 at parse time in every verb, including read verbs. 074 chose
+the lint tier for the same rule and this spec does not reopen that.
+
+## 5. Resolved decisions
+
+D-1 (2026-09-09, the edge target). The lint unit is claimed through
+`003-conformance-lint`, not through `074-shipped-is-not-the-same-as-working`,
+even though 074 is where `L-010` was established. Two reasons. 074 itself
+carries `lint.rs` through 003, so this follows the path already taken for this
+exact file. And 074 is still `status: draft`, held only by its §3.6, which is
+about deleting `kit/scripts/verify-spec.sh` and has nothing to do with this
+rule; making 079 depend on 074 would report 079 as blocked behind a decision it
+does not wait on. 074 is named throughout the prose as the rule's origin, which
+is where that relationship belongs.
+
+D-2 (2026-09-09, one code rather than `L-011`). The defect, the reasoning and
+the remedy are identical in both tables; only the sentence about what is lost
+differs, which 3.3 handles. A second code would make an adopter learn two names
+for one mistake, and would let a corpus pass `L-010` while carrying the same
+dead form one table over.
+
+## Verification
+
+Every assertion below fails against pre-079 code: `lint` does not read
+`[index.slices]` at all today, so the fixture that trips the rule exits 0.
+
+Each line is one command. Spec 049 §3.2 makes a fence's body line a command, so
+no line may depend on a variable another line set, and the fixture setup is one
+long line rather than a continuation.
+
+```verify:cli
+cargo build --release --locked
+cargo test -p spec-spine-core --test lint --locked
+# 3.1: a fixture whose only defect is a dead pattern in a slice.
+rm -rf "${TMPDIR:-/tmp}/ss079" && mkdir -p "${TMPDIR:-/tmp}/ss079/specs/001-x" && printf '[index.slices]\nworkflows = [".github/workflows/**"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-09"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n' > "${TMPDIR:-/tmp}/ss079/specs/001-x/spec.md"
+# 3.1: the warning tier refuses it under --fail-on-warn.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn ; test $? -eq 1
+# 3.2: the message names the table and the slice.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'L-010'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'index.slices'
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'workflows'
+# 3.3: the slice message does not claim a content hash is affected.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'index.slices' && ! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep 'index.slices' | grep -q 'content hash'
+# 3.4: the corrected form passes, so the test pins the boundary.
+printf '[index.slices]\nworkflows = [".github/workflows/**/*"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn
+rm -rf "${TMPDIR:-/tmp}/ss079"
+# 3.4: this repository declares no slices table, so its own lint is unmoved.
+target/release/spec-spine lint --fail-on-warn
+target/release/spec-spine compile --check
+```

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -204,24 +204,28 @@ D-1 (2026-09-09, the edge target). The lint unit is claimed through
 `003-conformance-lint`, not through `074-shipped-is-not-the-same-as-working`,
 even though 074 is where `L-010` was established, and the test file is claimed
 through `053-depends-on-ordinal-monotonicity`. Each unit is routed through the
-spec that **establishes** it: 003 establishes `crates/spec-spine-core/src/lint.rs`,
-and 053 establishes `crates/spec-spine-core/tests/lint.rs`, which it created
-because `L-007` was the first rule to need a dedicated lint test file. 074
+spec that **establishes** it: 003 establishes
+`crates/spec-spine-core/src/lint.rs`, and 053 establishes
+`crates/spec-spine-core/tests/lint.rs`, which it created because `L-007` was the
+first rule to need a dedicated lint test file. 074
 carries the same two units the same two ways, so this follows the path already
 taken for these exact files. The routing is worth stating because the corpus is
 not consistent about it: specs 057 and 058 carry `tests/lint.rs` through 003,
 which does not own it, and an `extends` unit is a first-class claim either way,
 so nothing refuses them.
 
+074 is left out of both edge lists for a second reason. It is still
+`status: draft`, held only by its §3.6, which is about deleting
+`kit/scripts/verify-spec.sh` and has nothing to do with this rule. Making 079
+depend on 074 would report 079 as blocked behind a decision it does not wait on.
+074 is named throughout the prose as the rule's origin, which is where that
+relationship belongs.
+
 053 also appears in `depends_on`, where the relationship is ownership routing
 rather than behavioral precedence: 079 needs nothing 053 decided about ordinal
 monotonicity, it needs the file 053 created. The field name implies more than is
 meant, so it is written down here rather than left for a reader auditing the
-dependency graph to find surprising. And 074 is still `status: draft`, held only by its §3.6, which is
-about deleting `kit/scripts/verify-spec.sh` and has nothing to do with this
-rule; making 079 depend on 074 would report 079 as blocked behind a decision it
-does not wait on. 074 is named throughout the prose as the rule's origin, which
-is where that relationship belongs.
+dependency graph to find surprising.
 
 D-2 (2026-09-09, one code rather than `L-011`). The defect, the reasoning and
 the remedy are identical in both tables; only the sentence about what is lost
@@ -246,9 +250,11 @@ rm -rf "${TMPDIR:-/tmp}/ss079" && mkdir -p "${TMPDIR:-/tmp}/ss079/specs/001-x" &
 # 3.1: the warning tier refuses it under --fail-on-warn.
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn ; test $? -eq 1
 # 3.2: the message names the table and the slice.
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'L-010'
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -qF 'index.slices'
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -q 'workflows'
+# Chained, not three independent greps: separate greps prove only that each
+# string appears somewhere, which an implementation splitting the message across
+# lines would satisfy while leaving 3.2's one-line rule unverified and 3.3's
+# scoped negative toothless. The chain proves all three share one line.
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -F 'L-010' | grep -F 'index.slices' | grep -q 'workflows'
 # 3.1: the tier. A bare `lint` reports the warning and still exits 0; an
 # implementation that promoted it to an error would pass every other line here.
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -140,9 +140,9 @@ The slice message MUST therefore speak about the slice's own hash, the one
 hash is affected. Reusing the existing sentence verbatim would ship a false
 statement under a true code.
 
-The prohibition is on the **claim**, in whichever spelling: neither
-`content hash` nor `contentHash` may appear in a slice's `L-010` message. Naming
-both forms is not pedantry. The acceptance in 3.4 asserts the absence of that
+The prohibition is on the **claim**, in whichever spelling: none of
+`content hash`, `content-hash` or `contentHash` may appear in a slice's `L-010`
+message, in any capitalisation. Naming every form is not pedantry. The acceptance in 3.4 asserts the absence of that
 phrase, and an assertion that matches only one spelling passes trivially against
 an implementation that emits the other, which would leave the rule this section
 exists to enforce untested.
@@ -154,6 +154,13 @@ cannot demonstrate the rule and could not regress if the rule were deleted.
 Acceptance MUST construct a config that trips the rule and assert the refusal
 against it, and MUST also assert the corrected form passes, so the test pins
 the boundary rather than the mere presence of a warning.
+
+The refusal assertion MUST be attributable to this rule. A bare `test $? -eq 1`
+on `lint --fail-on-warn` is satisfied by **any** warning, so it would pass on a
+fixture that tripped something unrelated, and would go on passing if this rule
+were later deleted while another warning took its place. The assertion MUST
+therefore check the same invocation's output for the slice violation as well as
+its exit code.
 
 The negative assertion of 3.3 MUST be scoped to the slice's own line, which
 3.2's one-line rule makes sound, rather than run over the whole output: the
@@ -268,8 +275,10 @@ cargo build --release --locked
 cargo test -p spec-spine-core --test lint --locked
 # 3.1: a fixture whose only defect is a dead pattern in a slice.
 rm -rf "${TMPDIR:-/tmp}/ss079" && mkdir -p "${TMPDIR:-/tmp}/ss079/specs/001-x" && printf '[index.slices]\nworkflows = [".github/workflows/**"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && printf -- '---\nid: "001-x"\ntitle: "x"\nstatus: draft\ncreated: "2026-09-09"\nsummary: "x"\nestablishes:\n  - "specs/001-x/spec.md"\n---\n\n# x\n' > "${TMPDIR:-/tmp}/ss079/specs/001-x/spec.md"
-# 3.1: the warning tier refuses it under --fail-on-warn.
-target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn ; test $? -eq 1
+# 3.1: the refusal is attributable to this rule. Exit 1 alone would be
+# satisfied by any warning at all, so the same invocation's output must also
+# carry the slice violation. One line, so no state crosses a line boundary.
+o=$(target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn 2>&1) ; test $? -eq 1 && printf '%s\n' "$o" | grep -F 'L-010' | grep -qF 'index.slices'
 # 3.2: the message names the table and the slice.
 # Chained, not three independent greps: separate greps prove only that each
 # string appears somewhere, which an implementation splitting the message across
@@ -282,7 +291,7 @@ target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint
 # 3.3: no line about a slice claims a content hash is affected. The line above
 # already asserts a slice line exists, so this one only has to be negative, and
 # it runs the binary once.
-! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -F 'index.slices' | grep -qiE 'content ?hash'
+! target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint 2>&1 | grep -F 'index.slices' | grep -qiE 'content[ -]?hash'
 # 3.4: the corrected form passes, so the test pins the boundary.
 printf '[index.slices]\nworkflows = [".github/workflows/**/*"]\n' > "${TMPDIR:-/tmp}/ss079/spec-spine.toml" && target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss079" lint --fail-on-warn
 rm -rf "${TMPDIR:-/tmp}/ss079"


### PR DESCRIPTION
Files spec 079 as `draft`. No code changes; the build is a separate PR.

## The gap

`L-010` (spec 074 §3.1) refuses an `[index] extra_hashed_inputs` pattern ending in `/**`, because in the `glob` crate `dir/**` enumerates directories and the hasher keeps only files. It reads that one table.

`[index.slices]` (spec 012) holds pattern lists too. `IndexConfig::slices` documents them as carrying "`extra_hashed_inputs` pattern semantics", and the slice walk keeps only files exactly as the global one does. So `dir/**` is equally inert there, and nothing says so.

## Why this is not hypothetical

An adopter audited on 2026-09-09 carried **nine** dead patterns across the two tables. The six in `extra_hashed_inputs` were found and fixed; the two in `[index.slices]` survived the same fix pass **and a review**, because the fix was driven off the lint's output and nothing named them.

Both survivors pointed at directories that do not exist yet. That is the worse half: they cost nothing on the day they are written and stay silently empty on the day the directory arrives.

An adopter who upgrades is currently told about one table and not the other, which is worse than being told about neither, because the silence reads as clearance.

## The part that is not a copy of 074

§3.3. The current `L-010` message ends "so it can contribute no bytes to any content hash". That is true of `extra_hashed_inputs` and **false of a slice**: spec 012 keeps slices out of `contentHash` by design, and a *correct* slice pattern contributes no bytes to it either. Reusing the sentence verbatim would ship a false statement under a true code. The slice message must speak about the slice's own hash, the one `index check --slice <name>` gates.

## Verification fails against pre-079 code

The decisive line builds a fixture whose only defect is a dead pattern in a slice, and asserts `lint --fail-on-warn` exits 1. Today it exits **0**, confirmed:

```
lint: 0 error(s), 0 warning(s), 0 info
  lint --fail-on-warn exit: 0
```

The block also pins the boundary rather than the presence of a warning: the corrected `**/*` form must pass. This repository declares no `[index.slices]` table, so its own lint cannot demonstrate the rule and could not regress if the rule were deleted, which is why acceptance is on a fixture (§3.4).

## Two edges worth a look at review

**The lint unit is claimed through `003-conformance-lint`, not through 074**, even though 074 is where `L-010` came from. 074 itself carries `lint.rs` through 003, so this follows the path already taken for the file; and 074 is still `draft`, held only by its §3.6 about deleting `kit/scripts/verify-spec.sh`, so depending on it would report 079 blocked behind a decision it does not wait on. Recorded as D-1.

**One code, not `L-011`.** Same defect, same reasoning, same remedy; only the sentence about what is lost differs, which §3.3 handles. Recorded as D-2.

## Out of scope, deliberately

`specs/012-index-hash-slices/spec.md:62` teaches the dead form, `workflows = [".github/workflows/**"]`, and adopter slice tables were copied from it. 012 is approved, and a new spec does not get to rewrite an approved spec's text through its own decision entry. That correction is a direct one-token human edit, taken outside this spec.

Gate: `compile` 80 specs 0 warnings, `lint` clean, `check` fresh on both trees, `couple` 0 with no waiver.