### PR TITLE
docs: CLAUDE.md names the ten skills the kit ships

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e4402f0bb1e0bff5600cc3d235bf4da7b67f12a7e2e8fae027bc9be8ce6a73b6"
+  "shardHash": "14d1da527abb85bae85f4fbac75c5eed39eca06ef5802a7f611faafbb284c999"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "647d4aa4c643180f64a60c27efb3ba2f7066c10e424423ecabd2ab36157b4ecd"
+  "shardHash": "c785129123f7c956da1da05b2d60d5fa19e8648390c3e954015cad6bc81e76c2"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "79e3379fd3c01011c6692538260021157dea5443bb7cc6f100934ed225bffb13"
+  "shardHash": "3190b0b19d9f622bd4d6cb9f2281227f292996c770be22ff6189802d448ba160"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.18.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e4c4a47e12647730fd2e918faaf5a3b780588337a74628c361c9384f225e15c"
+  "shardHash": "2851f5ea5e5f3a0cba54923815fb700838375fc5210f19e7d96923e65b62e517"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "709fb4983089286fde1bb04e3e3e3a6a4b9cf3c3baa8c3add9927f721928bac4"
+  "shardHash": "1f436cba753a39356c6073a21c74653cd0ce3b2f1c9a0539093d50f476865e55"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "313fd677f2bd54461f011a30e799692087864ab41838a53144d6feb5fa21505b"
+  "shardHash": "77d87d6db83f31bd389f6b23b504ddd923f90860f092f898e122f1ea0bf174f1"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5b2c52951ac84eac8010a6fb9244a199f0cf9efd942acabbd1b0e18c2d86cbce"
+  "shardHash": "01a3cabab1ec093fc7e1c6147d06566c307e7559684fa90af4634eb44790410e"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ffb2bd89962c3f8561506c0abb865dd01c1ee416f507e6c9cfa046298658b75e"
+  "shardHash": "d216c035699dad5a41b258dff9d9faf3b54495bdb5f54b17f0e52572bc1fcd09"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e834ee4f28f4c7fa73e9485576840b3c9b7a1f865e1c53c4769f13b12bdcdbb5"
+  "shardHash": "e93050dbe9c7ff54a7107c6791a3aab50fa6d88525596036a780c5b76a0e91af"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "04af8b1b2cc47cb68a1884d910d0039a4a1dc32900a28958cf377ef5f6233b38"
+  "shardHash": "126987718bf5ca75a4f1deb221ecd5fce76f864ae112474939a00c50e511098e"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5eb6cb35ef92341cc84174ecd8044bbc0037fdf4ef96cee8d704283c82a403a3"
+  "shardHash": "600f5845fb908c22d0e0cdb62218dfe8d51396c0215fd14fa1b0857bc0fef84f"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5f2a233d07301671f19fd48227429a5773f0d66df3995a6e65ce92f786cbc7b0"
+  "shardHash": "a2d89424485138379a14d63862388161614daeae2bd0bcc4b1c7aff7ddaa2485"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5b06ee70926312613c86ef8eaca31ae43cfe20932206cfd1503d65893917c133"
+  "shardHash": "74ad490db3347b4f4857ce5c0b90fb7afb3338e1a32d044635075564a1fcea05"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "adac8dd40730fd268efa83a087d9c6a63e612ecc2338be2baf23cc2bf761becc"
+  "shardHash": "c14e56147932dafd0ee1672e16d8a12a3b365cde1f6db36878a21bde2be3dd51"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ed2639999be515ec021aa4812a8213602b62c3cc66ddab00b964816880e149cc"
+  "shardHash": "2297cba5e0b938fa6ef7a8a23920ab9d29a00b011aac0a06c5106f8a0ea6dc36"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "29236424ab020ead3aa851fd19b2522009c97d2255e5a3c9f39a983c1cd4821c"
+  "shardHash": "30f9842a3efc777ce2984b076cfb929f11ccd7a36c20206e7686971b40da85b2"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b59b6487120e4796398cc573660c9d202a440a9bed70682d9af27ec991b4a3b3"
+  "shardHash": "a5edf53762ba20dc15b31f8cc87ae41df2052cca0c0b7fc10910239a94731fe7"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5732a4fd52c3b2e665e889226abd0d0de2cb42c1fba02f203a31f90f102b8f4"
+  "shardHash": "a259afe5a47b979b62c7e5b891dac61e137313c6e928265b4c311e9a2b2393c3"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bbb2c9ad5761b8d5aa2f8b1bbca65438ab6e313b08b8252ba577dd1e6402f44c"
+  "shardHash": "96e59475b9dfadf10e3e8ed6d3e20e93bd6c39db0075dd044e688d0a330bd83e"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "584075e069cef2a6c82c769c94a8d82de2755e418838da543631c3e4f34b794e"
+  "shardHash": "586c5752af9b15285c83225cc5fb1241c125d218080e5a6b4ba98b548f0e77f2"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f2ce60ed5a80e6b4f1b2d3ebe3f3d142abca1d5ff441a7f8adfc26cf9c2372cf"
+  "shardHash": "bf95adfa69d12619aa732eb37e62bfcddf769dc30619e301072ad1b24e9ffe63"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b494be52932220bd4cd82ec54f5516e932106f3f8ed9d979d3680c7a2519219b"
+  "shardHash": "1738af9f952ed554fc41ebcd9442943e351797ee630d6d8919beb6b8dbee7672"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6f92fc8a333498b7285fefad9b1746b3b09a5653a3f6e585fc20ec4a4d051020"
+  "shardHash": "fe6452b6469b7212bb845909cbe1b2624684598f39f616fc28783425a2dbf804"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a06d999a15c8edebc581e13716d8caa5fad84f0f4ca1cdba9cd4a10762e38334"
+  "shardHash": "3782c8c480ddfd26fad95e772b624dfc4a3ada3e66265cb9c2d0e6ffa9ce13e6"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2e072b06e5e5bb413247141e4191ae2cec0d1500d79662f5c232cc471d5e1076"
+  "shardHash": "2940ff8d7c6dbf584cd7789bcd37375fc1803e5fc3226d26474a2c657448be98"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d6c5a7d25efc352cb47c27c0f16a585b34ef51e10685af8ee6e519c3fd050f06"
+  "shardHash": "1c205073b7b1fbe7eaae85ab443cf73a9c0bba8c2b629647105512a33d18f7c6"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "17e9209b8f00e6fc3408933ae2079dbf7b2102c042804c88a1e30c49697ae4e9"
+  "shardHash": "5830f6a3ac58a417f8ba9a3e69e678d43283c56dcda05c9820d4f6ede2d85f72"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "045e63208afff663fe0c1fefa3e495341f9e95570aa54f42c22cb68983368c75"
+  "shardHash": "8eede4046bde0535e703d4f72a1ee8a3f151819d15357b3b88fccc7a2700065c"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dcefeb60b653d8d415c2538c13327a4e35a4d0b35c87329d34b577541f0f6ff8"
+  "shardHash": "b4fd05fcf7f334c3e9acf83cb4eab202772457c16030196ff53b622517519584"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8b596c3c94872ea6b8bf260d13b3194c2601257c939c77356e64e7fd1c81900a"
+  "shardHash": "4a12ced2b4e0bbebc5dc8cfda65729bccb997bf5aa515ba27c58777030cecb79"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bd9052fcf6db70bf48432c4c0a18bcbf58baf87368df124435659c7a76513eeb"
+  "shardHash": "50f204c98d596d3f89ae93c81c7005fcc421a78ce8c6ffcd675d3892bf63976d"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1862da2bb3ec90b7877f3ae148ecb0772980f105401499bcbef43e02f0a8cb3b"
+  "shardHash": "114f4fa63c2685d2ada4b024f547162741235ecd6cf844b07056613501e98900"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cab01c982ae429468dff8d424e4f0ba34f81e3a68434bdd3b4de417f4c60473e"
+  "shardHash": "93a518f78dc9314aafcca7988fbb8f0c8a050c4f5bafeffad62c33dee3b8fa50"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3950f21332647aaebe11d7fccab41c4cc15db99df5a0a034e53083852a10762e"
+  "shardHash": "34caf1fda393151302578fb728e70d6c1d1e14bb8b0117fe34a5d54f5fed79af"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "71106e4495185e03a0939e25e5fedf896098130c33cc228f354c5623d6ebb089"
+  "shardHash": "943a4ac7e2fdf7592b5688a28e5d8c55a8dcb01aadf09320aca1edcc5a4d9370"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f3f21760616b5513e018ea110e80fd5385d3ce15a70521e1866b9f7b039fb93d"
+  "shardHash": "694c1b91ad782126d77f8304cda41742e63de53b9e7b01890a4c7d1818571864"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "544d430028b01965420f1d556b8192fc3ef7d42ad1f7d5f8874cb289e551d30d"
+  "shardHash": "1d5f73299bb087e75efe2e13f6a1e0e5504aecfc8d5a8ad9f92d1ff75a6abbc9"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c967948166037d78743f7d8b7da483f5c8fc968c3377e4366b5074faaeab3027"
+  "shardHash": "234ffa83308f3502215dfb710c0c3621896021050ce7470c09292cfcdc5b714c"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4fd30ad5a29abab69cd1cafd3feb25154801ab9ef715280e0899d49e2db6c21f"
+  "shardHash": "8cf4edf34ee5a9778c530031d74921ee8952d273dc74eea7a775ca3834980b07"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "59ad4f0807106b11353088f4b40503230615238eae6b0f44adbd3f6eafe1b687"
+  "shardHash": "78e83b936ef67f4b3124cb5f5b49b73a2a2f43d303e0c86a6db2ea55c4502546"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d5986bec5b3fdfcd2b397477e1e9363e2d75037a6370c1159c311191ce611dbe"
+  "shardHash": "d971f4985018f3c57de21fe29449a35342fb7d55ba9027987f43c4152c129658"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "385db014fc14a2a65ff9df6ede337cc7f3445689e7a6f979ba29ff7f2f37dc10"
+  "shardHash": "f81be8387fcb80e94746db1219d69c082788a7bbffd44ffda4b3ef7db529de64"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5579fb3ff8b4eae7f608205554cc896557a6a19af9e372413e23c712c725744a"
+  "shardHash": "6c0436bbc9e335a788c67e7bf4c9df1f37439ccec02fc33fb5b99ff2cffb5a6f"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2ca0fa0ff634a0f9a49757201d4a41f487502fb8d9bc7ca0890d4f6e2ed4a235"
+  "shardHash": "e169cdb0437b5c0c85e5d41ce9ac12077530d28e1d1e84897ab3bfb7c5bd43e5"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "440ece71c3952ea99b78cc31b50144c1949a542b115893c597d3d9dd73eb09bb"
+  "shardHash": "f9414ac484831ca99744946ad8ef0b3e7f5e47f73725f6adaf8ed30c6358458a"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "119761f2a09b9a4e9c6a57794f24f7424f7e9318ffcd9dd630aa2ab76d915699"
+  "shardHash": "8a81b41c0bd9dfca7145cd4875e5ddc62ddcf3fcfd412a52a0d94439ec145317"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "40cdb5ee3e8f93d1729c4759bec8d4088a343021ae8ed25e5676a81d2b194266"
+  "shardHash": "fb330153f1ec85564979fefe360945bdb82364a0d90140c0293ab502fe6bac87"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7f3e17cd345deb4145d347821588ef38f76d813c0493b3bb543881d4706acb32"
+  "shardHash": "5c90283c7aa8a210538121308ddebd16a957cbb2bb44842da5fc42f469874d3d"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "219590675aada5de6b57907bbaaef04e43e1c4a681625d0b9ca4706afa8122b1"
+  "shardHash": "82e5a5859a7606d8562e61c72f4dc86c4248e530a87a1c82a905030a4e00db49"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0bd73960fd650abcbad96c82cbf58a2df9fe3991b8510fc240ad0cad6b04b832"
+  "shardHash": "7822673ba064197673396aadcf8f94448d356076bde919ac9c1a32f04c3de6dc"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b1b909dce18ea0cb861585e6381d3be03c48590993b9856c29a63cdae6567c6"
+  "shardHash": "86877c1638220039b37f35f6f9e3068e4f2d8523dacc3f38d79654294b5b71a4"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "16e49e140b6e2e6226cded9969c6b595d10154c4fa52210e084df88a70d832fb"
+  "shardHash": "e09a9f61daaac69c2f0f32ffc47508ef573d9f12b58fbfd68e0304f3e20b1323"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "987b2f4f38f6bcdc7ae30fa5e1f08e26481e305fe42db46926b8857488e84b0f"
+  "shardHash": "e868a9ea42b633125b66abbe51d724a980d277a6953c9958f8a86674b4dd8fc5"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cd5c32285da0547f3b89bae99de140c6e1ac946eb940dc085d761ec03fb0c84f"
+  "shardHash": "3ed41540a1165c91b19087bf42cc0f0b94527c9f4a600474c4db4bb03e38522e"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "817c69885f099c3e082ca225dc45b65ad14a4e32e805e56ce65954a59bcf5dd6"
+  "shardHash": "19aec1f6f91b23fa91e98a15bc7c3ed7fb18b50ad92e2232c8efadbfff8236d5"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c1c6f1d73b201779678bd38818c75dcc79a2910c477305efabfe11f2c148115b"
+  "shardHash": "0d2501177aa31150dc99266a97359e5772aaff4f2554f800a032a4c41ca0bdc1"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b2f381c8dde2e91f238f1ec547207b9d604b8a208917058fdc2e1eaee687e0d3"
+  "shardHash": "fba52caa94dfcf61e050f32c9d1c77aec25bd7d26052123877906d56d280df69"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "194736d0d9b015be27e1d0775941a4f1e99303c692ee49e19c65ff951522d533"
+  "shardHash": "2f9f02e97c9272db01418933d5761d64925167f4d6929f501376da3cdb232f60"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce071373a555aaa307db52887bca3b8c5fb842923ac3e7871fe30b5f8d906ff6"
+  "shardHash": "396d84959b5fcabbf59afc0850542f843267bf657dd6a45987f9b1cbc0d13f77"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bed98755cdbc28f174ac7c55cd3e6a9ece960ffeec5b3e6090a8b19f0fb4c85e"
+  "shardHash": "e7367ec45bf13537193411ce4a1d5a48adfef4c3e86f3f200fec68ee9507d71c"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "315600ae8915458becc3d96badddc47d7a2c2c44cd5765e30613697846536395"
+  "shardHash": "4a8847c3cf8a3b4845305082001a68325bbaabccf395f7c6a6a15701db7a1316"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bba2ab2f4423a15d45db41c0befde4ab1296a1ee23db019ebaaab6c51f517c04"
+  "shardHash": "cc16c9e2511d706c1bc920d75e5c0c559562449e0e88e5863cbfa363c30f9478"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a74450c96f7341ea962c315a4743f1b6e79c72f2281d1c86dd44c2f9f765f584"
+  "shardHash": "6a2b93e46ced1c1804ba4dba458eb5b0f5ad20dc7790577b1be5eb7ed7a72ffa"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2740005f59afdfc1b1df76f331edfdcaa123d54ae60dfd8c6bc79a72a4e17020"
+  "shardHash": "579815f8e4ca4e02c9211265f22a708b82e814d989c9fdcf74f91c55b021b486"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3001d37f6b6947bb513763192479ee83b2d8b43d49911f73f380477dbf4d9d1e"
+  "shardHash": "54c7da079f6db5b3b77cfc2dea72e7d790c989bfdc0c6480a67223bf11fd39f3"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b91ccdf2084e7175e78aa1dbb7af4beb44454faf1d6abff3d2fd00e962d210ff"
+  "shardHash": "07a37f92f9f087d9fca15a2e1a91b7f49202180a535340f896c028783dee8ab5"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4cf4141f69d03ad1554c81a3cc3ecf1a1978a95a9f4ca10ec794f26d5c30abb8"
+  "shardHash": "ec2ad73e44f5197951cd4a4272aabd499965286035c4c8393864b5271dda30cd"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b02dab48e0420b04a37646b9ff6c5edda5eaa386fea5e590b512e73e812e26c7"
+  "shardHash": "bbf54ffdbe50a64aef2c2a683db0b6ee1a751d3d0822852787dbcbaf20c59392"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bddb5f7c4e756dc585b18d1fe17fd90e5db19e94c17d0eedc031f22344617228"
+  "shardHash": "f49e72941b916e43be0b296cdbdde400f021672dfa2b73980473c1b47da642ca"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "785feeeb435f73f9d29eccfb375ad1db22985e6646a097fdaa4a9092523d8b41"
+  "shardHash": "6f1d9de409c5934912dda397722332b4c7775c2c8e4acd2cb49ce56e5b47f926"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4b04dd50578d243d7fdf103ded8f10195a0ace9605db88b8f04ea11ac9685fbc"
+  "shardHash": "e5f11699d6e1dced4304a3ad339d089fe83da782a24e38cd80159fbe0979cb1e"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dc69b396882ce68133c091f2b05a006855933b37358f2488278ba4adcf83170a"
+  "shardHash": "740a946bd1b6bfc842bcc6c738db1b43024bab0d71566644b7323da018b1bb3b"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "df5b8b5abc8e3be01a887ee546714ad7ce82fa13a5717ddf27f10d41a923324d"
+  "shardHash": "0f66337cd52a64843bde42bb448265a0a0753c478a0679482f43ca65e9e4fc94"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7b00f4e7e23e76aa45b78ae6a2e892f4920d3d88212fded6864ffee95fd2ef8e"
+  "shardHash": "7c0214e001db3cb07c7f94ebc990d7648f3ed235a31ff761a4da4bb1f328c6cf"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5dfe890f5ae4bcdd5ca4b2bf69f7ebb78b7c23d109bd221b9602a26831e67b1"
+  "shardHash": "d4ed26fbb529b4046ade974d5788157caec3b8e321a3bdbea145faa93a01bfdb"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6bb04830ef5b872355c521d95e6bbd38f46faa61499aa4863b60acc6f2862393"
+  "shardHash": "352a1901b508b25f0804f8b0da6c64d962ec69519de1b161361f233a6c0761dd"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "57257a1d7f206bc70c357dbabdaa71849b53c806bc89535a61aafd1321c4c03b"
+  "shardHash": "8d3f7fb65a7c948ad8bd1885a40e4cf07d57c44ee85c0c4714e18b3b7252bac9"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "376739339b56b2bd0ed647b43f4a6447ced64d4dd53d36d0412b746dc11fbcd0"
+  "shardHash": "a2aff30f78b11cc4ee940f4592af7ddd233e34c5d364d73e802b963acaee5747"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -341,5 +341,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bb9e5efe8aff436450a79bf617553745d20e26f5fc9021110f32441d1051c518"
+  "shardHash": "8b4d0fed0d34854bef7c0b65fa85119b97b67bfc084042f5e8849f1d09a52172"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -403,5 +403,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5213cf57daeae818b26f0453e57f11d85d04b15a03591dacfa44e4c95d15f2ea"
+  "shardHash": "40a4b4e53a03e81c92f815b3cf2fe2bf29d3b017f48863ffef7c701a46663064"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a5bd0a8170d2b9564cb70a0911b44461d437d20c9ee996ae67b46ed5b975414e"
+  "shardHash": "02f0ff6602e3528cf84e91a9c6a2769f6cc805dfea44633d74c6c0c6e852dcd2"
 }

--- a/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
@@ -340,5 +340,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "edea932b21656b3a5d90cca4a53576ef995533aa3348e83e1213e6d330c30074"
+  "shardHash": "30e1a9352f25aafabf49b687258fea100a143e4840b710e751e6e695baf1b73d"
 }

--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -32,5 +32,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bd7474361be66a88d63e668f77aa0d1f7797f82d0bbf9bb85694f81f3168ddfe"
+  "shardHash": "5b6b55a2f9b24d780cf171ca352879c9b6b5c59fb801e4facd4f522bbb0ebe60"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3392cf44ba8ab2dfb58015bfa3ea6dc10b3103ee8aa2f4f3f38c8bcc4789fb05"
+  "shardHash": "d2e8b32edb7da30bd534b75b31436df9d8e4e4bc9c8fb9ea484a9a409e2558e0"
 }

--- a/.derived/codebase-index/by-spec/080-a-gate-that-cannot-ask-says-so.json
+++ b/.derived/codebase-index/by-spec/080-a-gate-that-cannot-ask-says-so.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5459e52487ad626ec5fd02ca7a534639c987f32d59e6317b3d5c87c6ebb952d8"
+  "shardHash": "6127d95bb4a89f84f23f6a150bb3807c367de32e557083e6f6e2f6e15dceefce"
 }

--- a/.derived/codebase-index/by-spec/081-the-kit-ships-what-the-loop-calls.json
+++ b/.derived/codebase-index/by-spec/081-the-kit-ships-what-the-loop-calls.json
@@ -153,5 +153,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6f18fae9fe235cf275d49e2026cadd500c42eda6127251a710bd3de55e68d619"
+  "shardHash": "21ca79ed6b9cc52c2a9c0ef5e63cf1ed972779385d08d1a1abe86d9f8ac2d4c4"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ spec-spine index coverage   # which source files no spec specifically claims
 spec-spine couple           # the PR-time drift gate
 spec-spine registry plan    # the ready set: workable now vs blocked
 spec-spine index diagnostics  # unresolved-unit W-001 / W-002
+spec-spine index owner <path> # which specs own one path, and how (spec 055)
 spec-spine verify <id>      # run a spec's `## Verification` block
 ```
 
@@ -170,11 +171,14 @@ preserve the cited semantics when editing `couple.rs`.
    passes. An extends-carried unit is a first-class claim.
    **Do not "fix" these.** A validation requiring an `extends` unit to appear in
    its target's territory would refuse the repository's ownership model.
-3. **A `// Spec: specs/<id>/spec.md` comment header** in the first lines of the
-   file (`//`, not `//!`), for the extensions in `coverage.rs::SOURCE_EXTS` (rs,
-   ts, tsx, js, jsx, go, py, sh). It claims exactly the file it sits in, never a
-   subtree, and needs no frontmatter edit anywhere. This is how spec 032's
-   coverage debt was retired without touching the tier-1 bootstrap spec.
+3. **A `// Spec: specs/<id>/spec.md` comment header** in the **first 16 lines**
+   of the file, for the extensions in `coverage.rs::SOURCE_EXTS` (rs, ts, tsx,
+   js, jsx, go, py, sh). The scanner (`index.rs::scan_comment_headers`) strips
+   one `//` or `#` marker and then requires `Spec:`, so `.py` and `.sh` claim
+   with `#`, and `//!` does not claim at all (the `!` is left in the way). It
+   claims exactly the file it sits in, never a subtree, and needs no
+   frontmatter edit anywhere. This is how spec 032's coverage debt was retired
+   without touching the tier-1 bootstrap spec.
 
 ## Determinism is the central claim
 
@@ -234,14 +238,15 @@ dated decision the spec was silent on.
 
 ## The kit (`kit/`)
 
-`kit/` is the copy-ready Claude Code kit adopters install (specs 029/048/064/065):
-the fifteen skills, the agents, the rules, the hooks, `Makefile` and `govern.yml`.
-`crates/spec-spine-core/src/kit_embedded.rs` is **generated** from that tree by
-`scripts/gen-kit-embedded.py` so `init --with-kit` can write files the binary
-carries; `tests/scaffold.rs` asserts the two agree. Edit `kit/`, then regenerate.
-Never hand-edit `kit_embedded.rs`. This repo's own `.claude/skills/` is
-byte-identical to `kit/.claude/skills/` (spec 048 pins this); the project layer
-lives in `AGENTS.md`, not in the skills.
+`kit/` is the copy-ready Claude Code kit adopters install (specs
+029/048/064/065/081): the ten skills, the agents, the rules, the hooks
+(`settings.json`), the kit's own `AGENTS.md` and `README.md`, `Makefile` and
+`govern.yml`. `crates/spec-spine-core/src/kit_embedded.rs` is **generated** from
+that tree by `scripts/gen-kit-embedded.py` so `init --with-kit` can write files
+the binary carries; `tests/scaffold.rs` asserts the two agree. Edit `kit/`, then
+regenerate. Never hand-edit `kit_embedded.rs`. This repo's own `.claude/skills/`
+is byte-identical to `kit/.claude/skills/` (specs 048 and 081 pin this); the
+project layer lives in `AGENTS.md`, not in the skills.
 
 ## Schema & release versioning (two decoupled axes)
 


### PR DESCRIPTION
## What

`CLAUDE.md` still said the kit ships "the fifteen skills". Spec 081 cut it to
ten on 2026-09-09 and updated `AGENTS.md`, `kit/AGENTS.md` and `kit/README.md`;
`CLAUDE.md` was not in 081's territory (§2 names the three listings, not this
file) and was left behind. `/prime` reads `CLAUDE.md` as identity, so every
session since has opened on a false count.

## Why not a spec

`spec-spine index owner CLAUDE.md` reports no owner, and `.md` is not in
`coverage.rs::SOURCE_EXTS`, so neither `C-001` nor `C-002` is in play. This is
unowned prose being corrected to match shipped behavior, not a change to what
anything requires. `couple` confirms: 1 path checked, no drift.

## Also corrected in the same pass

The file was audited line by line rather than patched at the one known error.
Three further claims were wrong or incomplete, each checked against the code:

| claim | was | is |
|---|---|---|
| `// Spec:` header window | "the first lines" | first **16** lines (`index.rs::scan_comment_headers`) |
| accepted markers | "`//`, not `//!`" | `//` **or `#`**, not `//!`. `SOURCE_EXTS` includes `py` and `sh`, where `//` is not a comment |
| skills parity pin | spec 048 | specs 048 **and 081** |

and `index owner` was added to the verb reference: it is the governed read for
"which spec owns this path" (spec 055), and it is what answered the ownership
question above.

## What was checked and left alone

The toolchain pin (1.92.0) and MSRV (1.85), `SOURCE_EXTS`, the four determinism
triples in `determinism.yml`, both lifecycle enums in `frontmatter.rs`, the
schema versions (registry 1.2.0, index 1.1.0, verdict 0.3.0), the
`required_version = ">=0.17.0"` floor, the core module list, and the "a quarter
of tracked source files have no establisher" figure, which still measures 20/79
with 16 of them in `spec-spine-types`.

## The shard churn

`CLAUDE.md` is an `[index] extra_hashed_inputs` member, so this edit restales
the whole index. The 86 regenerated shards (82 `by-spec`, 4 `by-package`) ship
with the change that made them stale. No registry shard moves: a registry shard
hashes `spec.md` source bytes, which this does not touch.

## Gate

`compile`, `index`, `check --fail-on-unresolved --fail-on-warn`,
`lint --fail-on-warn`, `index coverage --fail-on-untraced`, `couple`, then
`cargo test --workspace --locked`, `clippy -D warnings`, `fmt --check`. All
green; binary 0.18.0.


---

## Verified claims (added after review)

Three review passes asked to confirm the two factual claims below, since a
diff-only reviewer cannot see the files they describe. Both were checked
before the text was written; the evidence is here so it does not have to be
re-derived.

**This PR changes exactly one non-generated file.** Everything else in the diff
is `.derived/` shards, regenerated because `CLAUDE.md` is an
`[index] extra_hashed_inputs` member. No `index.rs`, no `cmd_index.rs`, no
spec. A `CLAUDE.md`-only diff cannot introduce a behavioral change; it can only
describe one accurately or inaccurately.

```
$ git diff --stat origin/main...HEAD -- . ':(exclude).derived'
 CLAUDE.md | 31 ++++++++++++++++++-------------
 1 file changed, 18 insertions(+), 13 deletions(-)
```

**The 16-line window is exact**, in the function the doc names, and predates
this branch by three months:

```
$ grep -n 'take(16)' crates/spec-spine-core/src/index.rs
1006:            for line in content.lines().take(16) {

$ git log -1 -S'take(16)' -- crates/spec-spine-core/src/index.rs
97d0908 2026-06-09 Phase 3: codebase index + file/section/symbol unit grammar
```

**`index owner` is spec 055, not spec 032.** Two passes reasoned from spec
055's title (*the-ledger-answers-what-consumers-rebuild*) that ownership
queries sound like spec 032's territory. Reasonable inference, wrong
conclusion: §3.1 of spec 055 is headed `spec-spine index owner <path>`, its own
Verification block invokes the verb, and the verb shipped in that spec's PR
(#121) two days ago. The CLI's own help string carries the attribution this PR
copied:

```
$ spec-spine index --help
  owner        Report which specs own one path, and how (spec 055)
  coverage     Report which source files no spec specifically claims (spec 032)
```

Spec 032 governs `coverage`, a different verb listed one line below. The two
are adjacent in the help output and in `CLAUDE.md`, which is likely what makes
them easy to swap when reading a diff in isolation.
