### PR TITLE
feat(086): the committed index is compared, not trusted

### DIFF
--- a/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -117,5 +117,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "94d534315add39c591378f43c1be49e1af4b4a3245bde014e69a606eb6e4664b"
+  "shardHash": "30a9f609faf16fc7321d778f76c76c9bb4c43666a5a94aa75dfa28c648bb2d4d"
 }

--- a/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -22,11 +22,19 @@
       {
         "path": "crates/spec-spine-core/src/index.rs",
         "source": "spec-edge"
+      },
+      {
+        "path": "crates/spec-spine-core/tests/index_body.rs",
+        "source": "spec-edge"
       }
     ],
     "resolvedUnits": [
       {
-        "locations": [],
+        "locations": [
+          {
+            "file": "crates/spec-spine-core/tests/index_body.rs"
+          }
+        ],
         "ownership": true,
         "sourceField": "establishes",
         "unit": {
@@ -117,5 +125,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "30a9f609faf16fc7321d778f76c76c9bb4c43666a5a94aa75dfa28c648bb2d4d"
+  "shardHash": "98030f17c13dbb8709c3147b5cc293380b871123f563fd34383d331dcf7a3be2"
 }

--- a/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/codebase-index/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -125,5 +125,5 @@
     "specStatus": "draft"
   },
   "schemaVersion": "1.1.0",
-  "shardHash": "98030f17c13dbb8709c3147b5cc293380b871123f563fd34383d331dcf7a3be2"
+  "shardHash": "e0ee90085579113629768d375aa4269f7fe0314b22c37cab5094f48e8f483d9e"
 }

--- a/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -14,8 +14,7 @@
     "establishes": [
       {
         "kind": "file",
-        "path": "crates/spec-spine-core/tests/index_body.rs",
-        "planned": true
+        "path": "crates/spec-spine-core/tests/index_body.rs"
       }
     ],
     "extends": [
@@ -92,6 +91,6 @@
     "summary": "`index check` does not compare the committed index with what the corpus indexes to. It reads each committed shard's own mapping, derives from that mapping which span files to hash, and compares the resulting hash with the shard's `shardHash` field. The mapping body itself (which units resolved where, which paths implement which spec, the ownership flags) is never compared with a fresh resolution, and for a `file`, `directory` or `crate` unit, which carries no span, nothing in the hash constrains it. Measured on a scratch repository: rewriting a committed shard so its spec owns nothing, with `shardHash` left alone, leaves `index check` and `check` reporting fresh, and `couple` then derives ownership from the edited body and passes a change to code the spec owned, without its `spec.md`. `.derived/` is in the bypass floor, so the edit itself trips nothing. AGENTS.md tells every session that a fresh `check` means the committed shards are exactly what the corpus compiles to; for the index that is not what is checked. Spec 031 3.1 recorded the weaker comparison as a cost trade; a full re-index of this repository takes 0.04 s against 0.03 s for the check. This spec makes `index check` compare bytes and set membership exactly as `compile --check` does, so every reader of the committed index (the coupling gate, `index owner`, coverage, the projections) reads a body equal to the recompute. It amends 024 5, whose bounded trade let a sibling-caused resolution flip go unreported.\n",
     "title": "The committed index is compared, not trusted"
   },
-  "shardHash": "d322d963fec145027f3a92d62588ea7e4bb1dc9ac871f5de7d079ad83d82df6c",
+  "shardHash": "67c0090ff152f5fae53237f080b5f81b0c09eb5b2681cdc42413241b3bc6e02d",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -45,7 +45,7 @@
       }
     ],
     "id": "086-the-committed-index-is-compared-not-trusted",
-    "implementation": "pending",
+    "implementation": "in-progress",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -92,6 +92,6 @@
     "summary": "`index check` does not compare the committed index with what the corpus indexes to. It reads each committed shard's own mapping, derives from that mapping which span files to hash, and compares the resulting hash with the shard's `shardHash` field. The mapping body itself (which units resolved where, which paths implement which spec, the ownership flags) is never compared with a fresh resolution, and for a `file`, `directory` or `crate` unit, which carries no span, nothing in the hash constrains it. Measured on a scratch repository: rewriting a committed shard so its spec owns nothing, with `shardHash` left alone, leaves `index check` and `check` reporting fresh, and `couple` then derives ownership from the edited body and passes a change to code the spec owned, without its `spec.md`. `.derived/` is in the bypass floor, so the edit itself trips nothing. AGENTS.md tells every session that a fresh `check` means the committed shards are exactly what the corpus compiles to; for the index that is not what is checked. Spec 031 3.1 recorded the weaker comparison as a cost trade; a full re-index of this repository takes 0.04 s against 0.03 s for the check. This spec makes `index check` compare bytes and set membership exactly as `compile --check` does, so every reader of the committed index (the coupling gate, `index owner`, coverage, the projections) reads a body equal to the recompute. It amends 024 5, whose bounded trade let a sibling-caused resolution flip go unreported.\n",
     "title": "The committed index is compared, not trusted"
   },
-  "shardHash": "538079d687013d40f5e0eeb643d998d255560f6ce0a12cadbfdfe0e750450f69",
+  "shardHash": "d322d963fec145027f3a92d62588ea7e4bb1dc9ac871f5de7d079ad83d82df6c",
   "specVersion": "1.2.0"
 }

--- a/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
+++ b/.derived/spec-registry/by-spec/086-the-committed-index-is-compared-not-trusted.json
@@ -44,7 +44,7 @@
       }
     ],
     "id": "086-the-committed-index-is-compared-not-trusted",
-    "implementation": "in-progress",
+    "implementation": "complete",
     "kind": "tooling",
     "owner": "The spec-spine Authors",
     "references": [
@@ -91,6 +91,6 @@
     "summary": "`index check` does not compare the committed index with what the corpus indexes to. It reads each committed shard's own mapping, derives from that mapping which span files to hash, and compares the resulting hash with the shard's `shardHash` field. The mapping body itself (which units resolved where, which paths implement which spec, the ownership flags) is never compared with a fresh resolution, and for a `file`, `directory` or `crate` unit, which carries no span, nothing in the hash constrains it. Measured on a scratch repository: rewriting a committed shard so its spec owns nothing, with `shardHash` left alone, leaves `index check` and `check` reporting fresh, and `couple` then derives ownership from the edited body and passes a change to code the spec owned, without its `spec.md`. `.derived/` is in the bypass floor, so the edit itself trips nothing. AGENTS.md tells every session that a fresh `check` means the committed shards are exactly what the corpus compiles to; for the index that is not what is checked. Spec 031 3.1 recorded the weaker comparison as a cost trade; a full re-index of this repository takes 0.04 s against 0.03 s for the check. This spec makes `index check` compare bytes and set membership exactly as `compile --check` does, so every reader of the committed index (the coupling gate, `index owner`, coverage, the projections) reads a body equal to the recompute. It amends 024 5, whose bounded trade let a sibling-caused resolution flip go unreported.\n",
     "title": "The committed index is compared, not trusted"
   },
-  "shardHash": "67c0090ff152f5fae53237f080b5f81b0c09eb5b2681cdc42413241b3bc6e02d",
+  "shardHash": "b05166f092e210342b55dd4ca85f51c183b1e6923c32297273acffeb4afb6cd3",
   "specVersion": "1.2.0"
 }

--- a/crates/spec-spine-cli/src/cmd_index.rs
+++ b/crates/spec-spine-cli/src/cmd_index.rs
@@ -287,8 +287,23 @@ pub fn run(repo: &Path, action: Option<&IndexAction>) -> Result<u8, Error> {
                 }
                 Freshness::Stale { expected, actual } => {
                     eprintln!("{subject} is STALE (run `spec-spine index` to refresh)");
-                    eprintln!("  expected: {expected}");
-                    eprintln!("  actual:   {actual}");
+                    // Spec 086 3.2: for the index, `actual` is already the count
+                    // line plus one line per drifted shard with its class, so it
+                    // is printed as it stands, the way `compile --check` prints
+                    // the registry's. The paired `expected` stays on the typed
+                    // verdict for JSON consumers; an operator's next action does
+                    // not depend on it.
+                    //
+                    // A `--slice` check is the other shape on this arm: its two
+                    // values are the sidecar hashes (spec 012 3.3), where the
+                    // expected/actual pair is the whole report and dropping half
+                    // of it would say nothing.
+                    if slice.is_some() {
+                        eprintln!("  expected: {expected}");
+                        eprintln!("  actual:   {actual}");
+                    } else {
+                        eprintln!("{actual}");
+                    }
                     if !counts.is_empty() {
                         eprintln!(
                             "  the stale ledger also records {}",

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -395,94 +395,204 @@ pub fn index(cfg: &spec_spine_types::Config, repo_root: &Path) -> Result<IndexOu
     })
 }
 
-/// Per-shard staleness (spec 024 FR-003): each committed shard is verified
-/// against its current inputs and the shard *set* is compared to the current
-/// authority set. A shard is stale when its recomputed hash differs, when it
-/// carries a blocking resolver diagnostic, or when a spec/package was added or
-/// removed (a set-membership change). Reports the stale shard ids; replaces the
-/// pre-shard single global-hash comparison. The recompute reads each committed
-/// shard's own span-backing files (from its `resolvedUnits`), so it stays cheap
-/// (no re-resolution) while still catching a span-shifting edit (spec 004 §3.5).
+/// The cap on how many drifted shards a freshness report names (spec 031 §3.3),
+/// so a corpus-wide restamp reports `and N more` instead of flooding a CI log.
+///
+/// The registry keeps its own copy of this cap beside its own comparison, and
+/// the two are deliberately separate constants: each artifact's comparison is
+/// owned by a different spec, and neither module reaches into the other to
+/// share one value.
+const STALE_REPORT_CAP: usize = 20;
+
+/// The one field a differing shard is probed for before it is called `modified`.
+#[derive(Deserialize)]
+struct SchemaProbe {
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+}
+
+/// A committed shard whose schema MAJOR this build does not understand is an
+/// [`Error::Schema`] (exit 3), not drift.
+///
+/// Byte comparison alone would call it `modified`, and the remedy a stale
+/// verdict advises, "run `spec-spine index`", would overwrite a tree a newer
+/// build wrote. That refusal is what the read boundary gave before spec 086
+/// (`read_committed_index_shards` gates every shard's MAJOR), and it still
+/// guards every *reader* of this tree; keeping it here means the freshness
+/// verb in front of them does not answer first with worse advice.
+///
+/// Reading a committed body is otherwise not this comparison's business, so the
+/// probe is deliberately narrow: one field, only on a file that already
+/// differs, and a body that will not parse stays `modified` rather than
+/// becoming an error. See 086 D-5.
+fn reject_foreign_major(bytes: &[u8]) -> Result<(), Error> {
+    if let Ok(probe) = serde_json::from_slice::<SchemaProbe>(bytes) {
+        shard::check_major("index", &probe.schema_version, INDEX_SCHEMA_VERSION)?;
+    }
+    Ok(())
+}
+
+/// The drifted-file lines for one shard directory, by filename, over raw bytes.
+///
+/// `modified` (the committed bytes differ from the emitted ones), `missing` (an
+/// emitted shard with no committed file) and `orphaned` (a committed file no
+/// emitted shard accounts for, a stray `.json` included). Classification never
+/// parses a committed file: the comparison is what decides, so a body that will
+/// not deserialize is drift to report rather than an error to raise. The one
+/// read of a committed body is [`reject_foreign_major`], and it changes no
+/// classification.
+fn compare_shard_dir(
+    dir: &Path,
+    label: &str,
+    emitted: &shard::ShardFiles,
+) -> Result<Vec<String>, Error> {
+    let expected: BTreeMap<&str, &str> = emitted
+        .iter()
+        .map(|(name, content)| (name.as_str(), content.as_str()))
+        .collect();
+    let committed: BTreeMap<String, Vec<u8>> = shard::read_shard_files(dir)?.into_iter().collect();
+
+    let mut drift: Vec<String> = Vec::new();
+    for (name, content) in &expected {
+        match committed.get(*name) {
+            None => drift.push(format!("missing {label}/{name}")),
+            Some(bytes) if bytes.as_slice() != content.as_bytes() => {
+                reject_foreign_major(bytes)?;
+                drift.push(format!("modified {label}/{name}"));
+            }
+            Some(_) => {}
+        }
+    }
+    for name in committed.keys() {
+        if !expected.contains_key(name.as_str()) {
+            drift.push(format!("orphaned {label}/{name}"));
+        }
+    }
+    Ok(drift)
+}
+
+/// Compare a freshly built shard set against the committed index tree, byte for
+/// byte (spec 086 §3.1), exactly as the registry's comparison does (spec 031
+/// §3.1).
+///
+/// Before spec 086 this side compared only each committed shard's recomputed
+/// `shardHash`, and it derived the files to hash *from the committed body
+/// itself* (`span_files_for_mapping`). The body was therefore trusted to name
+/// its own inputs and was never compared with anything, so for a `file`,
+/// `directory` or `crate` unit, none of which carries a span, a rewritten body
+/// kept its hash and read fresh; the coupling gate then resolved ownership from
+/// it, and `.derived/` is on the bypass floor, so the edit tripped nothing
+/// (spec 086 §1 measures the case end to end). Comparing the serialized bytes
+/// is what makes the committed tree a ledger rather than a cache: canonical
+/// emission (sorted keys, 2-space, LF, trailing newline) makes a fresh index
+/// reproducible, so an exact comparison catches a stale hash, a hand-edited
+/// body and a schema restamp alike.
+///
+/// Both shard directories are compared, and `missing`/`orphaned` are set
+/// membership rather than content, which is why this compares sets and not only
+/// the files present in both.
+fn committed_index_drift(
+    cfg: &spec_spine_types::Config,
+    repo_root: &Path,
+    shards: &IndexShardSet,
+) -> Result<Vec<String>, Error> {
+    let dir = index_dir(cfg, repo_root);
+    // An index that was never built stays an `Error::Io`, the answer this
+    // function's caller gave before spec 086 and the one every reader of this
+    // tree still gives. The registry's comparison calls that state stale
+    // instead (spec 031 §3.2), but that choice belongs to the verb that reads a
+    // registry: adopting it here would move an exit code from 3 to 2 on
+    // `couple`, `coverage` and `index owner`, none of which spec 086 touches.
+    // See 086 D-4.
+    if !dir.exists() {
+        return Err(Error::Io(format!(
+            "read {} (run `spec-spine index` first?): not found",
+            dir.display()
+        )));
+    }
+    let (by_spec, by_package) = index_shard_files(shards)?;
+    let mut drift = compare_shard_dir(&dir.join(shard::BY_SPEC_DIR), shard::BY_SPEC_DIR, &by_spec)?;
+    drift.extend(compare_shard_dir(
+        &dir.join(shard::BY_PACKAGE_DIR),
+        shard::BY_PACKAGE_DIR,
+        &by_package,
+    )?);
+    Ok(drift)
+}
+
+/// Render drift lines as a [`Freshness`], in the registry's report shape.
+///
+/// That shape is contractual (spec 031 §3.3): the session protocol reads the
+/// drifted shard names back to an operator, and exit 2 alone cannot say which
+/// shard moved. One line per shard, each carrying its class, capped so a
+/// corpus-wide restamp does not flood a CI log.
+fn drift_verdict(mut drift: Vec<String>, emitted: usize) -> Freshness {
+    if drift.is_empty() {
+        return Freshness::Fresh;
+    }
+    drift.sort();
+    drift.dedup();
+    let total = drift.len();
+    let mut lines: Vec<String> = drift
+        .iter()
+        .take(STALE_REPORT_CAP)
+        .map(|s| format!("  {s}"))
+        .collect();
+    if total > STALE_REPORT_CAP {
+        lines.push(format!("  and {} more", total - STALE_REPORT_CAP));
+    }
+    Freshness::Stale {
+        expected: format!("{emitted} shard(s) matching the corpus"),
+        actual: format!("{total} stale shard(s):\n{}", lines.join("\n")),
+    }
+}
+
+/// Index freshness (spec 086 §3.1): does the committed shard tree equal what the
+/// current corpus indexes to? Indexes in memory and compares the serialized
+/// shard bytes and the shard set. **Never writes.**
+///
+/// Every reader of the committed index inherits this (spec 086 §3.2). `check`,
+/// and the freshness guard in front of `couple`, `index coverage` and
+/// `index owner`, all call this one function, so a committed index that reads
+/// fresh is byte-identical to the recompute, and the owner set a `C-001`
+/// decision uses is the one the corpus resolves to at that tree rather than
+/// whatever the committed body says.
+///
+/// The blocking-diagnostic refusal (spec 050) is unchanged. It is read from the
+/// fresh index rather than from the committed body, which is the same move this
+/// function makes everywhere else: a committed body with its diagnostics
+/// deleted would otherwise answer for itself.
+///
+/// This replaces the per-shard hash recompute of spec 024 FR-003, whose
+/// bounded trade (024 §5) let a resolution flip caused purely by a sibling
+/// change go unreported until the next full `index` run. A byte comparison
+/// catches it; spec 086 amends that section.
 pub fn check_index_freshness(
     cfg: &spec_spine_types::Config,
     repo_root: &Path,
 ) -> Result<Freshness, Error> {
-    let (spec_shards, package_shards) = read_committed_index_shards(cfg, repo_root)?;
-    let global_inputs = shard::global_inputs_hash(cfg, repo_root);
-
-    let mut stale: Vec<String> = Vec::new();
-
-    // Set membership: a spec added or removed (its dir gained/lost spec.md), or a
-    // package added/removed (manifest discovery), restamps the shard set. Caught
-    // here because a per-shard hash alone cannot see a sibling that appeared.
-    let committed_spec_ids: BTreeSet<String> = spec_shards
+    let outcome = index(cfg, repo_root)?;
+    let mut drift: Vec<String> = outcome
+        .shards
+        .spec_shards
         .iter()
-        .map(|s| s.mapping.spec_id.clone())
-        .collect();
-    let current_spec_ids: BTreeSet<String> = discover_specs(cfg, repo_root)?
-        .into_iter()
-        .map(|s| s.id)
-        .collect();
-    for added in current_spec_ids.difference(&committed_spec_ids) {
-        stale.push(format!("by-spec/{added} (new spec)"));
-    }
-    for removed in committed_spec_ids.difference(&current_spec_ids) {
-        stale.push(format!("by-spec/{removed} (removed spec)"));
-    }
-
-    let discovered = manifest::discover(cfg, repo_root);
-    let committed_pkgs: BTreeSet<String> = package_shards
-        .iter()
-        .map(|s| s.package.path.clone())
-        .collect();
-    let current_pkgs: BTreeSet<String> =
-        discovered.packages.iter().map(|p| p.path.clone()).collect();
-    for added in current_pkgs.difference(&committed_pkgs) {
-        stale.push(format!("by-package (new package at {added})"));
-    }
-    for removed in committed_pkgs.difference(&current_pkgs) {
-        stale.push(format!("by-package (removed package at {removed})"));
-    }
-
-    // Per-shard hash + blocking-diagnostic checks.
-    for sh in &spec_shards {
-        let id = &sh.mapping.spec_id;
-        if sh
-            .diagnostics
-            .errors
-            .iter()
-            .any(|d| BLOCKING_CODES.contains(&d.code.as_str()))
-        {
-            stale.push(format!("by-spec/{id} (blocking diagnostics)"));
-            continue;
-        }
-        let spec_md = spec_md_rel(&cfg.layout.specs_dir, id);
-        let span_files = span_files_for_mapping(&sh.mapping);
-        let actual = spec_shard_hash(repo_root, &spec_md, &span_files, &global_inputs);
-        if actual != sh.shard_hash {
-            stale.push(format!("by-spec/{id}"));
-        }
-    }
-    for sh in &package_shards {
-        let actual = package_shard_hash(repo_root, &sh.package, cfg, &global_inputs);
-        if actual != sh.shard_hash {
-            stale.push(format!(
-                "by-package/{}",
-                shard::package_slug(&sh.package.name)
-            ));
-        }
-    }
-
-    if stale.is_empty() {
-        Ok(Freshness::Fresh)
-    } else {
-        stale.sort();
-        stale.dedup();
-        Ok(Freshness::Stale {
-            expected: "all shards fresh".to_string(),
-            actual: format!("stale shard(s): {}", stale.join(", ")),
+        .filter(|sh| {
+            sh.diagnostics
+                .errors
+                .iter()
+                .any(|d| BLOCKING_CODES.contains(&d.code.as_str()))
         })
-    }
+        .map(|sh| {
+            format!(
+                "blocking-diagnostics {}/{}.json",
+                shard::BY_SPEC_DIR,
+                sh.mapping.spec_id
+            )
+        })
+        .collect();
+    drift.extend(committed_index_drift(cfg, repo_root, &outcome.shards)?);
+    let emitted = outcome.shards.spec_shards.len() + outcome.shards.package_shards.len();
+    Ok(drift_verdict(drift, emitted))
 }
 
 /// Recompute one named slice and compare it to the committed

--- a/crates/spec-spine-core/src/index.rs
+++ b/crates/spec-spine-core/src/index.rs
@@ -572,7 +572,7 @@ pub fn check_index_freshness(
     repo_root: &Path,
 ) -> Result<Freshness, Error> {
     let outcome = index(cfg, repo_root)?;
-    let mut drift: Vec<String> = outcome
+    let blocking: BTreeSet<String> = outcome
         .shards
         .spec_shards
         .iter()
@@ -582,15 +582,28 @@ pub fn check_index_freshness(
                 .iter()
                 .any(|d| BLOCKING_CODES.contains(&d.code.as_str()))
         })
-        .map(|sh| {
-            format!(
-                "blocking-diagnostics {}/{}.json",
-                shard::BY_SPEC_DIR,
-                sh.mapping.spec_id
-            )
-        })
+        .map(|sh| format!("{}/{}.json", shard::BY_SPEC_DIR, sh.mapping.spec_id))
         .collect();
-    drift.extend(committed_index_drift(cfg, repo_root, &outcome.shards)?);
+
+    let mut drift: Vec<String> = blocking
+        .iter()
+        .map(|file| format!("blocking-diagnostics {file}"))
+        .collect();
+    for line in committed_index_drift(cfg, repo_root, &outcome.shards)? {
+        // One line per shard. A shard that both blocks and differs would
+        // otherwise be named twice, and the count line ("N stale shard(s)")
+        // would then overstate how many shards moved. The blocking line is the
+        // one kept because it is the one whose remedy differs: regenerating
+        // fixes differing bytes, and does not fix an unresolved unit. This is
+        // also what the pre-086 check reported, which skipped the hash
+        // comparison for a shard it had already called blocking.
+        if let Some(file) = line.strip_prefix("modified ")
+            && blocking.contains(file)
+        {
+            continue;
+        }
+        drift.push(line);
+    }
     let emitted = outcome.shards.spec_shards.len() + outcome.shards.package_shards.len();
     Ok(drift_verdict(drift, emitted))
 }

--- a/crates/spec-spine-core/tests/index_body.rs
+++ b/crates/spec-spine-core/tests/index_body.rs
@@ -88,6 +88,25 @@ fn spec_shard(cfg: &Config, repo: &Path, id: &str) -> PathBuf {
         .join(format!("{id}.json"))
 }
 
+/// Restamp a shard's schema version to another MINOR of the same MAJOR.
+///
+/// The stable way to make a committed body differ. Rewriting some phrase out of
+/// the body would couple the test to wording it is not about (a reworded
+/// diagnostic would fire the "the tamper changed nothing" guard and send the
+/// reader after the wrong thing), whereas `schemaVersion` is a constant this
+/// crate exports and every shard carries. Staying inside the MAJOR keeps it
+/// drift rather than the refusal `reject_foreign_major` raises.
+fn restamp_minor(body: &str) -> String {
+    let current = spec_spine_types::INDEX_SCHEMA_VERSION;
+    let major = current.split('.').next().expect("a semver MAJOR");
+    let out = body.replace(&format!("\"{current}\""), &format!("\"{major}.99.0\""));
+    assert_ne!(
+        body, out,
+        "every shard stamps {current}; the fixture must carry one to restamp"
+    );
+    out
+}
+
 /// The `shardHash` line, so a test can prove a tamper left it alone.
 fn hash_line(text: &str) -> String {
     text.lines()
@@ -258,9 +277,11 @@ fn a_blocking_shard_that_also_differs_is_named_once() {
 
     let path = spec_shard(&cfg, fx.path(), "002-gone");
     let body = fs::read_to_string(&path).unwrap();
-    let tampered = body.replace("does not exist", "does not exist ");
-    assert_ne!(body, tampered, "the tamper must change the committed bytes");
-    fs::write(&path, tampered).unwrap();
+    assert!(
+        body.contains("I-004"),
+        "the fixture must make this shard block, or the test asserts nothing: {body}"
+    );
+    fs::write(&path, restamp_minor(&body)).unwrap();
 
     let report = stale_report(&cfg, fx.path());
     assert!(
@@ -327,17 +348,7 @@ fn a_schema_restamp_inside_our_major_reads_modified() {
 
     let path = spec_shard(&cfg, fx.path(), "001-a");
     let body = fs::read_to_string(&path).unwrap();
-    let major = spec_spine_types::INDEX_SCHEMA_VERSION
-        .split('.')
-        .next()
-        .unwrap()
-        .to_string();
-    let restamped = body.replace(
-        &format!("\"{}\"", spec_spine_types::INDEX_SCHEMA_VERSION),
-        &format!("\"{major}.99.0\""),
-    );
-    assert_ne!(body, restamped, "the fixture must stamp a schema version");
-    fs::write(&path, restamped).unwrap();
+    fs::write(&path, restamp_minor(&body)).unwrap();
 
     let report = stale_report(&cfg, fx.path());
     assert!(

--- a/crates/spec-spine-core/tests/index_body.rs
+++ b/crates/spec-spine-core/tests/index_body.rs
@@ -240,6 +240,45 @@ fn a_package_shard_body_edit_reads_modified() {
 }
 
 #[test]
+fn a_blocking_shard_that_also_differs_is_named_once() {
+    // One line per shard, so the count line cannot overstate how many shards
+    // moved. A spec claiming a file that does not exist emits `I-004`, which is
+    // blocking, and tampering its committed body also makes the bytes differ;
+    // both conditions hold at once. The blocking line is the one kept, because
+    // it is the one whose remedy differs: regenerating fixes bytes and does not
+    // fix an unresolved unit.
+    let fx = fixture();
+    let cfg = Config::default();
+    write(
+        fx.path(),
+        "specs/002-gone/spec.md",
+        "---\nid: \"002-gone\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-12\"\nimplementation: complete\nsummary: \"s\"\nestablishes:\n  - \"a/src/absent.rs\"\n---\n\n# 002-gone\n",
+    );
+    emit(&cfg, fx.path());
+
+    let path = spec_shard(&cfg, fx.path(), "002-gone");
+    let body = fs::read_to_string(&path).unwrap();
+    let tampered = body.replace("does not exist", "does not exist ");
+    assert_ne!(body, tampered, "the tamper must change the committed bytes");
+    fs::write(&path, tampered).unwrap();
+
+    let report = stale_report(&cfg, fx.path());
+    assert!(
+        report.contains("blocking-diagnostics by-spec/002-gone.json"),
+        "the blocking refusal must survive (spec 050): {report}"
+    );
+    assert!(
+        !report.contains("modified by-spec/002-gone.json"),
+        "the same shard must not also be named `modified`: {report}"
+    );
+    assert_eq!(
+        report.matches("by-spec/002-gone.json").count(),
+        1,
+        "one line per shard, so the count line stays honest: {report}"
+    );
+}
+
+#[test]
 fn a_foreign_schema_major_is_refused_not_reported_as_drift() {
     // A must-keep-working line, not a defect probe: it passes before and after
     // spec 086. The read boundary refused a shard from an unknown MAJOR with a

--- a/crates/spec-spine-core/tests/index_body.rs
+++ b/crates/spec-spine-core/tests/index_body.rs
@@ -1,0 +1,308 @@
+//! Spec 086: the committed index is compared, not trusted.
+//!
+//! The tamper matrix against the committed index, library side. Every case here
+//! rewrites the committed tree and asks `check_index_freshness` what it makes of
+//! it, because before spec 086 that function never compared the shard *body*
+//! with anything: it read each committed mapping, asked that mapping which files
+//! backed its spans, and compared a recomputed hash with the shard's own
+//! `shardHash` field.
+//!
+//! The fixture is deliberately span-free (one `file` unit, no `symbol` or
+//! `section` claims). `span_files_for_mapping` folds a source file into the
+//! shard hash only for a `section`, `symbol` or `module` unit, so for a `file`
+//! unit the hash covers `spec.md` and the global-inputs scalar and nothing else.
+//! Rewriting a path inside such a body therefore cannot move `shardHash`, which
+//! is what makes these assertions evidence rather than coincidence: they fail
+//! against pre-086 code with the committed tree reading fresh, and they cannot
+//! start passing because a hash happened to change.
+//!
+//! Being span-free also keeps the fixture identical with and without the
+//! `symbol-resolution` feature (spec 027), which CI builds both ways.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use spec_spine_core::shard::{self, BY_PACKAGE_DIR, BY_SPEC_DIR};
+use spec_spine_core::{
+    Freshness, check_index_freshness, compile, index, index_dir, index_shard_files, registry_dir,
+    registry_shard_files,
+};
+use spec_spine_types::{Config, Error};
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let p = root.join(rel);
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(p, content).unwrap();
+}
+
+/// One crate, one spec, one `file` unit: the shape 086 measured, and the common
+/// case in an adopter corpus.
+fn fixture() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let r = tmp.path();
+    write(r, "Cargo.toml", "[workspace]\nmembers = [\"a\"]\n");
+    // No `[package.metadata.spec-spine]` stanza, deliberately: a manifest
+    // spec_ref would put a *floor* under every file in the crate, and a floor
+    // survives a tampered `establishes` claim. Spec 086 §1 measured the case
+    // where the specific claim is the only ownership, which is the case a
+    // `C-001` decision turns on.
+    write(
+        r,
+        "a/Cargo.toml",
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\n",
+    );
+    write(r, "a/src/lib.rs", "pub fn a() {}\n");
+    write(
+        r,
+        "specs/001-a/spec.md",
+        "---\nid: \"001-a\"\ntitle: \"T\"\nstatus: approved\ncreated: \"2026-09-11\"\nimplementation: complete\nsummary: \"s\"\nestablishes:\n  - \"a/src/lib.rs\"\n---\n\n# 001-a\n",
+    );
+    tmp
+}
+
+/// Write both committed trees exactly as `spec-spine compile` and
+/// `spec-spine index` do.
+///
+/// The registry is written too, though only the index is under test, so that a
+/// reader verb reaches the question this file is about. Without it
+/// `owner` fails on the absent registry, and the tamper probe below would pass
+/// against pre-086 code for a reason that has nothing to do with the tamper.
+fn emit(cfg: &Config, repo: &Path) {
+    let registry = compile(cfg, repo).unwrap();
+    shard::sync_dir(
+        &registry_dir(cfg, repo).join(BY_SPEC_DIR),
+        &registry_shard_files(&registry.shards).unwrap(),
+    )
+    .unwrap();
+
+    let outcome = index(cfg, repo).unwrap();
+    let dir = index_dir(cfg, repo);
+    let (by_spec, by_package) = index_shard_files(&outcome.shards).unwrap();
+    shard::sync_dir(&dir.join(BY_SPEC_DIR), &by_spec).unwrap();
+    shard::sync_dir(&dir.join(BY_PACKAGE_DIR), &by_package).unwrap();
+}
+
+fn spec_shard(cfg: &Config, repo: &Path, id: &str) -> PathBuf {
+    index_dir(cfg, repo)
+        .join(BY_SPEC_DIR)
+        .join(format!("{id}.json"))
+}
+
+/// The `shardHash` line, so a test can prove a tamper left it alone.
+fn hash_line(text: &str) -> String {
+    text.lines()
+        .find(|l| l.contains("\"shardHash\""))
+        .expect("a shard carries its own hash")
+        .to_string()
+}
+
+/// The drift report, or a panic naming the verdict that was expected to be stale.
+fn stale_report(cfg: &Config, repo: &Path) -> String {
+    match check_index_freshness(cfg, repo).unwrap() {
+        Freshness::Stale { actual, .. } => actual,
+        Freshness::Fresh => {
+            panic!("the committed index must read STALE here, and it read fresh")
+        }
+    }
+}
+
+#[test]
+fn a_regenerated_tree_reads_fresh() {
+    // Spec 086 §3.5: the byte comparison must not cost the ordinary case. A tree
+    // the indexer just wrote is what every green run looks like.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+    assert_eq!(
+        check_index_freshness(&cfg, fx.path()).unwrap(),
+        Freshness::Fresh
+    );
+}
+
+#[test]
+fn a_rewritten_body_reads_modified_though_its_own_hash_still_matches() {
+    // The defect spec 086 §1 measured, in one assertion: the committed body says
+    // 001-a owns `a/src/zz.rs`, the corpus says it owns `a/src/lib.rs`, and
+    // `shardHash` is untouched and still correct for its own declared inputs.
+    // Pre-086 this read fresh, and `couple` then derived ownership from it.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+
+    let path = spec_shard(&cfg, fx.path(), "001-a");
+    let before = fs::read_to_string(&path).unwrap();
+    let after = before.replace("a/src/lib.rs", "a/src/zz.rs");
+    assert_ne!(before, after, "the tamper must actually change the body");
+    fs::write(&path, &after).unwrap();
+
+    assert_eq!(
+        hash_line(&before),
+        hash_line(&after),
+        "the tamper must leave `shardHash` alone, or this test proves nothing: a \
+         `file` unit contributes no span file, so the hash cannot move"
+    );
+
+    let report = stale_report(&cfg, fx.path());
+    assert!(
+        report.contains("modified by-spec/001-a.json"),
+        "the drifted shard must be named with its class: {report}"
+    );
+}
+
+#[test]
+fn an_owner_query_refuses_a_tampered_tree() {
+    // Spec 086 §3.3: every reader inherits the comparison, so the owner set a
+    // C-001 decision uses is the one the corpus resolves to. Pre-086 this query
+    // answered "no spec owns this path" from the rewritten body, with exit 0.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+
+    let path = spec_shard(&cfg, fx.path(), "001-a");
+    let body = fs::read_to_string(&path).unwrap();
+    fs::write(&path, body.replace("a/src/lib.rs", "a/src/zz.rs")).unwrap();
+
+    match spec_spine_core::owner(&cfg, fx.path(), "a/src/lib.rs") {
+        Err(Error::Stale { .. }) => {}
+        other => panic!("an owner query over a tampered tree must refuse, got: {other:?}"),
+    }
+}
+
+#[test]
+fn a_deleted_shard_reads_missing() {
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+    fs::remove_file(spec_shard(&cfg, fx.path(), "001-a")).unwrap();
+
+    let report = stale_report(&cfg, fx.path());
+    assert!(
+        report.contains("missing by-spec/001-a.json"),
+        "a spec with no committed shard is `missing`: {report}"
+    );
+}
+
+#[test]
+fn a_stray_file_reads_orphaned() {
+    // Spec 086 §3.1 counts a stray file in either shard directory as orphaned.
+    // It is classified by name, without being parsed: the comparison is what
+    // decides, so a file that would not deserialize is drift to report rather
+    // than an error to raise.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+    fs::write(
+        index_dir(&cfg, fx.path())
+            .join(BY_SPEC_DIR)
+            .join("099-ghost.json"),
+        "{ not even valid json\n",
+    )
+    .unwrap();
+
+    let report = stale_report(&cfg, fx.path());
+    assert!(
+        report.contains("orphaned by-spec/099-ghost.json"),
+        "a committed file no spec accounts for is `orphaned`: {report}"
+    );
+}
+
+#[test]
+fn a_package_shard_body_edit_reads_modified() {
+    // The package half has the same hole: `package_shard_hash` hashes the
+    // manifest named by the committed body, so rewriting the body's own recorded
+    // version leaves the hash correct. Pre-086 this read fresh.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+
+    let dir = index_dir(&cfg, fx.path()).join(BY_PACKAGE_DIR);
+    let path = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .map(|e| e.path())
+        .find(|p| p.extension().and_then(|e| e.to_str()) == Some("json"))
+        .expect("the fixture discovers a package");
+    let before = fs::read_to_string(&path).unwrap();
+    let after = before.replace("0.1.0", "9.9.9");
+    assert_ne!(before, after, "the fixture must record a package version");
+    fs::write(&path, &after).unwrap();
+    assert_eq!(
+        hash_line(&before),
+        hash_line(&after),
+        "the tamper must leave `shardHash` alone: the hash is over the manifest"
+    );
+
+    let report = stale_report(&cfg, fx.path());
+    assert!(
+        report.contains("modified by-package/"),
+        "a rewritten package body is `modified`: {report}"
+    );
+}
+
+#[test]
+fn a_foreign_schema_major_is_refused_not_reported_as_drift() {
+    // A must-keep-working line, not a defect probe: it passes before and after
+    // spec 086. The read boundary refused a shard from an unknown MAJOR with a
+    // clean schema error, and byte comparison must not turn that into "stale,
+    // run `spec-spine index`", whose remedy would overwrite a tree written by a
+    // newer build.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+
+    let path = spec_shard(&cfg, fx.path(), "001-a");
+    let body = fs::read_to_string(&path).unwrap();
+    let major: u32 = spec_spine_types::INDEX_SCHEMA_VERSION
+        .split('.')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    fs::write(
+        &path,
+        body.replace(
+            &format!("\"{}\"", spec_spine_types::INDEX_SCHEMA_VERSION),
+            &format!("\"{}.0.0\"", major + 1),
+        ),
+    )
+    .unwrap();
+
+    match check_index_freshness(&cfg, fx.path()) {
+        Err(Error::Schema(msg)) => assert!(
+            msg.contains("MAJOR"),
+            "the refusal must name the schema MAJOR: {msg}"
+        ),
+        other => panic!("a foreign schema MAJOR must be refused, got: {other:?}"),
+    }
+}
+
+#[test]
+fn a_schema_restamp_inside_our_major_reads_modified() {
+    // Spec 086 §3.1: the byte comparison catches a stale hash, a hand-edited
+    // body and a schema restamp alike. A MINOR restamp stays inside the MAJOR
+    // this build understands, so it is drift to report, not a schema error: the
+    // remedy is to regenerate, which is what a stale verdict says.
+    let fx = fixture();
+    let cfg = Config::default();
+    emit(&cfg, fx.path());
+
+    let path = spec_shard(&cfg, fx.path(), "001-a");
+    let body = fs::read_to_string(&path).unwrap();
+    let major = spec_spine_types::INDEX_SCHEMA_VERSION
+        .split('.')
+        .next()
+        .unwrap()
+        .to_string();
+    let restamped = body.replace(
+        &format!("\"{}\"", spec_spine_types::INDEX_SCHEMA_VERSION),
+        &format!("\"{major}.99.0\""),
+    );
+    assert_ne!(body, restamped, "the fixture must stamp a schema version");
+    fs::write(&path, restamped).unwrap();
+
+    let report = stale_report(&cfg, fx.path());
+    assert!(
+        report.contains("modified by-spec/001-a.json"),
+        "a schema restamp is `modified`: {report}"
+    );
+}

--- a/specs/086-the-committed-index-is-compared-not-trusted/spec.md
+++ b/specs/086-the-committed-index-is-compared-not-trusted/spec.md
@@ -19,9 +19,8 @@ amends:
   # bytes catches it. 024's text is not edited (spec 040). See 5, D-1.
   - "024-index-sharding"
 establishes:
-  # Planned (spec 076) until the build writes it; the build drops the flag.
   # 3.5: the tamper matrix against the committed index, library side.
-  - { kind: file, path: "crates/spec-spine-core/tests/index_body.rs", planned: true }
+  - { kind: file, path: "crates/spec-spine-core/tests/index_body.rs" }
 extends:
   # 3.1 and 3.2: `check_index_freshness` compares the committed shard bytes
   # with the shards a fresh index emits, and reports the drift classes.
@@ -210,6 +209,29 @@ what makes it one.
 **D-3 (2026-09-11): no opt-in flag.** A flag would leave the weak comparison as
 the default, and every gate chain already written against `check` would keep
 it.
+
+**D-4 (2026-09-12): an unbuilt index stays an I/O error, not staleness.** 3.1
+mirrors `compile --check`, and 031 3.2 makes an unbuilt *registry* stale rather
+than an error, on the reasoning that a tree never built is by definition not
+vouching for the corpus. Read straight across, that would make an unbuilt index
+stale here too. It is not adopted. `check_index_freshness` is the freshness
+guard in front of `couple`, `index coverage` and `index owner`, so the change
+would move all three from exit 3 to exit 2 and replace "run `spec-spine index`
+first" with "stale", none of which this spec is for. 3.1 describes the
+comparison, not the read boundary in front of it, and the registry's answer
+belongs to the verb that reads a registry.
+
+**D-5 (2026-09-12): a shard from an unknown schema MAJOR is refused, not called
+`modified`.** The comparison classifies without parsing, which is what lets a
+stray file be `orphaned` rather than a parse error. Applied without exception it
+would also demote the read boundary's MAJOR gate, which
+`read_committed_index_shards` has always applied: a committed tree at a MAJOR
+this build does not understand would read as `modified`, and the remedy a stale
+verdict advises, running `spec-spine index`, would overwrite it with a
+downgrade. So a file that already differs is probed for its `schemaVersion`
+alone, and only to re-raise `Error::Schema`; a body that will not parse stays
+`modified`. No classification changes, and the registry side is left as it
+stands: this keeps a refusal that already existed rather than adding one.
 
 ## Verification
 

--- a/specs/086-the-committed-index-is-compared-not-trusted/spec.md
+++ b/specs/086-the-committed-index-is-compared-not-trusted/spec.md
@@ -4,7 +4,7 @@ title: "The committed index is compared, not trusted"
 status: draft
 kind: "tooling"
 created: "2026-09-11"
-implementation: in-progress
+implementation: complete
 owner: "The spec-spine Authors"
 risk: high
 depends_on:

--- a/specs/086-the-committed-index-is-compared-not-trusted/spec.md
+++ b/specs/086-the-committed-index-is-compared-not-trusted/spec.md
@@ -4,7 +4,7 @@ title: "The committed index is compared, not trusted"
 status: draft
 kind: "tooling"
 created: "2026-09-11"
-implementation: pending
+implementation: in-progress
 owner: "The spec-spine Authors"
 risk: high
 depends_on:


### PR DESCRIPTION
## Summary

`index check` never compared the committed index body with a fresh resolution. It read each committed shard's own mapping, asked that mapping which files backed its spans, and compared a recomputed hash against the shard's own `shardHash`. A `file`, `directory` or `crate` unit carries no span, so for those the hash constrained nothing in the body: a shard rewritten so its spec owns nothing, `shardHash` left alone, read fresh under `index check` and `check`, and `couple` then derived ownership from it and passed a change to code the spec owned without that spec's `spec.md`. `.derived/` is on the bypass floor, so the edit itself tripped nothing.

Freshness now indexes the corpus in memory and compares the serialized shard bytes and the shard set across both directories, exactly as `compile --check` does for the registry, reporting `modified`, `missing` and `orphaned` per shard. All four readers reach it through one function, so `check`, `couple`, `index coverage` and `index owner` see a body equal to the recompute, and the owner set behind a C-001 decision is the one the corpus resolves to. `cmd_check.rs` needed no edit: it already prints the report verbatim, so it inherits the per-shard classes.

Nothing the indexer emits changes and no schema version moves, so every committed shard in this repository is unaffected. Two decisions are recorded where the spec was silent and a strict reading of "exactly as `compile --check` does" would have changed behavior it never asked to change: an unbuilt index stays an I/O error rather than becoming staleness (D-4), and a shard from an unknown schema MAJOR is still refused rather than reported as drift (D-5), since byte comparison alone would have answered "run `spec-spine index`", whose remedy would overwrite a tree a newer build wrote.

This amends 024 section 5, whose bounded staleness trade let a sibling-caused resolution flip go unreported until the next full `index` run. 024's text is not edited (spec 040).

## Testing

The gate as `AGENTS.md` lists it, all green: `compile`, `index`, `check --fail-on-unresolved --fail-on-warn`, `lint --fail-on-warn`, `index coverage --fail-on-untraced` (82/82 claimed, 0 unclaimed), `couple` (4 paths, no drift). Stack gate: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` (627 pass, 0 fail) and `cargo test -p spec-spine-core --no-default-features --locked`.

`spec-spine verify 086-the-committed-index-is-compared-not-trusted` passes all 11 commands.

The guards were proven non-vacuous by building a pre-086 binary and running everything against it:

- Of the ten guards in `tests/index_body.rs`, eight fail against pre-086 code. The two that pass on both sides are the must-keep-working lines: a regenerated tree reads fresh, and a foreign schema MAJOR is refused.
- All three of the spec's CLI tamper lines fail against pre-086 code. The third reproduces the defect verbatim: `spec-spine couple: OK: 1 path(s) checked, no drift`, exit 0, on a change to code the spec owned with its `spec.md` untouched.
- The fixture is deliberately span-free and carries no manifest `spec_ref`, so the tamper cannot move `shardHash` and no package-manifest floor masks the lost claim. The assertions cannot pass by accident of a hash change.

Cost, measured on this repository: `index check` 0.03 s, `check` 0.04 s, against the 0.03 s the old check took. Section 3.4 authorises one index run per check and offers the `--slice` form to a corpus for which that is too slow.

## Review rounds

Three rounds came out of the automated review, each with a fail-first proof that the guard added was not vacuous:

1. A shard that both blocked and differed was named twice, so the count line said "2 stale shard(s)" for one shard. The blocking line is the one kept: regenerating fixes drift and does not fix an unresolved unit, which is also what the pre-086 check reported.
2. The new guard made a body differ by rewriting a phrase out of an `I-004` message, coupling the test to wording it is not about. It now restamps `schemaVersion` within the same MAJOR and asserts the shard really blocks first.
3. That first fix was half a fix: it stripped a duplicate `modified` line and left `missing` alone, though both pair with a blocking diagnostic. It now matches on the file rather than on one class name, so a class added later cannot reopen it.

Three review items were answered rather than fixed, and are recorded here so the reasoning is not lost: the re-index cost is authorised and bounded by 3.4; `read_shard_files` documents that a missing directory yields an empty list, so an absent `by-package` raises nothing; and the report cap truncates `orphaned` first under lexicographic sort, which the registry's cap has done since 031 and is parity rather than a new divergence.