### PR TITLE
chore(release): bump package version to 0.18.0

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -4,8 +4,8 @@
     "name": "spec-spine",
     "path": "npm",
     "specRef": "007-distribution",
-    "version": "0.17.0"
+    "version": "0.18.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "032f542ccabba6f5a347acc27e7e4da30012a6099b3d45086832ab15e702ba67"
+  "shardHash": "14fc8680a4a2d1df9080be05744e1dc08e176e0ffa97fa44feae6242d703e8c7"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "glob",
  "jsonschema",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "spec-spine-types"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 # Shared metadata inherited by member crates via `field.workspace = true`.
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,8 +34,8 @@ time = { version = "0.3", features = ["formatting"] }
 # core and the type substrate stay crypto-free and key-free.
 ed25519-dalek = "3"
 # Internal crates (path + version so the published surface is not path-only).
-spec-spine-types = { version = "0.17.0", path = "crates/spec-spine-types" }
-spec-spine-core = { version = "0.17.0", path = "crates/spec-spine-core" }
+spec-spine-types = { version = "0.18.0", path = "crates/spec-spine-types" }
+spec-spine-core = { version = "0.18.0", path = "crates/spec-spine-core" }
 
 # The library must not contain unsafe; the public boundary is FFI-friendly without it.
 [workspace.lints.rust]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-spine",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required.",
   "keywords": [
     "spec",
@@ -42,11 +42,11 @@
     "smoke": "scripts/smoke-test.sh"
   },
   "optionalDependencies": {
-    "@spec-spine/cli-darwin-arm64": "0.17.0",
-    "@spec-spine/cli-darwin-x64": "0.17.0",
-    "@spec-spine/cli-linux-x64": "0.17.0",
-    "@spec-spine/cli-linux-arm64": "0.17.0",
-    "@spec-spine/cli-win32-x64": "0.17.0"
+    "@spec-spine/cli-darwin-arm64": "0.18.0",
+    "@spec-spine/cli-darwin-x64": "0.18.0",
+    "@spec-spine/cli-linux-x64": "0.18.0",
+    "@spec-spine/cli-linux-arm64": "0.18.0",
+    "@spec-spine/cli-win32-x64": "0.18.0"
   },
   "spec-spine": {
     "spec": "007-distribution"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -20,7 +20,7 @@ name = "spec-spine"
 # version by release.yml, and the lock check fails on a tag/version mismatch
 # (§3.5 parity). Tracks the workspace version; bumped in lockstep with
 # Cargo.toml and npm/package.json by scripts/bump_version.py.
-version = "0.17.0"
+version = "0.18.0"
 description = "The spec-spine CLI: compile a markdown spec corpus into a deterministic authority ledger and refuse code that drifts from its owning spec. Ships the prebuilt binary; no Rust toolchain required."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepares **v0.18.0**. Version-bump only; the tag is pushed after this merges.

## What ships

Nine specs, **072 through 080**, all ratified (corpus 81/81 approved, #153, #158, #160, #163, #166).

- **072** the default branch is resolved from the repository, never assumed to be `main`.
- **073** a workflow bump is not a governed change (the dependency-only self-clear reaches workflows).
- **074** eleven shipped-but-broken findings from the adopter audit: L-010 for dead `/**` globs, `init` writes what it names and the merge driver binding, `[meta] required_version` set here, the protocol schedules `--version`, and the kit stops shipping `verify-spec.sh` (3.6, resolved by amendment on 2026-09-09).
- **075** `spec-spine check`: one freshness verb for both committed trees; `/init` renamed `/prime`.
- **076** `planned: true` on a unit declares territory before it is written (registry schema 1.2.0).
- **077** `compile --fail-on-warn`, forwarded through `check`.
- **078** the New Sessions protocol has an owner (`AGENTS.md` established).
- **079** L-010 reads `[index.slices]` too, with a slice message that never claims a content hash.
- **080** the PR gate reads `check`'s exit code: stale is stale, a read not performed says so and names the binary and the 0.18.0 floor.

## Upgrade notes

**Adopters who copy the kit need 0.18.0 or later.** The hooks now run `spec-spine check`, which no earlier release carries; on an older binary the PR gate refuses every `gh pr create` and, as of 080, says which binary could not answer instead of calling the tree stale. Re-copy `settings.json`, `AGENTS.md` and the skills (`/init` is now `/prime`). The kit no longer ships `scripts/verify-spec.sh`; delete an older copy.

**Registry shards restamp.** `REGISTRY_SCHEMA_VERSION` moves 1.1.0 to 1.2.0 (additive: `planned`). The first `compile` under 0.18.0 rewrites every registry shard's `specVersion`; `shardHash` is unchanged. Commit the restamp.

## Schema axis

Registry 1.1.0 to 1.2.0 (spec 076, additive). Index, build-meta, config and verdict constants are unchanged since v0.17.0.

## Waiver

The gate reports the two violations every version-bump PR reports. Spec 030's auto-waiver correctly does **not** fire here: a package's own `version` field is not a dependency edit, so this needs the standing manual waiver. Approved by the maintainer for this release.

Spec-Drift-Waiver: A release version bump. `npm/package.json` and `py/pyproject.toml` change only their `version` field and the version-locked `optionalDependencies` pins, which specs 007 and 008 require to track the tag; neither spec's behavior changes, so there is nothing to author in them. This is the standing waiver every version-bump PR carries (cf. #57, #80, #88, #103, #109, #138, #142).

## Testing

- `scripts/bump_version.py --check 0.18.0`: all locations agree
- `cargo test --workspace --locked`, `clippy -D warnings`, `fmt --check`, `cargo package --workspace --locked`: clean
- `check --fail-on-unresolved --fail-on-warn`, `lint --fail-on-warn`, `index coverage --fail-on-untraced`: green, 81 shards fresh, 80/80 files claimed
- `couple`: the two C-001 violations above, cleared by the waiver