### PR TITLE
docs(085-088): four measured gaps in what authority evidence proves

### DIFF
--- a/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -1,0 +1,168 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "023-ledger-seal",
+      "042-per-spec-attestation",
+      "067-the-docs-name-what-adopters-derived",
+      "083-an-attestation-covers-the-territory-it-claims"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/verify_attestation.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/attest.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/attest.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/attest.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "docs/schema-versioning.md",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/verify_attestation_bytes.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/verify_attestation.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/attest.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/attest.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/attest.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/attest.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/attest.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/attest.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/schema-versioning.md"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/authority-evidence.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/04-authority-evidence-extension.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "specs/084-a-short-id-names-the-same-spec-at-every-verb/spec.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "specs/084-a-short-id-names-the-same-spec-at-every-verb/spec.md"
+        }
+      }
+    ],
+    "specId": "085-a-verifier-checks-the-bytes-it-was-given",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "022b715d36660ddefcfe28ea01c0150e1fe9a4b4a5accc8b57366eaf0c7672ac"
+}

--- a/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -164,5 +164,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "f15839a842cee94c35e0ad31bbe2009c67c0b8cd5a383e24b6a6bc465eaa90c5"
+  "shardHash": "384bbd1f4cbf82384472d891ad92328e0e0a1e29a5d293c7b87ff6558c9d94b6"
 }

--- a/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -164,5 +164,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "384bbd1f4cbf82384472d891ad92328e0e0a1e29a5d293c7b87ff6558c9d94b6"
+  "shardHash": "9534dc0b6308cb55a71adca62e46aafcc37c91b0e88b3cba5832d22e6df01d15"
 }

--- a/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -164,5 +164,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "022b715d36660ddefcfe28ea01c0150e1fe9a4b4a5accc8b57366eaf0c7672ac"
+  "shardHash": "f15839a842cee94c35e0ad31bbe2009c67c0b8cd5a383e24b6a6bc465eaa90c5"
 }

--- a/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -164,5 +164,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "9534dc0b6308cb55a71adca62e46aafcc37c91b0e88b3cba5832d22e6df01d15"
+  "shardHash": "d11ade8dd92e6f36b35a9243e7fadd5b22bb3d52fb408cadd0329a588a10e674"
 }

--- a/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -117,5 +117,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "a241018127576af6d3d0c95111e2441589ca0bdb4bd9925f4b90de1e69bd44d3"
+  "shardHash": "98a9491948ef942877aad7a61a1da138030e0e4d5714d1d9484f722543f60e18"
 }

--- a/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -1,0 +1,121 @@
+{
+  "mapping": {
+    "amends": [
+      "024-index-sharding"
+    ],
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate",
+      "024-index-sharding",
+      "031-registry-freshness-check",
+      "075-one-name-one-freshness-verb"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_check.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/cmd_index.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/index.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/index_body.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_check.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_check.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/index.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/authority-evidence.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/04-authority-evidence-extension.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "specs/031-registry-freshness-check/spec.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "specs/031-registry-freshness-check/spec.md"
+        }
+      }
+    ],
+    "specId": "086-the-committed-index-is-compared-not-trusted",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "a241018127576af6d3d0c95111e2441589ca0bdb4bd9925f4b90de1e69bd44d3"
+}

--- a/.derived/codebase-index/by-spec/087-an-authority-snapshot-says-what-it-read.json
+++ b/.derived/codebase-index/by-spec/087-an-authority-snapshot-says-what-it-read.json
@@ -1,0 +1,196 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "023-ledger-seal",
+      "024-index-sharding",
+      "031-registry-freshness-check",
+      "032-ownership-coverage",
+      "042-per-spec-attestation",
+      "057-claimed-but-unwitnessed",
+      "075-one-name-one-freshness-verb",
+      "083-an-attestation-covers-the-territory-it-claims",
+      "085-a-verifier-checks-the-bytes-it-was-given",
+      "086-the-committed-index-is-compared-not-trusted"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_attest.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/verify_attestation.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/version.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/snapshot.rs"
+        }
+      },
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/snapshot.rs"
+        }
+      },
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/snapshot.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_attest.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_attest.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/verify_attestation.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/version.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/authority-evidence.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/04-authority-evidence-extension.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      }
+    ],
+    "specId": "087-an-authority-snapshot-says-what-it-read",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "dfa7d1fbf19ff616ef942c3941a8bd0bcabaa6c5f04904333b0a5cce7de64573"
+}

--- a/.derived/codebase-index/by-spec/087-an-authority-snapshot-says-what-it-read.json
+++ b/.derived/codebase-index/by-spec/087-an-authority-snapshot-says-what-it-read.json
@@ -192,5 +192,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "61d899a32a93e339b651c7d22df8119a2717470583a85eaac7cf566fca74b6e1"
+  "shardHash": "0ff171d8444afcbe522235e25565286112758b2667d9d6acaac34ed84504bf60"
 }

--- a/.derived/codebase-index/by-spec/087-an-authority-snapshot-says-what-it-read.json
+++ b/.derived/codebase-index/by-spec/087-an-authority-snapshot-says-what-it-read.json
@@ -192,5 +192,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "dfa7d1fbf19ff616ef942c3941a8bd0bcabaa6c5f04904333b0a5cce7de64573"
+  "shardHash": "61d899a32a93e339b651c7d22df8119a2717470583a85eaac7cf566fca74b6e1"
 }

--- a/.derived/codebase-index/by-spec/088-a-change-is-classified-under-the-bases-rules.json
+++ b/.derived/codebase-index/by-spec/088-a-change-is-classified-under-the-bases-rules.json
@@ -1,0 +1,216 @@
+{
+  "mapping": {
+    "dependsOn": [
+      "000-spec-spine-bootstrap",
+      "005-coupling-gate",
+      "030-cargo-workflow-dependency-waiver",
+      "037-machine-readable-verdicts",
+      "040-amendment-authoring",
+      "049-verify-declared-acceptance",
+      "055-the-ledger-answers-what-consumers-rebuild",
+      "086-the-committed-index-is-compared-not-trusted"
+    ],
+    "implementingPaths": [
+      {
+        "path": "crates/spec-spine-cli/src/cmd_couple.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/src/main.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-cli/tests/cli.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/lib.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/verdict.rs",
+        "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-types/src/version.rs",
+        "source": "spec-edge"
+      }
+    ],
+    "resolvedUnits": [
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_delta.rs"
+        }
+      },
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/delta.rs"
+        }
+      },
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/delta.rs"
+        }
+      },
+      {
+        "locations": [],
+        "ownership": true,
+        "sourceField": "establishes",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/delta.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/cmd_couple.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/src/main.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-cli/tests/cli.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/lib.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/verdict.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/verdict.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "crates/spec-spine-types/src/version.rs"
+          }
+        ],
+        "ownership": true,
+        "sourceField": "extends",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/authority-evidence.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/02-agentic-builder-substrate.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/02-agentic-builder-substrate.md"
+        }
+      },
+      {
+        "locations": [
+          {
+            "file": "docs/design/04-authority-evidence-extension.md"
+          }
+        ],
+        "ownership": false,
+        "sourceField": "references",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      }
+    ],
+    "specId": "088-a-change-is-classified-under-the-bases-rules",
+    "specStatus": "draft"
+  },
+  "schemaVersion": "1.1.0",
+  "shardHash": "5e55c51d9e6a4dcf02b6aec2d0c26a4c5d74b8284a5e76e6700bd8d8558437bc"
+}

--- a/.derived/codebase-index/by-spec/088-a-change-is-classified-under-the-bases-rules.json
+++ b/.derived/codebase-index/by-spec/088-a-change-is-classified-under-the-bases-rules.json
@@ -212,5 +212,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "5e55c51d9e6a4dcf02b6aec2d0c26a4c5d74b8284a5e76e6700bd8d8558437bc"
+  "shardHash": "928fc5fcd419c28fce4d83ca2ef498ea06fbd4546ca16b47fdf6a238303c97c1"
 }

--- a/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -112,6 +112,6 @@
     "summary": "`verify-attestation` decides on a different object from the one it was handed. It deserializes the attestation without refusing members it does not know, and it checks the seal against a hash of its own re-serialization of what it parsed, never against the file's bytes. Measured at 75181a5: a sealed attestation with an injected `\"prCouple\": {\"ok\": true}` verifies as `match` and `valid` at exit 0, in both the corpus and the per-spec scope, and so does a reformatted copy. Separately, the corpus recompute never compares `schemaVersion`, so an attestation claiming `9.0.0` recomputes as `match` at exit 0, while the per-spec path reports an unnamed content mismatch. Spec 023 AC-4 already requires a single tampered payload byte to fail the signature, and the attestation module documents that loaders reject an unknown MAJOR, so this spec extends rather than amends: the verifier reads the file once, both modes decide on those bytes, every attestation and seal DTO refuses unknown members at exit 3, an unknown schema MAJOR is refused at exit 3 in the loaders' own words, and the corpus recompute compares the version. Nothing `attest` emits changes, and every attestation and seal it has ever written still verifies, provided the bytes were kept.\n",
     "title": "A verifier checks the bytes it was given"
   },
-  "shardHash": "38a82a618a4708f7029e469d433fa6b0a33e41bbe9fc74789849eeea7fec73ea",
+  "shardHash": "7db2f572b8791732988f27bbc21c62e5bf4664a5b75af7bc797f91fcc5046941",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -112,6 +112,6 @@
     "summary": "`verify-attestation` decides on a different object from the one it was handed. It deserializes the attestation without refusing members it does not know, and it checks the seal against a hash of its own re-serialization of what it parsed, never against the file's bytes. Measured at 75181a5: a sealed attestation with an injected `\"prCouple\": {\"ok\": true}` verifies as `match` and `valid` at exit 0, in both the corpus and the per-spec scope, and so does a reformatted copy. Separately, the corpus recompute never compares `schemaVersion`, so an attestation claiming `9.0.0` recomputes as `match` at exit 0, while the per-spec path reports an unnamed content mismatch. Spec 023 AC-4 already requires a single tampered payload byte to fail the signature, and the attestation module documents that loaders reject an unknown MAJOR, so this spec extends rather than amends: the verifier reads the file once, both modes decide on those bytes, every attestation and seal DTO refuses unknown members at exit 3, an unknown schema MAJOR is refused at exit 3 in the loaders' own words, and the corpus recompute compares the version. Nothing `attest` emits changes, and every attestation and seal it has ever written still verifies, provided the bytes were kept.\n",
     "title": "A verifier checks the bytes it was given"
   },
-  "shardHash": "6f3aad189e809499d5f76863140ef1efc35dc946d4860ba2e7c741e661c4bce3",
+  "shardHash": "e503dc75bfe8737e505558749f73757c386146b348a3583550189aa45991284a",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -1,0 +1,117 @@
+{
+  "record": {
+    "created": "2026-09-11",
+    "dependsOn": [
+      "023-ledger-seal",
+      "042-per-spec-attestation",
+      "067-the-docs-name-what-adopters-derived",
+      "083-an-attestation-covers-the-territory-it-claims"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-cli/tests/verify_attestation_bytes.rs",
+        "planned": true
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "023-ledger-seal",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/attest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "023-ledger-seal",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "023-ledger-seal",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/attest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "023-ledger-seal",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/tests/attest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "067-the-docs-name-what-adopters-derived",
+        "unit": {
+          "kind": "file",
+          "path": "docs/schema-versioning.md"
+        }
+      }
+    ],
+    "id": "085-a-verifier-checks-the-bytes-it-was-given",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "specs/084-a-short-id-names-the-same-spec-at-every-verb/spec.md"
+        }
+      }
+    ],
+    "risk": "high",
+    "sectionHeadings": [
+      "085: A verifier checks the bytes it was given",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The bytes are read once, and both modes decide on them",
+      "3.2 An unknown member is refused",
+      "3.3 An unknown schema MAJOR is refused, and the corpus recompute compares the version",
+      "3.4 The facade holds the same rules",
+      "3.5 The documentation says what is true",
+      "3.6 What must keep working",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md",
+    "status": "draft",
+    "summary": "`verify-attestation` decides on a different object from the one it was handed. It deserializes the attestation without refusing members it does not know, and it checks the seal against a hash of its own re-serialization of what it parsed, never against the file's bytes. Measured at 75181a5: a sealed attestation with an injected `\"prCouple\": {\"ok\": true}` verifies as `match` and `valid` at exit 0, in both the corpus and the per-spec scope, and so does a reformatted copy. Separately, the corpus recompute never compares `schemaVersion`, so an attestation claiming `9.0.0` recomputes as `match` at exit 0, while the per-spec path reports an unnamed content mismatch. Spec 023 AC-4 already requires a single tampered payload byte to fail the signature, and the attestation module documents that loaders reject an unknown MAJOR, so this spec extends rather than amends: the verifier reads the file once, both modes decide on those bytes, every attestation and seal DTO refuses unknown members at exit 3, an unknown schema MAJOR is refused at exit 3 in the loaders' own words, and the corpus recompute compares the version. Nothing `attest` emits changes, and every attestation and seal it has ever written still verifies, provided the bytes were kept.\n",
+    "title": "A verifier checks the bytes it was given"
+  },
+  "shardHash": "6f3aad189e809499d5f76863140ef1efc35dc946d4860ba2e7c741e661c4bce3",
+  "specVersion": "1.2.0"
+}

--- a/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -112,6 +112,6 @@
     "summary": "`verify-attestation` decides on a different object from the one it was handed. It deserializes the attestation without refusing members it does not know, and it checks the seal against a hash of its own re-serialization of what it parsed, never against the file's bytes. Measured at 75181a5: a sealed attestation with an injected `\"prCouple\": {\"ok\": true}` verifies as `match` and `valid` at exit 0, in both the corpus and the per-spec scope, and so does a reformatted copy. Separately, the corpus recompute never compares `schemaVersion`, so an attestation claiming `9.0.0` recomputes as `match` at exit 0, while the per-spec path reports an unnamed content mismatch. Spec 023 AC-4 already requires a single tampered payload byte to fail the signature, and the attestation module documents that loaders reject an unknown MAJOR, so this spec extends rather than amends: the verifier reads the file once, both modes decide on those bytes, every attestation and seal DTO refuses unknown members at exit 3, an unknown schema MAJOR is refused at exit 3 in the loaders' own words, and the corpus recompute compares the version. Nothing `attest` emits changes, and every attestation and seal it has ever written still verifies, provided the bytes were kept.\n",
     "title": "A verifier checks the bytes it was given"
   },
-  "shardHash": "e503dc75bfe8737e505558749f73757c386146b348a3583550189aa45991284a",
+  "shardHash": "38a82a618a4708f7029e469d433fa6b0a33e41bbe9fc74789849eeea7fec73ea",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -1,0 +1,97 @@
+{
+  "record": {
+    "amends": [
+      "024-index-sharding"
+    ],
+    "created": "2026-09-11",
+    "dependsOn": [
+      "004-codebase-index",
+      "005-coupling-gate",
+      "024-index-sharding",
+      "031-registry-freshness-check",
+      "075-one-name-one-freshness-verb"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/tests/index_body.rs",
+        "planned": true
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "004-codebase-index",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_index.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "075-one-name-one-freshness-verb",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_check.rs"
+        }
+      }
+    ],
+    "id": "086-the-committed-index-is-compared-not-trusted",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "specs/031-registry-freshness-check/spec.md"
+        }
+      }
+    ],
+    "risk": "high",
+    "sectionHeadings": [
+      "086: The committed index is compared, not trusted",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 `index check` compares bytes and sets",
+      "3.2 Every reader inherits it",
+      "3.3 What the gate's ownership now means",
+      "3.4 Cost",
+      "3.5 What must keep working",
+      "3.6 The trade in 024 5 changes",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/086-the-committed-index-is-compared-not-trusted/spec.md",
+    "status": "draft",
+    "summary": "`index check` does not compare the committed index with what the corpus indexes to. It reads each committed shard's own mapping, derives from that mapping which span files to hash, and compares the resulting hash with the shard's `shardHash` field. The mapping body itself (which units resolved where, which paths implement which spec, the ownership flags) is never compared with a fresh resolution, and for a `file`, `directory` or `crate` unit, which carries no span, nothing in the hash constrains it. Measured on a scratch repository: rewriting a committed shard so its spec owns nothing, with `shardHash` left alone, leaves `index check` and `check` reporting fresh, and `couple` then derives ownership from the edited body and passes a change to code the spec owned, without its `spec.md`. `.derived/` is in the bypass floor, so the edit itself trips nothing. AGENTS.md tells every session that a fresh `check` means the committed shards are exactly what the corpus compiles to; for the index that is not what is checked. Spec 031 3.1 recorded the weaker comparison as a cost trade; a full re-index of this repository takes 0.04 s against 0.03 s for the check. This spec makes `index check` compare bytes and set membership exactly as `compile --check` does, so every reader of the committed index (the coupling gate, `index owner`, coverage, the projections) reads a body equal to the recompute. It amends 024 5, whose bounded trade let a sibling-caused resolution flip go unreported.\n",
+    "title": "The committed index is compared, not trusted"
+  },
+  "shardHash": "538079d687013d40f5e0eeb643d998d255560f6ce0a12cadbfdfe0e750450f69",
+  "specVersion": "1.2.0"
+}

--- a/.derived/spec-registry/by-spec/087-an-authority-snapshot-says-what-it-read.json
+++ b/.derived/spec-registry/by-spec/087-an-authority-snapshot-says-what-it-read.json
@@ -1,0 +1,135 @@
+{
+  "record": {
+    "created": "2026-09-11",
+    "dependsOn": [
+      "023-ledger-seal",
+      "024-index-sharding",
+      "031-registry-freshness-check",
+      "032-ownership-coverage",
+      "042-per-spec-attestation",
+      "057-claimed-but-unwitnessed",
+      "075-one-name-one-freshness-verb",
+      "083-an-attestation-covers-the-territory-it-claims",
+      "085-a-verifier-checks-the-bytes-it-was-given",
+      "086-the-committed-index-is-compared-not-trusted"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-types/src/snapshot.rs",
+        "planned": true
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/src/snapshot.rs",
+        "planned": true
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/tests/snapshot.rs",
+        "planned": true
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "023-ledger-seal",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_attest.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "023-ledger-seal",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/verify_attestation.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      }
+    ],
+    "id": "087-an-authority-snapshot-says-what-it-read",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      }
+    ],
+    "risk": "high",
+    "sectionHeadings": [
+      "087: An authority snapshot says what it read",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The payload",
+      "3.2 What each member covers",
+      "3.3 The framed digest",
+      "3.4 Purity",
+      "3.5 Surface",
+      "3.6 What it proves, and what it does not",
+      "3.7 What must keep working",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/087-an-authority-snapshot-says-what-it-read/spec.md",
+    "status": "draft",
+    "summary": "A consumer that binds spec-spine's authority results to a revision needs five separate outputs today and still cannot answer four questions from them: whether the committed ledger matched the corpus (attestations recompute and never read the committed shards, and `check --json` reports booleans without the digests it compared), which configuration and governance files were read, what every spec's territory hashed to, and how much source no spec claims. This spec adds a third attestation scope, `attest --snapshot`, emitting an `AuthoritySnapshot`: the tool and schema versions, a digest of `spec-spine.toml`, the existing corpus hashes, the committed registry and index trees with a digest each and whether each matches the recompute, the governance inputs by path and digest, the gate verdicts, the ownership counts, the exclusions in force, and each spec's lifecycle with the hash of the `SpecAttestation` spec 042 would emit for it. New members use a framed digest, because the existing fold does not frame content and two trees can share one hash; existing members and payloads keep their constructions. The payload is pure, on demand, gitignored, sealable and verified under spec 085's rules. It commits to no git revision: the consumer binds the tree.\n",
+    "title": "An authority snapshot says what it read"
+  },
+  "shardHash": "fce116f811e67027db5a9bd704543f77a40a1a2f5ada21b8f6df2364c247df12",
+  "specVersion": "1.2.0"
+}

--- a/.derived/spec-registry/by-spec/087-an-authority-snapshot-says-what-it-read.json
+++ b/.derived/spec-registry/by-spec/087-an-authority-snapshot-says-what-it-read.json
@@ -130,6 +130,6 @@
     "summary": "A consumer that binds spec-spine's authority results to a revision needs five separate outputs today and still cannot answer four questions from them: whether the committed ledger matched the corpus (attestations recompute and never read the committed shards, and `check --json` reports booleans without the digests it compared), which configuration and governance files were read, what every spec's territory hashed to, and how much source no spec claims. This spec adds a third attestation scope, `attest --snapshot`, emitting an `AuthoritySnapshot`: the tool and schema versions, a digest of `spec-spine.toml`, the existing corpus hashes, the committed registry and index trees with a digest each and whether each matches the recompute, the governance inputs by path and digest, the gate verdicts, the ownership counts, the exclusions in force, and each spec's lifecycle with the hash of the `SpecAttestation` spec 042 would emit for it. New members use a framed digest, because the existing fold does not frame content and two trees can share one hash; existing members and payloads keep their constructions. The payload is pure, on demand, gitignored, sealable and verified under spec 085's rules. It commits to no git revision: the consumer binds the tree.\n",
     "title": "An authority snapshot says what it read"
   },
-  "shardHash": "fce116f811e67027db5a9bd704543f77a40a1a2f5ada21b8f6df2364c247df12",
+  "shardHash": "5221c1bb02e6418c66dc9d92687b81cedbd6327823b87c7ee94dc6b4cc97cc51",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/088-a-change-is-classified-under-the-bases-rules.json
+++ b/.derived/spec-registry/by-spec/088-a-change-is-classified-under-the-bases-rules.json
@@ -1,0 +1,146 @@
+{
+  "record": {
+    "created": "2026-09-11",
+    "dependsOn": [
+      "000-spec-spine-bootstrap",
+      "005-coupling-gate",
+      "030-cargo-workflow-dependency-waiver",
+      "037-machine-readable-verdicts",
+      "040-amendment-authoring",
+      "049-verify-declared-acceptance",
+      "055-the-ledger-answers-what-consumers-rebuild",
+      "086-the-committed-index-is-compared-not-trusted"
+    ],
+    "establishes": [
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-types/src/delta.rs",
+        "planned": true
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/src/delta.rs",
+        "planned": true
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-core/tests/delta.rs",
+        "planned": true
+      },
+      {
+        "kind": "file",
+        "path": "crates/spec-spine-cli/src/cmd_delta.rs",
+        "planned": true
+      }
+    ],
+    "extends": [
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/main.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "037-machine-readable-verdicts",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/verdict.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "005-coupling-gate",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/src/cmd_couple.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-core/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/lib.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "000-spec-spine-bootstrap",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-types/src/version.rs"
+        }
+      },
+      {
+        "nature": "additive",
+        "spec": "001-compile-registry",
+        "unit": {
+          "kind": "file",
+          "path": "crates/spec-spine-cli/tests/cli.rs"
+        }
+      }
+    ],
+    "id": "088-a-change-is-classified-under-the-bases-rules",
+    "implementation": "pending",
+    "kind": "tooling",
+    "owner": "The spec-spine Authors",
+    "references": [
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/authority-evidence.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/02-agentic-builder-substrate.md"
+        }
+      },
+      {
+        "role": "context",
+        "unit": {
+          "kind": "file",
+          "path": "docs/design/04-authority-evidence-extension.md"
+        }
+      }
+    ],
+    "risk": "high",
+    "sectionHeadings": [
+      "088: A change is classified under the base's rules",
+      "1. Purpose",
+      "2. Territory",
+      "3. Behavior",
+      "3.1 The verb and the seam",
+      "3.2 The base's rules classify",
+      "3.3 Classes",
+      "3.4 Detail carried per class",
+      "3.5 Prior policy",
+      "3.6 Report and versioning",
+      "3.7 What it does not claim",
+      "3.8 Tests (minimum)",
+      "4. Out of scope",
+      "5. Resolved decisions",
+      "Verification"
+    ],
+    "specPath": "specs/088-a-change-is-classified-under-the-bases-rules/spec.md",
+    "status": "draft",
+    "summary": "The coupling gate clears C-001 when any owning spec's `spec.md` is in the diff, and reads the owners from the candidate's own index. Measured on a scratch repository, a candidate that deletes a command from its own `## Verification` block while changing the code that command checked passes `couple` at exit 0, and so does a candidate that files a new draft spec with an `extends` edge on another spec's unit and rewrites that unit. Both are changes a reviewer must weigh under the rules that held before the change, and nothing reports them as such. Design note 02 G7 says no refusal should be asserted before it is designed, because the naive rule refuses legitimate refactors. This spec therefore adds a report, not a gate: `spec-spine delta --base B --head H` classifies every changed path into implementation, requirement, verification, authority, lifecycle, constitutional, policy, derived, bypassed, unowned or unknown, computed under the merge base's own configuration and index so a candidate cannot reclassify its change by editing `spec-spine.toml`. It records the base and head plan digests for every spec whose declared acceptance changed, the owner sets on both sides of every path whose ownership moved, and a `priorPolicy` block naming the classes a consumer must judge under the base's policy. It interprets no prose, infers no moves, and decides nothing.\n",
+    "title": "A change is classified under the base's rules"
+  },
+  "shardHash": "0aef54d5113ae531a15b2904e6ff93713c770158d56bb650c6c00e4915772edf",
+  "specVersion": "1.2.0"
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,9 @@
 > data substrate). **The library API, not the CLI, is the contract bindings
 > wrap.** This document describes the public Rust API and the JSON-in/JSON-out
 > facade. For the CLI surface see [adoption-guide.md](adoption-guide.md); for the
-> design rationale see [design/00-architecture.md](design/00-architecture.md).
+> design rationale see [design/00-architecture.md](design/00-architecture.md);
+> for what each result proves, and how to bind it to a revision, see
+> [authority-evidence.md](authority-evidence.md).
 
 spec-spine turns a markdown spec corpus into a typed, hash-verifiable authority
 ledger. Two views are emitted deterministically and joined at PR time:

--- a/docs/authority-evidence.md
+++ b/docs/authority-evidence.md
@@ -1,0 +1,442 @@
+# Consuming spec-spine authority evidence
+
+> For a consumer that stores, forwards or verifies what spec-spine says about a
+> repository: a local orchestrator, a hosted control plane, or a portable
+> review record. It maps each question to the verb and library function that
+> already answers it, states what every digest covers, and says what each
+> result proves and what it does not. Nothing here is a new API. Proposed
+> additions are in [design/04](design/04-authority-evidence-extension.md) and
+> in draft specs 085 to 088, and they are marked as proposals wherever they
+> appear.
+
+**Measured state.** Every output below was produced on 2026-09-11 at commit
+`75181a5` (main) by a binary built from that commit. The binary reports
+`spec-spine 0.18.0`, and so does the released `v0.18.0`, which is eight commits
+older and does not contain spec 083 (see §8). The corpus held 85 specs: 84
+`approved` with `implementation: complete`, and 084 `draft` with
+`implementation: pending`. Both committed trees were fresh. The hashes below
+reproduce only on a clean export of `75181a5` (§6); any other tree, including a
+working tree with later specs in it, gives different values, which is the
+point of them.
+
+## 1. The questions, and what already answers them
+
+| Question | CLI (read verbs never write) | Library / JSON facade | Output and version marker | Exit codes |
+|---|---|---|---|---|
+| Are the committed trees what the corpus compiles to? | `check [--fail-on-unresolved] [--fail-on-warn] --json` | `check_freshness_json`, `check_registry_freshness_json` | verdict envelope `0.3.0`, verb `check` | 0 fresh, 2 stale, 1 invalid or refused, 3 cannot read |
+| Registry half, index half separately | `compile --check --json`, `index check --json` | same | envelope `0.3.0`, verbs `compile.check`, `index.check` | same |
+| Does one spec validate? | `compile --spec <id> --json` | `compile_json` | envelope `0.3.0`, verb `compile.spec` | 0, 1, 3 |
+| Is the corpus conformant? | `lint --fail-on-warn --json` | `lint_json` | envelope `0.3.0`, report is the finding list | 0, 1, 3 |
+| Who owns a path, and how? | `index owner <path> --json` | `owners_for_path`, `classify`, `authorities` | raw JSON, **no envelope, no version field** | 0 (also when nothing owns it), 3 |
+| Which source files does no spec claim? | `index coverage [--fail-on-untraced] --json` | `coverage_json` | raw JSON, **no envelope, no version field** | 0, 1, 2, 3 |
+| Does a change drift from its owning spec? | `couple --base B --head H [--pr-body F] --json` | `couple_json` (caller supplies the parsed diff) | envelope `0.3.0`, verb `couple` | 0, 1 drift, 2 stale index, 3 |
+| What does a spec declare as acceptance? | `verify --plan --json <id>` | `verify_plan_json` | envelope `0.3.0`, verb `verify` | 0, 1 unknown id, 3 |
+| Run that acceptance (**executes**) | `verify <id> --json` | none: the library never runs a command | envelope `0.3.0`, `VerifyReport` | 0, 1, 3 |
+| What is workable now? | `registry plan --json` | `query_json` op `plan` | raw JSON, **no envelope, no version field** | 0, 3 |
+| Freeze the corpus verdict | `attest [--with-coupling] [--sign --key K] --json` | `attest_json` | `CorpusAttestation` `schemaVersion 0.1.0` inside envelope `0.3.0` | 0 whenever a payload was written, 3 |
+| Freeze one spec's territory | `attest --spec <full-id> [--sign --key K] --json` | `attest_spec_json` | `SpecAttestation` `schemaVersion 0.1.0` | 0 whenever a payload was written, 1 unknown id (the short id is refused until 084), 3 |
+| Check a frozen record | `verify-attestation [--spec <full-id>] --recompute \| --signature --public-key P --json` | `verify_attestation_json`, `verify_spec_attestation_json` (recompute only) | envelope `0.3.0` | 0 match, 1 mismatch or invalid, 3 |
+
+Three rules from the existing specs govern how these may be read:
+
+- **An `attest` exit code is not a verdict** (spec 042 3.1, amending 023). Exit
+  0 means a payload was written. The verdicts are inside it, and a failing one
+  is still exit 0. A caller that wants a refusal runs `check`, `lint` or
+  `couple`.
+- **`--json` changes what is written, never what is decided** (spec 037). Parse
+  the envelope; do not match prose. The prose is a rendering and has changed.
+- **`verify` is the one verb that executes** (spec 049 3.6). It runs commands
+  written in a markdown file, with the caller's environment, and is not a
+  sandbox. `verify --plan` reads the same commands without running them.
+
+## 2. Version axes
+
+Each is a compile-time constant in `crates/spec-spine-types/src/version.rs`
+or `attest.rs`, independent of the others and of the package version.
+
+| Artifact | Field | Current |
+|---|---|---|
+| registry shards | `specVersion` | `1.2.0` |
+| index shards | `schemaVersion` | `1.1.0` |
+| `CorpusAttestation` | `schemaVersion` | `0.1.0` |
+| `SpecAttestation` | `schemaVersion` | `0.1.0` |
+| verdict envelope | `schemaVersion` | `0.3.0` |
+| `build-meta.json` | `schemaVersion` | `0.1.0` (non-deterministic, gitignored) |
+| `spec-spine.toml` | `config_version` | `0.1.0` (optional key) |
+| the tool | `spec-spine --version`, `tool.version` in an attestation | `0.18.0` |
+
+`registry plan --json`, `index owner --json` and `index coverage --json` carry
+no version marker and do not emit sorted keys, although
+[api.md](api.md) §7 says every emitted JSON document does. A consumer that
+stores or digests their bytes has nothing to pin; use the enveloped verbs, or
+the facade, for anything retained.
+
+`docs/schema-versioning.md` still lists the registry and index at `1.0.0` and
+omits the two attestation axes and the envelope. The constants above are
+authoritative; draft spec 085 carries the correction.
+
+**The tool version is not a build identity.** A binary built from `main`
+prints the version of the last release it was bumped to, so between releases
+two binaries with different behavior print the same string (§8 shows one such
+pair). `tool.version` is what `verify-attestation --recompute` compares, so
+the same limit applies to it.
+
+## 3. Real outputs
+
+`check --fail-on-unresolved --fail-on-warn --json` at `75181a5` (running it
+twice gives byte-identical output):
+
+```json
+{
+  "exitCode": 0,
+  "ok": true,
+  "report": {
+    "index": {
+      "diagnostics": { "byCode": {}, "errors": 0, "warnings": 0 },
+      "fresh": true,
+      "unwitnessed": { "allowed": 72, "total": 72 }
+    },
+    "registry": { "fresh": true, "validationPassed": true, "warnings": 0 }
+  },
+  "schemaVersion": "0.3.0",
+  "verb": "check"
+}
+```
+
+`couple --base e4032ff --head 75181a5 --json`, in a clean checkout of
+`75181a5`:
+
+```json
+{
+  "exitCode": 0,
+  "ok": true,
+  "report": { "checkedPaths": 1, "violations": [] },
+  "schemaVersion": "0.3.0",
+  "verb": "couple"
+}
+```
+
+`attest --with-coupling --json`:
+
+```json
+{
+  "exitCode": 0,
+  "ok": true,
+  "report": {
+    "attestation": {
+      "inputsManifestHash": "65b0edf5fd8d55610acecac28b84c30fb9774acb4a61e6b280572b27ec0ffee4",
+      "registryHash": "b6eabbbb0c8d9cb48361083241da8bb5e86e0eec759063329352282d3119d9f2",
+      "schemaVersion": "0.1.0",
+      "tool": { "name": "spec-spine", "version": "0.18.0" },
+      "verdicts": {
+        "compile": { "ok": true },
+        "couple": {
+          "indexHash": "40146f4027e559bf1fa3eea0e7f5d3937968d7b23586d7815a81b806e62508d3",
+          "joinHash": "88e45bbaf3f2b5ca105460c2193ee41c7e2c0a47a824564db784e988e0e7dce4",
+          "ok": true
+        },
+        "lint": {
+          "findingsHash": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
+          "ok": true
+        }
+      }
+    },
+    "attestationHash": "44046b3957ede75148d10db258cca3e7c544fb90a7b13f124996c750ad6caf99"
+  },
+  "schemaVersion": "0.3.0",
+  "verb": "attest"
+}
+```
+
+`attest --spec 083-an-attestation-covers-the-territory-it-claims --json`
+(report only):
+
+```json
+{
+  "attestation": {
+    "lifecycle": { "implementation": "complete", "status": "approved" },
+    "schemaVersion": "0.1.0",
+    "specId": "083-an-attestation-covers-the-territory-it-claims",
+    "specSourceHash": "d99fcb2660da006550cc9af5141520b2609d90dd847985e0cc550768fbc4e789",
+    "tool": { "name": "spec-spine", "version": "0.18.0" },
+    "units": [
+      { "contentHash": "dbdaf78f424e1cc9aac210628de619f674d7aa0585299a79c2290949f55aed3d",
+        "unit": { "kind": "file", "path": "crates/spec-spine-cli/tests/cli.rs" } },
+      { "contentHash": "0e187540170816c69fa393a3ce7431a43477b25fb86f15ac6998957649ca25c3",
+        "unit": { "kind": "file", "path": "crates/spec-spine-core/src/attest.rs" } },
+      { "contentHash": "0cadd7dadbac3838681748e20686f3ae2db1be9a06e0c0e37ecb2741696a70e2",
+        "unit": { "kind": "file", "path": "crates/spec-spine-core/src/index.rs" } },
+      { "contentHash": "f7baeb9ff2eab0a8d0e3c9b9269c8a32692341833d54125d40c7ed2fe80b2600",
+        "unit": { "kind": "file", "path": "crates/spec-spine-core/tests/attest.rs" } }
+    ],
+    "verdicts": {
+      "compile": { "ok": true },
+      "lint": { "findingsHash": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570", "ok": true },
+      "resolution": { "ok": true }
+    }
+  },
+  "attestationHash": "ef0f30a757d9e5a5a64df62c2d3e010be7e989df5cafcbfa38097b5547a013f1"
+}
+```
+
+The same verb for the draft 084 reports `resolution.ok: false`, because three
+of its thirteen owning units are `planned` and not yet written; its lifecycle
+reads `draft` / `pending`, which is what makes that `false` interpretable
+(spec 042 3.1).
+
+`verify --plan --json 084-a-short-id-names-the-same-spec-at-every-verb`
+returns `{ "specId", "commands": [26 strings], "skipped": [] }` in the same
+envelope. `verify-attestation --recompute --signature --public-key P --json`
+on an untouched sealed pair:
+
+```json
+{
+  "exitCode": 0,
+  "ok": true,
+  "report": {
+    "outcome": "match",
+    "signature": { "keyId": "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c", "valid": true }
+  },
+  "schemaVersion": "0.3.0",
+  "verb": "verify-attestation"
+}
+```
+
+## 4. What each digest covers
+
+`content_hash` below is `hash::content_hash`: SHA-256 over
+`<repo-relative-POSIX-path> NUL <normalized text>` for each piece, pieces
+sorted by path, **concatenated with no separator between pieces**.
+Normalization strips a leading BOM and folds CRLF and CR to LF.
+
+| Digest | Where | Covers | Construction |
+|---|---|---|---|
+| `shardHash` | each committed registry shard | one `spec.md` | `content_hash([(spec path, text)])` |
+| `inputsManifestHash` | `CorpusAttestation`; the registry's `build.contentHash` | every `spec.md`, and nothing else | `content_hash` over `("spec:<id>", shardHash)` pairs |
+| `registryHash` | `CorpusAttestation` | the compiled aggregate registry, **recomputed in memory** | SHA-256 of its canonical JSON |
+| index shard hash | each committed index shard | the spec's `spec.md`, the files backing its `section` / `symbol` spans, and the global-inputs scalar | `content_hash` |
+| global-inputs scalar | inside every index shard hash | `spec-spine.toml` plus every `[index] extra_hashed_inputs` match, minus `layout.state_dir`; workflows fold as their governance projection (spec 073) | `content_hash` |
+| `indexHash` | `CorpusAttestation` under `--with-coupling` | the recomputed index's `contentHash` | fold of index shard hashes |
+| `joinHash` | same | the pair | SHA-256 of `"<registryHash>:<indexHash>"` |
+| `findingsHash` | both attestations | every lint finding, info tier included (corpus); the findings whose path is the spec's (per spec) | SHA-256 of canonical JSON of the list |
+| `specSourceHash` | `SpecAttestation` | one `spec.md` | SHA-256 of its normalized text, **no path prefix** |
+| unit `contentHash` | `SpecAttestation` | what an owning unit resolves to: files; directories walked under `resolver_exclusions` and `state_dir`; symlinks as their target text; non-UTF-8 files as the text `sha256:<hex of bytes>` | `content_hash` |
+| `attestationHash` | beside a payload, never inside it | the payload | SHA-256 of its canonical JSON, which is exactly the bytes written to disk |
+| seal `sig` | detached `.sig` | `attestationHash` | Ed25519 over its 32 raw bytes |
+| `registry show` `contentHash` | query output | one `spec.md` | the `shardHash` construction, although the prose line calls it "sha256 of this spec.md"; it does **not** equal `specSourceHash` for the same file |
+
+Every value above is independently recomputable from a tree and the same tool
+version, except the seal, which needs the public key. No key and no network is
+needed for anything else.
+
+### What the digests do not cover
+
+- **No attestation commits to a git revision or a repository identity.** The
+  payloads are content-addressed and git-agnostic by design (spec 023 3). The
+  binding to a commit is the consumer's record, and it is checkable by
+  recomputing from that commit's tree (§6).
+- **The corpus attestation does not commit to source code bytes**, even with
+  `--with-coupling`. A `file`, `directory` or `crate` unit carries no span, so
+  it contributes to no index hash (spec 057); this repository allows all 72 of
+  its such claims. `couple.ok` in a corpus attestation means "every claimed
+  unit resolves with no blocking resolver diagnostic". Only `SpecAttestation`
+  unit hashes cover claimed bytes, and only for the one spec's owning units.
+- **Nothing covers an unclaimed file.** `index coverage` reports them; no
+  attestation hashes them.
+- **Committed-shard freshness is not in any attestation.** `attest` recomputes
+  the registry and index from the tree. A committed shard tree that disagrees
+  with the corpus produces the same attestation as a fresh one. Freshness is a
+  separate answer, from `check`, and `check --json` reports booleans, not the
+  digests it compared.
+- **An index shard's hash does not cover its own body.** `shardHash` covers
+  the shard's inputs (the `spec.md`, the span files, the global scalar), and
+  `index check` compares only that field (§5).
+- **`spec-spine.toml` has no digest of its own** in a spec-corpus-only
+  attestation. It reaches `registryHash` only through what it changes in the
+  compile, and reaches `indexHash` through the global-inputs scalar.
+- **The normalization is deliberate and lossy.** CRLF and LF variants, and a
+  file with or without a BOM, hash identically.
+- **The fold is not injective.** Measured with the current binary: a claimed
+  directory holding `a` = `x` and `b` = `y` attests the same unit
+  `contentHash` as one holding only `a` = `x`, NUL, `d/b`, NUL, `y`, because
+  nothing frames one piece from the next. A binary file and a text file whose
+  content is the string `sha256:<that file's digest>` also attest identically.
+  Neither is reachable by accident in ordinary text; both are reachable on
+  purpose. Existing digests keep this construction so that historical evidence
+  stays interpretable; design/04 proposes a framed construction for new record
+  types only.
+
+## 5. Semantics that must not be collapsed
+
+| These are different | Because |
+|---|---|
+| `attest --with-coupling` and `couple --base B --head H` | The first asks whether every claimed unit resolves in one tree. The second asks whether a diff between two revisions touched owned code without its owning spec. Neither implies the other. |
+| a recomputed attestation and a fresh committed tree | `attest` never reads the committed shards. `check` does. |
+| `check` fresh and "the committed index is what the corpus indexes to" | `index check` does not re-resolve. It reads each committed shard's own mapping, hashes the span files that mapping names, and compares the result with `shardHash`. For a unit with no span (`file`, `directory`, `crate`) nothing constrains the body. Measured on a scratch repository: a shard rewritten so its spec owns nothing, `shardHash` untouched, reads fresh, and `couple` then derives ownership from it. The registry side compares bytes (spec 031 3.1). Draft spec 086 proposes the same for the index. |
+| `couple` exit 0 and "the owning spec approves this change" | C-001 clears when **any** owning spec's `spec.md` is in the diff. An edit that weakens that spec, including its `## Verification` block, clears it. The guard against that is a rule addressed to agents (`.claude/rules/adversarial-prompt-refusal.md`), not a mechanism; design note 02 G7 records it as unsolved. |
+| `couple` exit 0 and "the owners were the owners before this change" | Owners are read from the committed index **at the candidate**. A candidate that files a new spec with an `extends` edge on a unit becomes an owner of that unit in the same diff and clears C-001 with its own `spec.md`. That is the sanctioned route for legitimate work (spec 047), and it is also an authority transfer no one outside the diff approved. |
+| `couple`'s subject and the candidate commit | `couple` diffs `merge-base(B, H)...H` but checks freshness and resolves units in the working tree. It speaks for `H` only when the working tree is a clean checkout of `H`. Its report echoes neither commit. |
+| `verify` passing and the spec being satisfied | A declared command exited 0 on one machine at one time, under the candidate's own copy of the block. |
+| a valid seal and a trustworthy signer | The seal proves possession of a key. Which keys to trust is the consumer's policy (spec 023 6). |
+
+## 6. Binding authority evidence to a candidate revision, offline
+
+No hosted account is involved. The consumer supplies the revision; spec-spine
+supplies content-addressed results; a third party recomputes.
+
+```sh
+# The subject, from git (the consumer's job; spec-spine never runs git in its core).
+git rev-parse 75181a5 '75181a5^{tree}'
+#   75181a518e8bf69cc3a003b106cb483a9ed32454
+#   fc93c505763e60f3a23f9425b6f8c724009be578
+
+# A clean export of exactly that tree. An untracked or ignored file inside a
+# claimed directory changes a unit hash (spec 083 3.4), so never attest a
+# working tree you did not just check out.
+W=$(mktemp -d) && git archive 75181a5 | tar -x -C "$W"
+
+spec-spine --repo "$W" check --fail-on-unresolved --fail-on-warn --json > check.json
+spec-spine --repo "$W" attest --with-coupling --json > corpus.json
+spec-spine --repo "$W" attest --spec 084-a-short-id-names-the-same-spec-at-every-verb --json > spec.json
+spec-spine --repo "$W" verify --plan --json 084-a-short-id-names-the-same-spec-at-every-verb > plan.json
+
+# The diff verdict needs git: run it in a clean checkout whose HEAD is the candidate.
+spec-spine couple --base e4032ff --head 75181a5 --json > couple.json
+```
+
+A record the consumer keeps (this shape is a **proposal**, not a spec-spine
+output; the values are the real ones from that run):
+
+```json
+{
+  "subject": {
+    "repo": "git@github.com:statecrafting/spec-spine.git",
+    "commit": "75181a518e8bf69cc3a003b106cb483a9ed32454",
+    "tree": "fc93c505763e60f3a23f9425b6f8c724009be578"
+  },
+  "base": { "commit": "e4032ff2795bd132527726f38b4d29283b6d1413", "mergeBase": "e4032ff2795bd132527726f38b4d29283b6d1413" },
+  "tool": { "name": "spec-spine", "version": "0.18.0" },
+  "reads": [
+    { "verb": "check", "envelopeSchema": "0.3.0", "exitCode": 0,
+      "sha256": "aa1fc653cc1ce679f7ffb270e120421b14ba758ddb067336a814d7bec02a0d4d" },
+    { "verb": "couple", "envelopeSchema": "0.3.0", "exitCode": 0,
+      "sha256": "0f971f3223b514f29d8a8aa25e26696f941f3709088f743c4005b0ca1940db0b" }
+  ],
+  "attestations": [
+    { "type": "CorpusAttestation", "schemaVersion": "0.1.0", "scope": "specs+code",
+      "attestationHash": "44046b3957ede75148d10db258cca3e7c544fb90a7b13f124996c750ad6caf99" },
+    { "type": "SpecAttestation", "schemaVersion": "0.1.0",
+      "specId": "084-a-short-id-names-the-same-spec-at-every-verb",
+      "specSourceHash": "de71e87232a69abd2c1e45ba2415f0f8db68c72fdd6c727df7568e21357d8692",
+      "attestationHash": "ab0e784071cd3be65060f2ead325e0e2d87d3ff8f803f8fbdcea249b8ca05644" }
+  ],
+  "plan": { "specId": "084-a-short-id-names-the-same-spec-at-every-verb", "commands": 26,
+            "sha256": "0172fbfd35a0cd50be10d10c71802ac65d1d591c10677c11c8a5a390b7a1a3cc" }
+}
+```
+
+A verifier with the same tool version fetches the commit, checks that its tree
+id matches, exports it, reruns the same verbs and compares bytes, and runs
+`verify-attestation --recompute` against each stored payload. Every `sha256`
+above is over the exact envelope bytes, which are deterministic for a given
+tree and binary (measured for `check`). A `versionMismatch` is an **unknown**,
+not a failure of content: rerun under the recorded version.
+
+What that record then establishes, and nothing more: at that tree, under that
+tool version, the committed ledger matched the corpus; the corpus validated and
+linted clean; every claimed unit resolved; the diff from the merge base did not
+touch owned code without an owning `spec.md` in the same diff; spec 084's own
+text and owning units hashed to the listed values; and its declared acceptance
+was those 26 commands. It does not establish that the commands were run, that
+they pass, that the specification is correct, or that anyone with authority
+approved the change.
+
+## 7. Verification planning for content you do not trust
+
+1. **Read the plan, never the block.** `verify --plan --json <id>` is a pure
+   read and runs nothing. Parse it; do not re-implement the `## Verification`
+   grammar (spec 049 3.2). Blocks the tool does not run are listed under
+   `skipped` rather than dropped.
+2. **Read it from the trusted base, not from the candidate.** A candidate that
+   edits its own `## Verification` block and its code in one diff passes
+   `couple` (§5). Take the plan from the base revision's copy of the spec, or
+   treat any difference between the base and candidate plans as a change that
+   needs approval under the base's policy. Record `specSourceHash` for the copy
+   the plan came from. Draft spec 088 proposes a report that makes this
+   difference mechanical.
+3. **Execute only in a worker that was explicitly authorized to run it.** The
+   commands are shell (`sh -c`), inherit the caller's environment (spec 049
+   3.5), and are a stranger's in the general case. Never run them in a process
+   holding control-plane credentials. Isolation, credentials and time limits
+   are the consumer's policy; spec-spine does not sandbox and does not claim to.
+4. **Bind outputs to the evaluated revision.** Run in a clean checkout of the
+   candidate commit; record the commit, the tree, the plan digest and the
+   base-side `specSourceHash` with each command's exit code. `verify --json`
+   reports the failing command's own exit code inside the report, separately
+   from the process exit status.
+
+## 8. Cross-version and tamper behavior, measured
+
+Released `v0.18.0` was built from its tag and compared with a binary built
+from `75181a5`. Both print `spec-spine 0.18.0`.
+
+| Case | Result | Reading |
+|---|---|---|
+| `v0.18.0` `attest --spec` over all 85 specs | 71 succeed, 14 exit 3 ("Is a directory") | spec 083's fix is not released |
+| `75181a5` over the same | 85 succeed | |
+| per-spec attestation of 048 made at `75181a5`, verified by `v0.18.0` | exit 3, I/O error | the version stamps are equal, so the named `versionMismatch` outcome cannot fire |
+| corpus attestation made by either, verified by the other | `match` | historical corpus evidence is unaffected |
+| per-spec attestation of file-only 083, either direction | `match` | historical file-unit evidence is unaffected |
+
+Against a sealed attestation, using a scratch key:
+
+| Tamper | `--recompute` | `--signature` | Verdict |
+|---|---|---|---|
+| none | match | valid | exit 0 |
+| add an unknown member, top level or nested (`"prCouple": {"ok": true}`) | match | **valid** | **exit 0** |
+| add an unknown member to a per-spec attestation | match | **valid** | **exit 0** |
+| corpus `schemaVersion` set to `9.0.0` | **match** | invalid | exit 0 with recompute alone |
+| per-spec `schemaVersion` set to `9.0.0` | content mismatch, "tool.name or schemaVersion" | not run | exit 1 |
+| reformat without changing values (compact, reordered keys) | match | **valid** | exit 0 |
+| `tool.version` changed | `versionMismatch` | | exit 1 |
+| a verdict flipped | content mismatch naming the field | invalid | exit 1 |
+| duplicate key | refused, parse error | | exit 3 |
+
+The four bold rows are contract gaps, not intended behavior. Spec 023 AC-4
+says a single tampered payload byte fails the signature, and the attestation
+module's own documentation says loaders reject an unknown MAJOR. The verifier
+deserializes without refusing unknown members and re-canonicalizes before
+checking the seal, so the bytes it verifies are not the bytes a consumer reads.
+Until draft spec 085 lands, **a consumer must hash the stored file bytes itself
+and compare against `attestationHash`**, and must refuse members it does not
+know, rather than rely on `verify-attestation` to do either.
+
+## 9. The current consumer, mapped
+
+statecraft-cli at `6f49d9a` mints `acceptance.receipt` records
+(`members/src/orchestrator/receipt.ts`, `RECEIPT_SCHEMA_VERSION = 1`) and runs
+the gate floor `check --fail-on-warn`, `lint --fail-on-warn`,
+`couple --base <sha> --head HEAD` (`gate-contract.ts` `gateFloor`), without
+`--json`.
+
+| Receipt field | spec-spine counterpart | Binding today | Gap |
+|---|---|---|---|
+| `specId` | the registry id; `SpecAttestation.specId` | a string | no digest of the spec's text at base or candidate |
+| `repo.baseSha` | `couple --base` | argv only | `couple` resolves a merge base and echoes neither commit |
+| `repo.candidateSha` | the tree every read verb judged | none from spec-spine | holds only if the verbs ran in a clean checkout of it |
+| `suite.commands`, `suite.digest` | the verbs' argv | SHA-256 of canonical argv arrays | covers command text only: no outputs, no tool build, no config |
+| `policy.digest` | none | CLI gate contract plus profile | excludes `spec-spine.toml`, the constitution and the specs themselves |
+| `verifier.specSpine` | `spec-spine --version` | the raw string | not a build identity (§2) |
+| `results[].exitCode` | envelope `exitCode` | integers | the reports are discarded; exit codes 1, 2 and 3 are not distinguished in failure evidence |
+| `sensitivePaths` | overlaps the global-inputs set and the constitution | prefix list | a partial, CLI-local policy-delta detector |
+| none | `attestationHash` (corpus and per spec), `specSourceHash`, plan digest, envelope digests | none | the receipt carries no spec-spine result at all |
+
+Separately, the CLI's export and adoption paths run `attest --with-coupling` and
+`attest` and match `attestationHash:` in prose with a regular expression
+(`export.ts`, `adopt/holdback.ts`), the pattern spec 037's migration note
+names as the one that broke; `stages/verify.ts` re-implements the
+`## Verification` grammar rather than reading `verify --plan --json`. Its
+`spec-spine.toml` pins `required_version = "0.18.0"` (a caret range) and CI
+installs from `main`'s `install.sh` without a version, so it runs `v0.18.0`,
+which predates spec 083; it does not call `attest --spec` today. The requests
+this implies are in design/04 §7.

--- a/docs/design/04-authority-evidence-extension.md
+++ b/docs/design/04-authority-evidence-extension.md
@@ -133,7 +133,8 @@ spec's own attestation hashes to.
   "exclusions": {
     "resolverExclusions": ["target", "node_modules", ".derived", "dist", "build", ".next"],
     "stateDir": null,
-    "unwitnessedAllowed": ["..."]
+    "unwitnessedAllowed": ["..."],
+    "bypassPrefixes": [".github/", "docs/", "..."]
   }
 }
 ```

--- a/docs/design/04-authority-evidence-extension.md
+++ b/docs/design/04-authority-evidence-extension.md
@@ -1,0 +1,487 @@
+# 04: Authority evidence for consumers outside the repository
+
+A design note, not a spec. It records what spec-spine should grow so that a
+local orchestrator, a hosted control plane and a portable review record can
+consume its authority results bound to exact revisions, and, with equal weight,
+what it must refuse to grow. Four increments are filed alongside as drafts
+(specs 085 to 088). Everything else here is a proposal for review; no
+record shape in this note is emitted by any build.
+
+The factual base is [authority-evidence.md](../authority-evidence.md), which
+maps the existing verbs, digests and consumer fields with real outputs. This
+note does not repeat it; it cites its sections as AE §n.
+
+## 1. Where the requirement came from
+
+A planning packet dated 2026-09-11 (the "September 11 realignment" of the
+Statecraft family plan, kept outside this repository) proposes that
+spec-spine compile deterministic **authority snapshots**, **authority-change
+classifications against a trusted base**, **obligation records**, **context
+closures** and **work scopes**, while a separate issuer grants run-specific
+permits and executors enforce them. It numbers the ideas A01 to A10 and B01 to
+B35, and assigns this repository A01 to A09, B01, B03 to B05, B11, B15, B17,
+B18, B22, B24, B33 and B35.
+
+The packet is input, not authority. Its sample commands and record names are
+proposals, it approves nothing, and it assigns no spec ids. Where it disagrees
+with this repository's approved specs, the specs win and the disagreement is
+recorded in §10.
+
+## 2. The boundary, stated before the backlog
+
+Design note 02's test still applies: *would an adopter who will never run the
+orchestrator still want it?* The packet adds a second, which this note adopts:
+
+> spec-spine computes **deterministic payloads over explicit inputs**. It never
+> holds a key in the core, reads a clock, resolves an identity, issues a
+> permission, keeps a lease, executes a declared command on a stranger's behalf,
+> or queries telemetry.
+
+| Belongs here | Belongs to a consumer |
+|---|---|
+| Snapshot of the authority state of one tree, with exact coverage | Choosing which trees to snapshot, retaining them |
+| Classification of a change against a trusted base | Deciding who may approve which class, and recording the approval |
+| Obligation ids, their text digests and their declared verifiers | Running the verifiers, keeping their outputs |
+| Required context closure with inclusion reasons and gaps | Deciding what to send to a model, and reporting what was truncated |
+| Work scope: candidate territory, obligations, declared shared outputs, overlaps | Issuing a permit, enforcing it in an executor, leasing and fencing |
+| Strict, offline verification of spec-spine's own records | Composing records from several producers, trust roots, revocation |
+| Pure evaluation of explicit inputs (time, usage, policy) passed in by a caller | The clock, the usage counter, the policy store |
+
+Ownership cannot confer anything on the right-hand side. A work scope names
+where a candidate may write and what it must satisfy; it does not grant read
+access, network, secrets or the right to execute, and nothing in a spec's
+frontmatter can make it do so.
+
+## 3. Findings the proposals rest on
+
+Each was measured on 2026-09-11 against `75181a5` unless noted. AE §8 has the
+tables.
+
+| # | Finding | Evidence | Carried by |
+|---|---|---|---|
+| F1 | `verify-attestation` accepts unknown members and re-canonicalizes before checking the seal: an injected `"prCouple": {"ok": true}` verifies as `match` and `valid`, exit 0, in both scopes | AE §8; `verify_attestation.rs` `load_json`, `seal::verify` over `attestation_hash(loaded)` | 085 |
+| F2 | The corpus recompute never compares `schemaVersion`: `"9.0.0"` recomputes as `match`, exit 0. The per-spec path reports a generic content mismatch instead of refusing | AE §8; `attest.rs` `verify_recompute` | 085 |
+| F3 | `tool.version` is not a build identity. Released `v0.18.0` cannot attest 14 of 85 specs; a main build stamped `0.18.0` can; a per-spec attestation from the second is unverifiable by the first with exit 3, not the named `versionMismatch` | AE §8 | open decision D1 |
+| F4 | `hash::content_hash` frames the path but not the content, so two trees can fold to one digest; a binary file and a text file holding `sha256:<its digest>` attest identically | AE §4 | 087 (new records only) |
+| F5 | No attestation records committed-shard freshness, a config digest, or which governance files were read; `check --json` reports freshness as booleans without the digests compared | AE §4 | 087 |
+| F6 | `couple` diffs from a merge base it never reports, and a corpus attestation's `couple` block is a different question (resolution, not diff) | AE §5 | 088, request R2 |
+| F7 | C-001 clears on **any** owner's `spec.md` in the diff, and owners are read from the candidate's own index, so a candidate can weaken its own `## Verification` block, or claim territory with a new `extends`, and pass | AE §5; `couple.rs` "primary-owner heuristic"; reproduced in 088's `## Verification` | 088 (report only; note 02 G7 stands) |
+| F8 | `registry plan --json`, `index owner --json`, `index coverage --json` carry no version and emit unsorted keys, contrary to `api.md` §7 | AE §2 | small fix, unfiled |
+| F9 | `registry show` prints `contentHash ... (sha256 of this spec.md)` but the value is the path-prefixed shard hash, which differs from `specSourceHash` for the same file | AE §4 | small fix, unfiled |
+| F10 | `docs/schema-versioning.md` lists registry and index at `1.0.0` and omits the attestation and envelope axes, and says the artifact DTOs deny unknown fields, which only `Config`, the edge items and `Unit` do | AE §2 | 085 |
+| F11 | `index check` never compares the committed index body with a fresh resolution: it trusts the body to name its own span files and compares only `shardHash`. A shard rewritten so its spec owns nothing, `shardHash` untouched, reads fresh under `index check` and `check`, and `couple` then derives ownership from it. `.derived/` is bypassed, and no CI job diffs a regenerated index against the committed one | AE §5; `index.rs` `check_index_freshness`; spec 031 3.1 records the weaker comparison as a cost trade (a full `index` here takes 0.04 s against 0.03 s) | 086 |
+
+## 4. Proposed records
+
+**Every example in this section is a proposal.** Field names, versions and
+digest rules may change before a spec that defines them is approved. The
+`schemaVersion` values are what a first implementation would stamp; they are
+not emitted today. Digests shown as `...` are placeholders.
+
+### 4.1 Digest rules for new record types
+
+Existing payloads keep their constructions forever, so historical evidence
+stays interpretable (AE §4). New record types use one framed construction:
+
+```
+frame/1 = SHA-256( "spec-spine/frame/1" 0x00
+                   for each piece, sorted by path (byte order):
+                     kind   : 1 byte, 't' text | 'b' bytes | 'l' symlink target
+                     u64be(len(path)) path
+                     u64be(len(content)) content )
+```
+
+Text pieces keep the standing normalization (BOM stripped, CRLF and CR to
+LF) so a checkout's line endings do not change a digest; `b` pieces are raw
+bytes; `l` pieces are the link's target text. A record's own reference digest
+is SHA-256 of its canonical JSON bytes, as for the existing attestations, and a
+verifier hashes the bytes it holds rather than a re-serialization (085).
+
+Nothing here is called a Merkle root. A membership proof would need a defined
+tree, leaf encoding and proof format; §5 leaves that to a later increment that
+has a consumer for selective verification.
+
+### 4.2 AuthoritySnapshot (filed as draft 087)
+
+One on-demand, sealable record of the authority state of a tree: what was
+read, what it compiled to, whether the committed ledger matched, and what each
+spec's own attestation hashes to.
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "tool": { "name": "spec-spine", "version": "0.19.0" },
+  "digest": "frame/1",
+  "config": { "present": true, "hash": "..." },
+  "schemas": { "registry": "1.2.0", "index": "1.1.0", "corpusAttestation": "0.1.0", "specAttestation": "0.1.0" },
+  "corpus": { "specs": 85, "inputsManifestHash": "65b0edf5...", "registryHash": "b6eabbbb..." },
+  "committed": {
+    "registry": { "files": 85, "hash": "...", "matchesRecompute": true },
+    "index": { "files": 89, "hash": "...", "matchesRecompute": true }
+  },
+  "governanceInputs": { "paths": ["AGENTS.md", "CLAUDE.md", "spec-spine.toml", "..."], "hash": "..." },
+  "verdicts": {
+    "compile": { "ok": true, "errors": 0, "warnings": 0 },
+    "lint": { "ok": true, "findingsHash": "37517e5f..." },
+    "resolution": { "ok": true, "blocking": 0, "unresolved": 0 },
+    "ownership": { "sourceFiles": 80, "claimed": 80, "floorOnly": 0, "unclaimed": 0 }
+  },
+  "specs": [
+    { "id": "083-an-attestation-covers-the-territory-it-claims", "status": "approved",
+      "implementation": "complete", "specAttestationHash": "ef0f30a7..." }
+  ],
+  "exclusions": {
+    "resolverExclusions": ["target", "node_modules", ".derived", "dist", "build", ".next"],
+    "stateDir": null,
+    "unwitnessedAllowed": ["..."]
+  }
+}
+```
+
+It proves, for a tree and a tool version: exactly which inputs were read and
+what they hashed to; whether the committed shards equal the recompute (the
+freshness answer, carried as data rather than inferred from a recompute); the
+gate verdicts; and a per-spec attestation hash for every spec, so one spec's
+evidence can be checked against the snapshot without the rest. It does not
+prove: anything about a revision (the consumer binds the tree, AE §6),
+anything about unclaimed files beyond their count, the correctness of any
+spec, or that anyone approved the state.
+
+### 4.3 AuthorityDelta (filed as draft 088)
+
+A classification of every path a change touches, computed under the **base**
+revision's configuration so a candidate cannot reclassify its own change by
+editing `spec-spine.toml`.
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "tool": { "name": "spec-spine", "version": "0.19.0" },
+  "classifiedUnder": "base",
+  "base": { "commit": "e4032ff2...", "mergeBase": "e4032ff2..." },
+  "head": { "commit": "75181a51..." },
+  "changes": [
+    { "path": "specs/084-a-short-id-names-the-same-spec-at-every-verb/spec.md", "change": "added",
+      "specId": "084-a-short-id-names-the-same-spec-at-every-verb",
+      "classes": ["authority", "requirement", "verification", "lifecycle"],
+      "authority": { "added": { "establishes": 3, "extends": 10, "references": 2, "amends": ["016-short-id-resolution"] } },
+      "verification": { "basePlanHash": null, "headPlanHash": "..." } },
+    { "path": ".derived/spec-registry/by-spec/084-a-short-id-names-the-same-spec-at-every-verb.json",
+      "change": "added", "classes": ["derived"] }
+  ],
+  "counts": { "implementation": 0, "requirement": 1, "verification": 1, "authority": 1, "lifecycle": 1,
+              "constitutional": 0, "policy": 0, "derived": 2, "bypassed": 0, "unowned": 0, "unknown": 0 },
+  "priorPolicy": { "required": true, "classes": ["authority", "lifecycle", "requirement", "verification"] }
+}
+```
+
+It proves which structural classes a change falls into under the base's rules.
+It does not decide whether the change is acceptable, and it does not interpret
+prose: any byte change to a spec body outside `## Verification` is a
+`requirement` change, conservatively, whatever the words say.
+
+### 4.4 Obligation records (proposed P1, not filed)
+
+Stable ids for what a spec requires, so evidence can name what it evaluates.
+Declared in frontmatter, compiled into the registry record:
+
+```yaml
+obligations:
+  - { id: REQ-1, kind: requirement, section: "3.1", units: ["crates/spec-spine-cli/src/verify_attestation.rs"] }
+  - { id: INV-1, kind: invariant, section: "3.3" }
+  - { id: VER-1, kind: verification, verifies: [REQ-1, INV-1],
+      inputs: ["crates/spec-spine-cli/tests/verify_attestation_tamper.rs"] }
+```
+
+```json
+{ "id": "085-a-verifier-checks-the-bytes-it-was-given#REQ-1",
+  "kind": "requirement", "sectionHash": "...", "units": [ { "kind": "file", "path": "..." } ],
+  "verifiedBy": ["085-...#VER-1"] }
+```
+
+Rules a compile would enforce: an id is unique within its spec; a `verifies`
+reference names an id that exists; a `section` names a heading that exists;
+`sectionHash` is the frame/1 digest of that section's text, alongside the
+spec's full-content hash, never instead of it. A `verification` obligation's
+`inputs` are the files its commands read; declaring them is what lets a delta
+(4.3) see that a candidate changed the tests that judge it, which today it
+cannot (they classify as `implementation`). An evidence record produced by a
+consumer references obligations as `{ "obligation", "subject", "relation":
+"evaluates", "result", "evidence" }`; spec-spine can check that the ids exist
+in a snapshot, never that the result is true.
+
+### 4.5 ContextClosure (proposed P1, not filed)
+
+The context a spec's work structurally requires, with a reason for every item,
+under a named rule version:
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "rules": "closure/1",
+  "snapshot": "<AuthoritySnapshot attestationHash>",
+  "root": "085-a-verifier-checks-the-bytes-it-was-given",
+  "required": [
+    { "kind": "spec", "id": "085-...", "reason": "root", "shardHash": "..." },
+    { "kind": "spec", "id": "023-ledger-seal", "reason": "depends_on", "shardHash": "..." },
+    { "kind": "spec", "id": "084-a-short-id-names-the-same-spec-at-every-verb", "reason": "co-owner",
+      "unit": "crates/spec-spine-cli/src/verify_attestation.rs", "shardHash": "..." },
+    { "kind": "file", "path": "standards/spec/constitution.md", "reason": "constitution", "hash": "..." }
+  ],
+  "optional": [ { "kind": "file", "path": "docs/design/04-authority-evidence-extension.md", "reason": "references" } ],
+  "missing": [ { "unit": { "kind": "file", "path": "crates/spec-spine-cli/tests/verify_attestation_tamper.rs" },
+                 "reason": "planned-not-written" } ],
+  "complete": false
+}
+```
+
+`closure/1` would include the root, its transitive `depends_on`, every spec it
+amends, extends, refines, supersedes or constrains, every spec that amends it,
+every co-owner of a unit it owns, the constitution and contract, and the root's
+owned units; `references` go to `optional`. A consumer that sends less than
+`required` must report what it omitted, and a closure with anything omitted or
+missing is not complete. It proves inclusion under those rules. It does not
+prove that the graph is complete, that the context was sufficient, or that a
+model read it.
+
+### 4.6 WorkScope (proposed P1, not filed)
+
+Where a candidate for one spec may write, what it must satisfy, and what it may
+collide with. Not a permit.
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "snapshot": "<AuthoritySnapshot attestationHash>",
+  "closure": "<ContextClosure hash>",
+  "spec": "085-a-verifier-checks-the-bytes-it-was-given",
+  "mutable": [
+    { "unit": { "kind": "file", "path": "crates/spec-spine-cli/src/verify_attestation.rs" },
+      "via": "extends", "coOwners": ["023-ledger-seal", "042-per-spec-attestation", "084-a-short-id-names-the-same-spec-at-every-verb"] },
+    { "unit": { "kind": "file", "path": "crates/spec-spine-cli/tests/verify_attestation_tamper.rs", "planned": true },
+      "via": "establishes" }
+  ],
+  "ownSpec": { "path": "specs/085-.../spec.md", "permittedEdits": ["claim-created-file", "dated-decision", "implementation-field"] },
+  "shared": [ { "path": ".derived/", "reason": "regenerated" }, { "path": "Cargo.lock", "reason": "lockfile" } ],
+  "obligations": ["085-...#VER-1"],
+  "overlaps": [
+    { "spec": "084-a-short-id-names-the-same-spec-at-every-verb", "kind": "file",
+      "paths": ["crates/spec-spine-cli/src/verify_attestation.rs", "crates/spec-spine-core/src/attest.rs",
+                "crates/spec-spine-core/src/lib.rs"] }
+  ]
+}
+```
+
+The overlap in this example is real: drafts 084 and 085 both extend those
+files, so they are not safe to build in parallel even though neither depends
+on the other. `registry plan` lists both as ready today and has no way to say
+so. Disjoint scopes would still not prove independence (a shared lockfile, a
+generated shard, an API another spec consumes); `shared` names the declared
+ones and anything undeclared stays unknown, never "safe".
+
+### 4.7 Verifier coverage rules
+
+What an independent verifier must do with any spec-spine record, whoever
+packages it:
+
+1. **Hash the bytes it holds.** A record is referenced by SHA-256 over its
+   exact stored bytes. Refuse bytes that are not the canonical serialization of
+   their own parse (sorted keys, two-space indent, LF, one trailing newline);
+   spec-spine writes nothing else.
+2. **Parse strictly.** An unknown member or a duplicate key is a refusal, not
+   an ignored extra.
+3. **Dispatch on type and version.** The record type comes from the
+   consumer's envelope; an unknown `schemaVersion` MAJOR is `unsupported`, which
+   is neither pass nor fail. Each version keeps its own digest construction;
+   never re-derive an old digest under a new rule.
+4. **Keep outcomes separate.** Integrity, signature, subject binding,
+   recompute, freshness and policy are each `pass`, `fail`, `unknown` or
+   `not-applicable`. None is folded into another.
+5. **Recompute only under the recorded tool version and subject tree.** A
+   missing tree or a different version is `unknown`.
+6. **Trust nothing the bundle selects for itself.** A key or trust root shipped
+   inside a bundle does not authorize it.
+7. **Never execute.** A verification plan is data. A verifier reads it and
+   never runs it.
+
+Draft 085 makes spec-spine's own `verify-attestation` satisfy 1 to 3 for the
+existing attestations; the rest are properties of the consumer's verifier.
+
+## 5. Increments, in dependency order
+
+| Phase | Increment | Register ids | State | Exit evidence |
+|---|---|---|---|---|
+| P0 | **085** a verifier checks the bytes it was given | B33, B34 (prerequisite), A08 | draft, filed | every F1/F2 tamper row refuses; historical corpus and file-unit attestations still `match` |
+| P0 | **086** the committed index is compared, not trusted | B11, B33 | draft, filed (amends 024 5) | a rewritten shard body reads stale under `index check`, `check` and `couple`; a regenerated tree reads fresh |
+| P0 | **087** an authority snapshot says what it read | B11, A08, B33 | draft, filed | one record answers AE §4's "not covered" list for a tree; framed digests; recompute and seal via 085 |
+| P0 | **088** a change is classified under the base's rules | A03, A08, B35 | draft, filed | weakening one's own plan, a new `extends` claim, a config edit and an ambiguous move each classify; `couple` alone passes all four |
+| P1 | obligation records (4.4) | A01, A02, A08 | proposed | duplicate or unknown ids refuse at compile; declared verifier inputs reach the delta |
+| P1 | context closure (4.5) | B04, B05 | proposed | missing and optional items explicit; a truncated delivery cannot claim completeness |
+| P1 | work scope (4.6) | B01 | proposed | overlap between two ready specs is reported; scope references snapshot and closure digests |
+| P1 | receipt links and an offline verifier | A01, B33, B34 | consumer-owned; spec-spine supplies fixtures | one existing-repo change explained and independently checked (AE §6 is the manual form) |
+| P2 | declared impact and conflict sets | A04, A05, B03 | proposed | direct and transitive impact with provenance; unknown boundaries explicit |
+| P2 | interface references and pinned imports | B22, A06 | proposed | a provider/consumer seam pinned by digest across two corpora in this family |
+| P2 | reviewed move mapping | A07 | proposed | a rename needs an explicit mapping; git similarity is a suggestion only |
+| P2 | typed overlays: effect contracts, budgets, dependency rationale, contract adapters | B15, B18, B24, A09 | proposed, via the overlay seam | overlay records validate and are digest-pinned; core `Unit` identity untouched |
+| P2 | waiver lifecycle over explicit inputs | B17 | proposed | expiry and usage evaluated from caller-supplied time and usage; no counter in an authored file |
+
+Nothing in P1 or P2 is filed. Each should be filed only after the P0 record
+vocabulary it builds on is approved, because obligations, closures and scopes
+all reference a snapshot digest.
+
+## 6. The register, disposition by disposition
+
+| Id | Proposal | Here | What spec-spine does | What stays outside |
+|---|---|---|---|---|
+| A01 | Evidence graph | P1 | obligation ids, typed references, validation that referenced ids exist | observations, retention, the claim that a result supports anything beyond the bounded obligation |
+| A02 | Typed invariants | P1 | `invariant` obligations with scope and an optional overlay predicate reference | executing predicates; prose stays authored truth |
+| A03 | Authority-transition policy | P0 (088) | classification against the base | identity, approval, the decision |
+| A04 | Change-impact compiler | P2 | declared impact over existing edges, with provenance and unknown boundaries | semantic blast radius |
+| A05 | Parallel-work planner | P1/P2 | overlap and shared-output sets (4.6) | reservation, scheduling |
+| A06 | Cross-repository federation | P2 interface snapshots only | digest-pinned imports with namespace and version | discovery, fetching, trust in the exporter |
+| A07 | Rename / move semantics | P2 | a reviewed mapping as authored data; 088 reports delete and add, never inferred identity | similarity detection as authority |
+| A08 | Semantic fingerprints | P0/P1 | framed structured digests beside full-content hashes | any heuristic or model deciding a prose change is harmless |
+| A09 | Machine-checkable contracts | P2 overlay | digest of the contract and of the verifier's declared inputs | running the checkers |
+| B01 | Compile work permits | P1 as WorkScope | the scope | the permit, its issuer, its enforcement |
+| B03 | Authority leases | P2 | conflict scopes | TTL, fencing, revocation, the lease store |
+| B04 | Smallest sufficient context | P1 as required closure | required plus separately labeled optional | any claim of minimality or sufficiency |
+| B05 | Context sufficiency proofs | P1 as closure certificate | inclusion under a named rule version | truncation by a provider, comprehension |
+| B11 | Governance Merkle root | P0 as snapshot digests | 086 (the committed ledger is what it claims) and 087 (framed digests, coverage, exclusions) | membership proofs until a consumer needs selective verification |
+| B15 | Effects as authority units | P2 overlay prototype | typed effect-contract references | mapping to real effects; `Unit` identity unchanged |
+| B17 | Waiver half-life | P2 | pure evaluation of explicit time, ancestry and usage inputs | atomic consumption of usage |
+| B18 | Constraint budgets | P2 overlay | typed declarations: dimension, unit, window, authority | measurement and enforcement |
+| B22 | Interface boundaries | P2 | typed provider and consumer references with pinned digests | API-specific checks |
+| B24 | Dependency justification | P2 overlay | declared rationale bound to package identity | any inference that a dependency is unused |
+| B33 | Minimal proof protocol | P0/P1 | its own payloads, validated strictly (085), named with stable types and versions | the envelope, composition, trust decisions |
+| B35 | Policy compiler, not runtime | throughout | pure functions of explicit inputs | keys, clocks, locks, approvals, I/O, revocation state |
+
+## 7. Requests to other repositories
+
+Each names the consumer that would act on it. None changes that repository's
+contract from here; they are proposals for its own governance.
+
+**statecraft-cli**
+
+- **R1.** Parse envelopes instead of prose. `members/src/orchestrator/export.ts`
+  (`runCorpusAttest`) and `adopt/holdback.ts` (`attestationHash`) match
+  `attestationHash:` in prose; use `spec-spine attest --json` and read
+  `.report.attestationHash`. The attestation's path is
+  `<derived_dir>/attestation/attestation.json`, a function of the repository,
+  not of stdout.
+- **R2.** A receipt revision that carries spec-spine results, not just exit
+  codes: per gate command, the envelope `schemaVersion` and SHA-256 of the
+  envelope bytes (run with `--json`); an `authority` block with the corpus
+  `attestationHash`, the spec's `SpecAttestation` hash and `specSourceHash`, and
+  the plan digest (AE §6 is a worked example); and the merge base `couple`
+  diffed from. When 087 lands, the snapshot hash replaces most of that block.
+- **R3.** Read acceptance through `spec-spine verify --plan --json` rather than
+  a second `## Verification` parser (`stages/verify.ts`), and take the plan from
+  the base revision's copy of the spec, recording its `specSourceHash`.
+  `verify:browser` blocks appear under `skipped`, so the CLI's browser path
+  keeps working.
+- **R4.** Hash stored attestation bytes and refuse unknown members yourself
+  until a release contains 085 (AE §8). `export.ts` already hashes the bytes;
+  keep that and add the member check.
+- **R5.** Do not promise the spec 083 subtree fix to users of `v0.18.0`. The
+  pin is `required_version = "0.18.0"` (caret) and CI installs `main`'s
+  `install.sh` unpinned, which resolves to `v0.18.0`, which predates 083. After
+  the release that contains it, raise the floor and pin the installer to the
+  same version.
+- **R6.** Decide whether the universal gate floor should add
+  `--fail-on-unresolved` to `check` (this repository's floor has it; the CLI's
+  does not), and record 1, 2 and 3 as distinct failures in evidence.
+- **R7.** Run declared acceptance only in an explicitly authorized worker,
+  behind the credential fence (spec 125) or the sandbox draft (126); not in a
+  process holding credentials.
+
+**Statecraft (hosted control plane)**
+
+- **S1.** Never execute `## Verification` commands in the control plane. Accept
+  spec-spine envelopes and attestation payloads, recomputed or verified by a
+  trusted worker under the recorded tool version.
+- **S2.** Store `{repo, commit, tree}` beside every spec-spine digest; treat a
+  `versionMismatch` or an unavailable tree as `unknown`.
+- **S3.** Evaluate 088's `priorPolicy.required` classes under the base's policy
+  and record the approval reference in the permit; spec-spine only classifies.
+- **S4.** Lead the composition envelope (payload type names, media types, any
+  in-toto predicate type). spec-spine will supply stable type names and
+  versions for its payloads and review the mapping.
+
+**hqgit**
+
+- **H1.** Reference spec-spine records by `(type, schemaVersion, SHA-256 of the
+  record bytes)` together with the subject tree and commit. Where hqgit's own
+  identifiers use a different algorithm or encoding, keep both in the cross
+  reference with explicit algorithm ids; do not re-derive spec-spine digests.
+
+**Fixtures offered to all three:** the tamper and cross-version cases of AE §8,
+as runnable commands in 085's `## Verification` block, and AE §6's worked
+binding, which a verifier can reproduce from the public history of this
+repository.
+
+## 8. Declared versus enforced
+
+| Guarantee as declared | Where declared | Enforced today? |
+|---|---|---|
+| A single tampered payload byte fails the signature | spec 023 AC-4 | For existing members only. Added members and reformatting verify (F1) |
+| Loaders reject an unknown schema MAJOR | `docs/schema-versioning.md`; `types/src/attest.rs` | For registry and index loaders. Not for attestation verification (F2) |
+| Artifact DTOs deny unknown fields | `docs/schema-versioning.md` | `Config`, edge items and `Unit` only (F10) |
+| Every emitted JSON document has sorted keys | `api.md` §7 | Not `registry plan`, `index owner` or `index coverage` (F8) |
+| `tool.version` is the reproducibility anchor | spec 023 FR-005 | Not a build identity (F3) |
+| The corpus attestation with coupling covers "specs and code in sync" | spec 023 FR-002 | Resolution only; no code bytes and no diff (AE §4, §5) |
+| `verify` never enters the gate chain | spec 049 3.6 | Yes: CI and the floor exclude it |
+| No lint rule consumes a `SpecAttestation` | spec 042 3.4 | By review only, as 042 says itself |
+| An agent does not weaken the spec it is implementing | `.claude/rules/adversarial-prompt-refusal.md` | A prompt; the gate passes it (F7) |
+| A fresh `check` means the committed shards are exactly what the corpus compiles to | `AGENTS.md` (Freshness) | For the registry. For the index, only the hash fields are compared (F11) |
+
+## 9. Decisions this note does not make
+
+- **D1. Build identity.** Options: stamp new record types with the source
+  commit (reproducible per source, but absent from a crates.io build); give
+  `main` a pre-release version after every release (distinguishes builds, but
+  this repository's own `required_version = ">=0.17.0"` does not match
+  pre-release versions under Cargo's semver rules); or document the limit.
+  Recommendation: document now, decide with the next release.
+- **D2. Refusal codes in 085.** The draft refuses unknown members and unknown
+  MAJOR versions at exit 3 (parse and schema, the standing contract) and makes
+  a non-canonical byte sequence a failed verification at exit 1. A reviewer may
+  prefer one named `unsupported` outcome at exit 1 for all three.
+- **D2a. The 024 amendment in 086.** Comparing index bytes reports a
+  sibling-caused resolution flip that spec 024 5 deliberately left unreported.
+  The draft declares `amends: 024`; a reviewer may instead prefer to make only
+  the coupling gate resolve ownership afresh (086 D-2 records why the draft
+  does not).
+- **D3. What 087 embeds per spec.** The draft embeds each `SpecAttestation`
+  hash, which inherits F4 for unit bytes. The alternative is a framed territory
+  digest per spec, which is new work and a second hash over the same files.
+- **D4. Where prior-policy enforcement lives.** Recommended: in the consumer
+  that issues permits, reading 088. A refusing mode in `couple` is note 02 G7
+  and should stay design-first.
+- **D5. Obligation vocabulary.** Kinds, id syntax, frontmatter versus a fenced
+  block, and whether `constraint` is a fourth kind.
+- **D6. The neutral verifier's home.** A family decision; spec-spine's part is
+  the fixtures and strict payload validation in its own crates.
+- **D7. Envelopes for the unversioned reads.** Wrap `registry plan`,
+  `index owner` and `index coverage` in the spec 037 envelope, or add a version
+  field to each.
+- **D8. Constitutional edits and bootstrap.** Whether any change to tier-1
+  anchors or `standards/spec/` can be accepted under the candidate's policy
+  (this note's answer is no), and what authorizes the first snapshot a consumer
+  trusts.
+
+## 10. Where the packet and this repository disagree
+
+- **Baseline.** The packet records `HEAD 6fca5ee` with 083 draft. At `75181a5`,
+  083 is approved (ratified in #176) and 084 is filed as a draft (#177): 85
+  specs, 84 approved and complete, one draft and pending.
+- **Enforcement.** The packet asks for prior-policy handling. Note 02 G7 says no
+  mechanism should be asserted before it is designed, because the naive rule
+  refuses legitimate refactors. 088 therefore reports and does not refuse.
+- **Committed evidence.** None of the proposed records is committed. Specs 042
+  3.3 and note 02 §5 explain why: a committed evidence tree needs its own
+  freshness gate and restales on every edit.
+- **Vocabulary.** This repository reserves "certificate" for testimony of a
+  non-reproducible event (spec 023 §7) and uses "attestation" for recomputable
+  records. The packet's "proof" language is avoided here for the same reason it
+  gives: a digest commits to bytes; it proves nothing about intent.
+- **Merkle.** Not used. The existing folds are sorted hashes, not trees.

--- a/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
+++ b/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
@@ -267,7 +267,7 @@ Against pre-085 code the lines split three ways:
 
 - **Fail first.** The two injected-member lines, the nested-member line, the
   per-spec member line, the seal member line, both unknown-MAJOR lines, the
-  same-MAJOR version line and the reformatted-bytes line. They exit 0 or 1
+  same-MAJOR version line and both reformatted-bytes lines. They exit 0 or 1
   today where 3 or 1 is required, and they are the evidence that the defect
   is fixed.
 - **Pass before and after.** The baseline, the `tool.version` line, the verdict
@@ -280,8 +280,10 @@ Against pre-085 code the lines split three ways:
 
 Two vacuous passes are closed. Each refusal line checks the exit code **and**
 that stderr names the member or the MAJOR, so a line cannot pass because a file
-was missing (also exit 3). The reformatted-bytes line asserts exit 1 exactly,
-so it cannot pass on a usage error.
+was missing (also exit 3). Both reformatted-bytes lines assert exit 1
+exactly, so neither can pass on a usage error, and the recompute one also
+asserts the outcome and the difference 3.1 spells out, so it cannot pass on a
+mismatch found for some other reason.
 
 ```verify:cli
 cargo build --release --locked
@@ -300,6 +302,7 @@ D="${TMPDIR:-/tmp}/ss085"; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "9.0
 D="${TMPDIR:-/tmp}/ss085"; A=.derived/attestation/by-spec/083-an-attestation-covers-the-territory-it-claims.json; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "9.0.0"/' "$A" > "$D/s3.json"; target/release/spec-spine verify-attestation --spec 083-an-attestation-covers-the-territory-it-claims --attestation "$D/s3.json" --recompute 2> "$D/s3.err"; test $? -eq 3 && grep -q "MAJOR 9" "$D/s3.err"
 D="${TMPDIR:-/tmp}/ss085"; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "0.2.0"/' .derived/attestation/attestation.json > "$D/t4.json"; target/release/spec-spine verify-attestation --attestation "$D/t4.json" --recompute --json > "$D/t4.out"; test $? -eq 1 && grep -q '"schemaVersion (0.2.0' "$D/t4.out"
 D="${TMPDIR:-/tmp}/ss085"; tr -d '\n' < .derived/attestation/attestation.json > "$D/t6.json"; target/release/spec-spine verify-attestation --attestation "$D/t6.json" --seal .derived/attestation/attestation.sig --signature --public-key "$D/pub"; test $? -eq 1
+D="${TMPDIR:-/tmp}/ss085"; tr -d '\n' < .derived/attestation/attestation.json > "$D/t6r.json"; target/release/spec-spine verify-attestation --attestation "$D/t6r.json" --recompute --json > "$D/t6r.out"; test $? -eq 1 && grep -q contentMismatch "$D/t6r.out" && grep -q "bytes are not the canonical serialization" "$D/t6r.out"
 D="${TMPDIR:-/tmp}/ss085"; sed 's/"version": "[^"]*"/"version": "0.0.1"/' .derived/attestation/attestation.json > "$D/r1.json"; target/release/spec-spine verify-attestation --attestation "$D/r1.json" --recompute --json > "$D/r1.out"; test $? -eq 1 && grep -q versionMismatch "$D/r1.out"
 D="${TMPDIR:-/tmp}/ss085"; sed 's/"ok": true/"ok": false/' .derived/attestation/attestation.json > "$D/r2.json"; target/release/spec-spine verify-attestation --attestation "$D/r2.json" --recompute --json > "$D/r2.out"; test $? -eq 1 && grep -q contentMismatch "$D/r2.out"
 D="${TMPDIR:-/tmp}/ss085"; awk '/"registryHash":/ && !done {print "  \"registryHash\": \"00\","; done=1} {print}' .derived/attestation/attestation.json > "$D/r3.json"; target/release/spec-spine verify-attestation --attestation "$D/r3.json" --recompute 2> "$D/r3.err"; test $? -eq 3 && grep -q registryHash "$D/r3.err"

--- a/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
+++ b/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
@@ -1,0 +1,303 @@
+---
+id: "085-a-verifier-checks-the-bytes-it-was-given"
+title: "A verifier checks the bytes it was given"
+status: draft
+kind: "tooling"
+created: "2026-09-11"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: high
+depends_on:
+  - "023-ledger-seal"
+  - "042-per-spec-attestation"
+  - "067-the-docs-name-what-adopters-derived"
+  - "083-an-attestation-covers-the-territory-it-claims"
+establishes:
+  # Planned (spec 076) until the build writes it; the build drops the flag.
+  # 3.6: the tamper and version matrix, end to end through the binary.
+  - { kind: file, path: "crates/spec-spine-cli/tests/verify_attestation_bytes.rs", planned: true }
+extends:
+  # 3.2: every attestation and seal DTO refuses a member it does not know.
+  - { spec: "023-ledger-seal", unit: "crates/spec-spine-types/src/attest.rs", nature: additive }
+  # 3.1 and 3.3: the verifier reads the file once, gates the version, and hashes what it read.
+  - { spec: "023-ledger-seal", unit: "crates/spec-spine-cli/src/verify_attestation.rs", nature: additive }
+  # 3.3: the corpus recompute compares schemaVersion like every other member.
+  - { spec: "023-ledger-seal", unit: "crates/spec-spine-core/src/attest.rs", nature: additive }
+  # 3.4: the facade parses strictly, gates the version, and accepts the text form.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  # 3.6: library-level guards beside the existing attestation tests.
+  - { spec: "023-ledger-seal", unit: "crates/spec-spine-core/tests/attest.rs", nature: additive }
+  # 3.5: the versions table and the unknown-member sentence.
+  - { spec: "067-the-docs-name-what-adopters-derived", unit: "docs/schema-versioning.md", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/authority-evidence.md" }, role: context }
+  - { unit: { kind: file, path: "docs/design/04-authority-evidence-extension.md" }, role: context }
+  - { unit: { kind: file, path: "specs/084-a-short-id-names-the-same-spec-at-every-verb/spec.md" }, role: context }
+summary: >
+  `verify-attestation` decides on a different object from the one it was handed.
+  It deserializes the attestation without refusing members it does not know, and
+  it checks the seal against a hash of its own re-serialization of what it
+  parsed, never against the file's bytes. Measured at 75181a5: a sealed
+  attestation with an injected `"prCouple": {"ok": true}` verifies as `match`
+  and `valid` at exit 0, in both the corpus and the per-spec scope, and so does
+  a reformatted copy. Separately, the corpus recompute never compares
+  `schemaVersion`, so an attestation claiming `9.0.0` recomputes as `match` at
+  exit 0, while the per-spec path reports an unnamed content mismatch. Spec 023
+  AC-4 already requires a single tampered payload byte to fail the signature,
+  and the attestation module documents that loaders reject an unknown MAJOR, so
+  this spec extends rather than amends: the verifier reads the file once, both
+  modes decide on those bytes, every attestation and seal DTO refuses unknown
+  members at exit 3, an unknown schema MAJOR is refused at exit 3 in the
+  loaders' own words, and the corpus recompute compares the version. Nothing
+  `attest` emits changes, and every attestation and seal it has ever written
+  still verifies, provided the bytes were kept.
+---
+
+# 085: A verifier checks the bytes it was given
+
+## 1. Purpose
+
+Spec 023 made the corpus attestation "the most verifiable link in any audit
+chain that contains it", and spec 042 extended the same record to one spec for
+consumers outside this repository. Both are checked by `verify-attestation`,
+which a consumer runs precisely so that it does not have to reimplement the
+check. Measured on 2026-09-11 against a sealed pair written by `attest --sign`
+with a scratch key:
+
+| What was done to the stored file | `--recompute` | `--signature` | Exit |
+|---|---|---|---|
+| nothing | match | valid | 0 |
+| a top-level member added: `"prCouple": {"ok": true}` | match | valid | **0** |
+| a nested member added under `verdicts.compile` | match | valid | **0** |
+| a member added to a per-spec attestation's first unit | match | valid | **0** |
+| reformatted: newlines removed, values unchanged | match | valid | **0** |
+| corpus `schemaVersion` changed to `9.0.0`, recompute only | **match** | not run | **0** |
+| corpus `schemaVersion` changed to `0.2.0`, recompute only | **match** | not run | **0** |
+| per-spec `schemaVersion` changed to `9.0.0` | mismatch, "tool.name or schemaVersion" | not run | 1 |
+| `tool.version` changed | `versionMismatch` | | 1 |
+| a verdict flipped | mismatch naming it | invalid | 1 |
+| a key duplicated | parse error | | 3 |
+
+The consumer that motivated per-spec attestations reads the file with its own
+parser after spec-spine says it is valid. In the bold rows that consumer reads
+members spec-spine never verified. A verdict about one object has been
+reported as a verdict about another.
+
+Three mechanisms produce the rows:
+
+- **Unknown members are dropped.** None of `CorpusAttestation`,
+  `SpecAttestation`, their nested types or `LedgerSeal` refuses an unknown
+  field, so serde discards it. `docs/schema-versioning.md` says the artifact
+  DTOs refuse unknown fields; only `Config`, the edge items and `Unit` do.
+- **The seal is checked over a re-serialization.** `verify_attestation.rs`
+  computes `attestation_hash(&loaded)`, the SHA-256 of the canonical JSON of the
+  parsed value, and checks the seal against that. For a file `attest` wrote the
+  two are the same bytes; for any other file they are not, and the difference is
+  exactly what the bold rows exploit.
+- **The corpus recompute compares member by member and skips one.**
+  `verify_recompute` compares `tool.name`, both input hashes and each verdict,
+  and never `schemaVersion`. The per-spec path compares the whole value, so it
+  notices, but its report cannot say what it noticed.
+
+Spec 023 AC-4 requires "a single tampered payload byte fails the signature",
+and FR-004 has `--recompute` check "the emitted hashes against the
+attestation". The attestation DTO module documents that loaders reject an
+unknown MAJOR. The code does none of the three for these inputs.
+
+## 2. Territory
+
+- `crates/spec-spine-types/src/attest.rs`: `deny_unknown_fields` on every
+  attestation and seal type.
+- `crates/spec-spine-cli/src/verify_attestation.rs`: one read of the file, the
+  version gate, the seal over the bytes read, and the byte comparison in
+  `--recompute`.
+- `crates/spec-spine-core/src/attest.rs`: `verify_recompute` compares
+  `schemaVersion`; both recompute paths name it.
+- `crates/spec-spine-core/src/lib.rs`: the two verification facades.
+- `crates/spec-spine-core/tests/attest.rs` and the new
+  `crates/spec-spine-cli/tests/verify_attestation_bytes.rs`: the guards.
+- `docs/schema-versioning.md`: the versions table and the sentence about which
+  DTOs refuse unknown fields.
+
+Drafts 084 and 085 both extend `verify_attestation.rs`, `core/src/attest.rs`
+and `core/src/lib.rs`. Neither needs the other's behavior, so there is no
+`depends_on` edge, but they are not safe to build in parallel: build them one
+after the other, and the second rebases.
+
+## 3. Behavior
+
+### 3.1 The bytes are read once, and both modes decide on them
+
+`verify-attestation` MUST read the attestation file once and hold its exact
+bytes. Every mode MUST decide on those bytes:
+
+- `--signature` MUST verify the seal over SHA-256 of the bytes read, not over a
+  re-serialization of their parse. For every file `attest` has written, the
+  file is the canonical JSON, so the two digests are equal and every existing
+  seal verifies exactly as before.
+- `--recompute` MUST compare the recomputed canonical bytes with the bytes
+  read. When the parsed values are equal and the bytes are not, the outcome is
+  `contentMismatch` with the difference `bytes are not the canonical
+  serialization`, at exit 1.
+
+The rule is the one a consumer can check without trusting anything: the digest
+a record is referenced by is SHA-256 over the stored bytes, and a verifier that
+approves a record approves those bytes.
+
+### 3.2 An unknown member is refused
+
+`CorpusAttestation`, `SpecAttestation`, `ToolStamp`, `CompileVerdict`,
+`LintVerdict`, `CoupleVerdict`, `Verdicts`, `SpecVerdicts`, `ResolutionVerdict`,
+`AttestedUnit`, `AttestedLifecycle` and `LedgerSeal` MUST refuse unknown
+fields. A file carrying a member this build does not know MUST fail to load, at
+exit 3 as a parse error naming the member, before either mode runs.
+
+An unknown member is a claim this build cannot evaluate. A verifier that drops
+it has verified a smaller object than the one it was handed. The refusal is
+also the honest answer across versions: a newer producer's additive member,
+met by an older verifier, becomes "cannot read" rather than today's false
+`valid`, or the false `invalid` that 3.1 alone would give.
+
+### 3.3 An unknown schema MAJOR is refused, and the corpus recompute compares the version
+
+Before either mode runs, the verifier MUST parse the payload's `schemaVersion`
+as `MAJOR.MINOR.PATCH` and refuse a MAJOR other than this build's for that
+payload type, at exit 3, with the message the registry and index loaders use
+(`attestation schema MAJOR 9 is unsupported (this build understands 0.x)`). A
+value that is not semver is refused at exit 3 too.
+
+The corpus recompute MUST compare `schemaVersion` like every other member, and
+both recompute paths MUST name it (`schemaVersion (0.2.0 -> 0.1.0)`) rather
+than report `tool.name or schemaVersion`. The order of checks is: the MAJOR
+gate, then spec 023 FR-005's `tool.version` comparison, then content, so an
+unreadable payload is never reported as a version or content difference.
+
+### 3.4 The facade holds the same rules
+
+`verify_attestation_json` and `verify_spec_attestation_json` receive the
+attestation inside a JSON request, so the file's bytes never reach them. They
+MUST apply 3.2 and 3.3 to the value they receive. They MUST also accept
+`attestationText`, a string holding the attestation's exact bytes, as an
+alternative to `attestation`, and apply 3.1 to it. A request carrying both, or
+neither, is refused as a parse error. The response shape is unchanged, which
+keeps the CLI's `--json` report and the facade byte-identical for the same
+inputs (spec 037 3.1).
+
+### 3.5 The documentation says what is true
+
+`docs/schema-versioning.md` MUST list every versioned artifact at its current
+constant (registry `1.2.0`, index `1.1.0`, corpus attestation `0.1.0`, per-spec
+attestation `0.1.0`, verdict envelope `0.3.0`, `build-meta` `0.1.0`, config
+`0.1.0`), and MUST say which DTOs refuse unknown fields: `Config`, the edge
+items, `Unit`, and after this spec every attestation and seal type. The
+registry and index DTOs do not, and their per-shard MAJOR gate is their guard.
+It MUST tell a consumer to store the bytes `attest` wrote, since a
+re-serialized copy no longer verifies under 3.1.
+
+### 3.6 What must keep working
+
+- `attest` emits byte-identical output in both scopes, and
+  `ATTESTATION_SCHEMA_VERSION` and `SPEC_ATTESTATION_SCHEMA_VERSION` do not
+  change. This spec changes what a verifier accepts, never what a producer
+  writes.
+- Every attestation and seal `attest` has written, stored unmodified, verifies
+  with the outcome and exit code it has today. That includes corpus
+  attestations and file-unit per-spec attestations written by `v0.18.0`, which
+  recompute as `match` under the current build (measured).
+- The rows of 1 that are not bold keep their outcomes and exit codes.
+- Spec 083's fixtures keep passing.
+
+## 4. Out of scope
+
+**A build identity.** Two binaries that print `0.18.0` can behave differently,
+and `tool.version` cannot tell them apart. That is a release-process question
+recorded as design/04 D1, not a verifier rule.
+
+**A framed digest construction.** `hash::content_hash` does not frame content,
+so two trees can fold to one unit hash. Changing it would change every
+historical digest; draft 087 proposes a framed construction for new record
+types only.
+
+**Refusing unknown members in the registry and index DTOs.** Their loaders gate
+the MAJOR per shard, and a committed shard is regenerated rather than handed
+between parties. Whether they should also refuse unknown members is a separate
+question with a restale cost.
+
+**Trust in the signer.** Which keys a consumer accepts stays the consumer's
+policy (spec 023 6).
+
+**The short id at `verify-attestation --spec`.** Draft 084.
+
+## 5. Resolved decisions
+
+**D-1 (2026-09-11): `extends`, not `amends`.** Spec 023 AC-4 already requires a
+tampered payload byte to fail the signature, FR-004 already has the recompute
+check the attestation's hashes, and the DTO module already documents the MAJOR
+rule. This spec makes the code do what those say. It changes a verdict only for
+inputs spec-spine never emitted. The reasoning is spec 083 D-1's: declaring an
+amendment would record a change of requirement that did not happen.
+
+**D-2 (2026-09-11): exit 3 for an unknown member or MAJOR, exit 1 for bytes that
+are not canonical.** A member or a MAJOR this build does not know makes the
+file one it cannot read, which is the standing "3 for I/O, parse or schema
+trouble" (spec 042 3.5). A file whose values are right and whose bytes are not
+the ones attested has been read and has failed verification, which is 1. The
+alternative, one `unsupported` outcome at exit 1 for all three, is recorded as
+design/04 D2 for the reviewer.
+
+**D-3 (2026-09-11): no schema version moves.** Nothing emitted changes, so no
+payload gains or loses a member. A version bump would tell consumers the shape
+changed when only the reader did.
+
+## Verification
+
+Each line below is one command, run in its own `sh -c` from the repository root
+(spec 049 3.5), so no line depends on a variable another line set. The scratch
+files live at a fixed path for that reason. The key is a fixed test seed; the
+public key is read back from the seal's default `keyId`, which is the hex public
+key.
+
+Against pre-085 code the lines split three ways:
+
+- **Fail first.** The two injected-member lines, the nested-member line, the
+  per-spec member line, both unknown-MAJOR lines, the same-MAJOR version line
+  and the reformatted-bytes line. They exit 0 or 1 today where 3 or 1 is
+  required, and they are the evidence that the defect is fixed.
+- **Pass before and after.** The baseline, the `tool.version` line, the verdict
+  flip, the duplicate key, the per-spec recompute of a directory-unit spec and a
+  file-unit spec, the line that the written bytes hash to `attestationHash`, and
+  the closing `check`. They guard 3.6.
+- **Setup and cleanup.** The build, the scratch directory, the key, the two
+  `attest` runs that write the pairs, the public-key read, and the final
+  `rm -rf`.
+
+Two vacuous passes are closed. Each refusal line checks the exit code **and**
+that stderr names the member or the MAJOR, so a line cannot pass because a file
+was missing (also exit 3). The reformatted-bytes line asserts exit 1 exactly,
+so it cannot pass on a usage error.
+
+```verify:cli
+cargo build --release --locked
+rm -rf "${TMPDIR:-/tmp}/ss085" && mkdir -p "${TMPDIR:-/tmp}/ss085"
+printf '0707070707070707070707070707070707070707070707070707070707070707' > "${TMPDIR:-/tmp}/ss085/k"
+target/release/spec-spine attest --sign --key "${TMPDIR:-/tmp}/ss085/k" >/dev/null
+target/release/spec-spine attest --spec 083-an-attestation-covers-the-territory-it-claims --sign --key "${TMPDIR:-/tmp}/ss085/k" >/dev/null
+sed -n 's/.*"keyId": "\([0-9a-f]*\)".*/\1/p' .derived/attestation/attestation.sig > "${TMPDIR:-/tmp}/ss085/pub" && test -s "${TMPDIR:-/tmp}/ss085/pub"
+target/release/spec-spine verify-attestation --recompute --signature --public-key "${TMPDIR:-/tmp}/ss085/pub"
+D="${TMPDIR:-/tmp}/ss085"; awk 'NR==1{print; print "  \"prCouple\": {\"ok\": true},"; next} {print}' .derived/attestation/attestation.json > "$D/t1.json"; target/release/spec-spine verify-attestation --attestation "$D/t1.json" --seal .derived/attestation/attestation.sig --signature --public-key "$D/pub" 2> "$D/t1.err"; test $? -eq 3 && grep -q prCouple "$D/t1.err"
+D="${TMPDIR:-/tmp}/ss085"; awk 'NR==1{print; print "  \"prCouple\": {\"ok\": true},"; next} {print}' .derived/attestation/attestation.json > "$D/t1r.json"; target/release/spec-spine verify-attestation --attestation "$D/t1r.json" --recompute 2> "$D/t1r.err"; test $? -eq 3 && grep -q prCouple "$D/t1r.err"
+D="${TMPDIR:-/tmp}/ss085"; awk '/"compile": \{/{print; print "      \"ignoredWarnings\": 12,"; next} {print}' .derived/attestation/attestation.json > "$D/t2.json"; target/release/spec-spine verify-attestation --attestation "$D/t2.json" --seal .derived/attestation/attestation.sig --recompute --signature --public-key "$D/pub" 2> "$D/t2.err"; test $? -eq 3 && grep -q ignoredWarnings "$D/t2.err"
+D="${TMPDIR:-/tmp}/ss085"; A=.derived/attestation/by-spec/083-an-attestation-covers-the-territory-it-claims; awk '/"contentHash":/ && !done {print "        \"coveredBy\": \"review\","; done=1} {print}' "$A.json" > "$D/s1.json"; target/release/spec-spine verify-attestation --spec 083-an-attestation-covers-the-territory-it-claims --attestation "$D/s1.json" --seal "$A.sig" --recompute --signature --public-key "$D/pub" 2> "$D/s1.err"; test $? -eq 3 && grep -q coveredBy "$D/s1.err"
+D="${TMPDIR:-/tmp}/ss085"; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "9.0.0"/' .derived/attestation/attestation.json > "$D/t3.json"; target/release/spec-spine verify-attestation --attestation "$D/t3.json" --recompute 2> "$D/t3.err"; test $? -eq 3 && grep -q "MAJOR 9" "$D/t3.err"
+D="${TMPDIR:-/tmp}/ss085"; A=.derived/attestation/by-spec/083-an-attestation-covers-the-territory-it-claims.json; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "9.0.0"/' "$A" > "$D/s3.json"; target/release/spec-spine verify-attestation --spec 083-an-attestation-covers-the-territory-it-claims --attestation "$D/s3.json" --recompute 2> "$D/s3.err"; test $? -eq 3 && grep -q "MAJOR 9" "$D/s3.err"
+D="${TMPDIR:-/tmp}/ss085"; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "0.2.0"/' .derived/attestation/attestation.json > "$D/t4.json"; target/release/spec-spine verify-attestation --attestation "$D/t4.json" --recompute --json > "$D/t4.out"; test $? -eq 1 && grep -q '"schemaVersion (0.2.0' "$D/t4.out"
+D="${TMPDIR:-/tmp}/ss085"; tr -d '\n' < .derived/attestation/attestation.json > "$D/t6.json"; target/release/spec-spine verify-attestation --attestation "$D/t6.json" --seal .derived/attestation/attestation.sig --signature --public-key "$D/pub"; test $? -eq 1
+D="${TMPDIR:-/tmp}/ss085"; sed 's/"version": "[^"]*"/"version": "0.0.1"/' .derived/attestation/attestation.json > "$D/r1.json"; target/release/spec-spine verify-attestation --attestation "$D/r1.json" --recompute --json > "$D/r1.out"; test $? -eq 1 && grep -q versionMismatch "$D/r1.out"
+D="${TMPDIR:-/tmp}/ss085"; sed 's/"ok": true/"ok": false/' .derived/attestation/attestation.json > "$D/r2.json"; target/release/spec-spine verify-attestation --attestation "$D/r2.json" --recompute --json > "$D/r2.out"; test $? -eq 1 && grep -q contentMismatch "$D/r2.out"
+D="${TMPDIR:-/tmp}/ss085"; awk '/"registryHash":/ && !done {print "  \"registryHash\": \"00\","; done=1} {print}' .derived/attestation/attestation.json > "$D/r3.json"; target/release/spec-spine verify-attestation --attestation "$D/r3.json" --recompute 2> "$D/r3.err"; test $? -eq 3 && grep -q registryHash "$D/r3.err"
+target/release/spec-spine attest --spec 048-kit-ships-the-governed-loop-skills >/dev/null && target/release/spec-spine verify-attestation --spec 048-kit-ships-the-governed-loop-skills --recompute
+target/release/spec-spine verify-attestation --spec 083-an-attestation-covers-the-territory-it-claims --recompute --signature --public-key "${TMPDIR:-/tmp}/ss085/pub"
+H=$(target/release/spec-spine attest --json | sed -n 's/.*"attestationHash": "\([0-9a-f]*\)".*/\1/p'); F=.derived/attestation/attestation.json; if command -v sha256sum >/dev/null 2>&1; then G=$(sha256sum "$F" | cut -d' ' -f1); else G=$(shasum -a 256 "$F" | cut -d' ' -f1); fi; test -n "$H" && test "$H" = "$G"
+target/release/spec-spine check
+rm -rf "${TMPDIR:-/tmp}/ss085"
+```

--- a/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
+++ b/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
@@ -61,8 +61,8 @@ Spec 023 made the corpus attestation "the most verifiable link in any audit
 chain that contains it", and spec 042 extended the same record to one spec for
 consumers outside this repository. Both are checked by `verify-attestation`,
 which a consumer runs precisely so that it does not have to reimplement the
-check. Measured on 2026-09-11 against a sealed pair written by `attest --sign`
-with a scratch key:
+check. Measured on 2026-09-11, and the seal row on 2026-09-12, against a
+sealed pair written by `attest --sign` with a scratch key:
 
 | What was done to the stored file | `--recompute` | `--signature` | Exit |
 |---|---|---|---|
@@ -71,6 +71,7 @@ with a scratch key:
 | a nested member added under `verdicts.compile` | match | valid | **0** |
 | a member added to a per-spec attestation's first unit | match | valid | **0** |
 | reformatted: newlines removed, values unchanged | match | valid | **0** |
+| an unknown member added to the seal: `"revokedAt"` | | valid | **0** |
 | corpus `schemaVersion` changed to `9.0.0`, recompute only | **match** | not run | **0** |
 | corpus `schemaVersion` changed to `0.2.0`, recompute only | **match** | not run | **0** |
 | per-spec `schemaVersion` changed to `9.0.0` | mismatch, "tool.name or schemaVersion" | not run | 1 |
@@ -260,9 +261,10 @@ key.
 Against pre-085 code the lines split three ways:
 
 - **Fail first.** The two injected-member lines, the nested-member line, the
-  per-spec member line, both unknown-MAJOR lines, the same-MAJOR version line
-  and the reformatted-bytes line. They exit 0 or 1 today where 3 or 1 is
-  required, and they are the evidence that the defect is fixed.
+  per-spec member line, the seal member line, both unknown-MAJOR lines, the
+  same-MAJOR version line and the reformatted-bytes line. They exit 0 or 1
+  today where 3 or 1 is required, and they are the evidence that the defect
+  is fixed.
 - **Pass before and after.** The baseline, the `tool.version` line, the verdict
   flip, the duplicate key, the per-spec recompute of a directory-unit spec and a
   file-unit spec, the line that the written bytes hash to `attestationHash`, and
@@ -288,6 +290,7 @@ D="${TMPDIR:-/tmp}/ss085"; awk 'NR==1{print; print "  \"prCouple\": {\"ok\": tru
 D="${TMPDIR:-/tmp}/ss085"; awk 'NR==1{print; print "  \"prCouple\": {\"ok\": true},"; next} {print}' .derived/attestation/attestation.json > "$D/t1r.json"; target/release/spec-spine verify-attestation --attestation "$D/t1r.json" --recompute 2> "$D/t1r.err"; test $? -eq 3 && grep -q prCouple "$D/t1r.err"
 D="${TMPDIR:-/tmp}/ss085"; awk '/"compile": \{/{print; print "      \"ignoredWarnings\": 12,"; next} {print}' .derived/attestation/attestation.json > "$D/t2.json"; target/release/spec-spine verify-attestation --attestation "$D/t2.json" --seal .derived/attestation/attestation.sig --recompute --signature --public-key "$D/pub" 2> "$D/t2.err"; test $? -eq 3 && grep -q ignoredWarnings "$D/t2.err"
 D="${TMPDIR:-/tmp}/ss085"; A=.derived/attestation/by-spec/083-an-attestation-covers-the-territory-it-claims; awk '/"contentHash":/ && !done {print "        \"coveredBy\": \"review\","; done=1} {print}' "$A.json" > "$D/s1.json"; target/release/spec-spine verify-attestation --spec 083-an-attestation-covers-the-territory-it-claims --attestation "$D/s1.json" --seal "$A.sig" --recompute --signature --public-key "$D/pub" 2> "$D/s1.err"; test $? -eq 3 && grep -q coveredBy "$D/s1.err"
+D="${TMPDIR:-/tmp}/ss085"; awk 'NR==1{print; print "  \"revokedAt\": \"2026-01-01\","; next} {print}' .derived/attestation/attestation.sig > "$D/sl.sig"; target/release/spec-spine verify-attestation --seal "$D/sl.sig" --signature --public-key "$D/pub" 2> "$D/sl.err"; test $? -eq 3 && grep -q revokedAt "$D/sl.err"
 D="${TMPDIR:-/tmp}/ss085"; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "9.0.0"/' .derived/attestation/attestation.json > "$D/t3.json"; target/release/spec-spine verify-attestation --attestation "$D/t3.json" --recompute 2> "$D/t3.err"; test $? -eq 3 && grep -q "MAJOR 9" "$D/t3.err"
 D="${TMPDIR:-/tmp}/ss085"; A=.derived/attestation/by-spec/083-an-attestation-covers-the-territory-it-claims.json; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "9.0.0"/' "$A" > "$D/s3.json"; target/release/spec-spine verify-attestation --spec 083-an-attestation-covers-the-territory-it-claims --attestation "$D/s3.json" --recompute 2> "$D/s3.err"; test $? -eq 3 && grep -q "MAJOR 9" "$D/s3.err"
 D="${TMPDIR:-/tmp}/ss085"; sed 's/"schemaVersion": "0.1.0"/"schemaVersion": "0.2.0"/' .derived/attestation/attestation.json > "$D/t4.json"; target/release/spec-spine verify-attestation --attestation "$D/t4.json" --recompute --json > "$D/t4.out"; test $? -eq 1 && grep -q '"schemaVersion (0.2.0' "$D/t4.out"

--- a/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
+++ b/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
@@ -195,6 +195,11 @@ registry and index DTOs do not, and their per-shard MAJOR gate is their guard.
 It MUST tell a consumer to store the bytes `attest` wrote, since a
 re-serialized copy no longer verifies under 3.1.
 
+The parenthetical is the set as it stands today; the requirement is each
+artifact's current constant, not these literals. Draft 088 moves the verdict
+envelope to its next MINOR when it adds the `delta` verb token, so whichever of
+the two builds second writes the value the constant holds by then.
+
 ### 3.6 What must keep working
 
 - `attest` emits byte-identical output in both scopes, and

--- a/specs/086-the-committed-index-is-compared-not-trusted/spec.md
+++ b/specs/086-the-committed-index-is-compared-not-trusted/spec.md
@@ -1,0 +1,238 @@
+---
+id: "086-the-committed-index-is-compared-not-trusted"
+title: "The committed index is compared, not trusted"
+status: draft
+kind: "tooling"
+created: "2026-09-11"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: high
+depends_on:
+  - "004-codebase-index"
+  - "005-coupling-gate"
+  - "024-index-sharding"
+  - "031-registry-freshness-check"
+  - "075-one-name-one-freshness-verb"
+amends:
+  # 024 5 accepts that a resolution flip caused purely by a sibling change is
+  # not caught by `index check` and is healed by a later `index` run. Comparing
+  # bytes catches it. 024's text is not edited (spec 040). See 5, D-1.
+  - "024-index-sharding"
+establishes:
+  # Planned (spec 076) until the build writes it; the build drops the flag.
+  # 3.5: the tamper matrix against the committed index, library side.
+  - { kind: file, path: "crates/spec-spine-core/tests/index_body.rs", planned: true }
+extends:
+  # 3.1 and 3.2: `check_index_freshness` compares the committed shard bytes
+  # with the shards a fresh index emits, and reports the drift classes.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-core/src/index.rs", nature: additive }
+  # 3.2: `index check` prints the three drift classes by shard.
+  - { spec: "004-codebase-index", unit: "crates/spec-spine-cli/src/cmd_index.rs", nature: additive }
+  # 3.2: `check` reports the index half with the same classes.
+  - { spec: "075-one-name-one-freshness-verb", unit: "crates/spec-spine-cli/src/cmd_check.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/authority-evidence.md" }, role: context }
+  - { unit: { kind: file, path: "docs/design/04-authority-evidence-extension.md" }, role: context }
+  - { unit: { kind: file, path: "specs/031-registry-freshness-check/spec.md" }, role: context }
+summary: >
+  `index check` does not compare the committed index with what the corpus
+  indexes to. It reads each committed shard's own mapping, derives from that
+  mapping which span files to hash, and compares the resulting hash with the
+  shard's `shardHash` field. The mapping body itself (which units resolved
+  where, which paths implement which spec, the ownership flags) is never
+  compared with a fresh resolution, and for a `file`, `directory` or `crate`
+  unit, which carries no span, nothing in the hash constrains it. Measured on a
+  scratch repository: rewriting a committed shard so its spec owns nothing,
+  with `shardHash` left alone, leaves `index check` and `check` reporting fresh,
+  and `couple` then derives ownership from the edited body and passes a change
+  to code the spec owned, without its `spec.md`. `.derived/` is in the bypass
+  floor, so the edit itself trips nothing. AGENTS.md tells every session that a
+  fresh `check` means the committed shards are exactly what the corpus compiles
+  to; for the index that is not what is checked. Spec 031 3.1 recorded the
+  weaker comparison as a cost trade; a full re-index of this repository takes
+  0.04 s against 0.03 s for the check. This spec makes `index check` compare
+  bytes and set membership exactly as `compile --check` does, so every reader
+  of the committed index (the coupling gate, `index owner`, coverage, the
+  projections) reads a body equal to the recompute. It amends 024 5, whose
+  bounded trade let a sibling-caused resolution flip go unreported.
+---
+
+# 086: The committed index is compared, not trusted
+
+## 1. Purpose
+
+Two committed trees back every read verb and the coupling gate: the registry
+and the index. Spec 031 made the registry's freshness check byte-exact:
+`compile --check` re-emits every shard and compares bytes, which "catches a
+stale hash, a hand-edited shard body, and a schema-version restamp alike". The
+same section records that the index side is weaker, "because its inputs (code
+spans) are too expensive to re-resolve".
+
+What the weaker check actually does is in `index.rs::check_index_freshness`.
+For each committed spec shard it reads the committed mapping, asks that mapping
+which files back its spans (`span_files_for_mapping(&sh.mapping)`), hashes the
+spec's `spec.md`, those files and the global-inputs scalar, and compares the
+result with the shard's `shardHash`. The body is trusted to name its own inputs
+and is never compared with anything. For a unit with no span (every `file`,
+`directory` and `crate` unit, which is 72 of this repository's claims and the
+common case in an adopter corpus) the body can say anything at all.
+
+Measured on 2026-09-11 in a scratch repository whose spec `001-a` establishes
+`src/a.rs`:
+
+```
+$ spec-spine check                          # committed trees as generated
+spec-registry: fresh
+codebase-index: fresh
+# rewrite .derived/codebase-index/by-spec/001-a.json so 001-a owns nothing;
+# leave "shardHash" as it was
+$ spec-spine index check ; echo $?
+index is fresh
+0
+# commit that, plus an edit to src/a.rs, without touching specs/001-a/spec.md
+$ spec-spine couple --base main --head HEAD --json
+{ "exitCode": 0, "report": { "checkedPaths": 1, "violations": [] }, ... }
+$ spec-spine index owner src/a.rs
+src/a.rs
+  (no spec owns this path)
+```
+
+The gate derived ownership from a body nobody checked. Continuous integration
+does not catch it either: the self-governance job runs `check`, and the
+determinism job regenerates the trees and compares the four platforms with each
+other, never with the committed copy.
+
+The cost argument does not survive measurement here: `spec-spine index` over
+this repository's 85 specs and 4 packages takes 0.04 s, against 0.03 s for
+`index check`. A corpus heavy in `symbol` units pays for tree-sitter
+resolution, which is the case spec 031 had in mind; 3.4 keeps that cost bounded.
+
+## 2. Territory
+
+- `crates/spec-spine-core/src/index.rs`: `check_index_freshness` re-emits the
+  shard set in memory and compares it with the committed files.
+- `crates/spec-spine-cli/src/cmd_index.rs` and `cmd_check.rs`: the report names
+  each drifted shard with its class.
+- `crates/spec-spine-core/tests/index_body.rs`: the guards.
+
+No committed shard changes, no emitted byte changes, and no schema moves.
+
+## 3. Behavior
+
+### 3.1 `index check` compares bytes and sets
+
+`index check` MUST index the corpus in memory, without writing, and compare the
+result with the committed index tree:
+
+- **modified**: a committed shard file whose bytes differ from the shard the
+  in-memory index emits. This covers a stale `shardHash`, a hand-edited body,
+  and a schema restamp alike.
+- **missing**: a spec or package with no committed shard.
+- **orphaned**: a committed shard with no spec or package behind it, including
+  a stray file in either shard directory.
+
+The `--slice` form keeps its current sidecar comparison. The existing
+blocking-diagnostic refusal stays. The exit code is unchanged: 2 when anything
+drifted.
+
+### 3.2 Every reader inherits it
+
+`check`, and the freshness guard in front of `couple` and `index coverage`,
+call the same comparison, so after this spec a committed index that reads fresh
+is byte-identical to the recompute. The reports name each drifted shard with
+its class, as `compile --check` does for the registry.
+
+### 3.3 What the gate's ownership now means
+
+`couple` loads owners from the committed index only after 3.1 has passed. The
+owner set a C-001 decision uses is therefore the owner set the corpus resolves
+to at that tree, not whatever the committed body says.
+
+This does not settle who may change ownership. A candidate can still claim a
+unit through a new `extends` edge in its own `spec.md` and regenerate the index
+honestly; that is a legitimate route (spec 047) and a structural change a
+reviewer must see. Draft 088 classifies it. This spec only ensures the body the
+gate reads is the one the corpus produces.
+
+### 3.4 Cost
+
+The in-memory index is the one `spec-spine index` builds, so the check costs
+one index run and one comparison, never a write. A corpus for which that is too
+slow keeps the `--slice` form for scoped checks. The measurement in 1 is
+recorded so a later reviewer can repeat it rather than restate the premise.
+
+### 3.5 What must keep working
+
+- A tree regenerated by `spec-spine index` reads fresh, and nothing the indexer
+  emits changes.
+- `check --fail-on-unresolved --fail-on-warn` keeps its current meaning on a
+  fresh tree.
+- The four-triple determinism gate is unaffected: it compares emitted trees,
+  which this spec does not change.
+
+### 3.6 The trade in 024 5 changes
+
+024 5 accepts that a resolution flip caused purely by a sibling change (a unit
+that begins resolving because another PR added the file) is not caught by
+`index check` and is healed by a later `index` run. A byte comparison catches
+it: after both PRs merge, the committed shard differs from the recompute, and
+`check` reports it until someone runs `index`. With the merge queue (spec 020)
+the speculative build of the second PR sees the flip before it merges, and the
+remedy is the one 024 already names. FR-005's guarantee, no textual conflict
+between disjoint changes, is untouched: this spec changes what is reported, not
+what is written.
+
+## 4. Out of scope
+
+**Deciding who may claim a unit.** 3.3; draft 088.
+
+**Signing or hashing the committed body into a new field.** A digest of the
+body stored beside the body can be rewritten with it. Only a comparison with a
+fresh resolution establishes anything.
+
+**The registry side.** Spec 031 already compares bytes.
+
+## 5. Resolved decisions
+
+**D-1 (2026-09-11): `amends` 024.** 024 5 is a deliberate statement of what
+index staleness does not catch, and this spec changes it. The amendment is
+declared here and 024's text is untouched (spec 040). 031 3.1's sentence about
+the index side is descriptive of 024's behavior, not a requirement of 031, so no
+edge to 031 is needed beyond the reference.
+
+**D-2 (2026-09-11): fix the check, not only the gate.** The alternative was to
+make `couple` resolve ownership from a fresh in-memory index and leave `index
+check` as it is. That repairs one reader and leaves `index owner`, coverage and
+every consumer of the committed tree reading an unchecked body, while `check`
+continues to report it fresh. The committed tree is the ledger; the check is
+what makes it one.
+
+**D-3 (2026-09-11): no opt-in flag.** A flag would leave the weak comparison as
+the default, and every gate chain already written against `check` would keep
+it.
+
+## Verification
+
+Each line runs in its own `sh -c` from the repository root (spec 049 3.5). The
+scratch repository lives at a fixed path; each tampering line restores the
+shard before its final assertion.
+
+Against pre-086 code, the three tamper lines fail (the check and the gate both
+report success on a rewritten body) and are the evidence. The regenerate line,
+this repository's own `check`, and the setup lines pass before and after. The
+tamper rewrites a path inside the body, which cannot move `shardHash` for a
+`file` unit, so the line cannot pass by accident of a hash change.
+
+```verify:cli
+cargo build --release --locked
+rm -rf "${TMPDIR:-/tmp}/ss086" && mkdir -p "${TMPDIR:-/tmp}/ss086/specs/001-a" "${TMPDIR:-/tmp}/ss086/src"
+printf -- '---\nid: "001-a"\ntitle: "a"\nstatus: approved\ncreated: "2026-09-11"\nimplementation: complete\nsummary: "s"\nestablishes:\n  - "src/a.rs"\n---\n\n# a\n' > "${TMPDIR:-/tmp}/ss086/specs/001-a/spec.md"
+printf 'pub fn a() {}\n' > "${TMPDIR:-/tmp}/ss086/src/a.rs"
+D="${TMPDIR:-/tmp}/ss086"; S=target/release/spec-spine; $S --repo "$D" compile >/dev/null && $S --repo "$D" index >/dev/null && $S --repo "$D" check
+D="${TMPDIR:-/tmp}/ss086"; S=target/release/spec-spine; F="$D/.derived/codebase-index/by-spec/001-a.json"; cp "$F" "$D/bak"; sed 's#"src/a.rs"#"src/zz.rs"#g' "$D/bak" > "$F"; $S --repo "$D" index check > "$D/out" 2>&1; R=$?; cp "$D/bak" "$F"; test $R -eq 2 && grep -q "001-a" "$D/out"
+D="${TMPDIR:-/tmp}/ss086"; S=target/release/spec-spine; F="$D/.derived/codebase-index/by-spec/001-a.json"; cp "$F" "$D/bak"; sed 's#"src/a.rs"#"src/zz.rs"#g' "$D/bak" > "$F"; $S --repo "$D" check >/dev/null 2>&1; R=$?; cp "$D/bak" "$F"; test $R -eq 2
+D="${TMPDIR:-/tmp}/ss086"; S="$PWD/target/release/spec-spine"; cd "$D" && git init -q -b main && git -c user.email=t@example.invalid -c user.name=t add -A && git -c user.email=t@example.invalid -c user.name=t commit -qm base && sed -i.orig 's#"src/a.rs"#"src/zz.rs"#g' .derived/codebase-index/by-spec/001-a.json && rm .derived/codebase-index/by-spec/001-a.json.orig && printf 'pub fn a() { edited(); }\n' > src/a.rs && git -c user.email=t@example.invalid -c user.name=t commit -qam tamper && "$S" couple --base main~1 --head HEAD >/dev/null 2>&1; R=$?; git reset -q --hard main~1; test $R -eq 2
+D="${TMPDIR:-/tmp}/ss086"; S=target/release/spec-spine; $S --repo "$D" index >/dev/null && $S --repo "$D" index check
+target/release/spec-spine check
+rm -rf "${TMPDIR:-/tmp}/ss086"
+```

--- a/specs/087-an-authority-snapshot-says-what-it-read/spec.md
+++ b/specs/087-an-authority-snapshot-says-what-it-read/spec.md
@@ -1,0 +1,345 @@
+---
+id: "087-an-authority-snapshot-says-what-it-read"
+title: "An authority snapshot says what it read"
+status: draft
+kind: "tooling"
+created: "2026-09-11"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: high
+depends_on:
+  - "023-ledger-seal"
+  - "024-index-sharding"
+  - "031-registry-freshness-check"
+  - "032-ownership-coverage"
+  - "042-per-spec-attestation"
+  - "057-claimed-but-unwitnessed"
+  - "075-one-name-one-freshness-verb"
+  - "083-an-attestation-covers-the-territory-it-claims"
+  - "085-a-verifier-checks-the-bytes-it-was-given"
+  - "086-the-committed-index-is-compared-not-trusted"
+establishes:
+  # Planned (spec 076) until the build writes them; the build drops the flag.
+  # 3.1: the payload DTO and its schema constant.
+  - { kind: file, path: "crates/spec-spine-types/src/snapshot.rs", planned: true }
+  # 3.1 to 3.4: the pure builder, the framed digest, and the recompute.
+  - { kind: file, path: "crates/spec-spine-core/src/snapshot.rs", planned: true }
+  # 3.6 and 3.7: determinism, separation and framing guards.
+  - { kind: file, path: "crates/spec-spine-core/tests/snapshot.rs", planned: true }
+extends:
+  # 3.5: `attest --snapshot`, written and sealed like the other two scopes.
+  - { spec: "023-ledger-seal", unit: "crates/spec-spine-cli/src/cmd_attest.rs", nature: additive }
+  # 3.5: `verify-attestation --snapshot`, under spec 085's rules.
+  - { spec: "023-ledger-seal", unit: "crates/spec-spine-cli/src/verify_attestation.rs", nature: additive }
+  # 3.5: the flag declarations.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  # 3.5: the module, its re-exports and the two facades.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  # 3.1: the DTO re-export and `SNAPSHOT_SCHEMA_VERSION`.
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/version.rs", nature: additive }
+  # 3.6: end-to-end coverage of the flag.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/authority-evidence.md" }, role: context }
+  - { unit: { kind: file, path: "docs/design/04-authority-evidence-extension.md" }, role: context }
+summary: >
+  A consumer that binds spec-spine's authority results to a revision needs five
+  separate outputs today and still cannot answer four questions from them:
+  whether the committed ledger matched the corpus (attestations recompute and
+  never read the committed shards, and `check --json` reports booleans without
+  the digests it compared), which configuration and governance files were read,
+  what every spec's territory hashed to, and how much source no spec claims.
+  This spec adds a third attestation scope, `attest --snapshot`, emitting an
+  `AuthoritySnapshot`: the tool and schema versions, a digest of
+  `spec-spine.toml`, the existing corpus hashes, the committed registry and
+  index trees with a digest each and whether each matches the recompute, the
+  governance inputs by path and digest, the gate verdicts, the ownership
+  counts, the exclusions in force, and each spec's lifecycle with the hash of
+  the `SpecAttestation` spec 042 would emit for it. New members use a framed
+  digest, because the existing fold does not frame content and two trees can
+  share one hash; existing members and payloads keep their constructions. The
+  payload is pure, on demand, gitignored, sealable and verified under spec
+  085's rules. It commits to no git revision: the consumer binds the tree.
+---
+
+# 087: An authority snapshot says what it read
+
+## 1. Purpose
+
+`docs/authority-evidence.md` §6 binds spec-spine's results to one commit by
+hand: `check --json`, `attest --with-coupling`, `attest --spec`, `verify --plan`
+and `couple`, five outputs a consumer must store and re-run separately. Even
+together they leave four gaps, all measured at `75181a5`:
+
+- **Freshness is not in any record.** `attest` compiles and indexes in memory
+  and never reads `.derived/`, so a stale committed tree and a fresh one produce
+  the same attestation. `check --json` reports `"fresh": true` and nothing it
+  compared. A consumer can store that the ledger was fresh; it cannot store
+  what "fresh" was a statement about.
+- **The inputs are not named.** `inputsManifestHash` covers the `spec.md` files
+  and nothing else. The configuration reaches a corpus attestation only through
+  what it changes in the compile, and the governance files (`AGENTS.md`, the
+  constitution, the workflows, this repository's thirty-odd
+  `extra_hashed_inputs` patterns) reach it only inside the index scalar, under
+  `--with-coupling`, and never by name.
+- **Territory needs one call per spec.** A per-spec attestation is the only
+  record that hashes claimed bytes. Eighty-five specs means eighty-five
+  invocations and eighty-five hashes with nothing tying them together.
+- **Unclaimed source has no record at all.** `index coverage` counts it; no
+  attestation mentions it.
+
+A fifth problem is in the hash construction the new record would otherwise
+reuse. `hash::content_hash` writes each piece as path, NUL, content, with
+nothing between one piece's content and the next piece's path. Measured with the
+current binary: a claimed directory holding `a` = `x` and `b` = `y` produces
+the same unit hash as one holding a single `a` whose content is `x`, `d/b`,
+NUL, `y`. And since spec 083 encodes a non-UTF-8 file as the text
+`sha256:<hex>`, a binary file and a text file holding that string hash alike.
+Neither happens by accident in ordinary text. Both can be done on purpose, and
+a record whose job is exact coverage should not inherit them.
+
+## 2. Territory
+
+- `crates/spec-spine-types/src/snapshot.rs`: `AuthoritySnapshot` and its
+  members, all refusing unknown fields (spec 085 3.2), and
+  `SNAPSHOT_SCHEMA_VERSION` re-exported through `version.rs`.
+- `crates/spec-spine-core/src/snapshot.rs`: the builder, the `frame/1` digest,
+  and `verify_snapshot_recompute`.
+- `crates/spec-spine-core/tests/snapshot.rs`: the guards in 3.6 and 3.7.
+- `cmd_attest.rs`, `verify_attestation.rs`, `main.rs`: the `--snapshot` flag on
+  both verbs.
+- Both `lib.rs` files: the module, the re-exports, and two facades.
+- `crates/spec-spine-cli/tests/cli.rs`: end-to-end coverage.
+
+No committed artifact changes and no existing payload changes.
+
+## 3. Behavior
+
+### 3.1 The payload
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "tool": { "name": "spec-spine", "version": "<x.y.z>" },
+  "digest": "frame/1",
+  "config": { "present": true, "hash": "<frame/1 over spec-spine.toml>" },
+  "schemas": { "registry": "1.2.0", "index": "1.1.0", "corpusAttestation": "0.1.0", "specAttestation": "0.1.0" },
+  "corpus": { "specs": 85, "inputsManifestHash": "<spec 023>", "registryHash": "<spec 023>" },
+  "committed": {
+    "registry": { "files": 85, "hash": "<frame/1>", "matchesRecompute": true },
+    "index": { "files": 89, "hash": "<frame/1>", "matchesRecompute": true }
+  },
+  "governanceInputs": { "paths": ["AGENTS.md", "..."], "hash": "<frame/1>" },
+  "verdicts": {
+    "compile": { "ok": true, "errors": 0, "warnings": 0 },
+    "lint": { "ok": true, "findingsHash": "<spec 023>" },
+    "resolution": { "ok": true, "blocking": 0, "unresolved": 0 },
+    "ownership": { "sourceFiles": 80, "claimed": 80, "floorOnly": 0, "unclaimed": 0 },
+    "unwitnessed": { "total": 72, "allowed": 72 }
+  },
+  "specs": [
+    { "id": "<id>", "status": "approved", "implementation": "complete", "specAttestationHash": "<hex>" }
+  ],
+  "exclusions": {
+    "resolverExclusions": ["target", "node_modules", ".derived", "dist", "build", ".next"],
+    "stateDir": null,
+    "unwitnessedAllowed": ["crates/**/*.rs"],
+    "bypassPrefixes": [".github/", "docs/", "..."]
+  }
+}
+```
+
+The payload is canonical JSON (sorted keys, two-space indent, LF, one trailing
+newline). `attestationHash` is SHA-256 of those bytes and is emitted beside the
+payload, never inside it, exactly as for specs 023 and 042.
+
+### 3.2 What each member covers
+
+- **`config`**: `present` is false and `hash` is absent when there is no
+  `spec-spine.toml` (the defaults applied). Otherwise `hash` is `frame/1` over
+  that one file as text.
+- **`schemas`**: the build's constants, so a consumer knows which record lines
+  the rest of the payload was computed under.
+- **`corpus`**: the spec count and spec 023's two hashes, under 023's
+  construction, so a snapshot joins an existing corpus attestation by value.
+- **`committed.registry`, `committed.index`**: `files` counts the committed
+  shard files the freshness reads compare (the registry's `by-spec/`, the
+  index's `by-spec/` and `by-package/`, and the slices sidecar when it exists).
+  `hash` is `frame/1` over those files, read as text, keyed by repo-relative
+  path. `matchesRecompute` is true exactly when every committed shard file is
+  byte-identical to the shard the recompute emits and the two sets match: the
+  comparison `compile --check` makes for the registry (spec 031 3.1) and the
+  one spec 086 makes `index check` perform for the index. It carries no
+  `--fail-on-*` refusal; those inputs are counts under `verdicts`. When a tree is absent, `files` is 0,
+  `matchesRecompute` is false, and `hash` is absent rather than the digest of
+  nothing (spec 083 3.3's reasoning).
+- **`governanceInputs`**: `paths` lists, sorted, every file that feeds the
+  index's global-inputs scalar (`spec-spine.toml` and every
+  `[index] extra_hashed_inputs` match outside `layout.state_dir`); `hash` is
+  `frame/1` over those files as raw text. Workflows are hashed as written, not
+  as spec 073's governance projection: see 5, D-4.
+- **`verdicts`**: `compile` and `lint` mean what they mean in spec 023 (lint's
+  floor is error or warning). `resolution.ok` is false when any owning unit is
+  unresolved or any blocking resolver diagnostic exists, and the two counts say
+  which. `ownership` is the `index coverage` report's four counts.
+  `unwitnessed` is spec 057's pair.
+- **`specs`**: one entry per spec in registry order. `implementation` is
+  omitted only when the frontmatter omits it, as in spec 042 3.1.
+  `specAttestationHash` is the `attestationHash` that `attest --spec <id>`
+  would emit for the same tree and tool version, byte for byte. A consumer
+  holding a snapshot and one spec's attestation checks the one against the
+  other by equality, without recomputing the rest.
+- **`exclusions`**: what was deliberately not read or not held to account: the
+  resolver exclusions, the state root, the unwitnessed allowances, and the
+  effective bypass prefixes (the floor plus the configured ones).
+
+### 3.3 The framed digest
+
+Every member this spec introduces with a `hash` uses `frame/1`:
+
+```
+SHA-256( "spec-spine/frame/1" 0x00
+         for each piece, sorted by path in byte order:
+           kind: one byte, 't' for text, 'b' for bytes, 'l' for a symlink's target text
+           u64 big-endian length of path, path
+           u64 big-endian length of content, content )
+```
+
+A file that is valid UTF-8 is a `t` piece, with the standing normalization (BOM
+stripped, CRLF and CR to LF) applied before its length is taken. Any other file
+is a `b` piece holding its exact bytes. Paths are repo-relative POSIX. The
+construction is injective over piece sets, so the two collisions in 1 cannot
+occur in a `frame/1` digest.
+
+Members that exist in other payloads (`inputsManifestHash`, `registryHash`,
+`findingsHash`, `specAttestationHash`) keep their constructions. Changing them
+would change every historical digest a consumer holds.
+
+### 3.4 Purity
+
+The payload MUST be a pure function of `(config, file contents)`, the
+committed shard files included: no clock, no environment, no git, no key.
+Re-running on an unchanged tree at the same tool version MUST yield
+byte-identical output. It is a snapshot of the tree it read: an untracked file
+inside a claimed directory changes that spec's `specAttestationHash` (spec 083
+3.4), so a consumer binding a snapshot to a revision computes it on a clean
+export of that revision.
+
+### 3.5 Surface
+
+- `spec-spine attest --snapshot [--sign --key <path>] [--json]` writes
+  `<derived_dir>/attestation/snapshot.json`, and its seal beside it as
+  `snapshot.sig`, under the existing `.gitignore` entry. It exits 0 whenever a
+  payload was written, whatever the verdicts say (spec 042 3.1: a record, not a
+  gate). `--snapshot` combined with `--spec` or `--with-coupling` is refused at
+  exit 3 with a message saying the two flags cannot combine, because each names
+  a different scope.
+- `spec-spine verify-attestation --snapshot --recompute | --signature
+  --public-key <path>` verifies it under every rule of spec 085. The recompute
+  names the member that moved, as the other two scopes do.
+- `attest_snapshot_json(config_json, repo_root)` returns
+  `{ "attestation", "attestationHash" }`. `verify_snapshot_attestation_json`
+  takes the request shape spec 085 3.4 defines.
+- `SNAPSHOT_SCHEMA_VERSION = "0.1.0"`, independent of every other axis, pinned
+  by a test like the others.
+
+### 3.6 What it proves, and what it does not
+
+For one tree and one tool version it establishes exactly which inputs were
+read and what they hashed to, whether the committed ledger equals the
+recompute, the verdicts the gate would reach, and every spec's attestation
+hash. It does not establish anything about a revision (the consumer binds
+`{repo, commit, tree}` and recomputes), anything about unclaimed files beyond
+their count, whether any specification is correct, or that anyone approved the
+state. `docs/authority-evidence.md` MUST say so in its digest table when this
+ships.
+
+### 3.7 What must keep working
+
+`CorpusAttestation` and `SpecAttestation` are byte-identical to their pre-087
+output. No committed shard moves. No gate verb changes its answer.
+
+## 4. Out of scope
+
+**A revision or repository identity in the payload.** See 5, D-1.
+
+**Membership proofs.** The `specs` list allows one-by-one checking by equality.
+A tree with proofs for partial disclosure is a later record with a named
+consumer.
+
+**Imported snapshots from other repositories.** Pinned cross-corpus imports are
+a P2 proposal in design note 04.
+
+**Obligations, context closures, work scopes.** Proposed in design note 04; each
+references this payload's hash, which is why this comes first.
+
+**Committing snapshots.** Spec 042 3.3's reasons apply with more force to a
+record that changes on every edit to any claimed file.
+
+## 5. Resolved decisions
+
+**D-1 (2026-09-11): the payload is git-free.** The core has no git (a
+workspace invariant), and a tree is what the payload reads. The mapping from a
+revision to a tree is git's, recorded by the consumer next to the snapshot hash
+and checkable by anyone who exports that revision and recomputes.
+
+**D-2 (2026-09-11): a third scope of `attest`, not a new version of the
+corpus attestation.** Adding members to `CorpusAttestation` would change the
+`attestationHash` consumers already pin (statecraft-cli's adoption holdback
+records it), and would turn a stable record into a moving one. A new record on
+its own schema axis leaves every existing hash meaning what it meant.
+
+**D-3 (2026-09-11): each spec is represented by its existing attestation
+hash.** The alternative, a framed territory digest per spec, would hash the
+same files a second way. The cost is that unit bytes inside a
+`SpecAttestation` keep the unframed construction; design note 04 D3 records
+the trade for review.
+
+**D-4 (2026-09-11): governance inputs are hashed as written.** Spec 073 folds a
+workflow as its governance projection so that an action-version bump does not
+restale every committed shard. A snapshot is on demand and never committed, so
+that churn does not arise, and the true answer to "which bytes were read" is the
+bytes.
+
+**D-5 (2026-09-11): `matchesRecompute` is the plain freshness answer.** The
+`--fail-on-unresolved` and `--fail-on-warn` refusals are policy on top of
+freshness; the snapshot records their inputs as counts and leaves the policy to
+the reader.
+
+## Verification
+
+Each line runs in its own `sh -c` from the repository root (spec 049 3.5). The
+scratch corpus lives at a fixed path, and each line that mutates it undoes the
+mutation before its final assertion.
+
+Against pre-087 code every line that calls `attest --snapshot` or
+`verify-attestation --snapshot` fails, since neither flag exists. That includes
+the scope-refusal line: an unknown flag also exits 3, so the line asserts the
+refusal's own wording, which a usage error does not contain. The setup lines
+and the closing `check` pass before and after.
+
+The framing line is the only one that can tell `frame/1` from the unframed
+fold: the two scratch trees fold to one index scalar today, so their
+`governanceInputs.hash` values differ only if the framing does its job. The
+separation line proves `matchesRecompute` reads the committed tree: it changes
+a committed shard and nothing the recompute reads, then asserts the recomputed
+`registryHash` did not move while `matchesRecompute` did.
+
+```verify:cli
+cargo build --release --locked
+target/release/spec-spine attest --snapshot --json > "${TMPDIR:-/tmp}/ss087-self.json" && grep -q '"matchesRecompute": true' "${TMPDIR:-/tmp}/ss087-self.json"
+A=$(target/release/spec-spine attest --snapshot --json); B=$(target/release/spec-spine attest --snapshot --json); test -n "$A" && test "$A" = "$B"
+H=$(target/release/spec-spine attest --spec 083-an-attestation-covers-the-territory-it-claims --json | sed -n 's/.*"attestationHash": "\([0-9a-f]*\)".*/\1/p'); test -n "$H" && grep -q "\"specAttestationHash\": \"$H\"" .derived/attestation/snapshot.json
+test "$(grep -c '"specAttestationHash"' .derived/attestation/snapshot.json)" -eq "$(target/release/spec-spine registry list --ids-only | wc -l)"
+target/release/spec-spine verify-attestation --snapshot --recompute
+rm -rf "${TMPDIR:-/tmp}/ss087" && mkdir -p "${TMPDIR:-/tmp}/ss087/specs/001-a" "${TMPDIR:-/tmp}/ss087/g"
+printf -- '[index]\nextra_hashed_inputs = ["g/*"]\n' > "${TMPDIR:-/tmp}/ss087/spec-spine.toml"
+printf -- '---\nid: "001-a"\ntitle: "t"\nstatus: draft\ncreated: "2026-09-11"\nsummary: "s"\nestablishes:\n  - "g/"\n---\n\n# t\n' > "${TMPDIR:-/tmp}/ss087/specs/001-a/spec.md"
+D="${TMPDIR:-/tmp}/ss087"; S=target/release/spec-spine; printf 'x' > "$D/g/a"; printf 'y' > "$D/g/b"; A=$($S --repo "$D" attest --snapshot --json | awk '/"governanceInputs": \{/{getline; print; exit}'); rm "$D/g/b"; printf 'xg/b\000y' > "$D/g/a"; B=$($S --repo "$D" attest --snapshot --json | awk '/"governanceInputs": \{/{getline; print; exit}'); rm -f "$D/g/a"; printf 'x' > "$D/g/a"; test -n "$A" && test -n "$B" && test "$A" != "$B"
+D="${TMPDIR:-/tmp}/ss087"; S=target/release/spec-spine; $S --repo "$D" compile >/dev/null && $S --repo "$D" index >/dev/null && $S --repo "$D" attest --snapshot --json > "$D/before.json" && F="$D/.derived/spec-registry/by-spec/001-a.json" && cp "$F" "$D/shard.bak" && printf ' ' >> "$F" && $S --repo "$D" attest --snapshot --json > "$D/after.json"; R=$?; cp "$D/shard.bak" "$F"; test $R -eq 0 && grep -q '"matchesRecompute": false' "$D/after.json" && test "$(grep '"registryHash"' "$D/before.json")" = "$(grep '"registryHash"' "$D/after.json")"
+D="${TMPDIR:-/tmp}/ss087"; S=target/release/spec-spine; A=$($S --repo "$D" attest --snapshot --json); printf '# a comment\n' >> "$D/spec-spine.toml"; B=$($S --repo "$D" attest --snapshot --json); printf -- '[index]\nextra_hashed_inputs = ["g/*"]\n' > "$D/spec-spine.toml"; test "$A" != "$B" && test "$(echo "$A" | grep '"inputsManifestHash"')" = "$(echo "$B" | grep '"inputsManifestHash"')"
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss087" attest --snapshot --spec 001-a >/dev/null 2> "${TMPDIR:-/tmp}/ss087/scope.err"; test $? -eq 3 && grep -q "cannot combine" "${TMPDIR:-/tmp}/ss087/scope.err"
+rm -rf "${TMPDIR:-/tmp}/ss087" "${TMPDIR:-/tmp}/ss087-self.json"
+target/release/spec-spine check
+```

--- a/specs/087-an-authority-snapshot-says-what-it-read/spec.md
+++ b/specs/087-an-authority-snapshot-says-what-it-read/spec.md
@@ -315,8 +315,9 @@ mutation before its final assertion.
 
 Against pre-087 code every line that calls `attest --snapshot` or
 `verify-attestation --snapshot` fails, since neither flag exists. That includes
-the scope-refusal line: an unknown flag also exits 3, so the line asserts the
-refusal's own wording, which a usage error does not contain. The setup lines
+both scope-refusal lines, one per flag 3.5 names: an unknown flag also exits 3,
+so each line asserts the refusal's own wording, which a usage error does not
+contain. The setup lines
 and the closing `check` pass before and after.
 
 The framing line is the only one that can tell `frame/1` from the unframed
@@ -340,6 +341,7 @@ D="${TMPDIR:-/tmp}/ss087"; S=target/release/spec-spine; printf 'x' > "$D/g/a"; p
 D="${TMPDIR:-/tmp}/ss087"; S=target/release/spec-spine; $S --repo "$D" compile >/dev/null && $S --repo "$D" index >/dev/null && $S --repo "$D" attest --snapshot --json > "$D/before.json" && F="$D/.derived/spec-registry/by-spec/001-a.json" && cp "$F" "$D/shard.bak" && printf ' ' >> "$F" && $S --repo "$D" attest --snapshot --json > "$D/after.json"; R=$?; cp "$D/shard.bak" "$F"; test $R -eq 0 && grep -q '"matchesRecompute": false' "$D/after.json" && test "$(grep '"registryHash"' "$D/before.json")" = "$(grep '"registryHash"' "$D/after.json")"
 D="${TMPDIR:-/tmp}/ss087"; S=target/release/spec-spine; A=$($S --repo "$D" attest --snapshot --json); printf '# a comment\n' >> "$D/spec-spine.toml"; B=$($S --repo "$D" attest --snapshot --json); printf -- '[index]\nextra_hashed_inputs = ["g/*"]\n' > "$D/spec-spine.toml"; test "$A" != "$B" && test "$(echo "$A" | grep '"inputsManifestHash"')" = "$(echo "$B" | grep '"inputsManifestHash"')"
 target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss087" attest --snapshot --spec 001-a >/dev/null 2> "${TMPDIR:-/tmp}/ss087/scope.err"; test $? -eq 3 && grep -q "cannot combine" "${TMPDIR:-/tmp}/ss087/scope.err"
+target/release/spec-spine --repo "${TMPDIR:-/tmp}/ss087" attest --snapshot --with-coupling >/dev/null 2> "${TMPDIR:-/tmp}/ss087/scope2.err"; test $? -eq 3 && grep -q "cannot combine" "${TMPDIR:-/tmp}/ss087/scope2.err"
 rm -rf "${TMPDIR:-/tmp}/ss087" "${TMPDIR:-/tmp}/ss087-self.json"
 target/release/spec-spine check
 ```

--- a/specs/088-a-change-is-classified-under-the-bases-rules/spec.md
+++ b/specs/088-a-change-is-classified-under-the-bases-rules/spec.md
@@ -1,0 +1,275 @@
+---
+id: "088-a-change-is-classified-under-the-bases-rules"
+title: "A change is classified under the base's rules"
+status: draft
+kind: "tooling"
+created: "2026-09-11"
+implementation: pending
+owner: "The spec-spine Authors"
+risk: high
+depends_on:
+  - "000-spec-spine-bootstrap"
+  - "005-coupling-gate"
+  - "030-cargo-workflow-dependency-waiver"
+  - "037-machine-readable-verdicts"
+  - "040-amendment-authoring"
+  - "049-verify-declared-acceptance"
+  - "055-the-ledger-answers-what-consumers-rebuild"
+  - "086-the-committed-index-is-compared-not-trusted"
+establishes:
+  # Planned (spec 076) until the build writes them; the build drops the flag.
+  # 3.6: the report DTO and `DELTA_SCHEMA_VERSION`.
+  - { kind: file, path: "crates/spec-spine-types/src/delta.rs", planned: true }
+  # 3.2 to 3.5: the pure classifier over two trees.
+  - { kind: file, path: "crates/spec-spine-core/src/delta.rs", planned: true }
+  # 3.8: the classification matrix.
+  - { kind: file, path: "crates/spec-spine-core/tests/delta.rs", planned: true }
+  # 3.1: the verb: git, the two exports, and the envelope.
+  - { kind: file, path: "crates/spec-spine-cli/src/cmd_delta.rs", planned: true }
+extends:
+  # 3.1: the verb's declaration, and the envelope's new verb token.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/src/main.rs", nature: additive }
+  - { spec: "037-machine-readable-verdicts", unit: "crates/spec-spine-types/src/verdict.rs", nature: additive }
+  # 3.1: the merge-base and diff plumbing `couple` already has, shared rather than copied.
+  - { spec: "005-coupling-gate", unit: "crates/spec-spine-cli/src/cmd_couple.rs", nature: additive }
+  # 3.6: the module, its re-exports, the facade, and the schema constant.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-core/src/lib.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/lib.rs", nature: additive }
+  - { spec: "000-spec-spine-bootstrap", unit: "crates/spec-spine-types/src/version.rs", nature: additive }
+  # 3.8: end-to-end coverage of the verb.
+  - { spec: "001-compile-registry", unit: "crates/spec-spine-cli/tests/cli.rs", nature: additive }
+references:
+  - { unit: { kind: file, path: "docs/authority-evidence.md" }, role: context }
+  - { unit: { kind: file, path: "docs/design/02-agentic-builder-substrate.md" }, role: context }
+  - { unit: { kind: file, path: "docs/design/04-authority-evidence-extension.md" }, role: context }
+summary: >
+  The coupling gate clears C-001 when any owning spec's `spec.md` is in the
+  diff, and reads the owners from the candidate's own index. Measured on a
+  scratch repository, a candidate that deletes a command from its own
+  `## Verification` block while changing the code that command checked passes
+  `couple` at exit 0, and so does a candidate that files a new draft spec with
+  an `extends` edge on another spec's unit and rewrites that unit. Both are
+  changes a reviewer must weigh under the rules that held before the change,
+  and nothing reports them as such. Design note 02 G7 says no refusal should be
+  asserted before it is designed, because the naive rule refuses legitimate
+  refactors. This spec therefore adds a report, not a gate: `spec-spine delta
+  --base B --head H` classifies every changed path into implementation,
+  requirement, verification, authority, lifecycle, constitutional, policy,
+  derived, bypassed, unowned or unknown, computed under the merge base's own
+  configuration and index so a candidate cannot reclassify its change by
+  editing `spec-spine.toml`. It records the base and head plan digests for
+  every spec whose declared acceptance changed, the owner sets on both sides
+  of every path whose ownership moved, and a `priorPolicy` block naming the
+  classes a consumer must judge under the base's policy. It interprets no
+  prose, infers no moves, and decides nothing.
+---
+
+# 088: A change is classified under the base's rules
+
+## 1. Purpose
+
+A consumer that approves or rejects a candidate needs to know what kind of
+change it is judging. spec-spine knows the structure: which paths are owned,
+by whom, which spec text declares which acceptance. It reports none of it per
+change. `couple` answers one question, whether owned code moved without an
+owning `spec.md` in the same diff, and the answer is yes for two changes that
+should never be approved on the candidate's own say-so. Measured on 2026-09-11
+in a scratch repository whose approved spec `001-a` establishes `src/a.rs` and
+declares two acceptance commands (`test -f src/a.rs`, `grep -q "fn a"
+src/a.rs`):
+
+| Candidate | `couple` | Plan after |
+|---|---|---|
+| deletes the `grep` line from 001-a's `## Verification` and renames `fn a` | exit 0, no violation | `test -f src/a.rs` only, which passes |
+| files draft `002-b` with `extends: {spec: 001-a, unit: src/a.rs}` and rewrites `src/a.rs` | exit 0, no violation | unchanged; `index owner src/a.rs` now names 002-b too |
+
+The first is a candidate weakening the acceptance that judges it. The second
+is an authority transfer approved by nobody outside the diff. Both are the
+sanctioned shapes for legitimate work too: specs are edited when behavior
+changes, and `extends` is how a spec claims a unit it must touch (spec 047).
+That is exactly why note 02 G7 refuses to assert a mechanism before a design:
+a rule that refuses these shapes refuses refactors.
+
+What can be done without that design is to say what changed, structurally,
+under rules the candidate did not write. A reviewer, or an issuer granting a
+permit, then decides under the base's policy. statecraft-cli already
+approximates the first half locally with a prefix list of policy-sensitive
+paths; this is the version that knows what a spec is.
+
+## 2. Territory
+
+- `crates/spec-spine-types/src/delta.rs` and `crates/spec-spine-core/src/delta.rs`:
+  the report and the pure classifier.
+- `crates/spec-spine-cli/src/cmd_delta.rs`: the verb.
+- `cmd_couple.rs`: the merge-base and diff helpers, shared.
+- `main.rs`, `verdict.rs`, both `lib.rs`, `version.rs`: declarations, the
+  `delta` verb token, the facade, `DELTA_SCHEMA_VERSION`.
+- `crates/spec-spine-core/tests/delta.rs` and `crates/spec-spine-cli/tests/cli.rs`.
+
+## 3. Behavior
+
+### 3.1 The verb and the seam
+
+`spec-spine delta --base <ref> --head <ref> [--json]` MUST:
+
+1. resolve `merge-base(base, head)`, as `couple` does, and list the changed
+   paths of `merge-base...head` with renames disabled;
+2. export the merge-base tree and the head tree to two temporary directories
+   (the committed `.derived/` included), and remove them afterwards;
+3. pass both roots, the path list and the three commit ids to the core.
+
+The core function is pure over `(base root, head root, changed paths,
+commit ids)`: it reads files, never git, never the clock. The commit ids are
+echoed, not computed.
+
+The verb exits 0 whenever a report was produced, whatever it says, and 3 for
+I/O, git or parse trouble. It is a record, not a gate (spec 042 3.1's rule for
+`attest`, for the same reason).
+
+### 3.2 The base's rules classify
+
+Classification MUST use the merge base's `spec-spine.toml` and the merge base's
+committed index (read through the loaders and compared under spec 086 before
+use). A change to the configuration is itself classified (`policy`); it does
+not change how the rest of its own diff is classified. Owner sets are derived
+with `owners_for_path` (spec 055) against the base index and against the head
+index, whole-file.
+
+### 3.3 Classes
+
+A path carries every class that applies, and at least one.
+
+| Class | Applies when |
+|---|---|
+| `implementation` | the path has at least one owner at base or head and is none of the kinds below |
+| `requirement` | a `spec.md` whose body outside `## Verification` changed, or whose frontmatter changed in a key no other class names |
+| `verification` | a `spec.md` whose `verify:cli` plan (spec 049's parser) differs between base and head, including a spec added or removed |
+| `authority` | a `spec.md` whose typed edges or `depends_on` changed; or any path whose owner set differs between base and head |
+| `lifecycle` | `status`, `implementation`, `superseded_by` or `retirement_rationale` changed |
+| `constitutional` | a path under the base's `standards_dir`; or a `spec.md` that declares `unamendable` anchors at base or head |
+| `policy` | `spec-spine.toml`, or a path matched by the base's `[index] extra_hashed_inputs` |
+| `derived` | a path under the base's `derived_dir` |
+| `bypassed` | covered by the base's bypass floor and configured prefixes, and by no class above |
+| `unowned` | no owner at base or head, not bypassed |
+| `unknown` | a `spec.md` or configuration that fails to parse on either side, or anything the rules above cannot place |
+
+Frontmatter keys spec-spine does not model, including declared
+`extra_known_keys`, are `requirement`: an unrecognized change is treated as a
+change to what is required, never as nothing. A parse failure is `unknown`,
+never `implementation`.
+
+With renames disabled, a move is a removal and an addition. The report never
+infers that the two are one file; identity transfer is a reviewed mapping and a
+later proposal (design note 04, P2).
+
+### 3.4 Detail carried per class
+
+- `verification`: `basePlanHash` and `headPlanHash`, each SHA-256 of the
+  canonical JSON of the plan's `commands` list (absent on the side where the
+  spec does not exist), and the counts of commands only in base and only in
+  head.
+- `authority`: for a `spec.md`, the edges added and removed by type; for any
+  path, `baseOwners` and `headOwners`.
+- `lifecycle`: each changed key with its base and head value.
+
+### 3.5 Prior policy
+
+`priorPolicy.required` MUST be true when any path carries `requirement`,
+`verification`, `authority`, `lifecycle`, `constitutional`, `policy` or
+`unknown`, and `priorPolicy.classes` lists which. The report MUST say, in the
+verb's help and in `docs/authority-evidence.md`, that `required: false` means
+only that no structural class above changed. It does not mean the change is
+safe, correct or approved.
+
+spec-spine never evaluates the approval. A consumer judges each listed class
+under the base revision's policy and records who approved it.
+
+### 3.6 Report and versioning
+
+The report is canonical JSON: `schemaVersion`, `tool`, `classifiedUnder:
+"base"`, `base`, `mergeBase`, `head`, `changes` sorted by path, `counts` per
+class, and `priorPolicy`. `DELTA_SCHEMA_VERSION` starts at `0.1.0` on its own
+axis. The envelope gains the verb token `delta`, an additive change that moves
+`VERDICT_SCHEMA_VERSION` to its next MINOR (spec 037's own rule). The facade
+`delta_json(request)` takes `{ config?, baseRoot, headRoot, changed, commits }`
+and returns the same report.
+
+### 3.7 What it does not claim
+
+It interprets no prose: any byte change to a spec body outside `## Verification`
+is `requirement`, whatever the words say. It cannot see a change to a file a
+verification command reads unless that file is declared as the command's input;
+today such a change is `implementation`, and design note 04 4.4 proposes the
+declaration. It decides nothing and refuses nothing.
+
+### 3.8 Tests (minimum)
+
+The classification matrix covers: a code edit with its owning spec untouched;
+a body edit; a `## Verification` command removed (the first row of 1); a new
+spec with an `extends` edge on another spec's unit plus an edit to that unit
+(the second row of 1); a status flip; a `spec-spine.toml` edit that also tries
+to widen the bypass floor for its own diff; an edit under `standards/`; a
+`git mv` of an owned file; a `spec.md` that fails to parse at head; and an
+unchanged tree, which reports no changes and `required: false`.
+
+## 4. Out of scope
+
+**Refusing anything.** Note 02 G7.
+
+**Recording approvals.** The consumer's.
+
+**Obligation ids and declared verifier inputs.** Design note 04 4.4.
+
+**Similarity-based move detection.** 3.3.
+
+**Semantic comparison of prose.** 3.7.
+
+## 5. Resolved decisions
+
+**D-1 (2026-09-11): the base's configuration and index classify.** A candidate
+that edits `spec-spine.toml` to add a bypass prefix would otherwise have its own
+diff classified under the prefix it just added. The base is the only side the
+candidate did not write.
+
+**D-2 (2026-09-11): two exported trees, not blobs.** The core already reads
+trees; handing it two roots keeps it pure and lets it reuse the compiler, the
+loaders and `owners_for_path` unchanged, rather than teaching each to read a git
+object.
+
+**D-3 (2026-09-11): a report, not a gate.** Recorded above and in note 02 G7.
+A later spec may add a refusing mode once a design distinguishes a weakening
+from a refactor; this report is the evidence such a design would need.
+
+**D-4 (2026-09-11): conservative defaults.** Unmodeled keys are `requirement`
+and parse failures are `unknown`, because a classifier that defaulted to the
+harmless class would report exactly the changes it did not understand as the
+ones that need no review.
+
+## Verification
+
+Each line runs in its own `sh -c` from the repository root (spec 049 3.5). The
+scratch repository lives at a fixed path.
+
+Against pre-088 code every line that calls `delta` fails, since the verb does
+not exist; those lines are the evidence. The two `couple` lines pass before
+and after: they record that the gate alone admits both candidates in 1, which
+is the premise, and they would fail loudly if a later change made `couple`
+refuse them, which would be worth knowing.
+
+```verify:cli
+cargo build --release --locked
+rm -rf "${TMPDIR:-/tmp}/ss088" && mkdir -p "${TMPDIR:-/tmp}/ss088/specs/001-a" "${TMPDIR:-/tmp}/ss088/src"
+printf -- '---\nid: "001-a"\ntitle: "a"\nstatus: approved\ncreated: "2026-09-11"\nimplementation: complete\nsummary: "s"\nestablishes:\n  - "src/a.rs"\n---\n\n# a\n\n## Verification\n\n```verify:cli\ntest -f src/a.rs\ngrep -q "fn a" src/a.rs\n```\n' > "${TMPDIR:-/tmp}/ss088/specs/001-a/spec.md"
+printf 'pub fn a() {}\n' > "${TMPDIR:-/tmp}/ss088/src/a.rs"
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && "$S" compile >/dev/null && "$S" index >/dev/null && git init -q -b main && git add -A && git -c user.email=t@example.invalid -c user.name=t commit -qm base
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && git switch -qc weaken && sed -i.orig '/grep -q "fn a"/d' specs/001-a/spec.md && rm specs/001-a/spec.md.orig && printf 'pub fn b() {}\n' > src/a.rs && "$S" compile >/dev/null && "$S" index >/dev/null && git add -A && git -c user.email=t@example.invalid -c user.name=t commit -qm weaken && git switch -q main
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && git switch -qc transfer && mkdir -p specs/002-b && printf -- '---\nid: "002-b"\ntitle: "b"\nstatus: draft\ncreated: "2026-09-11"\nimplementation: pending\nsummary: "s"\nextends:\n  - { spec: "001-a", unit: "src/a.rs", nature: additive }\n---\n\n# b\n' > specs/002-b/spec.md && printf 'pub fn a() { rewritten(); }\n' > src/a.rs && "$S" compile >/dev/null && "$S" index >/dev/null && git add -A && git -c user.email=t@example.invalid -c user.name=t commit -qm transfer && git switch -q main
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && git switch -q weaken && "$S" couple --base main --head HEAD; R=$?; git switch -q main; test $R -eq 0
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && git switch -q transfer && "$S" couple --base main --head HEAD; R=$?; git switch -q main; test $R -eq 0
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && "$S" delta --base main --head weaken --json > "$D/w.json" && grep -q '"verification"' "$D/w.json" && grep -q '"headPlanHash"' "$D/w.json" && grep -q '"required": true' "$D/w.json"
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && "$S" delta --base main --head transfer --json > "$D/t.json" && grep -q '"authority"' "$D/t.json" && grep -q '"002-b"' "$D/t.json" && grep -q '"required": true' "$D/t.json"
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && git switch -qc policy && printf -- '[coupling]\nbypass_prefixes = ["src/"]\n' > spec-spine.toml && printf 'pub fn a() { unreviewed(); }\n' > src/a.rs && git add -A && git -c user.email=t@example.invalid -c user.name=t commit -qm policy && "$S" delta --base main --head policy --json > "$D/p.json"; R=$?; git switch -q main; test $R -eq 0 && grep -q '"policy"' "$D/p.json" && grep -q '"implementation"' "$D/p.json"
+D="${TMPDIR:-/tmp}/ss088"; S="$PWD/target/release/spec-spine"; cd "$D" && "$S" delta --base main --head main --json > "$D/n.json" && grep -q '"required": false' "$D/n.json"
+rm -rf "${TMPDIR:-/tmp}/ss088"
+target/release/spec-spine check
+```


### PR DESCRIPTION
## Summary

Files four drafts (`status: draft`, `implementation: pending`) and the two
documents they come from. Nothing is implemented here; this is the filing
half of the loop.

Each draft records a gap **measured**, not asserted: at `75181a5` for the
two defects, and on a scratch repository for the two new records.

- **085, a verifier checks the bytes it was given.** `verify-attestation`
  deserializes without refusing unknown members and checks the seal against
  a hash of its own re-serialization, never the file's bytes. A sealed
  attestation carrying an injected `"prCouple": {"ok": true}` verifies as
  `match` and `valid` at exit 0, in both scopes, and so does a reformatted
  copy. Separately the corpus recompute never compares `schemaVersion`, so
  a `9.0.0` attestation recomputes as `match`. Spec 023 AC-4 already
  requires a tampered payload byte to fail, so this `extends`, it does not
  amend. Nothing `attest` emits changes.
- **086, the committed index is compared, not trusted.** `index check`
  derives which spans to hash from each committed shard's own mapping, then
  compares that hash with the shard's `shardHash`. The body itself is never
  compared with a fresh resolution, and a `file`, `directory` or `crate`
  unit carries no span to constrain it. Rewriting a shard so its spec owns
  nothing, `shardHash` untouched, leaves `check` reporting fresh, and
  `couple` then clears a change to code the spec owned. `.derived/` is on
  the bypass floor, so the edit itself trips nothing.
- **087, an authority snapshot says what it read.** Adds `attest --snapshot`,
  a third scope emitting an `AuthoritySnapshot`, so a consumer can bind the
  committed ledger, the governance inputs, the gate verdicts and the
  ownership counts to a tree. New members use a framed digest, because the
  existing fold does not frame content and two trees can share one hash.
  Gitignored, on demand, sealable, verified under 085's rules.
- **088, a change is classified under the base's rules.** Adds
  `spec-spine delta --base B --head H`, a **report, not a gate** (design
  note 02 G7: no refusal asserted before it is designed). It classifies
  every changed path under the merge base's own configuration and index, so
  a candidate cannot reclassify its change by editing `spec-spine.toml`.

### Why four in one PR

They are one designed family from `docs/design/04-authority-evidence-extension.md`,
and the dependency order is real: 087 is blocked by 085 and 086, 088 by 086.
Filing them together keeps the design note and the drafts reviewable as one
argument. Each is still built and ratified on its own, one spec per PR, as
`AGENTS.md` requires. Precedent: #104 filed 045/046/047 together.

### Amendment

086 declares `amends: 024-index-sharding`: 024 section 5 accepted that a
resolution flip caused purely by a sibling change is not caught by
`index check` and heals on a later run. Comparing bytes catches it. Per spec
040 the edge lives in the amending spec's frontmatter and `024`'s own
`spec.md` is **not** edited.

## Testing

Full gate from `AGENTS.md`, green against the committed change:

| step | result |
|---|---|
| `compile` | 89 specs, 0 warnings |
| `index` | 4 packages, 89 mappings, 0 error diagnostics |
| `check --fail-on-unresolved --fail-on-warn` | exit 0, both trees fresh |
| `lint --fail-on-warn` | exit 0, 0 errors / 0 warnings / 0 info |
| `index coverage --fail-on-untraced` | exit 0, 80/80 claimed (100%), 12 `planned` |
| `couple --base origin/main --head HEAD` | exit 0, 4 paths checked, no drift |
| `cargo test --workspace --locked` | exit 0 |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | exit 0 |
| `cargo fmt --all --check` | exit 0 |

Regenerating the shards was byte-identical to what the branch carried.

### The Verification blocks fail first

All four `## Verification` blocks were run through `spec-spine verify <id>`
against this unbuilt code. All four **fail**, which is what makes them
evidence rather than decoration:

- `085` fails at command 8: the injected-member tamper reports
  `signature: VALID` and exits 0 where 3 is required. The defect, live.
- `086` fails at command 6: the rewritten shard body does not make
  `index check` exit 2.
- `087` fails at command 2: `error: unexpected argument '--snapshot' found`.
- `088` fails at command 10: `error: unrecognized subcommand 'delta'`.

088's two `couple` lines, which run before that, **pass**: both the
verification-weakening candidate and the authority-transfer candidate get
`couple: OK: 2 path(s) checked, no drift`. That is the spec's premise,
measured.

No waiver is requested; the gate is green on its own.