### PR TITLE
chore(085): ratify (draft -> approved)

### DIFF
--- a/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/codebase-index/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -169,8 +169,8 @@
       }
     ],
     "specId": "085-a-verifier-checks-the-bytes-it-was-given",
-    "specStatus": "draft"
+    "specStatus": "approved"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "11e8a7a7b98e96fe3c08052fbbea813c35cbec505e5d258ebdfbb0695fba1ca5"
+  "shardHash": "11ccdf0d0023b243b71150c86665c6201bc45643faac2fde3945ceb80d008ace"
 }

--- a/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
+++ b/.derived/spec-registry/by-spec/085-a-verifier-checks-the-bytes-it-was-given.json
@@ -107,10 +107,10 @@
       "Verification"
     ],
     "specPath": "specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md",
-    "status": "draft",
+    "status": "approved",
     "summary": "`verify-attestation` decides on a different object from the one it was handed. It deserializes the attestation without refusing members it does not know, and it checks the seal against a hash of its own re-serialization of what it parsed, never against the file's bytes. Measured at 75181a5: a sealed attestation with an injected `\"prCouple\": {\"ok\": true}` verifies as `match` and `valid` at exit 0, in both the corpus and the per-spec scope, and so does a reformatted copy. Separately, the corpus recompute never compares `schemaVersion`, so an attestation claiming `9.0.0` recomputes as `match` at exit 0, while the per-spec path reports an unnamed content mismatch. Spec 023 AC-4 already requires a single tampered payload byte to fail the signature, and the attestation module documents that loaders reject an unknown MAJOR, so this spec extends rather than amends: the verifier reads the file once, both modes decide on those bytes, every attestation and seal DTO refuses unknown members at exit 3, an unknown schema MAJOR is refused at exit 3 in the loaders' own words, and the corpus recompute compares the version. Nothing `attest` emits changes, and every attestation and seal it has ever written still verifies, provided the bytes were kept.\n",
     "title": "A verifier checks the bytes it was given"
   },
-  "shardHash": "a1e794a91a2b1ba77827a6549d3a4ba78387b9e3def252ccab9560c6f6998375",
+  "shardHash": "af7d6f6854afd075158bb793715e98852834eb1c592a15a0862d5e185f19312e",
   "specVersion": "1.2.0"
 }

--- a/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
+++ b/specs/085-a-verifier-checks-the-bytes-it-was-given/spec.md
@@ -1,7 +1,7 @@
 ---
 id: "085-a-verifier-checks-the-bytes-it-was-given"
 title: "A verifier checks the bytes it was given"
-status: draft
+status: approved
 kind: "tooling"
 created: "2026-09-11"
 implementation: complete


### PR DESCRIPTION
## Summary

Flips spec 085 from `draft` to `approved` now that it is built, merged
(#181) and its `## Verification` block passes on the merged sha. This is
the ratify half of the repository's file-as-draft, build, then ratify loop
(`AGENTS.md`, "Working the backlog", step 6).

Nothing but the lifecycle key changes; `implementation` is already
`complete`. The corpus moves to 86 approved of 90.

## Testing

`spec-spine check --fail-on-unresolved --fail-on-warn`, `lint --fail-on-warn`,
`index coverage --fail-on-untraced` and `couple --base origin/main --head HEAD`
all exit 0, with the regenerated shards committed alongside the flip.

On the merged sha, `spec-spine verify 085-a-verifier-checks-the-bytes-it-was-given`
passed: 25 commands, all exit 0.