### PR TITLE
feat(079): a dead glob is dead in both tables

### DIFF
--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8576a124905c57b8fa8b07b91dfa2d9d9e903fb73d357b00a5b9a2c16a074ca7"
+  "shardHash": "b4d48533e8fadb5e546c68a7e843a5a66d7ede71104fa98600c6e85cc2a83dea"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -26,7 +26,7 @@
       }
     ],
     "id": "079-a-dead-glob-is-dead-in-both-tables",
-    "implementation": "pending",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "risk": "low",
@@ -48,6 +48,6 @@
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 carried seventeen dead patterns, nine in the table the lint reads and eight in the table it does not. A fix pass corrected all nine and six of the eight; the two survivors reached an already-reviewed pull request and were caught by a second human reading, since no tool could report them. Both pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "73393c1dfb78ee4b9f46b070c2090220cab3c8ed3be61242fa70635d9d0fdaa9",
+  "shardHash": "996321491dfa7a90bf8f780ae20a5eb6e87750cf74525ff9f3b5864116a3f8ce",
   "specVersion": "1.2.0"
 }

--- a/crates/spec-spine-core/src/lint.rs
+++ b/crates/spec-spine-core/src/lint.rs
@@ -289,19 +289,50 @@ pub fn lint(cfg: &Config, repo_root: &Path) -> Result<LintReport, Error> {
     //
     // Warning tier, so `lint --fail-on-warn` refuses it. Unlike `L-008`, which
     // flags a state a corpus may hold deliberately, this one never is.
-    for pattern in &cfg.index.extra_hashed_inputs {
-        if pattern.ends_with("/**") {
-            violations.push(warn(
-                "L-010",
+    //
+    // Second table (spec 079 3.1): `[index.slices]` carries pattern lists with
+    // `extra_hashed_inputs` semantics and the slice walk keeps only files, so
+    // `dir/**` is equally inert there. One code, not `L-011` (079 D-2): the
+    // defect and the remedy are identical, only the sentence about what is
+    // lost differs. An adopter audited on 2026-09-09 carried eight of these in
+    // slices after a fix pass had cleaned the table this lint already read.
+    //
+    // Each message names its table, and for a slice the slice, on one line
+    // (079 3.2). The slice message speaks about the slice's own hash, the one
+    // `index check --slice <name>` gates, and never about a content hash:
+    // slices are independent of `contentHash` by spec 012's design, so the
+    // `extra_hashed_inputs` sentence would be a false statement under a true
+    // code (079 3.3). One emission site for both tables, so the code stays
+    // unique by construction.
+    let global_dead = cfg
+        .index
+        .extra_hashed_inputs
+        .iter()
+        .filter(|p| p.ends_with("/**"))
+        .map(|pattern| {
+            format!(
+                "[index] extra_hashed_inputs pattern '{pattern}' matches \
+                 directories only, so it can contribute no bytes to any \
+                 content hash. Write it as '{pattern}/*' to match the files \
+                 under it"
+            )
+        });
+    let slice_dead = cfg.index.slices.iter().flat_map(|(name, patterns)| {
+        patterns
+            .iter()
+            .filter(|p| p.ends_with("/**"))
+            .map(move |pattern| {
                 format!(
-                    "[index] extra_hashed_inputs pattern '{pattern}' matches \
-                     directories only, so it can contribute no bytes to any \
-                     content hash. Write it as '{pattern}/*' to match the files \
-                     under it"
-                ),
-                Some("spec-spine.toml".to_string()),
-            ));
-        }
+                    "[index.slices] '{name}' pattern '{pattern}' matches \
+                     directories only, so it can contribute no bytes to the \
+                     '{name}' slice hash that `index check --slice {name}` \
+                     gates. Write it as '{pattern}/*' to match the files under \
+                     it"
+                )
+            })
+    });
+    for message in global_dead.chain(slice_dead) {
+        violations.push(warn("L-010", message, Some("spec-spine.toml".to_string())));
     }
 
     Ok(LintReport { violations })

--- a/crates/spec-spine-core/tests/lint.rs
+++ b/crates/spec-spine-core/tests/lint.rs
@@ -632,6 +632,130 @@ fn the_l010_message_names_the_working_form() {
     assert!(msg.contains("standards/**/*"), "{msg}");
 }
 
+// ── spec 079 3.1 to 3.4: L-010 reads `[index.slices]` too ───────────────────
+
+/// A corpus with one well-formed spec and the given `[index.slices]` table.
+/// No `extra_hashed_inputs`, so every `L-010` here is attributable to a slice.
+fn corpus_with_slices(slices: &[(&str, &[&str])]) -> (tempfile::TempDir, Config) {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "specs/001-a/spec.md", &spec("001-a", &[]));
+    write(tmp.path(), "src/001-a.rs", "pub fn a() {}\n");
+    let table: String = slices
+        .iter()
+        .map(|(name, patterns)| {
+            let list: String = patterns.iter().map(|p| format!("\"{p}\", ")).collect();
+            format!("{name} = [{list}]\n")
+        })
+        .collect();
+    let cfg = load_config(&format!("[index.slices]\n{table}")).unwrap();
+    (tmp, cfg)
+}
+
+fn l010_messages(tmp: &tempfile::TempDir, cfg: &Config) -> Vec<(String, Severity)> {
+    spec_spine_core::lint::lint(cfg, tmp.path())
+        .unwrap()
+        .violations
+        .into_iter()
+        .filter(|v| v.code == "L-010")
+        .map(|v| (v.message, v.severity))
+        .collect()
+}
+
+/// Spec 079 3.1: the same rule, the same code, the same tier, applied to every
+/// pattern in every slice. The check is on the pattern: `deploy/**` pointed at
+/// a directory that did not exist yet, which is exactly the entry that would
+/// have stayed silently empty on the day it arrived.
+#[test]
+fn l010_refuses_a_slice_pattern_that_can_match_no_file() {
+    let (tmp, cfg) = corpus_with_slices(&[
+        ("workflows", &[".github/workflows/**"]),
+        ("ops", &["deploy/**", "eval/**", "Makefile"]),
+    ]);
+    let found = l010_messages(&tmp, &cfg);
+    assert_eq!(found.len(), 3, "one per dead pattern: {found:?}");
+    assert!(
+        found.iter().all(|(_, sev)| *sev == Severity::Warning),
+        "L-010 stays warning tier for slices: {found:?}"
+    );
+}
+
+/// Spec 079 3.4: the corrected form passes, so the test pins the boundary and
+/// not the mere presence of a warning.
+#[test]
+fn l010_is_silent_on_the_working_slice_form() {
+    let (tmp, cfg) = corpus_with_slices(&[
+        ("workflows", &[".github/workflows/**/*"]),
+        ("ops", &["deploy/**/*", "not/written/yet/**/*", "Makefile"]),
+    ]);
+    assert!(
+        l010_messages(&tmp, &cfg).is_empty(),
+        "the working form must not be flagged"
+    );
+}
+
+/// Spec 079 3.2: one code now covers two tables, so the message names the
+/// table and the slice, on one line, so a reader can find the offending line
+/// without guessing which table it came from.
+#[test]
+fn the_slice_l010_message_names_the_table_the_slice_and_the_working_form() {
+    let (tmp, cfg) = corpus_with_slices(&[("workflows", &[".github/workflows/**"])]);
+    let found = l010_messages(&tmp, &cfg);
+    let (msg, _) = found.first().expect("L-010 fired");
+    assert!(!msg.contains('\n'), "one line per violation: {msg:?}");
+    assert!(msg.contains("[index.slices]"), "{msg}");
+    assert!(msg.contains("'workflows'"), "{msg}");
+    assert!(msg.contains(".github/workflows/**/*"), "{msg}");
+}
+
+/// Spec 079 3.3: slices are independent of `contentHash` by spec 012's design,
+/// so the slice message must not claim a content hash is affected, in any
+/// spelling. The `extra_hashed_inputs` form says it legitimately, which is
+/// why the assertion is scoped to a corpus with no such table.
+#[test]
+fn the_slice_l010_message_does_not_claim_a_content_hash() {
+    let (tmp, cfg) = corpus_with_slices(&[("workflows", &[".github/workflows/**"])]);
+    let found = l010_messages(&tmp, &cfg);
+    let (msg, _) = found.first().expect("L-010 fired");
+    let lower = msg.to_lowercase();
+    for spelling in ["content hash", "content-hash", "contenthash"] {
+        assert!(
+            !lower.contains(spelling),
+            "slice message claims {spelling:?}: {msg}"
+        );
+    }
+    assert!(
+        msg.contains("slice hash"),
+        "the message speaks about the slice's own hash: {msg}"
+    );
+}
+
+/// Both tables at once: the two forms of the one code stay separable by the
+/// table they name, which is what makes 3.3's scoped negative sound.
+#[test]
+fn l010_reports_both_tables_and_each_form_names_its_own_table() {
+    let (tmp, mut cfg) = corpus_with_slices(&[("workflows", &[".github/workflows/**"])]);
+    cfg.index
+        .extra_hashed_inputs
+        .push("standards/**".to_string());
+    let found = l010_messages(&tmp, &cfg);
+    assert_eq!(found.len(), 2, "{found:?}");
+    let global: Vec<_> = found
+        .iter()
+        .filter(|(m, _)| m.contains("[index] extra_hashed_inputs"))
+        .collect();
+    let slice: Vec<_> = found
+        .iter()
+        .filter(|(m, _)| m.contains("[index.slices]"))
+        .collect();
+    assert_eq!(global.len(), 1, "{found:?}");
+    assert_eq!(slice.len(), 1, "{found:?}");
+    assert!(global[0].0.contains("content hash"), "{found:?}");
+    assert!(
+        !slice[0].0.to_lowercase().contains("content hash"),
+        "{found:?}"
+    );
+}
+
 // ── spec 076 §3.3 and §3.4: the flag cannot outlive the work ────────────────
 
 /// A corpus whose one spec claims `unit_yaml` at the given lifecycle.

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -18,7 +18,7 @@ summary: >
   rule to the second table, and requires the slice message to speak about the
   slice's own hash rather than repeating a sentence about `contentHash` that is
   false for slices.
-implementation: pending
+implementation: complete
 owner: "The spec-spine Authors"
 risk: low
 depends_on:


### PR DESCRIPTION
Builds spec 079 (`implementation: complete`; ratify follows in a separate PR).

## What

- `L-010` now reads `[index.slices]` as well as `[index] extra_hashed_inputs`. A pattern ending in `/**` enumerates directories and the slice walk keeps only files, so it is inert in both tables (3.1).
- One code, not `L-011` (D-2), emitted from one site so `lint_diagnostic_codes_are_unique` still holds.
- The slice message names the table and the slice on one line (3.2), and speaks about the slice's own hash, the one `index check --slice <name>` gates. It never claims a content hash, because slices are independent of `contentHash` by spec 012's design (3.3).

## Evidence

- `spec-spine verify 079`: passed, 11/11 commands. The two rule-carrying lines fail against pre-079 code (`lint` did not read slices at all).
- Five new tests in `crates/spec-spine-core/tests/lint.rs`, on fixtures since this corpus declares no slices table (3.4).
- Gate as `AGENTS.md` lists it: green. `cargo test --workspace`, clippy `-D warnings`, fmt: green.

## Territory

Both units are carried by `extends` through their establishers (003 for `lint.rs`, 053 for `tests/lint.rs`), the route 074 took for the same files. `couple`: 3 paths checked, no drift.

Spec 012's own example (line 62) still teaches the dead form; that one-token edit lands before the ratify PR, outside this spec per its §4.
