### PR TITLE
chore(079): ratify (draft -> approved); 012's example teaches the live glob form

### DIFF
--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0cb98f239cb57bff3005435f4a64d702592d7017ab0d0c93720ae757d0c008f9"
+  "shardHash": "54c6a1bc1a9f1de4cb1f92c5aa9c2025951ecae18ba86b94de07774b6d227069"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -45,8 +45,8 @@
       }
     ],
     "specId": "079-a-dead-glob-is-dead-in-both-tables",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b4d48533e8fadb5e546c68a7e843a5a66d7ede71104fa98600c6e85cc2a83dea"
+  "shardHash": "5de7f0486158f1f077e997b833052712b298201a02642ff024c36c3ded8ead0f"
 }

--- a/.derived/spec-registry/by-spec/012-index-hash-slices.json
+++ b/.derived/spec-registry/by-spec/012-index-hash-slices.json
@@ -99,6 +99,6 @@
     "summary": "Named sub-hashes of the index's input set: an adopter declares glob groups under `[index.slices]`, the indexer emits a per-slice content hash into `build.sliceHashes` (additive index-schema MINOR), and `spec-spine index check --slice <name>` gates on exactly that slice -- fresh (0), stale (2), config/IO error (3). Generalizes the narrow high-value staleness gate OAP runs over its agent-config files (settings/MCP JSON) without hardcoding any adopter's file list into the core.\n",
     "title": "Index: named hash slices and `index check --slice <name>`"
   },
-  "shardHash": "6f32352ebc96b9dc307fa10d466d416eb5885ea87e27e9b0e65944c1b8205f9c",
+  "shardHash": "fef5ca06e8a92bb6ff921a371daef35ac26e764fdd8665649c3f1e420c31fdbc",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/spec-registry/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -44,10 +44,10 @@
       "Verification"
     ],
     "specPath": "specs/079-a-dead-glob-is-dead-in-both-tables/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`L-010` refuses a pattern ending in `/**` in `[index] extra_hashed_inputs`, where it enumerates directories and can contribute no bytes. `[index.slices]` carries pattern lists with the same documented semantics and the same file-only walk, and the lint is silent about it. An adopter audited on 2026-09-09 carried seventeen dead patterns, nine in the table the lint reads and eight in the table it does not. A fix pass corrected all nine and six of the eight; the two survivors reached an already-reviewed pull request and were caught by a second human reading, since no tool could report them. Both pointed at directories that do not exist yet, so they would have stayed silently empty on the day those directories arrived. This spec extends the rule to the second table, and requires the slice message to speak about the slice's own hash rather than repeating a sentence about `contentHash` that is false for slices.\n",
     "title": "A dead glob is dead in both tables"
   },
-  "shardHash": "996321491dfa7a90bf8f780ae20a5eb6e87750cf74525ff9f3b5864116a3f8ce",
+  "shardHash": "af215f50fae9dbe9788d4f4a0e230b31fa5a0758003d36f75b00d3358f6705c9",
   "specVersion": "1.2.0"
 }

--- a/specs/012-index-hash-slices/spec.md
+++ b/specs/012-index-hash-slices/spec.md
@@ -59,7 +59,7 @@ and the embedded index JSON schema; the new check surfaces through 001's
 ```toml
 [index.slices]
 agent-config = [".claude/settings.json", ".mcp.json"]
-workflows    = [".github/workflows/**"]
+workflows = [".github/workflows/**/*"]
 ```
 
 - Each key is a slice name (`[a-z0-9][a-z0-9-]*`); each value is a non-empty

--- a/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
+++ b/specs/079-a-dead-glob-is-dead-in-both-tables/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "079-a-dead-glob-is-dead-in-both-tables"
 title: "A dead glob is dead in both tables"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-09"
 summary: >


### PR DESCRIPTION
Flips spec 079 `draft -> approved`. Its build merged in #162 with `implementation: complete` and `spec-spine verify 079` at 11/11. Corpus after this: 79 approved, 074 held draft on its §3.6.

## The ratifier's check, done first

079 §4 left one thing for the ratifier: spec 012's own example still taught `workflows = [".github/workflows/**"]`, the dead form 079 now refuses, and adopter slice tables were copied from it. The maintainer's one-token edit to line 62 (`**` to `**/*`) lands in this same PR, before the flip, so no window exists in which the corpus ratifies a rule its own specification contradicts. 012 is approved; the edit is the human's, taken outside 079 as that spec required.

## Gate

`check`, `lint --fail-on-warn`, `index coverage --fail-on-untraced`: green. `couple`: 2 paths, no drift. Four shards regenerate (012 and 079, both trees).
