### PR TITLE
chore(074, 080): ratify (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -338,8 +338,8 @@
       }
     ],
     "specId": "074-shipped-is-not-the-same-as-working",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "36cfc3f20b8dc3af301383139170c1d5cbb909c8588e1c887358952adac7e86b"
+  "shardHash": "63f495546edd83b8a91aaed99126790a09e36afbe23bd5b256d0d33598614330"
 }

--- a/.derived/codebase-index/by-spec/080-a-gate-that-cannot-ask-says-so.json
+++ b/.derived/codebase-index/by-spec/080-a-gate-that-cannot-ask-says-so.json
@@ -96,8 +96,8 @@
       }
     ],
     "specId": "080-a-gate-that-cannot-ask-says-so",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "78cab1db7b6b5e098c920823cb016e0ea5dccfe2342e03532dd3d6675baf2ac5"
+  "shardHash": "14df4c09651b64d4501fd8d5d325704534063b609f6dd0b0eeb045496b3a47e0"
 }

--- a/.derived/spec-registry/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/spec-registry/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -195,10 +195,10 @@
       "Verification"
     ],
     "specPath": "specs/074-shipped-is-not-the-same-as-working/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "Two adopters installed spec-spine on the same day and each found a shipped artifact that does not do what it says. A glob form that matches no files reached one by hand and the other through a pre-069 scaffold, where the fix to the default can never arrive and 069's migration note explicitly does not look. `init --with-kit` writes the merge-driver hooks without an executable bit and without the binding that makes them fire. It installs a script the tool absorbed two releases ago, and it will write a second spec at an ordinal the corpus already uses. The session protocol calls a version read a precondition and never schedules it, while the skill beside it still prescribes the stderr ritual that protocol retired. Every one of these shipped for the same reason: the acceptance asserted that a thing exists rather than that it works. This spec closes them together and adds the refusal that would have caught the first one in an adopter's own config.\n",
     "title": "Shipped is not the same as working"
   },
-  "shardHash": "944a5a09d9bfbbba0d547838ce041433609f5d1f32fb927f611c1795b116c93c",
+  "shardHash": "903ef56524a2f2e06cb499e1363120ae5e8426d5d797f5da1eee5bbc32581bea",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/080-a-gate-that-cannot-ask-says-so.json
+++ b/.derived/spec-registry/by-spec/080-a-gate-that-cannot-ask-says-so.json
@@ -68,10 +68,10 @@
       "Verification"
     ],
     "specPath": "specs/080-a-gate-that-cannot-ask-says-so/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The kit's PR gate runs `spec-spine check` and reports any non-zero exit as \"a committed shard tree is stale\". Exit 3 is not staleness: it is the read not having been performed, and the commonest way to get it is a binary that predates the verb, which every released spec-spine does. On 2026-09-09 the gate refused two adopter pull requests with a staleness message against trees the adopters' own pinned binaries called fresh, and the whole `gh pr create` command was refused before anything in it ran. This spec makes the gate read the exit code it already has: stale is reported as stale, a read that did not happen is reported as that, with the binary and the floor the verb needs named, and both still refuse. It also moves the kit's stated floor to the release that carries the verb.\n",
     "title": "A gate that cannot ask says so"
   },
-  "shardHash": "d98fc2ca9aa6fa4793891709c15bd7e884484bd5c78044cab7e670203fbeba41",
+  "shardHash": "70dad28052f24907fb037b93fa770b4b82a2d18788cbbe7dd652135d314b82fe",
   "specVersion": "1.2.0"
 }

--- a/specs/074-shipped-is-not-the-same-as-working/spec.md
+++ b/specs/074-shipped-is-not-the-same-as-working/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "074-shipped-is-not-the-same-as-working"
 title: "Shipped is not the same as working"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-08"
 implementation: complete

--- a/specs/080-a-gate-that-cannot-ask-says-so/spec.md
+++ b/specs/080-a-gate-that-cannot-ask-says-so/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "080-a-gate-that-cannot-ask-says-so"
 title: "A gate that cannot ask says so"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-09"
 summary: >


### PR DESCRIPTION
Flips two specs `draft -> approved`:

- **074** (shipped is not the same as working): held at draft since 2026-09-08 on its §3.6, which approved 051 §3.2 forbade. The maintainer resolved it by amendment on 2026-09-09 (deleted the kit script by hand, 074 amends 051 and 048, 048 D-7), built in #164 with `verify 074` 9/9.
- **080** (a gate that cannot ask says so): built in #165 with `verify 080` 4/4.

Corpus after this: **81/81 approved**, `registry plan` reports nothing ready, nothing blocked. Gate green; `couple` clean. Four shards regenerate.

Next: the 0.18.0 release, which the kit's hooks now require (they call `check`).
