### PR TITLE
chore(083): ratify (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/083-an-attestation-covers-the-territory-it-claims.json
+++ b/.derived/codebase-index/by-spec/083-an-attestation-covers-the-territory-it-claims.json
@@ -91,8 +91,8 @@
       }
     ],
     "specId": "083-an-attestation-covers-the-territory-it-claims",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d17bece61a8f723510f400e42a1b5443b75505285988f9bc2b9fc802f9f24549"
+  "shardHash": "e2f5340b4bc2ea06a0cc488dd429a65fa6db1cadcad2492d16a13cc6fe921c1f"
 }

--- a/.derived/spec-registry/by-spec/083-an-attestation-covers-the-territory-it-claims.json
+++ b/.derived/spec-registry/by-spec/083-an-attestation-covers-the-territory-it-claims.json
@@ -69,10 +69,10 @@
       "Verification"
     ],
     "specPath": "specs/083-an-attestation-covers-the-territory-it-claims/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`attest_spec` hashes a unit by opening each resolved location with `read_to_string`. Several unit spellings resolve to a directory rather than to a file, so the read fails with `Is a directory` and the verb exits 3: fourteen of this corpus's eighty-three specs cannot be attested at all, and the failure arrives as an I/O error rather than as a verdict. The dominant spelling is not the obvious one: thirteen of the fourteen are plain `file` units whose path is a subtree (`npm/`, `.claude/skills/`), which spec 000 4.2 defines as resolving identically to an explicit `directory` unit. Spec 042 3.1 already states what should happen, that `units` carries \"the content hash of what it resolved to\" for every owning unit, without qualifying by kind, so this spec changes nothing 042 requires and supplies the implementation that sentence never had. A directory-resolved location is walked instead of opened: every file beneath it, pruned by `index.resolver_exclusions` and `layout.state_dir` through the indexer's existing walker, folded into the same path-sorted `hash::content_hash` construction the file units already use. The walk is deliberately not extension-filtered, because the coverage universe's source extensions would hash zero files for a markdown-only directory such as `.claude/agents/` and emit a confident hash over nothing. A directory that walks to no files at all hashes its own path as a single piece, so an empty claim cannot attest as SHA-256 of the empty input, a constant every empty claim would otherwise share. No previously emitted payload changes value, because every spec this reaches could not produce one.\n",
     "title": "An attestation covers the territory it claims"
   },
-  "shardHash": "882b88790df212401f9d9c396e64a75b1091219d060a1364047b4a27cce1ae24",
+  "shardHash": "d41440bce2533ae8faaba1d46eefc29a2b3cf57b44bbc94983df1e73983b1f4c",
   "specVersion": "1.2.0"
 }

--- a/specs/083-an-attestation-covers-the-territory-it-claims/spec.md
+++ b/specs/083-an-attestation-covers-the-territory-it-claims/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "083-an-attestation-covers-the-territory-it-claims"
 title: "An attestation covers the territory it claims"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-10"
 implementation: complete


### PR DESCRIPTION
The ratify half of spec 083, per `AGENTS.md` "Working the backlog" step 6.
#175 landed the spec at `status: draft`, `implementation: complete`; this PR
flips `status` alone and touches nothing else.

```
$ git diff --stat origin/main...HEAD -- . ':(exclude).derived'
 specs/083-an-attestation-covers-the-territory-it-claims/spec.md | 2 +-
```

Corpus moves to **84/84 approved**.

## Merging this is the approval

Nothing here is a technical decision. Approval is a human act, and `registry
plan` schedules on `implementation` and dependencies alone. An agent opens this
PR; it does not merge it on its own authority.

## What you are approving

083 makes `attest --spec` cover the territory a spec claims. Before it, 14 of the
corpus's 83 specs (007, 008, 020, 029, 048, 051, 064, 068, 072, 074, 075, 077,
081, 082) could not be attested at all: `attest_spec` opened every resolved
location with `read_to_string`, a subtree claim resolves to a directory, and the
verb exited 3 with an I/O error instead of producing a payload.

The rule is keyed to the resolved location, not the declared kind, because 13 of
the 14 fail on a plain `file` unit whose path is a subtree and only one on an
explicit `directory` unit. A directory-resolved location is walked through the
indexer's walker under the one exclusion policy (`resolver_exclusions` plus
`layout.state_dir`), not extension-filtered, with symlinks hashed as their
target text rather than followed, non-UTF-8 files hashed as a digest of their
bytes, and an empty directory hashing its own repo-relative path instead of
SHA-256 of nothing. No `amends` on 042 (D-1): 042 3.1 already required a hash
for every owning unit, and the code never implemented it.

## Two things 083 records but does not decide

Both were left in #175's body as recorded silences, candidates for a later spec,
not defects:

- a claimed path that is **itself** a symlink is dereferenced at the top level
  (`path.is_dir()`); 3.2 constrains only links met during the walk;
- symlink target text goes through `to_string_lossy` (Windows separators,
  U+FFFD).

## Evidence, on this branch

```
$ spec-spine verify 083
verify: 083-an-attestation-covers-the-territory-it-claims: passed (18 command(s))
```

That includes attesting every spec in the corpus, which was false for 14 of 83.
The spec can now attest itself:

```
$ spec-spine attest --spec 083-an-attestation-covers-the-territory-it-claims
  attestationHash: ef0f30a757d9e5a5a64df62c2d3e010be7e989df5cafcbfa38097b5547a013f1
```

`.derived/attestation/` is gitignored (`.gitignore:30`), so the payload is
produced on demand and cannot appear in this diff by construction.

## Gate

```
$ spec-spine check --fail-on-unresolved --fail-on-warn   # exit 0, both trees fresh
$ spec-spine lint --fail-on-warn                          # 0 error, 0 warning, 0 info
$ spec-spine index coverage --fail-on-untraced            # 80/80, exit 0
$ spec-spine couple --base origin/main --head HEAD        # 1 path checked, no drift
$ cargo test --workspace --locked                         # 30 suites, 604 passed, 0 failed
$ cargo clippy --workspace --all-targets --locked -- -D warnings   # clean
$ cargo fmt --all --check                                 # clean
```

Both regenerated 083 shards ship with the flip.

## Next

Spec 084, the short spec id argument that 083 4 names as out of scope, is filed
in a separate PR.
