### PR TITLE
feat(089): a skip and a failure are different answers

### DIFF
--- a/.derived/codebase-index/by-package/spec-spine-cli.json
+++ b/.derived/codebase-index/by-package/spec-spine-cli.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ff36582a7420ad3dc0f9d0e5baa0fe56c3e42d04455e237c6863d6722cd0e4d5"
+  "shardHash": "19c0b09918dbc6617898f6e2806f53182659abc21c8b7d85ddb56cb9efeb694f"
 }

--- a/.derived/codebase-index/by-package/spec-spine-core.json
+++ b/.derived/codebase-index/by-package/spec-spine-core.json
@@ -6,5 +6,5 @@
     "specRef": "001-compile-registry"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d577167179e908f91031e62674c6b0721a0aa2e541e7e1779e1b06a2e74895f1"
+  "shardHash": "7e18a303cafa0620bb07e4c61b381e5a16203cbf47a87fd538d308a438d5b70c"
 }

--- a/.derived/codebase-index/by-package/spec-spine-types.json
+++ b/.derived/codebase-index/by-package/spec-spine-types.json
@@ -6,5 +6,5 @@
     "specRef": "000-spec-spine-bootstrap"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7d5d2cd86183c1b45d475522cc3ee66268d7c9050b1cfb8bb1c85c26a2d5c1c8"
+  "shardHash": "f2c47671ed17d0e93339e4d8efdff4f7f721f0c1f54a512504ff901ce50f910e"
 }

--- a/.derived/codebase-index/by-package/spec-spine.json
+++ b/.derived/codebase-index/by-package/spec-spine.json
@@ -7,5 +7,5 @@
     "version": "0.18.0"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "bd83177da334194a69087b46405093d73a7cb55842baeecf30800c4428fcef30"
+  "shardHash": "a24d1de4263a8f56a199692b313205bba07887bd443aa3f14f87157901d70d4f"
 }

--- a/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
+++ b/.derived/codebase-index/by-spec/000-spec-spine-bootstrap.json
@@ -26,5 +26,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "93bb7242928b22cdb6b6788b66535a84896ee38bd8235d3d75cec13cb1dab176"
+  "shardHash": "3c4aa7fb1602ff1c50078232abd03c16ace436b3b207f35fac031b4ba4e1d9c5"
 }

--- a/.derived/codebase-index/by-spec/001-compile-registry.json
+++ b/.derived/codebase-index/by-spec/001-compile-registry.json
@@ -138,5 +138,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "98a2c2ef12f3fbb673b6f6f9ac0daef65d4e70eb7a4b5c08f7991af196c686e6"
+  "shardHash": "46bddfb04be1b3600a432670c1c336b27b0ef0516330cd865e8c2038b3d3b8c9"
 }

--- a/.derived/codebase-index/by-spec/002-registry-query.json
+++ b/.derived/codebase-index/by-spec/002-registry-query.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3bbb33e6fe24049fbfc753c6ae13ec06e3a4a500a3c6f7efc11dffbf6537f809"
+  "shardHash": "7dbe7485c24a60aabaab3e5d8252ec223da8693c07ffeef93cca950cc2416f6d"
 }

--- a/.derived/codebase-index/by-spec/003-conformance-lint.json
+++ b/.derived/codebase-index/by-spec/003-conformance-lint.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "007d043a7198c5c61657b3a5cc75b9700f14a8304f29fcee84a4ce5961a573ef"
+  "shardHash": "bd83f8a0bfe9bd83c66e9e71fc772d4b6efa05e657f0f75e642a5cfbf1d401c5"
 }

--- a/.derived/codebase-index/by-spec/004-codebase-index.json
+++ b/.derived/codebase-index/by-spec/004-codebase-index.json
@@ -131,5 +131,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0a3eea4f86cfe2344672beceba34b754159b4cdcfadcdf84accdea1af723388d"
+  "shardHash": "ee052db799261332c0e4029eb56e1f11ec470616b04b14175d5de22dd39559c5"
 }

--- a/.derived/codebase-index/by-spec/005-coupling-gate.json
+++ b/.derived/codebase-index/by-spec/005-coupling-gate.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "6f2d7cb159486ba9e560e8f5f2647a730d763e0847ec81b6d5ae79541c1c4461"
+  "shardHash": "ade489ad9c61d7ad8f59f71440c1c41af63c1b8ed79d716b3e655ee86fa7be3b"
 }

--- a/.derived/codebase-index/by-spec/006-init-scaffold.json
+++ b/.derived/codebase-index/by-spec/006-init-scaffold.json
@@ -113,5 +113,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b9dafa560d502a7b558cbaa3a2453e0ce034dc8dd3090bcc221f9911c417cf78"
+  "shardHash": "944f7f6252d23e0ce5004a46b75906a88f6d9e1f0d3310fe38c4857d5f7a3901"
 }

--- a/.derived/codebase-index/by-spec/007-distribution.json
+++ b/.derived/codebase-index/by-spec/007-distribution.json
@@ -103,5 +103,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "da4696c69a1013f10a30aff6c8ae57969507bbc63fcbfa93cb518e3c315a6b78"
+  "shardHash": "6122d9b04ea08a75ca40506545a426e292489f7f6b07244ab1820344dedbe93e"
 }

--- a/.derived/codebase-index/by-spec/008-python-distribution.json
+++ b/.derived/codebase-index/by-spec/008-python-distribution.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "51c76b36216f2dba72f76f1050ac55c53a8cbe90c98c70cf3db01522ab8271e0"
+  "shardHash": "f644e1efe2aa9cf0cf3ff9daa8fde374ab22e7b2e67f6c8230c646e764b3420b"
 }

--- a/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
+++ b/.derived/codebase-index/by-spec/009-coupling-floor-claim-precedence.json
@@ -82,5 +82,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "14844dda09504013b053405f13b355ac138a46b99c7365e68bdab6f7f672772c"
+  "shardHash": "0c5b35d092a32803ea8adbdb9c9876ce7ed12b536e912edd9414a75f63fab910"
 }

--- a/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
+++ b/.derived/codebase-index/by-spec/010-registry-query-projection-flags.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "60624ea712e8fdaaba69903a8872f7dd322c4784776f65e7b69685ce27fe1971"
+  "shardHash": "66ed058b57ae88ad903e01d29c54083ed6079d2d516624c2c2f0b6aa9ec03476"
 }

--- a/.derived/codebase-index/by-spec/011-index-render-orphans.json
+++ b/.derived/codebase-index/by-spec/011-index-render-orphans.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0865042b8cceb566660c00ff68553d7082fc7be1b6d1bc33c804ce3acaea1bf5"
+  "shardHash": "511e0b2c392b5de8134584b493c597d70c0e404dcefb4d4eacab71dcbc83c376"
 }

--- a/.derived/codebase-index/by-spec/012-index-hash-slices.json
+++ b/.derived/codebase-index/by-spec/012-index-hash-slices.json
@@ -164,5 +164,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1483d26a3e3e8cb9eba52c2e5a2c74d974d04982ba367c681dfe2ac04bbc7cde"
+  "shardHash": "5b126184ff9640f7250ebb7541f790756f06b85d294b87c071ab0789cfdbfb86"
 }

--- a/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
+++ b/.derived/codebase-index/by-spec/013-declared-extra-frontmatter-passthrough.json
@@ -181,5 +181,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b0643818e5b2d5ecae89d445330b89c882364aec488d8b9ba55b4cf5cfbca206"
+  "shardHash": "abc86e96cd24802decfb19b5fd3bb66051a45cab772bb3617fbb76d5ba3d8789"
 }

--- a/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
+++ b/.derived/codebase-index/by-spec/014-edge-paths-grammar-sugar.json
@@ -96,5 +96,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "88783c0350f76045629bfb3a4bba3e41f4b938636af7d52315ca8776c6b5fc86"
+  "shardHash": "289ed00c67b520c950c16d799c83684bbb5f151c3f352ac782d2ae864dacace0"
 }

--- a/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
+++ b/.derived/codebase-index/by-spec/015-establishes-wrapper-na-alias.json
@@ -79,5 +79,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a774375e33967b6cc88e7d84682644fe6b6f06d4431cb08b4e38722b41dba172"
+  "shardHash": "3c1251aa9cee89928f6a16905d44f13308f0c274b19ebe99339cae8c878a4b7a"
 }

--- a/.derived/codebase-index/by-spec/016-short-id-resolution.json
+++ b/.derived/codebase-index/by-spec/016-short-id-resolution.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "3db467bc448353e1c17a577036cf3ef6878eec46e2cc90f4038641b176a28201"
+  "shardHash": "ffadbf5ac399c3aed08365e4d74ccd220d7fb0eb0fd57acf8efa4c8db70b2cd6"
 }

--- a/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
+++ b/.derived/codebase-index/by-spec/017-directory-crate-module-units.json
@@ -130,5 +130,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "21d00d11189fd86cd3b154bca3962e887ca6df6817b995d678ce1a606ba17936"
+  "shardHash": "888832d089e7e88c99ef9b0513b1eda30143df560a0e880deda4086363fbbf11"
 }

--- a/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
+++ b/.derived/codebase-index/by-spec/018-constrains-discriminator-optional-unit.json
@@ -114,5 +114,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "870c4786ae2af5a84cf1c5074403ab598ff3b1c09203565210be34b5effd819f"
+  "shardHash": "933f698693bbae931d961e93124a82b3c83b0459674bd89df5eec03d82eb9a0f"
 }

--- a/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
+++ b/.derived/codebase-index/by-spec/019-structured-partial-supersedes.json
@@ -250,5 +250,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b8932f8c563072e142a535f149387a78e9f7a069b196c009d5eda538de151e3f"
+  "shardHash": "a44e2dc177276ce52fc1260c5e176444402ee7a4be1e095c9d025abb8fbd6e35"
 }

--- a/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
+++ b/.derived/codebase-index/by-spec/020-derived-artifact-merge-driver.json
@@ -30,5 +30,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b6f86743c844ab601d84bd89f87582ea348c246965c79b2b983b174e7883cd1f"
+  "shardHash": "0f45353b6d58465b1d566bf909f2ca3c5eeba0df7cd1c678d1514de088576785"
 }

--- a/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
+++ b/.derived/codebase-index/by-spec/021-release-supply-chain-artifacts.json
@@ -45,5 +45,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "200e6c0e35ad849e1e49755eafe1a8dedcae627f096efd8c0e77fc1a14efe1a6"
+  "shardHash": "d689562b47dcf7a4b888ce719d1a2bddc8c1d0b3acc2d90ee49638e88c4c2501"
 }

--- a/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
+++ b/.derived/codebase-index/by-spec/022-keypath-section-anchors.json
@@ -29,5 +29,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "526b520187face0b1385150a8d867770399da0a5bbf32a167c78890d20b6c549"
+  "shardHash": "bb5d3e4fadbfccea5f9bae22dee96e9ede71760b64bbbe9757940bd80c5aa7f8"
 }

--- a/.derived/codebase-index/by-spec/023-ledger-seal.json
+++ b/.derived/codebase-index/by-spec/023-ledger-seal.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0a1e97592a222f1025dc5ef0a337f46b128007d55b79393c0490c92d02b17838"
+  "shardHash": "a6ede298de7cd3e523733603d5f67810c119256a7b59bfac6d30adcf76f66401"
 }

--- a/.derived/codebase-index/by-spec/024-index-sharding.json
+++ b/.derived/codebase-index/by-spec/024-index-sharding.json
@@ -480,5 +480,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f173fa57b5a419a452651182bdccab1d14cb8d09ae6e42567bdd903f9f91ab42"
+  "shardHash": "73a686c19158b1784c7011ab388f7e66951fc62857cc79f451dd5334f255eab3"
 }

--- a/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
+++ b/.derived/codebase-index/by-spec/025-unresolved-unit-severity.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "253b904b71888e1419b0743d70976610ffa8188f73c5b87bcf5a364585cd2d37"
+  "shardHash": "6275eb0907630ad9ecfd3ee1bf564f3d19053aac788bc3e8850b10a3a52ec6ed"
 }

--- a/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
+++ b/.derived/codebase-index/by-spec/026-resolution-discovery-fixes.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "79884bf542139c28d3c432a261e3b95f393356b1aff6ea2834358fedcfbf8a00"
+  "shardHash": "ad0c1930c5c4941cb944c6baf135f1f7837e1ade0e1ac33a990739af1021696d"
 }

--- a/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
+++ b/.derived/codebase-index/by-spec/027-symbol-resolution-feature-gate.json
@@ -80,5 +80,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fa491318093816e07ad6acd9a4ccecf187a8cb89ba19addcc9f89523657e3018"
+  "shardHash": "c28a619d48c789fe7ce525c28747c985b7c6da803af0ba8ecd905d4f10996a16"
 }

--- a/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
+++ b/.derived/codebase-index/by-spec/028-references-provenance-derived-at.json
@@ -92,5 +92,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7c0521938f747fe6f87721bac6facf4d73fbc913031db9e58bbe3c906154c829"
+  "shardHash": "ae0f6d33f7c0f61ed81d86ee41db2b68b026731abb904fcf02a69d3e7cc5f021"
 }

--- a/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
+++ b/.derived/codebase-index/by-spec/029-claude-code-skill-kit.json
@@ -28,5 +28,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "8be5c89d2c4c5fb88e8a3677c75993ff4e8de7a467435ba51bba7e61569a2656"
+  "shardHash": "601658a5584ccc56cd6fb18790c6b34179e86b7a5eef90a9a4db22cd6dbc0320"
 }

--- a/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
+++ b/.derived/codebase-index/by-spec/030-cargo-workflow-dependency-waiver.json
@@ -101,5 +101,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "32b537cf35fe1c03ef6cead04bfc1b6fd6f0cd4cd1e40b8ea72313018d77c928"
+  "shardHash": "c298a0da3d6e0463ed75d72b72a3264feff3616f19d7628c2f717d5d5106b527"
 }

--- a/.derived/codebase-index/by-spec/031-registry-freshness-check.json
+++ b/.derived/codebase-index/by-spec/031-registry-freshness-check.json
@@ -140,5 +140,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "4612b2ea04a4aee7c10bdf096be01110fec614a2c4f27bcac4c7c2c7fa0171a2"
+  "shardHash": "c4656b814ce124a408a81e0c629bc3287cbade1ade334664e76a62ad11c0bc2b"
 }

--- a/.derived/codebase-index/by-spec/032-ownership-coverage.json
+++ b/.derived/codebase-index/by-spec/032-ownership-coverage.json
@@ -247,5 +247,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d8c27f36f048a042cefe0ed143edc430cf0222c6f4426fe8ceeedf872bf60668"
+  "shardHash": "080f9935d329b349972867149353f6b8e97aa40063f3bb11e7deb199277db92d"
 }

--- a/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
+++ b/.derived/codebase-index/by-spec/033-dependency-cycle-refusal.json
@@ -46,5 +46,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "472035dd0d529dc4aebb6ed68da4c56e77af1b243b1f5ef4bea14ec968dd273e"
+  "shardHash": "6e18e3c7bb2060192fa962fd66759f83ab0ee4fb27b7b3220405f2fcea7f8489"
 }

--- a/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
+++ b/.derived/codebase-index/by-spec/034-references-non-owning-paths.json
@@ -49,5 +49,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "17f7e315bc39e12405e70a7943113c20c7fb7eae8eb4035fd02971684716f74e"
+  "shardHash": "ca5ac524ec9f6e1d6e54830901e63bed3f69bcb5dd32ca710f3356e2f3b8e0bd"
 }

--- a/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
+++ b/.derived/codebase-index/by-spec/035-stdout-closed-reader.json
@@ -199,5 +199,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e3b7c5412a738f8ed7b1adca69673c0673e2356773c8dd535e530f2fb01b54c6"
+  "shardHash": "3196704a6932a7756243f0f4af5e04dbfa94d6a6188207c16601ec0b7aea5d96"
 }

--- a/.derived/codebase-index/by-spec/036-configured-corpus-root.json
+++ b/.derived/codebase-index/by-spec/036-configured-corpus-root.json
@@ -66,5 +66,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b23f337cf6d84db7978530d12eb82fd7b9e1c6ef40f7073467b6d491cd3f01a2"
+  "shardHash": "9aa4517bde2904c1c58443e15afd91a6527ad0721e0322dea52c8017e9e9f722"
 }

--- a/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
+++ b/.derived/codebase-index/by-spec/037-machine-readable-verdicts.json
@@ -263,5 +263,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2e380944c0af55e2e00dd0aaba5282a42cb8b4400ccdf0d757a7fa59256d4bd2"
+  "shardHash": "0c353735a382a1888e7bff2fcf893df2494e3fee916433a42cb3e18f9e3c3dca"
 }

--- a/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
+++ b/.derived/codebase-index/by-spec/038-registry-plan-ready-set.json
@@ -126,5 +126,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "69ca8daaaac074057867329c218b8460fe92ed7f409c887d2650700c896a2dea"
+  "shardHash": "8f1186287d62d941cdb792d618758d82f24986487ca7a3f2b9fc199f50b1314d"
 }

--- a/.derived/codebase-index/by-spec/039-declared-state-dir.json
+++ b/.derived/codebase-index/by-spec/039-declared-state-dir.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "15140784e54a6e80251f9c1057b309a1427f56ded2ae277ca0fe104917e554bd"
+  "shardHash": "1de7ae8bddd75e362f9a695a433aaeb6fe27522aebcb36596159a9938c40d467"
 }

--- a/.derived/codebase-index/by-spec/040-amendment-authoring.json
+++ b/.derived/codebase-index/by-spec/040-amendment-authoring.json
@@ -72,5 +72,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "698ac5e95d14c8a6003c5e325f8e8eebd73ad12c37c84f0e82ef8e91a78ba247"
+  "shardHash": "3a2ee112e71008efd2982d0e55e4fcbb1f885fd6289a716cfeaa447860b84506"
 }

--- a/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
+++ b/.derived/codebase-index/by-spec/041-completion-held-to-claims.json
@@ -62,5 +62,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0180becc0654ffd4b5da98913a79c6225d1278124ccfb787ba5aae9761d2e9d5"
+  "shardHash": "f8743fb7af1e35ee26a195d8844844251077eefd1fdc6511a4bcc89f67a59670"
 }

--- a/.derived/codebase-index/by-spec/042-per-spec-attestation.json
+++ b/.derived/codebase-index/by-spec/042-per-spec-attestation.json
@@ -229,5 +229,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "92f6f17d5dbda70eef6ff32366600f4f0af8b56d55ed141a515a498e94dcf4e5"
+  "shardHash": "efbd4871c6189c3de2b81c1f0b504c5f940716f4492eac5b3eb1772e5dd75d2b"
 }

--- a/.derived/codebase-index/by-spec/043-governance-document-gaps.json
+++ b/.derived/codebase-index/by-spec/043-governance-document-gaps.json
@@ -137,5 +137,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e6ebe7860e47325fe4fa79172b3a269bd9b2438991ce2d3907b5c9ad57102657"
+  "shardHash": "cd7a1b47b76f213155ea84ff4ad6c6a6b9171e525c17a764de9ce34d2e371664"
 }

--- a/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
+++ b/.derived/codebase-index/by-spec/044-in-progress-is-in-flight.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "37f2b500a9d9c4c28452cee73cd79317c255fed635ecfd63f73fa2e6c5d44072"
+  "shardHash": "d010391189f21209d5aa50b04592568bec4e418f3defce92ba0083ab1127bc3d"
 }

--- a/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
+++ b/.derived/codebase-index/by-spec/045-absent-implementation-defers-to-status.json
@@ -136,5 +136,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9f2b55bac56afab9e77089502f24b59df32800fa064b18342920096943d9b5b9"
+  "shardHash": "e0ae7dc9cd00b877ea8cdb75cc478832f5807926bee8b52b4b1c181ee86246b6"
 }

--- a/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
+++ b/.derived/codebase-index/by-spec/046-kit-hooks-read-never-write.json
@@ -75,5 +75,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "d0362247254d55f75836e8064b5ba81d8eaadd737b0c98581deb6d2f3d51e575"
+  "shardHash": "682766dc0602b4b220695c16a16a765020cbfd4972f9a2f3e060290c8fef1439"
 }

--- a/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
+++ b/.derived/codebase-index/by-spec/047-harness-rules-name-the-legitimate-edits.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b557951255bb12a5a97673c8185f79db4c6676f046fac6d8a3011418a2fceee5"
+  "shardHash": "f6d2226e708e0bc979203d3c184fee5c99670bd1f3e77381d06f24f308b73703"
 }

--- a/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
+++ b/.derived/codebase-index/by-spec/048-kit-ships-the-governed-loop-skills.json
@@ -200,5 +200,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "756f2e31670ffa7d4f75c350702f960f65d8d343c8b5ab3f042e94171c1883b8"
+  "shardHash": "4f4f6e8aac623d60b5625ae9b2c96d3c19760e65edc00390d1e9cc338ba5eccc"
 }

--- a/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
+++ b/.derived/codebase-index/by-spec/049-verify-declared-acceptance.json
@@ -239,5 +239,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "60b1d55c5c4be4617683d815fba9bb30a6235a614df83a7fb2ef0dfd1aadf496"
+  "shardHash": "6452edd89ef841b7f9dcb391e6565e18180aed63e75c3faafdd0457ef3956baa"
 }

--- a/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
+++ b/.derived/codebase-index/by-spec/050-index-diagnostics-reach-a-gate.json
@@ -141,5 +141,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "29ccbfdd3e3104cc67e7217e09486683b02ff610c4f19dec91bbc7c191130365"
+  "shardHash": "4e002cf136d8d8479d263810a0565418cfd95269933eff2a2c36c9591d8cc6bc"
 }

--- a/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
+++ b/.derived/codebase-index/by-spec/051-harness-runs-the-verbs-it-ships.json
@@ -197,5 +197,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c3569e8ec74fd605635da9271aa23c33af5ab9ed9ed283c3706dbdae3cf09473"
+  "shardHash": "5d69da2272f6c2e68f425e3450876bb9758e4d128c6c1e0437637493102abe94"
 }

--- a/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
+++ b/.derived/codebase-index/by-spec/052-couple-names-the-crossing.json
@@ -226,5 +226,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f453ff626663e77c2e0af986d862ab1733e8ab969bd371e3b1c81feb8dccac85"
+  "shardHash": "bba36060e475a4411a62af212ae2cb2a6cc96663b3d840421a398fa6e6bf799c"
 }

--- a/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
+++ b/.derived/codebase-index/by-spec/053-depends-on-ordinal-monotonicity.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "719a59ff6ed87b5760d404381b8d21358ff50fef2977a8201beb19853a1d450c"
+  "shardHash": "4212e6206f8c9af9c1459548debec5d2aa384139e3511022fcf64299f19aabe1"
 }

--- a/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
+++ b/.derived/codebase-index/by-spec/054-effective-config-is-a-governed-read.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "2339a69fc21fec8f6c2e5f3659b6ade978420b7a5a2ab3cd0abfd6717c941689"
+  "shardHash": "2c4b8fecc4e66b3bb44b81a13855efbfaf6151413b4790a20695ca2f9eef0820"
 }

--- a/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
+++ b/.derived/codebase-index/by-spec/055-the-ledger-answers-what-consumers-rebuild.json
@@ -163,5 +163,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "aa2fbd23d14741f2afd7da2503de2efcb5ff85414b9b2b17e45d3f7458f65901"
+  "shardHash": "38ded883a5764132800f402240439d6f8dafdcf30e579c94e16e6242df868de4"
 }

--- a/.derived/codebase-index/by-spec/056-compile-one-spec.json
+++ b/.derived/codebase-index/by-spec/056-compile-one-spec.json
@@ -196,5 +196,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "66d3c0827f347268fcaf3cd771974c6f0db50ae83a81508ef47ad2680d98c4da"
+  "shardHash": "8b82443617a48a2080883e6482c869489ace32f9f6f3b0fdf69c65408a660f63"
 }

--- a/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
+++ b/.derived/codebase-index/by-spec/057-claimed-but-unwitnessed.json
@@ -176,5 +176,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b52ce6cba3f2c6014559e8a55f582d6e443c4ca6627b1625f394442bb360c07c"
+  "shardHash": "9f5255c5873136db14842407617c9b970b6bdcee2f45f32c7547f7a4dfd3438c"
 }

--- a/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
+++ b/.derived/codebase-index/by-spec/058-retroactive-adoption-shape.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "0849e4ef655d1bbf49721f49ef7d1f258b15e6b81f08cba87bfb01d52eaf200c"
+  "shardHash": "e94ae5dc8c7f11589b7f12d08abbe6fe58cd57b3c55e9c3b1164d906b4cc410f"
 }

--- a/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
+++ b/.derived/codebase-index/by-spec/059-read-verbs-on-a-code-free-corpus.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b512d2e290c0a8ee479c5852a1988028c377a8a6da607d963328ede5db30cf6f"
+  "shardHash": "216304c1240ad235227e92f607d82f05fd888efbfb4f8220b4193c9a9887ea09"
 }

--- a/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
+++ b/.derived/codebase-index/by-spec/060-plan-answers-the-whole-question.json
@@ -124,5 +124,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2662581d4431948ff2db5d0d6b55047a8413c01eabdaeefef529a0ae62dc91a"
+  "shardHash": "90f758c2daf857a4aee75cbaa9d49f4f0d16c5a84e2075719a6a63dea3ab4fa0"
 }

--- a/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
+++ b/.derived/codebase-index/by-spec/061-the-scaffold-ships-what-adopters-wrote.json
@@ -86,5 +86,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f3282b8c5c24f2612d272cb2d34861b3f485fd3750ede02d019482e45b00e556"
+  "shardHash": "e0a8d6c1a20692e47150d8229b258124071b6414f2664a8ac4c2d7e0d8e9cf59"
 }

--- a/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
+++ b/.derived/codebase-index/by-spec/062-a-version-pin-the-cli-can-check.json
@@ -158,5 +158,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "85547cd5b53c1adcb3e2252f0d1f009e256fc36f4e5b03ba37428cdf5922aa6f"
+  "shardHash": "598c65c6bff0458da3bb336a99728035913733e56d26eb339a12e47500a4575e"
 }

--- a/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
+++ b/.derived/codebase-index/by-spec/063-a-stale-binary-is-not-a-stale-ledger.json
@@ -145,5 +145,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "c9563b3b4100daf1242d9a73caa70df5b697cc898be3db84312940f92a38d09c"
+  "shardHash": "d18e90b960a4d9e07fe2e305eec43e0e6e06f85a60e4e1f483d228d20224586b"
 }

--- a/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
+++ b/.derived/codebase-index/by-spec/064-the-kit-ships-the-composite-gate.json
@@ -227,5 +227,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9a341b392986b93b3ed80d7e39d199a99235e0dc076e4010193de4cec756629a"
+  "shardHash": "acbca6900468d5c8069bcfb82799551f6d4f4144b736e1f0022602a70144a9ea"
 }

--- a/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
+++ b/.derived/codebase-index/by-spec/065-init-and-the-kit-are-one-adoption.json
@@ -210,5 +210,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "02ea0be6958278241360c614b3eff347cfb5c866670feabda0bef205de9f523a"
+  "shardHash": "e5f7a8df606ff3ecf72cbb29782dcc96e4babcf087d48f54d72ba95c5786d4b0"
 }

--- a/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
+++ b/.derived/codebase-index/by-spec/066-the-contract-records-the-lifecycle-table.json
@@ -91,5 +91,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "870bd20cc825d454ecd1cb5338801ffa92d683335bdbb4fa7d2988a0eb29ac37"
+  "shardHash": "c6792e215174b1b0eabe8e623395fca167f963dc3bfa2200d751190f05d74a4f"
 }

--- a/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
+++ b/.derived/codebase-index/by-spec/067-the-docs-name-what-adopters-derived.json
@@ -108,5 +108,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e46d0ee050b94bacafd2ffd6041f1d9c24fdc6711973e0790b64c48c9365ade9"
+  "shardHash": "eaaff8698f89025a90be288213286d950deac3f4604da9d8807d0f6026cfee64"
 }

--- a/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
+++ b/.derived/codebase-index/by-spec/068-a-path-scoped-rule-example.json
@@ -175,5 +175,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9eaa463b2aa552ba690c8eac5d218c9b768410d9fb1a51d376d086b651d41c23"
+  "shardHash": "8b01ebcd263e493908bf02bfaefd862a31e6553eab14d45ff2370b8d6202cf12"
 }

--- a/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
+++ b/.derived/codebase-index/by-spec/069-the-shipped-default-hashes-what-it-names.json
@@ -132,5 +132,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "34c2b42ba8b0ffcf7d743e94767b99562d6ccb04e9cb733d1722f6b0d1bc5c18"
+  "shardHash": "36dc19ed30a36305bf6057ce01618c69f70264f37f07a23ad11fbbe872f8d25b"
 }

--- a/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
+++ b/.derived/codebase-index/by-spec/070-a-malformed-id-is-refused-not-a-panic.json
@@ -59,5 +59,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "693b4c61a9a6ce118a5c45915fe81ec2d395027f8e1a7d2d7bcbdd0131ef6715"
+  "shardHash": "c5bea19771ceeeab3bbe094b9082d652da832cf7226dec939a4f5e1ef3296b64"
 }

--- a/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
+++ b/.derived/codebase-index/by-spec/071-a-tag-push-is-not-a-push-to-main.json
@@ -97,5 +97,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "fcc7cfc05e41e1d0484811bf1b88a08ea78c7bdf296c215026e1eb388970b50b"
+  "shardHash": "7ddf8c27ce7dcd6408663fd7e30cc26081cd15fde6448fcb067aa99d2ea2a860"
 }

--- a/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
+++ b/.derived/codebase-index/by-spec/072-the-default-branch-is-configured-not-assumed.json
@@ -218,5 +218,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ee4d411c4fe1ae4886ed62e4b627afef39691d04f0396183ce66a4fd9336045d"
+  "shardHash": "a56302514d65f4a2178cada171e836019d4ddccff15356312a73dd1dd198ea11"
 }

--- a/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
+++ b/.derived/codebase-index/by-spec/073-a-workflow-bump-is-not-a-governed-change.json
@@ -147,5 +147,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "ce8595503abed7be1651dd89f83cc27ec843246e68ccb9132a608c265ed4537a"
+  "shardHash": "69c4b96e4469f5d085bf118066f2445e1536c3c52819b59fc34df816d79ff62b"
 }

--- a/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
+++ b/.derived/codebase-index/by-spec/074-shipped-is-not-the-same-as-working.json
@@ -341,5 +341,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "7c016392267810dcdbf88b762e50e6814e4888ca443aafe4ad50d9809e60fc4d"
+  "shardHash": "2aa5d293a29a94fd1a3ed5d6a81053ee7e4c9819576ddead41b9c8beb9ddc57d"
 }

--- a/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
+++ b/.derived/codebase-index/by-spec/075-one-name-one-freshness-verb.json
@@ -403,5 +403,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "b924ab989baed09f75a5ab7b6bbaa823666d2bddfd69f42ff3d313c1cd1d70f2"
+  "shardHash": "ff970451565e6bf04e3807ed795e67e724f1630b4c24ec3f5a313da104fdb1d5"
 }

--- a/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
+++ b/.derived/codebase-index/by-spec/076-planned-territory-is-declared-not-inferred.json
@@ -323,5 +323,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "22cc7cb32c4414636f3f662149612c63d57bb8c89d97253615da10fd54b899d8"
+  "shardHash": "d8e4c57d65fc2a1fc13f3ec04f5bfbd814f97e68b1d0da3933c411686abb489a"
 }

--- a/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
+++ b/.derived/codebase-index/by-spec/077-compile-warnings-reach-the-gate.json
@@ -340,5 +340,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a3d981de81b472c87cd567961c0f91dde17839577d8b9b9254e89c2d2d82f132"
+  "shardHash": "ba8ec175129fda63b1e07a4e5caf06477adbdfe80d27cd7042069de3e3d5c4f4"
 }

--- a/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
+++ b/.derived/codebase-index/by-spec/078-the-protocol-has-an-owner.json
@@ -32,5 +32,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "653f7663a794a44b6bae2d50d48de200c4ef17e4385cbdcc11e4b1ca5656adec"
+  "shardHash": "e411fd71ff894c7b9e5dc867a68d21af94fc25d76748dff2951a18f66caaa374"
 }

--- a/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
+++ b/.derived/codebase-index/by-spec/079-a-dead-glob-is-dead-in-both-tables.json
@@ -48,5 +48,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "de52bdfc22c60a34c6f5aec8f249da06a651e533745f1376f4d5ee475d8b5df4"
+  "shardHash": "45e0e01db682bbd0603853ee0d2c75d11a385067d74ea4102cc0b8ede6c5b041"
 }

--- a/.derived/codebase-index/by-spec/080-a-gate-that-cannot-ask-says-so.json
+++ b/.derived/codebase-index/by-spec/080-a-gate-that-cannot-ask-says-so.json
@@ -99,5 +99,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1cec1c47f8db5a6f964ce3244580b0d1cde4a9cc6802517b3a32c69ffa77f59f"
+  "shardHash": "9d954a1981bacecd1956e9acadf65cbb2735ef5c0481546222f6426daa14b7d0"
 }

--- a/.derived/codebase-index/by-spec/081-the-kit-ships-what-the-loop-calls.json
+++ b/.derived/codebase-index/by-spec/081-the-kit-ships-what-the-loop-calls.json
@@ -153,5 +153,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "30c6028102c0d27df06fcf76170f5fe162843a1b6b29ac99d3efe23769775f29"
+  "shardHash": "f7ada2a7d043a2f9e6d95423bacc83f664fc82346029a5152c138696ee9f68cf"
 }

--- a/.derived/codebase-index/by-spec/083-an-attestation-covers-the-territory-it-claims.json
+++ b/.derived/codebase-index/by-spec/083-an-attestation-covers-the-territory-it-claims.json
@@ -94,5 +94,5 @@
     "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "e2f5340b4bc2ea06a0cc488dd429a65fa6db1cadcad2492d16a13cc6fe921c1f"
+  "shardHash": "81360597b466c3cd8514b17cf30137fcd7ce27c76977ed00724bddacc7e054c9"
 }

--- a/.derived/codebase-index/by-spec/084-a-short-id-names-the-same-spec-at-every-verb.json
+++ b/.derived/codebase-index/by-spec/084-a-short-id-names-the-same-spec-at-every-verb.json
@@ -242,5 +242,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "cbd4bb9b3f96c6715104f2e8886623f979d881e949913a8552cc580bf0a8d071"
+  "shardHash": "c65a226cacdf776325296c04c0d0ca4e8a65158deb0fb2af2657e34f02dde276"
 }

--- a/.derived/codebase-index/by-spec/089-a-skip-and-a-failure-are-different-answers.json
+++ b/.derived/codebase-index/by-spec/089-a-skip-and-a-failure-are-different-answers.json
@@ -1,41 +1,24 @@
 {
   "mapping": {
     "dependsOn": [
-      "048-kit-ships-the-governed-loop-skills",
-      "081-the-kit-ships-what-the-loop-calls"
+      "064-the-kit-ships-the-composite-gate",
+      "065-init-and-the-kit-are-one-adoption"
     ],
     "implementingPaths": [
-      {
-        "path": ".claude/skills/",
-        "source": "spec-edge"
-      },
       {
         "path": "crates/spec-spine-core/src/kit_embedded.rs",
         "source": "spec-edge"
       },
       {
-        "path": "crates/spec-spine-core/tests/kit_skills.rs",
+        "path": "crates/spec-spine-core/tests/kit_gate.rs",
         "source": "spec-edge"
       },
       {
-        "path": "kit/.claude/skills/",
+        "path": "kit/Makefile",
         "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
-      {
-        "locations": [
-          {
-            "file": ".claude/skills/"
-          }
-        ],
-        "ownership": true,
-        "sourceField": "extends",
-        "unit": {
-          "kind": "file",
-          "path": ".claude/skills/"
-        }
-      },
       {
         "locations": [
           {
@@ -52,33 +35,33 @@
       {
         "locations": [
           {
-            "file": "crates/spec-spine-core/tests/kit_skills.rs"
+            "file": "crates/spec-spine-core/tests/kit_gate.rs"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "crates/spec-spine-core/tests/kit_skills.rs"
+          "path": "crates/spec-spine-core/tests/kit_gate.rs"
         }
       },
       {
         "locations": [
           {
-            "file": "kit/.claude/skills/"
+            "file": "kit/Makefile"
           }
         ],
         "ownership": true,
         "sourceField": "extends",
         "unit": {
           "kind": "file",
-          "path": "kit/.claude/skills/"
+          "path": "kit/Makefile"
         }
       }
     ],
-    "specId": "082-a-refusal-is-not-a-remediation-round",
-    "specStatus": "approved"
+    "specId": "089-a-skip-and-a-failure-are-different-answers",
+    "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "73da2850ffca0840defac6d3ef2383ccc2c1940a079f10d8f3eac92f56a9db99"
+  "shardHash": "1a8f107be3e241300aeafc76899889029c9fbb4542490a501508e5fd09a34f65"
 }

--- a/.derived/spec-registry/by-spec/089-a-skip-and-a-failure-are-different-answers.json
+++ b/.derived/spec-registry/by-spec/089-a-skip-and-a-failure-are-different-answers.json
@@ -1,0 +1,58 @@
+{
+  "record": {
+    "created": "2026-09-11",
+    "dependsOn": [
+      "064-the-kit-ships-the-composite-gate",
+      "065-init-and-the-kit-are-one-adoption"
+    ],
+    "extends": [
+      {
+        "nature": "corrective",
+        "spec": "064-the-kit-ships-the-composite-gate",
+        "unit": {
+          "kind": "file",
+          "path": "kit/Makefile"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "064-the-kit-ships-the-composite-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/kit_gate.rs"
+        }
+      },
+      {
+        "nature": "corrective",
+        "spec": "065-init-and-the-kit-are-one-adoption",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/kit_embedded.rs"
+        }
+      }
+    ],
+    "id": "089-a-skip-and-a-failure-are-different-answers",
+    "implementation": "complete",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "risk": "medium",
+    "sectionHeadings": [
+      "089: A skip and a failure are different answers",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The guard is an explicit conditional",
+      "3.2 The acceptance runs the shipped lines, in both states",
+      "3.3 The embedded copy is regenerated",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/089-a-skip-and-a-failure-are-different-answers/spec.md",
+    "status": "draft",
+    "summary": "The kit's Makefile guards its language targets on a manifest probe, written as `test -f M && cmd || echo skipping`. That is not an if/else: the `||` branch fires when the probe is false OR when the command fails, so on a repository that HAS the manifest a failing command exits 0 having printed \"no manifest, skipping\". Any adopter who copies `kit/govern.yml` unmodified into a repository with a `Cargo.toml` gets a build job that cannot fail: a broken `cargo test`, a `cargo fmt --check` diff and a `clippy -D warnings` hit are all reported as a skip and the check goes green. Spec 064's acceptance could not catch it, because it asserts the probe is a manifest probe and that is true of the broken shape and the fixed one alike. This spec makes the guard an explicit `if`, and adds the acceptance that tells the two apart: the shipped recipe lines are run in both states.\n",
+    "title": "A skip and a failure are different answers"
+  },
+  "shardHash": "b3708ac32cd646a2d52c7e71affda5a6e8eda559ecb6c408d31efaa27338ef8e",
+  "specVersion": "1.2.0"
+}

--- a/crates/spec-spine-core/src/kit_embedded.rs
+++ b/crates/spec-spine-core/src/kit_embedded.rs
@@ -2116,6 +2116,13 @@ exit 0
 # with cargo installed and no Cargo.toml is the specify-first case, which is
 # three of the four governed repositories, and probing for the tool answers the
 # wrong question. Every guarded target is a clean no-op on a code-free corpus.
+#
+# The guard is an explicit `if`, never `test -f M && cmd || echo skipping`
+# (spec 089). `&&`/`||` is not if/else: the `||` branch fires when EITHER the
+# probe is false OR the command fails, so on a repository that HAS the manifest
+# a failing command exits 0 having printed "no manifest, skipping". That makes
+# `govern.yml`'s `make build test fmt clippy` job unfailable, which is the worst
+# shape a gate can have: the repository looks defended and is not.
 
 SPEC_SPINE ?= spec-spine
 # Spec 072 3.3: the coupling base follows the branch this repository
@@ -2150,17 +2157,17 @@ verify:
 	$(SPEC_SPINE) verify $(SPEC)
 
 test:
-	@test -f Cargo.toml && cargo test --workspace --locked || echo "no Cargo.toml, skipping"
-	@test -f package.json && npm test --if-present || echo "no package.json, skipping"
+	@if test -f Cargo.toml; then cargo test --workspace --locked; else echo "no Cargo.toml, skipping"; fi
+	@if test -f package.json; then npm test --if-present; else echo "no package.json, skipping"; fi
 
 build:
-	@test -f Cargo.toml && cargo build --workspace --locked || echo "no Cargo.toml, skipping"
+	@if test -f Cargo.toml; then cargo build --workspace --locked; else echo "no Cargo.toml, skipping"; fi
 
 fmt:
-	@test -f Cargo.toml && cargo fmt --all --check || echo "no Cargo.toml, skipping"
+	@if test -f Cargo.toml; then cargo fmt --all --check; else echo "no Cargo.toml, skipping"; fi
 
 clippy:
-	@test -f Cargo.toml && cargo clippy --workspace --all-targets --locked -- -D warnings || echo "no Cargo.toml, skipping"
+	@if test -f Cargo.toml; then cargo clippy --workspace --all-targets --locked -- -D warnings; else echo "no Cargo.toml, skipping"; fi
 
 help:
 	@echo "gate     the governed loop, read-only"

--- a/crates/spec-spine-core/tests/kit_gate.rs
+++ b/crates/spec-spine-core/tests/kit_gate.rs
@@ -283,3 +283,105 @@ fn the_gitattributes_stanza_matches_the_committed_shard_globs() {
         );
     }
 }
+
+/// The guarded recipe lines of one Makefile target, `@` stripped, in order.
+/// These are shell commands: make runs each recipe line in its own shell, so
+/// the line's exit status is the target's verdict for that step.
+fn guarded_lines(makefile: &str, target: &str) -> Vec<String> {
+    target_body(makefile, target)
+        .lines()
+        .map(|l| l.trim_start().trim_start_matches('@').to_string())
+        .filter(|l| l.contains("test -f "))
+        .collect()
+}
+
+/// Rewrite a guarded line so its command is `false`, leaving the probe and the
+/// else-branch exactly as shipped. Returns `None` for a line that is not an
+/// if/else, which the test above already refuses.
+fn with_failing_command(line: &str) -> Option<String> {
+    let (probe, rest) = line.split_once("; then ")?;
+    let (_command, tail) = rest.split_once("; else ")?;
+    Some(format!("{probe}; then false; else {tail}"))
+}
+
+/// §3.1 (spec 089): a guarded target distinguishes "the manifest is absent"
+/// from "the command failed". `test -f M && cmd || echo skipping` does not:
+/// `||` fires for either, so a failing command exits 0 printing a false skip.
+/// Static half, so the shape is refused at review time and not only at run
+/// time.
+#[test]
+fn a_guarded_target_does_not_conflate_a_skip_with_a_failure() {
+    let makefile = read("kit/Makefile");
+    for target in ["test", "build", "fmt", "clippy"] {
+        let lines = guarded_lines(&makefile, target);
+        assert!(!lines.is_empty(), "`{target}` has no guarded line");
+        for line in lines {
+            assert!(
+                !(line.contains("&&") && line.contains("|| echo")),
+                "`{target}` guards with `&& ... || echo`, so a failing command \
+                 is reported as a skip: {line}"
+            );
+            assert!(
+                line.starts_with("if test -f ")
+                    && line.contains("; then ")
+                    && line.contains("; else ")
+                    && line.ends_with("fi"),
+                "`{target}` must guard with an explicit if/else: {line}"
+            );
+        }
+    }
+}
+
+/// §3.2 (spec 089): the shipped recipe lines are RUN, in both states, so the
+/// two answers are proved rather than asserted about the text.
+///
+/// This is the acceptance the defect got past. Spec 064's
+/// `language_targets_probe_for_a_manifest_not_a_tool` passes for the broken
+/// shape and the fixed one alike, because both contain `test -f Cargo.toml`;
+/// an acceptance that never forces a command to fail cannot tell them apart.
+#[test]
+fn a_guarded_recipe_skips_when_absent_and_fails_when_the_command_fails() {
+    let makefile = read("kit/Makefile");
+    let run = |script: &str, dir: &Path| {
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .current_dir(dir)
+            .output()
+            .expect("sh is available")
+    };
+
+    for target in ["test", "build", "fmt", "clippy"] {
+        for line in guarded_lines(&makefile, target) {
+            // The manifest is absent: the command never runs, the line exits 0
+            // and says so. This is spec 064 3.1's no-op, still true.
+            let empty = tempfile::tempdir().unwrap();
+            let out = run(&line, empty.path());
+            assert!(
+                out.status.success(),
+                "`{target}` must be a clean no-op with no manifest: {line}"
+            );
+            assert!(
+                String::from_utf8_lossy(&out.stdout).contains("skipping"),
+                "`{target}` must say it skipped: {line}"
+            );
+
+            // The manifest is present and the command fails: the line must
+            // fail. Under the old shape this printed "skipping" and exited 0.
+            let present = tempfile::tempdir().unwrap();
+            fs::write(present.path().join("Cargo.toml"), "").unwrap();
+            fs::write(present.path().join("package.json"), "{}").unwrap();
+            let forced = with_failing_command(&line)
+                .unwrap_or_else(|| panic!("`{target}` line is not an if/else: {line}"));
+            let out = run(&forced, present.path());
+            assert!(
+                !out.status.success(),
+                "`{target}` reported a failing command as success: {forced}"
+            );
+            assert!(
+                !String::from_utf8_lossy(&out.stdout).contains("skipping"),
+                "`{target}` called a failure a skip: {forced}"
+            );
+        }
+    }
+}

--- a/kit/Makefile
+++ b/kit/Makefile
@@ -18,6 +18,13 @@
 # with cargo installed and no Cargo.toml is the specify-first case, which is
 # three of the four governed repositories, and probing for the tool answers the
 # wrong question. Every guarded target is a clean no-op on a code-free corpus.
+#
+# The guard is an explicit `if`, never `test -f M && cmd || echo skipping`
+# (spec 089). `&&`/`||` is not if/else: the `||` branch fires when EITHER the
+# probe is false OR the command fails, so on a repository that HAS the manifest
+# a failing command exits 0 having printed "no manifest, skipping". That makes
+# `govern.yml`'s `make build test fmt clippy` job unfailable, which is the worst
+# shape a gate can have: the repository looks defended and is not.
 
 SPEC_SPINE ?= spec-spine
 # Spec 072 3.3: the coupling base follows the branch this repository
@@ -52,17 +59,17 @@ verify:
 	$(SPEC_SPINE) verify $(SPEC)
 
 test:
-	@test -f Cargo.toml && cargo test --workspace --locked || echo "no Cargo.toml, skipping"
-	@test -f package.json && npm test --if-present || echo "no package.json, skipping"
+	@if test -f Cargo.toml; then cargo test --workspace --locked; else echo "no Cargo.toml, skipping"; fi
+	@if test -f package.json; then npm test --if-present; else echo "no package.json, skipping"; fi
 
 build:
-	@test -f Cargo.toml && cargo build --workspace --locked || echo "no Cargo.toml, skipping"
+	@if test -f Cargo.toml; then cargo build --workspace --locked; else echo "no Cargo.toml, skipping"; fi
 
 fmt:
-	@test -f Cargo.toml && cargo fmt --all --check || echo "no Cargo.toml, skipping"
+	@if test -f Cargo.toml; then cargo fmt --all --check; else echo "no Cargo.toml, skipping"; fi
 
 clippy:
-	@test -f Cargo.toml && cargo clippy --workspace --all-targets --locked -- -D warnings || echo "no Cargo.toml, skipping"
+	@if test -f Cargo.toml; then cargo clippy --workspace --all-targets --locked -- -D warnings; else echo "no Cargo.toml, skipping"; fi
 
 help:
 	@echo "gate     the governed loop, read-only"

--- a/specs/089-a-skip-and-a-failure-are-different-answers/spec.md
+++ b/specs/089-a-skip-and-a-failure-are-different-answers/spec.md
@@ -1,0 +1,208 @@
+---
+id: "089-a-skip-and-a-failure-are-different-answers"
+title: "A skip and a failure are different answers"
+status: draft
+kind: "tooling"
+created: "2026-09-11"
+summary: >
+  The kit's Makefile guards its language targets on a manifest probe, written
+  as `test -f M && cmd || echo skipping`. That is not an if/else: the `||`
+  branch fires when the probe is false OR when the command fails, so on a
+  repository that HAS the manifest a failing command exits 0 having printed
+  "no manifest, skipping". Any adopter who copies `kit/govern.yml` unmodified
+  into a repository with a `Cargo.toml` gets a build job that cannot fail:
+  a broken `cargo test`, a `cargo fmt --check` diff and a `clippy -D warnings`
+  hit are all reported as a skip and the check goes green. Spec 064's
+  acceptance could not catch it, because it asserts the probe is a manifest
+  probe and that is true of the broken shape and the fixed one alike. This
+  spec makes the guard an explicit `if`, and adds the acceptance that tells
+  the two apart: the shipped recipe lines are run in both states.
+implementation: complete
+owner: "The spec-spine Authors"
+risk: medium
+depends_on:
+  - "064-the-kit-ships-the-composite-gate"
+  - "065-init-and-the-kit-are-one-adoption"
+extends:
+  # 3.1: the five guarded recipe lines.
+  - { spec: "064-the-kit-ships-the-composite-gate", unit: "kit/Makefile", nature: corrective }
+  # 3.2: the acceptance that runs the shipped lines in both states.
+  - { spec: "064-the-kit-ships-the-composite-gate", unit: "crates/spec-spine-core/tests/kit_gate.rs", nature: additive }
+  # 3.3: the embedded copy `init --with-kit` writes.
+  - { spec: "065-init-and-the-kit-are-one-adoption", unit: "crates/spec-spine-core/src/kit_embedded.rs", nature: corrective }
+---
+
+# 089: A skip and a failure are different answers
+
+## 1. Purpose
+
+`kit/Makefile` guards each language target so the whole gate is a clean no-op
+on a corpus with no code. That intent is right and spec 064 section 3.1 argues
+it well: a machine with `cargo` installed and no `Cargo.toml` is the
+specify-first case, three of the four governed repositories, and probing for
+the tool answers the wrong question.
+
+The implementation of that intent conflates two different answers:
+
+```make
+	@test -f Cargo.toml && cargo test --workspace --locked || echo "no Cargo.toml, skipping"
+```
+
+`cmd_a && cmd_b || cmd_c` is not an if/else. `cmd_c` runs when **either**
+`cmd_a` or `cmd_b` fails, so it is only safe when `cmd_b` cannot fail. Here
+`cmd_b` is the entire test suite. On a repository that has the manifest, a
+failing `cargo test` falls into the same branch as an absent `Cargo.toml`, the
+target prints `no Cargo.toml, skipping` (a false statement about a file that
+is right there) and exits 0.
+
+Reproduced with the probe true and the command forced to fail:
+
+| form | output | exit |
+|---|---|---|
+| `test -f Cargo.toml && false \|\| echo "no Cargo.toml, skipping"` | `no Cargo.toml, skipping` | 0 |
+| `if test -f Cargo.toml; then false; else echo "skipping"; fi` | nothing | 1 |
+
+**Where it bites.** `kit/govern.yml` line 81 is `- run: make build test fmt
+clippy`, gated on the `has_cargo` job output. An adopter who copies that
+workflow unmodified into a repository with a `Cargo.toml` gets a Rust job that
+cannot fail. That is the worst shape a gate can have: the repository looks
+defended and is not, and nothing in the run says otherwise.
+
+**What it costs today: nothing, and that is luck rather than design.** Every
+current copy dodges it by accident. This repository's `ci.yml` runs
+`make -f kit/Makefile gate`, and `gate` has no guarded line; the cargo stack
+runs directly in the same workflow. `canonical-keysort-json` deleted the probe
+and build jobs when it copied `govern.yml`, to avoid running every cargo
+command twice per pull request. `statecrafting-profile` runs the four targets
+but has no manifest at all, so the job is gated off. `statecrafting` replaced
+the guarded `test:` target with a plain `npm test`. The defect is latent, and
+a latent defect in a shipped template is a defect with an audience of everyone
+who has not adopted yet.
+
+Found on 2026-09-11 while adopting the 0.18.0 kit into `statecraft.ing`, which
+patched the two `package.json` lines locally under its own spec 005 and
+recorded the divergence as a decision. That patch is the adopter-side workaround.
+This is the fix.
+
+## 2. Territory
+
+- **Owns nothing new.** Three units, all extended from their owners: the five
+  guarded recipe lines in `kit/Makefile` and the test file that holds the kit
+  gate's acceptance (spec 064), and the generated module `init --with-kit`
+  writes from the kit (spec 065).
+- **Does not touch `gate`, `refresh` or `verify`.** They carry no guarded line
+  and no manifest probe. The read-only contract spec 064 section 3.1 places on
+  `gate` is unchanged and still asserted.
+- **Does not touch `kit/govern.yml`.** The workflow is correct; it calls
+  targets that were not. Fixing the Makefile fixes the job.
+- **Does not touch this repository's own gate.** `ci.yml` calls
+  `make -f kit/Makefile gate` and runs cargo directly, so nothing here changes
+  what this repository's CI enforces.
+
+## 3. Behavior
+
+### 3.1 The guard is an explicit conditional
+
+Each of the five guarded recipe lines MUST be written as:
+
+```make
+	@if test -f <manifest>; then <command>; else echo "no <manifest>, skipping"; fi
+```
+
+`test -f` is kept as the probe rather than `[ -f ]` so spec 064's
+`language_targets_probe_for_a_manifest_not_a_tool` keeps passing unchanged:
+the probe it asserts is still there, and this spec changes only what happens
+to the command's exit status. The no-op property that guard exists for is
+unchanged: with the manifest absent, the command never runs, the line prints
+the skip and exits 0.
+
+The header comment states the rule next to the manifest-probe rule it
+qualifies, because the `||` form is the one a reader reaches for and the next
+person to touch this file needs to know why it is not used.
+
+### 3.2 The acceptance runs the shipped lines, in both states
+
+Spec 064's `language_targets_probe_for_a_manifest_not_a_tool` asserts each
+target's body contains `test -f Cargo.toml` or `test -f package.json`. Both
+the broken and the fixed shape satisfy it. An acceptance that never forces a
+command to fail cannot distinguish a guard from a swallow, so this spec adds
+two tests to `crates/spec-spine-core/tests/kit_gate.rs`:
+
+- **static**: no guarded line combines `&&` with `|| echo`, and every guarded
+  line is the `if test -f ...; then ...; else ...; fi` form. This refuses the
+  shape at review time rather than only at run time.
+- **behavioral**: each guarded line is extracted from the shipped
+  `kit/Makefile` and executed, twice. With no manifest present it must exit 0
+  and print the skip. With the manifest present and its command replaced by
+  `false`, it must exit non-zero and must not print the skip.
+
+The behavioral test runs the **shipped bytes**, not a hand-written copy of
+them, which is the only form that would have caught the original defect. It
+runs each line under `sh -c` rather than through `make`: make runs every
+recipe line in its own shell, so the line's exit status is the target's
+verdict for that step, and testing the line directly removes a dependency on
+`make` being installed wherever the suite runs.
+
+Both tests fail against pre-089 code and pass after it. Spec 064's own test
+passes in both states, which is the point.
+
+### 3.3 The embedded copy is regenerated
+
+`crates/spec-spine-core/src/kit_embedded.rs` is generated from `kit/` by
+`scripts/gen-kit-embedded.py`, and `init --with-kit` writes the embedded bytes
+rather than reading `kit/`. A fix to `kit/Makefile` that does not regenerate
+the module fixes the file in this repository and ships the broken one to every
+new adopter. The module is regenerated in the same change, and the existing
+test asserting the two agree holds it there.
+
+## 4. Out of scope
+
+- **A lint.** The conflating form is a shell idiom, not a corpus property, and
+  a `spec-spine` lint over adopter Makefiles is a different tool than the one
+  this repository builds. The static test in 3.2 covers the file that ships.
+- **Auditing every adopter's own Makefile.** Adopters customize the language
+  targets (`statecrafting` already replaced `test:` outright), so their copies
+  are theirs. The release note is the right instrument: adopters re-copy
+  `kit/Makefile`.
+- **`kit/govern.yml`.** Correct as written; see section 2.
+- **The `||` idiom elsewhere in the kit.** The hooks in `kit/settings.json`
+  use `||` for control flow in several places, all of them where the left side
+  is a probe that cannot meaningfully "fail" in the swallow sense. Re-reading
+  them is worthwhile and is not this change.
+
+## 5. Resolved decisions
+
+- **2026-09-11: `test -f` is kept, `[ -f ]` rejected.** Both are POSIX and
+  equivalent. `test -f` keeps spec 064's acceptance passing without editing
+  it, so the diff stays about the defect. Editing another spec's assertion to
+  accommodate a fix that did not need to would be noise in exactly the place
+  where noise is expensive.
+- **2026-09-11: the behavioral test runs `sh -c`, not `make`.** Running the
+  real `make` would also exercise make's own failure propagation, which is not
+  in doubt and is not what broke. `sh -c` on the recipe line tests the thing
+  that was wrong, needs no `make` on the test host, and runs in milliseconds.
+- **2026-09-11: the cargo lines are fixed here even though no repository
+  currently runs them through this Makefile.** The adopter that found this
+  patched only its two `package.json` lines, correctly, because it has no
+  `Cargo.toml`. The kit is the template, and a template is fixed for the
+  adopter who has not arrived yet.
+- **2026-09-11: `nature: corrective` on `kit/Makefile` and the embedded
+  module.** The edges to those two units change behavior the owning specs
+  described, rather than adding to it. The edge on the test file is
+  `additive`: spec 064's tests all stay and two join them.
+
+## Verification
+
+Each line is one command. The first three fail against pre-089 code: the two
+new tests do not exist, and the shipped Makefile carries the conflating form.
+
+```verify:cli
+cargo test -p spec-spine-core --test kit_gate --locked
+# 3.1: no guarded line conflates a false probe with a failed command.
+! grep -qE '^	@test -f .+ && .+ \|\| echo' kit/Makefile
+# 3.1: all five guarded lines are the explicit conditional.
+sh -c 'test "$(grep -cE "^	@if test -f " kit/Makefile)" = 5'
+# 3.3: the embedded copy adopters receive carries the fixed bytes.
+grep -qF 'if test -f Cargo.toml; then cargo test --workspace --locked' crates/spec-spine-core/src/kit_embedded.rs
+grep -qF 'if test -f package.json; then npm test --if-present' crates/spec-spine-core/src/kit_embedded.rs
+```


### PR DESCRIPTION
## Summary

`kit/Makefile` guards its language targets like this:

```make
	@test -f Cargo.toml && cargo test --workspace --locked || echo "no Cargo.toml, skipping"
```

`cmd_a && cmd_b || cmd_c` is not an if/else. The `||` branch fires when
**either** the probe is false **or** the command fails, so the idiom is only
safe when `cmd_b` cannot fail. Here `cmd_b` is the entire test suite. On a
repository that **has** the manifest, a failing `cargo test` lands in the same
branch as an absent `Cargo.toml`: the target prints `no Cargo.toml, skipping`
about a file that is sitting right there, and exits 0.

| form | probe true, command fails | exit |
|---|---|---|
| `test -f Cargo.toml && false \|\| echo "no Cargo.toml, skipping"` | prints the skip | **0** |
| `if test -f Cargo.toml; then false; else echo "skipping"; fi` | prints nothing | **1** |

**Why it matters.** `kit/govern.yml` line 81 is `- run: make build test fmt
clippy`, gated on the `has_cargo` job output. An adopter who copies that
workflow unmodified into a repository with a `Cargo.toml` gets a Rust job that
**cannot fail**: a broken test, a `cargo fmt --check` diff and a
`clippy -D warnings` hit all read as a skip. That is the worst shape a gate can
have, because the repository looks defended and is not.

**Nothing is broken today, and that is luck rather than design.** Every current
copy dodges it by accident, and I checked each one before writing the spec:

- this repository's `ci.yml` runs `make -f kit/Makefile gate`, and `gate` has
  no guarded line; the cargo stack runs directly in the same workflow;
- `canonical-keysort-json` deleted the probe and build jobs when it copied
  `govern.yml`, to avoid running every cargo command twice per PR;
- `statecrafting-profile` runs the four targets but has no manifest at all, so
  the job is gated off;
- `statecrafting` replaced the guarded `test:` target with a plain `npm test`.

The defect is latent, and a latent defect in a shipped template has an audience
of everyone who has not adopted yet.

## The fix

The five guarded recipe lines become
`@if test -f <manifest>; then <command>; else echo "no <manifest>, skipping"; fi`.

`test -f` is kept rather than `[ -f ]` so spec 064's
`language_targets_probe_for_a_manifest_not_a_tool` passes **unchanged**: the
probe it asserts is still there, and the diff stays about the defect rather
than spilling into another spec's assertion. The no-op property the guard
exists for is unchanged and is now actually tested.

`crates/spec-spine-core/src/kit_embedded.rs` is regenerated in the same change.
`init --with-kit` writes the embedded bytes, so a fix that skips the generator
fixes this repository and ships the broken Makefile to every new adopter.

## The acceptance that was missing

Spec 064's test asserts each target body contains `test -f Cargo.toml`. That is
true of the broken shape **and** the fixed one, so an acceptance that never
forces a command to fail could not tell them apart. Two tests join it in
`kit_gate.rs`:

- **static**: no guarded line combines `&&` with `|| echo`, and every guarded
  line is the explicit conditional. Refuses the shape at review time.
- **behavioral**: each guarded line is extracted from the shipped
  `kit/Makefile` and executed twice. No manifest present, it must exit 0 and
  print the skip. Manifest present with the command replaced by `false`, it
  must exit non-zero and must not print the skip.

The behavioral test runs the **shipped bytes**, not a hand-written copy, which
is the only form that would have caught the original. It runs each line under
`sh -c` rather than through `make`: make runs every recipe line in its own
shell, so the line's exit status is the target's verdict for that step, and
this needs no `make` on the test host.

Both new tests **fail against pre-089 code**; 064's test passes in both states.
I verified that by reverting the Makefile and re-running, which is the evidence
the spec's section 3.2 claims.

## Testing

```
spec-spine check --fail-on-unresolved --fail-on-warn    both trees fresh
spec-spine lint --fail-on-warn                          0 errors, 0 warnings
spec-spine index coverage --fail-on-untraced            all packages 100%
spec-spine couple --base origin/main                    4 paths checked, no drift, no waiver
spec-spine verify 089                                   passed (5 commands)
cargo test --workspace --locked                         30 suites, 0 failures
cargo clippy --workspace --all-targets -- -D warnings   clean
cargo fmt --all --check                                 clean
```

Every index shard restaled, as expected: `kit/Makefile` is in
`[index] extra_hashed_inputs`, so it folds into the global scalar.

## Notes for the merge

- **`status: draft` is deliberate.** Ratification is a human flip, per this
  repo's `chore(NNN): ratify (draft -> approved)` convention.
- Found while adopting the 0.18.0 kit into `statecraft.ing`, which patched its
  two `package.json` lines locally under its own spec 005 and recorded the
  divergence as a dated decision. That was the adopter-side workaround; this is
  the fix.
- Built in a worktree off `main` so the in-flight `085-087-authority-evidence`
  branch and its four uncommitted draft specs were left untouched.
- **Adopters should re-copy `kit/Makefile`** once this lands.
