### PR TITLE
chore(089): ratify (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/089-a-skip-and-a-failure-are-different-answers.json
+++ b/.derived/codebase-index/by-spec/089-a-skip-and-a-failure-are-different-answers.json
@@ -60,8 +60,8 @@
       }
     ],
     "specId": "089-a-skip-and-a-failure-are-different-answers",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "1a8f107be3e241300aeafc76899889029c9fbb4542490a501508e5fd09a34f65"
+  "shardHash": "c249230bfb7712e2b2f5f61d8c2b04bf4dfe92f617ee8a04202080bcd92b3f0e"
 }

--- a/.derived/spec-registry/by-spec/089-a-skip-and-a-failure-are-different-answers.json
+++ b/.derived/spec-registry/by-spec/089-a-skip-and-a-failure-are-different-answers.json
@@ -49,10 +49,10 @@
       "Verification"
     ],
     "specPath": "specs/089-a-skip-and-a-failure-are-different-answers/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "The kit's Makefile guards its language targets on a manifest probe, written as `test -f M && cmd || echo skipping`. That is not an if/else: the `||` branch fires when the probe is false OR when the command fails, so on a repository that HAS the manifest a failing command exits 0 having printed \"no manifest, skipping\". Any adopter who copies `kit/govern.yml` unmodified into a repository with a `Cargo.toml` gets a build job that cannot fail: a broken `cargo test`, a `cargo fmt --check` diff and a `clippy -D warnings` hit are all reported as a skip and the check goes green. Spec 064's acceptance could not catch it, because it asserts the probe is a manifest probe and that is true of the broken shape and the fixed one alike. This spec makes the guard an explicit `if`, and adds the acceptance that tells the two apart: the shipped recipe lines are run in both states.\n",
     "title": "A skip and a failure are different answers"
   },
-  "shardHash": "b3708ac32cd646a2d52c7e71affda5a6e8eda559ecb6c408d31efaa27338ef8e",
+  "shardHash": "e2a8de53745e48d8928974a5b08e213786bc2cd0450e94f708de1341576d9f1b",
   "specVersion": "1.2.0"
 }

--- a/specs/089-a-skip-and-a-failure-are-different-answers/spec.md
+++ b/specs/089-a-skip-and-a-failure-are-different-answers/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "089-a-skip-and-a-failure-are-different-answers"
 title: "A skip and a failure are different answers"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-11"
 summary: >


### PR DESCRIPTION
089 was built and merged as `2ecd8c1` (#178) and has sat at `status: draft`,
`implementation: complete` ever since. That pair is the lifecycle discrepancy
the revision-3 packet asked to resolve "without assuming a merge approved the
spec". It did not. This is the approval.

## Evidence gathered before the flip

Measured at `0e41641` on `spec-spine 0.18.0`:

| case | old shape | shipped shape |
|---|---|---|
| manifest present, command fails | prints `no Cargo.toml, skipping`, **exit 0** | no output, **exit 1** |
| manifest absent | skips, exit 0 | skips, exit 0 |

The second row matters as much as the first: spec 064's specify-first no-op
still holds, so the fix bought the failure signal without costing the skip.

- `kit/Makefile` carries no `test -f M && cmd || echo` shape, and all five
  guarded recipe lines are an explicit `if`.
- `spec-spine verify 089` passes all five declared commands.
- `cargo test -p spec-spine-core --test kit_gate` passes 10 of 10, including
  `a_guarded_recipe_skips_when_absent_and_fails_when_the_command_fails`, which
  runs each shipped line with its command forced to `false`.

## Gate

`check --fail-on-unresolved --fail-on-warn`, `lint --fail-on-warn`,
`index coverage --fail-on-untraced` and `couple` all exit 0; `cargo test`,
`clippy -D warnings` and `fmt --check` are green. Only 089's two shards move,
since a `spec.md` edit restales its own shards and nothing else.

## Adopter note for the release

This fix is **not** delivered by bumping a version pin. The defect is in the
file adopters copy, so the release notes have to tell them to re-copy
`kit/Makefile`.

No waiver is needed or claimed.