### PR TITLE
chore(082): ratify (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/082-a-refusal-is-not-a-remediation-round.json
+++ b/.derived/codebase-index/by-spec/082-a-refusal-is-not-a-remediation-round.json
@@ -77,8 +77,8 @@
       }
     ],
     "specId": "082-a-refusal-is-not-a-remediation-round",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cedbc1a5805bd4871670e486a8b59b890ca4292b7754504fcf607a7f3235a3b1"
+  "shardHash": "9294c33318ee6741972aad96e0924274ccacba1f789b3e3714131930ee1e402c"
 }

--- a/.derived/spec-registry/by-spec/082-a-refusal-is-not-a-remediation-round.json
+++ b/.derived/spec-registry/by-spec/082-a-refusal-is-not-a-remediation-round.json
@@ -59,10 +59,10 @@
       "Verification"
     ],
     "specPath": "specs/082-a-refusal-is-not-a-remediation-round/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`/shepherd` bounds remediation to two rounds and treats every red required check as remediable until it is inside the fix. Its one escalation, the coupling gate, is stated at step 2 of the remediation procedure, so it is read after the session has already committed to fixing. Three further classes are not an agent's to fix either and the skill names none of them: a never-touch artefact the path-scoped rule covers, a dependency cycle, and an ambient input reaching a hashed path. Each can burn both rounds before anyone learns the answer was always \"ask a human\". This spec folds the severity triage spec 081 4 deferred into `/shepherd`: classify before editing, spend a round only on what a session may legitimately fix, and never spend one on a class whose only remedy is a human decision.\n",
     "title": "A refusal is not a remediation round"
   },
-  "shardHash": "207d03fb0664680092dcdecf515c34607e8b0bb8a416aeb5835af0dbac564bbe",
+  "shardHash": "c2d6109e3cc4e0897c5872fc2bf36bc7a5feca540407b61a90fc0da145b35a06",
   "specVersion": "1.2.0"
 }

--- a/specs/082-a-refusal-is-not-a-remediation-round/spec.md
+++ b/specs/082-a-refusal-is-not-a-remediation-round/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "082-a-refusal-is-not-a-remediation-round"
 title: "A refusal is not a remediation round"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-09"
 summary: >


### PR DESCRIPTION
The ratify half of spec 082, per `AGENTS.md` "Working the backlog" step 6.
#171 landed the spec at `status: draft`, `implementation: complete`; this PR
flips `status` alone and touches nothing else.

```
$ git diff --stat origin/main...HEAD -- . ':(exclude).derived'
 specs/082-a-refusal-is-not-a-remediation-round/spec.md | 2 +-
```

Corpus moves to **83/83 approved**.

## Merging this is the approval

Nothing here is a technical decision. `/next` will not offer a spec whose
`status` is not `approved`, because approval is a human act and `registry plan`
schedules on `implementation` and dependencies alone. An agent opens this PR; it
does not merge it on its own authority.

## What you are approving

082 folds the severity triage spec 081 §4 deferred into `/shepherd`: classify a
red required check before editing anything, and a **CRITICAL finding consumes no
remediation round**. The four CRITICAL rows are a closed list (D-2): a coupling
refusal needing a spec this session is not implementing or a waiver; a hand-edit
to an artefact the path-scoped rule names; a dependency cycle; an ambient input
reaching a hashed path.

Eight AI review passes ran on #171. Three found genuine defects, all fixed
before merge:

| pass | defect |
|---|---|
| 4 | the branch was deleting 15 tracked `.agents/` files by accident |
| 5 | the CRITICAL report claimed threads were `none` when they were never fetched |
| 6 | the non-CRITICAL branch fell through unrouted, licensing "fix the HIGH while a human looks at the CRITICAL" |

Pass 8 returned **no findings**.

## Two things 082 names but does not fix

Both are recorded in §4 and D-3 rather than silently absorbed, and both are
owed their own spec:

- **`.agents/skills/`**: an unowned, unreferenced 15-skill tree carrying the
  five skills 081 removed and citing a `.Codex/rules/` path that does not
  exist, added by 081's own commit while its §2 read "No new file".
- **`/shepherd`'s Step 3b reachability**: review threads are reachable only
  through failure. Now two gaps, the green path and the CRITICAL path, which a
  follow-up should take together.

## Gate

`check --fail-on-unresolved --fail-on-warn`, `lint --fail-on-warn`,
`index coverage --fail-on-untraced`, all green. Both regenerated shards ship
with the flip.


---

## Acceptance evidence (added after review)

A review asked for visible attestation evidence behind the `approved` flip. Two
things are worth separating: what this repo requires, and what the evidence
actually is.

### `spec-spine verify 082`, on this branch

```
$ spec-spine verify 082
verify: 082-a-refusal-is-not-a-remediation-round: passed (11 command(s))
```

All eleven `verify:cli` commands, run against the merged code on the ratified
tree. The pin inside it (`shepherd_classifies_before_it_spends_a_round`) was
checked to fail against pre-082 code before it was written, so it is not a
vacuous assertion.

### Governance gate

```
$ spec-spine check --fail-on-unresolved --fail-on-warn   # exit 0
$ spec-spine lint --fail-on-warn                          # 0 error, 0 warning, 0 info
$ spec-spine index coverage --fail-on-untraced            # exit 0
```

### Why no attestation file appears in the diff

`.derived/attestation/` is gitignored (`.gitignore:30`). Per-spec attestations
(spec 042) are produced on demand, never committed, so one could not be visible
in a diff by construction. That is a deliberate design choice, not an omission
here.

### Why `approved` does not imply witnessed acceptance

`standards/spec/contract.md` defines both lifecycle keys as **scheduling**, and
states plainly:

> **`approved` plus `pending` is a work order.** It is the state a
> specify-first corpus lives in for months, and it is the state
> `spec-spine registry plan` offers as ready.

A spec is routinely approved with no implementation at all; that is what
specify-first means. Approval accepts the spec as authority. It is not a claim
that code satisfies it, and no gate makes that claim: spec 049 §4 says so
directly, that verifying code matches a spec's prose is something "no gate
does, and this verb does not either."

082 happens to arrive with `implementation: complete` because it was built
before ratification, which is this repository's local order (`AGENTS.md` step
6), not a general precondition for `approved`.
